### PR TITLE
Chemvend Jugs Adjustments (Again)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -104,7 +104,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockChemVendFilled
-  cost: 6300 #Delta V - was 3820, see rebase PR #53
+  cost: 1 #Delta V - was 3820, see rebase PR #53
   category: Medical
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -4,24 +4,24 @@
     Jug: 4
 ## Delta V - begin jug adjustments, see rebase PR #53
     JugAluminium: 2
-    JugCarbon: 8
-    JugChlorine: 3
+    JugCarbon: 4
+    JugChlorine: 2
     JugCopper: 2
     JugEthanol: 2
     JugFluorine: 2
-    JugHydrogen: 4
+    JugHydrogen: 3
     JugIodine: 2
-    JugIron: 4
+    JugIron: 2
     JugLithium: 2
     JugMercury: 2
-    JugNitrogen: 5
-    JugOxygen: 6
-    JugPhosphorus: 5
-    JugPotassium: 5
-    JugRadium: 4
-    JugSilicon: 5
-    JugSodium: 4
-    JugSugar: 5
+    JugNitrogen: 2
+    JugOxygen: 3
+    JugPhosphorus: 2
+    JugPotassium: 2
+    JugRadium: 2
+    JugSilicon: 3
+    JugSodium: 2
+    JugSugar: 2
     JugSulfur: 2
 ## Delta V - end change of jug adjustments
   emaggedInventory:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Based on these calculations from Discord user Seafoam Green. Fixes my untested numbers in the previous PR that were too high.

I do worry this is too close to the original numbers, but the math is here. I would like to talk more about these numbers as a community before anything like this is merged.

I do have some concerns:

- Spaceacillin is left off of this.
- Tranex is left out of this. If you're wondering why I care about cillin or tranex, its because those are how you make medicated sutures. Not necessary to have in the calcs, but worth bringing up.
- Sigy is left off, but Seafoam said there was enough leftover for about 400u of it.
- I'm not sure this leaves enough for botany. Should probably calc that.
- Saline is left out. Not that important, but sodium is left out of the numbers entirely. I just set it back to 2.
- Tricord is left out of this calc, which is dylo and inapro. Nobody makes inapro for anything other than tricord anyway so that's accounted for at least.
- Dylo is also used in mindbreaker, which isn't calced here. Maybe not important, but Dylo is in high demand as a stepping stone for other drugs, maybe worth an extra jug for its supplies.
- All of this uses current-branch numbers. **_I have no idea what the rebase numbers or recipes are._** All of this needs testing.

![image](https://github.com/DeltaV-Station/Delta-v-rebase/assets/52761126/8ee9c26f-d672-45eb-8bca-b2456885cfbd)
![image](https://github.com/DeltaV-Station/Delta-v-rebase/assets/52761126/b82c6ada-a387-43cb-a9e2-7cd24231ecd7)

Secondary concerns:
- Are the vends too slow? Can/should we speed them up?
- Some stations have two chemvends in the main medbay's chemistry lab, some only have one. Some have them in the extra medbays, which are often wrenched to the main one. Should we make mapping guidelines that account for that? What's the best practice?
- What should we ACTUALLY be aiming for medbays to start with stock for? 20 25u pills of each important drug? We want them to be restocking, but how often? Our goals should be clearly stated if we're going to make more tweaks.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
