### PR TITLE
Prevent crafting of the Clown Hardsuit

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -681,16 +681,15 @@
 #MISC. HARDSUITS
 #Clown Hardsuit
 - type: entity
-  parent: ClothingHeadEVAHelmetBase # DeltaV - Clown Hardsuit crafting recipe uses an EVA suit to craft.
+  parent: ClothingHeadHelmetHardsuitSecurity
   id: ClothingHeadHelmetHardsuitClown
   noSpawn: true
-  name: clown EVA helmet # DeltaV - Clown Hardsuit crafting recipe uses an EVA suit to craft.
-  description: A clown EVA helmet.
+  name: clown hardsuit helmet
+  description: A clown hardsuit helmet.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/clown.rsi
   - type: Clothing
-    equippedPrefix: off # Fix lack of helmet while not using the flashlight feature.
     sprite: Clothing/Head/Hardsuits/clown.rsi
     equipSound: /Audio/Mecha/mechmove03.ogg
-    unequipSound: /Audio/Mecha/mechmove03.ogg # DeltaV - This doesn't need to make a fart noise.
+    unequipSound: /Audio/Effects/Emotes/parp1.ogg

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -853,8 +853,8 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
-  - type: Construction
-    graph: ClownHardsuit
-    node: clownHardsuit
+  # - type: Construction # DeltaV - Prevent clowns from making the hardsuit
+  #   graph: ClownHardsuit
+  #   node: clownHardsuit
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitClown

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -829,36 +829,32 @@
 #MISC. HARDSUITS
 #Clown Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitEVA # DeltaV - Clown Hardsuit crafting recipe uses an EVA suit to craft.
+  parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitClown
-  name: clown EVA suit # DeltaV - Clown Hardsuit crafting recipe uses an EVA suit to craft.
-  description: A custom made clown softsuit. # DeltaV - Clown Hardsuit crafting recipe uses an EVA suit to craft.
+  name: clown hardsuit
+  description: A custom made clown hardsuit.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/clown.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Hardsuits/clown.rsi
-  # - type: PressureProtection # DeltaV - Clown Hardsuit inherits from the normal eva suit, entirely cosmetic.
-  #   highPressureMultiplier: 0.5
-  #   lowPressureMultiplier: 1000
-  # - type: ExplosionResistance
-  #   damageCoefficient: 0.9
-  # - type: Armor
-  #   modifiers:
-  #     coefficients:
-  #       Blunt: 0.9
-  #       Slash: 0.9
-  #       Piercing: 0.9
-  #       Caustic: 0.8
-  # - type: ClothingSpeedModifier
-  #   walkModifier: 0.9
-  #   sprintModifier: 0.9
+  - type: PressureProtection
+    highPressureMultiplier: 0.5
+    lowPressureMultiplier: 1000
+  - type: ExplosionResistance
+    damageCoefficient: 0.9
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Caustic: 0.8
+  - type: ClothingSpeedModifier
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: Construction
     graph: ClownHardsuit
     node: clownHardsuit
   - type: ToggleableClothing
-    slot: head
     clothingPrototype: ClothingHeadHelmetHardsuitClown
-  - type: ContainerContainer # DeltaV - Allows the EVA suit to have built in 'hardsuit' helmet
-    containers:
-      toggleable-clothing: !type:ContainerSlot {}

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -1,13 +1,13 @@
-- type: construction
-  name: clown hardsuit
-  id: ClownHardsuit
-  graph: ClownHardsuit
-  startNode: start
-  targetNode: clownHardsuit
-  category: construction-category-clothing
-  description: A modified hardsuit fit for a clown.
-  icon: { sprite: Clothing/OuterClothing/Hardsuits/clown.rsi, state: icon }
-  objectType: Item
+# - type: construction # DeltaV - Prevent clowns from making the hardsuit
+#   name: clown hardsuit
+#   id: ClownHardsuit
+#   graph: ClownHardsuit
+#   startNode: start
+#   targetNode: clownHardsuit
+#   category: construction-category-clothing
+#   description: A modified hardsuit fit for a clown.
+#   icon: { sprite: Clothing/OuterClothing/Hardsuits/clown.rsi, state: icon }
+#   objectType: Item
 
 - type: construction
   name: bone armor


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Reverts the previous changes to make it more EVA like and prevents it from being craftable.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
As per discussion with Leo.
Prevents it from existing in game outside of mapper/admin spawn.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- remove: Removed the clown hardsuit from being craftable.
