### PR TITLE
Update e_sword.yml

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -209,9 +209,9 @@
     sprite: Objects/Weapons/Melee/e_sword_double.rsi
   - type: Reflect
     enabled: true
-    reflectProb: 1
+    reflectProb: .80 #DeltaV: 80% Energy Reflection but no ballistics.
     spread: 75
     reflects:   
-      - Energy        #DeltaV: 100% Energy Reflection but no ballistics. 
+      - Energy #DeltaV: 80% Energy Reflection but no ballistics. 
   - type: UseDelay
     delay: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

reverts the godmode 100% reflect chance for energy weapons on double e-sword
