### PR TITLE
Psychic Birbs & Doggos

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/harpy.yml
@@ -32,4 +32,4 @@
   - type: NpcFactionMember
     factions:
     - NanoTrasen
-#  - type: PotentialPsionic
+  - type: PotentialPsionic

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/vulpkanin.yml
@@ -24,7 +24,7 @@
     - type: NpcFactionMember
       factions:
         - NanoTrasen
-#    - type: PotentialPsionic
+    - type: PotentialPsionic
     - type: Respirator
       damage:
        types:

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/harpy.yml
@@ -76,7 +76,6 @@
       - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
       - map: [ "mask" ]
       - map: [ "head" ]
-  - type: PotentialPsionic
   
   - type: HumanoidAppearance
     species: Harpy

--- a/Resources/Prototypes/DeltaV/SoundCollections/harpy.yml
+++ b/Resources/Prototypes/DeltaV/SoundCollections/harpy.yml
@@ -158,7 +158,6 @@
   id: HarpyBeeps
   files:
     - /Audio/Weapons/Guns/EmptyAlarm/smg_empty_alarm.ogg
-    - /Audio/Weapons/flash.ogg
     - /Audio/Items/beep.ogg
     - /Audio/Items/flashlight_pda.ogg
     - /Audio/Items/locator_beep.ogg


### PR DESCRIPTION
## About the PR
That bird is a wizard

## Technical details
This just uncomments out the PotentialPsionic component from Harpies. They had to have it commented out during development because Harpies were developed before Psionics. Now I'm re-enabling the component. 

**Changelog**
:cl: VMSolidus
- fix: Harpies and Vulpkanin can now be Psychic

