### PR TITLE
Fix prescription glasses working from pockets

### DIFF
--- a/Content.Client/SimpleStation14/Overlays/Systems/NearsightedSystems.cs
+++ b/Content.Client/SimpleStation14/Overlays/Systems/NearsightedSystems.cs
@@ -32,15 +32,21 @@ public sealed class NearsightedSystem : EntitySystem
 
     private void OnEquip(GotEquippedEvent args)
     {
+        // Note: it would be cleaner to check if the glasses are being equipped
+        // to the eyes rather than the pockets using `args.SlotFlags.HasFlag(SlotFlags.EYES)`,
+        // but this field is not present on GotUnequippedEvent. This method is
+        // used for both equip and unequip to make it consistent between checks.
         if (TryComp<NearsightedComponent>(args.Equipee, out var nearsighted) &&
-            EnsureComp<TagComponent>(args.Equipment).Tags.Contains("GlassesNearsight"))
+            EnsureComp<TagComponent>(args.Equipment).Tags.Contains("GlassesNearsight") &&
+            args.Slot == "eyes")
             UpdateShader(nearsighted, true);
     }
 
     private void OnUnEquip(GotUnequippedEvent args)
     {
         if (TryComp<NearsightedComponent>(args.Equipee, out var nearsighted) &&
-            EnsureComp<TagComponent>(args.Equipment).Tags.Contains("GlassesNearsight"))
+            EnsureComp<TagComponent>(args.Equipment).Tags.Contains("GlassesNearsight") &&
+            args.Slot == "eyes")
             UpdateShader(nearsighted, false);
     }
 


### PR DESCRIPTION
## About the PR
Fixes #241, a bug where equipping glasses in a pocket slot worked as well as the eyes slot.

## Why / Balance
N/A

## Technical details
Checks that the equipped glasses are being equipped to the `"eyes"` slot for the purposes of applying the nearsighted shader.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/DeltaV-Station/Delta-v-rebase/assets/8277780/d31e0cdd-4b0a-413b-a18d-c71cbded7cee)
![image](https://github.com/DeltaV-Station/Delta-v-rebase/assets/8277780/adab7a41-fe1f-4005-9adf-7aeb14989136)

## Breaking changes
N/A

**Changelog**