### PR TITLE
Re-adds directional tinted windows

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Structures/Windows/tinted_windows.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Windows/tinted_windows.yml
@@ -1,0 +1,21 @@
+- type: entity
+  id: WindowTintedDirectional
+  parent: WindowDirectional
+  name: directional tinted window
+  description: Don't smudge up the glass down there.
+  placement:
+    mode: SnapgridCenter
+    snap:
+    - Window
+  components:
+  - type: Sprite
+    sprite: Structures/Windows/directional.rsi
+    state: tinted_window
+  - type: Tag
+    tags:
+      - ForceNoFixRotations
+  - type: Icon
+    sprite: Structures/Windows/directional.rsi
+    state: tinted_window
+  - type: Occluder
+    boundingBox: "-0.5,-0.5,0.5,-0.3"

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -74,7 +74,7 @@ SpeedLoaderPistolHighVelocity: SpeedLoaderPistol
 #MountainRockMining: AsteroidRockMining #DeltaV
 
 # 2023-08-08
-WindowTintedDirectional: WindowFrostedDirectional # DeltaV
+#WindowTintedDirectional: WindowFrostedDirectional # DeltaV
 
 # 2023-08-10
 SyringeSpaceacillin: null


### PR DESCRIPTION
## About the PR
Re-adds directional tinted windows that were removed by WD.

## Why / Balance
Many of the maps use them for functional occlusion.

## Technical details
n/n

## Media
n/a
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a

**Changelog**
n/a
