### PR TITLE
Revert "Update e_sword.yml"

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -209,9 +209,9 @@
     sprite: Objects/Weapons/Melee/e_sword_double.rsi
   - type: Reflect
     enabled: true
-    reflectProb: .80 #DeltaV: 80% Energy Reflection but no ballistics.
+    reflectProb: 1
     spread: 75
     reflects:   
-      - Energy #DeltaV: 80% Energy Reflection but no ballistics. 
+      - Energy        #DeltaV: 100% Energy Reflection but no ballistics. 
   - type: UseDelay
     delay: 1


### PR DESCRIPTION
Reverts DeltaV-Station/Delta-v#323

Having 100% **ENERGY** reflection isn't really god mode. In fact, it is quite the opposite however it makes fights more predictable instead of randomly reflecting an entire ballistic magazine or not reflecting any disabler shots all the sudden. 

https://github.com/DeltaV-Station/Delta-v/assets/139474617/774656ad-40e4-4883-ba7e-638c2364dc4b

