### PR TITLE
Mediborg Candy Frabication

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -132,7 +132,7 @@
     noMindState: medical_e_r
   - type: Construction
     node: medical
-  - type: FabricateCandy # Nyanotrasen - The medical cyborg can generate healing candies.
+  - type: FabricateCandy # Nyanotrasen - The medical cyborg can generate candies filled with medicine.
 
 - type: entity
   id: BorgChassisService

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -132,6 +132,7 @@
     noMindState: medical_e_r
   - type: Construction
     node: medical
+  - type: FabricateCandy # Nyanotrasen - The medical cyborg can generate healing candies.
 
 - type: entity
   id: BorgChassisService


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Re-adds the old mediborg ability to fabricate candy to cyborgs using the medical model.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Funny medical candies. Can help heal injuries, will also feed the poor doctors dying of starvation because they never take a break to eat the food that the Chef made.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Cyborgs using the Medical model can now print candies with medicine once again.
