### PR TITLE
Increase default lobby duration

### DIFF
--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -1,6 +1,7 @@
 [game]
 desc             = "Featuring loads of unique content and psionics."
 lobbyenabled     = true
+lobbyduration    = 240
 
 [infolinks]
 discord    = "https://discord.gg/deltav"


### PR DESCRIPTION
Go from 2 minutes and 30 seconds to 4 minutes. We already use these values anyways, this just saves a line in the server config