### PR TITLE
Add access wire to airlocks

### DIFF
--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -4,6 +4,7 @@
   - !type:PowerWireAction
   - !type:PowerWireAction
     pulseTimeout: 15
+  - !type:AccessWireAction # Nyanotrasen
   - !type:DoorBoltWireAction
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
@@ -26,11 +27,12 @@
   wires:
   - !type:PowerWireAction
     pulseTimeout: 10
+  - !type:AccessWireAction # Nyanotrasen
   - !type:DoorBoltWireAction
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
-  dummyWires: 5
+  dummyWires: 4 # Nyanotrasen, lowered by one to account for the access wire
 
 - type: wireLayout
   id: Vending


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Re-added access wires to airlocks

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
They were not re-added since rebase and are a very nice to have feature.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
This is only a yaml change since upstream has all the code this used to use already included.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Airlocks now have access wires
