### PR TITLE
Forcefully reset invalid job preferences

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -581,6 +581,7 @@ namespace Content.Client.Preferences.UI
 
                     category.AddChild(selector);
                     _jobPriorities.Add(selector);
+                    EnsureJobRequirementsValid(); // DeltaV
 
                     selector.PriorityChanged += priority =>
                     {
@@ -605,6 +606,28 @@ namespace Content.Client.Preferences.UI
 
                 }
             }
+        }
+
+        /// <summary>
+        /// DeltaV - Make sure that no invalid job priorities get through.
+        /// </summary>
+        private void EnsureJobRequirementsValid()
+        {
+            var changed = false;
+            foreach (var selector in _jobPriorities)
+            {
+                if (_requirements.IsAllowed(selector.Proto, out var _) || selector.Priority == JobPriority.Never)
+                    continue;
+
+                selector.Priority = JobPriority.Never;
+                Profile = Profile?.WithJobPriority(selector.Proto.ID, JobPriority.Never);
+                changed = true;
+            }
+            if (!changed)
+                return;
+
+            _needUpdatePreview = true;
+            Save();
         }
 
         private void OnFlavorTextChange(string content)
@@ -729,6 +752,7 @@ namespace Content.Client.Preferences.UI
             CharacterSlot = _preferencesManager.Preferences.SelectedCharacterIndex;
 
             UpdateControls();
+            EnsureJobRequirementsValid(); // DeltaV
             _needUpdatePreview = true;
         }
 


### PR DESCRIPTION
## About the PR
This'll cause all invalid preferences to be reset upon being loaded. This should prevent people from being able to ready up as a job they shouldn't have access to if it was set to high prior to being locked.

## Why / Balance
Apparently this was an issue that exists

**Changelog**

:cl:
- tweak: Invalid job preferences are now reset to never upon loading in.
