### PR TITLE
Adjusted roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -23,7 +23,7 @@
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"
   supervisors: job-supervisors-captain
-  canBeAntag: true # DeltaV - Can be antagonist
+  canBeAntag: false
   access:
   - Cargo
   - Salvage

--- a/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/janitor.yml
@@ -8,6 +8,7 @@
   supervisors: job-supervisors-hop
   access:
   - Janitor
+  - Service # DeltaV - quite honestly the most noble service occupation
   - Maintenance
   special:
   - !type:GiveItemOnHolidaySpecial

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -10,6 +10,7 @@
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service
   canBeAntag: true # DeltaV - Can be antagonist
+  antagAdvantage: 1 # DeltaV - Reduced TC: Accesses
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -24,7 +24,7 @@
   icon: "JobIconHeadOfPersonnel"
   requireAdminNotify: true
   supervisors: job-supervisors-captain
-  canBeAntag: true # DeltaV - Can be antagonist
+  canBeAntag: false
   access:
   - Command
   - HeadOfPersonnel

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -23,7 +23,7 @@
   icon: "JobIconChiefMedicalOfficer"
   requireAdminNotify: true
   supervisors: job-supervisors-captain
-  canBeAntag: true # DeltaV - Can be antagonist
+  canBeAntag: false
   access:
   - Medical
   - Command


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Command roles that have `canBeAntagonist: true` have it set to `false`. Janitor gains service access because for some godforsaken reason they didn't have it already.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

We want to hold command to a higher standard but also allow traitor command that isn't held to this expectation. This results in *more* poor command members that neglect their staff, regardless of whether or not they have a gameplay-related reason to do it.

**Changelog**
They'll figure it out.