### PR TITLE
Updates mob spawners for Arena

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -64,13 +64,13 @@
     radius: 1.2
     energy: 2
     color: "#4faffb"
-  - type: GhostTakeoverAvailable
+  #- type: GhostTakeoverAvailable # Delta V: Moves ghost takeover to child
   - type: Speech
     speechVerb: LargeMob
 
 - type: entity
   name: space bear
-  id: MobBearSpace
+  id: MobBearSpaceNPC # Delta V : remove ghosttakeover comps
   parent: MobSpaceBasic
   description: It looks friendly. Why don't you give it a hug?
   components:
@@ -110,10 +110,7 @@
     interactFailureString: petting-failure-bear
     interactSuccessSound:
       path: /Audio/Animals/sloth_squeak.ogg
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-space-bear-name
-    description: ghost-role-information-space-bear-description
+  # Moved to Nyanotrasen\Entities\Mobs\NPCs\space.yml
 
 - type: entity
   id: MobBearSpaceSalvage
@@ -129,7 +126,7 @@
 
 - type: entity
   name: space kangaroo
-  id: MobKangarooSpace
+  id: MobKangarooSpaceNPC # Delta V : remove ghosttakeover comps
   parent: MobSpaceBasic
   description: It looks friendly. Why don't you give it a hug?
   components:
@@ -182,10 +179,7 @@
     interfaces:
     - key: enum.StrippingUiKey.Key
       type: StrippableBoundUserInterface
-  - type: GhostRole
-    prob: 0.25
-    name: ghost-role-information-space-kangaroo-name
-    description: ghost-role-information-space-kangaroo-description
+  # Moved to Nyanotrasen\Entities\Mobs\NPCs\space.yml
 
 - type: entity
   id: MobKangarooSpaceSalvage
@@ -201,7 +195,7 @@
 
 - type: entity
   name: space spider
-  id: MobSpiderSpace
+  id: MobSpiderSpaceNPC # Delta V : remove ghosttakeover comps
   parent: MobSpaceBasic
   description: It's so glowing, it looks dangerous.
   components:
@@ -278,10 +272,7 @@
     color: "#4faffb"
   - type: NoSlip
   - type: IgnoreSpiderWeb
-  - type: GhostRole
-    prob: 0.30
-    name: ghost-role-information-space-spider-name
-    description: ghost-role-information-space-spider-description
+  # Moved to Nyanotrasen\Entities\Mobs\NPCs\space.yml
   - type: Speech
     speechVerb: Arachnid
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -96,13 +96,13 @@
     spawned:
     - id: FoodMeatXeno
       amount: 5
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-xeno-name
-    description: ghost-role-information-xeno-description
-    rules: ghost-role-information-xeno-rules
+  #- type: GhostRole # Delta V - Moves ghost role from parent to child
+  #  allowMovement: true # Delta V - Moves ghost role from parent to child
+  #  allowSpeech: true # Delta V - Moves ghost role from parent to child
+  #  makeSentient: true # Delta V - Moves ghost role from parent to child
+  #  name: ghost-role-information-xeno-name # Delta V - Moves ghost role from parent to child
+  #  description: ghost-role-information-xeno-description # Delta V - Moves ghost role from parent to child
+  #  rules: ghost-role-information-xeno-rules # Delta V - Moves ghost role from parent to child
   # - type: GhostTakeoverAvailable # Delta V - Moves ghost role from parent to child
   - type: TypingIndicator
     proto: alien

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/mobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/mobs.yml
@@ -94,7 +94,7 @@
       layers:
         - state: red
         - sprite: Mobs/Aliens/Xenos/burrower.rsi
-          state: crit
+          state: walking
         - state: ai
     - type: RandomSpawner
       prototypes:
@@ -118,7 +118,7 @@
       layers:
         - state: red
         - sprite: Mobs/Aliens/Argocyte/argocyte_common.rsi
-          state: crawler_dead
+          state: crawler
         - state: ai
     - type: RandomSpawner
       prototypes:
@@ -143,7 +143,7 @@
       layers:
         - state: red
         - sprite: Mobs/Aliens/Lavaland/watcher.rsi
-          state: dead
+          state: unshaded
         - state: ai
     - type: RandomSpawner
       prototypes:
@@ -164,7 +164,7 @@
       layers:
         - state: red
         - sprite: Mobs/Animals/spacespider.rsi
-          state: spacespider_dead
+          state: spacespider
         - state: ai
     - type: RandomSpawner
       prototypes:
@@ -181,7 +181,7 @@
       layers:
         - state: red
         - sprite: Mobs/Animals/kangaroo.rsi
-          state: kangaroo-space-dead
+          state: kangaroo-space
         - state: ai
     - type: RandomSpawner
       prototypes:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/mobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/mobs.yml
@@ -129,9 +129,9 @@
         - MobArgocyteGlider
         - MobArgocyteHarvester
         - MobArgocyteCrawler
-        - MobArgocyteFounder # need to test they don't break out
+        - MobArgocyteFounder
       rarePrototypes:
-        - MobArgocyteLeviathing # need to test they don't break out
+        - MobArgocyteLeviathing
       rareChance: 0.10
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/mobs.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/mobs.yml
@@ -14,7 +14,7 @@
         - MobCarp
         - MobCarpMagic
         - MobCarpHolo
-        - MobCarpMagic
+        - MobCarpRainbow
 
 - type: entity
   name: NPC Snake Spawner
@@ -88,6 +88,7 @@
   name: Xeno Spawner
   id: XenoAISpawner
   parent: MarkerBase
+  suffix: No Ghost Takeover
   components:
     - type: Sprite
       layers:
@@ -106,4 +107,88 @@
         - MobXenoSpitterNPC
       rarePrototypes:
         - MobXenoQueenNPC
+      rareChance: 0.10
+
+- type: entity
+  name: Argocyte Spawner
+  id: ArgocyteAISpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Mobs/Aliens/Argocyte/argocyte_common.rsi
+          state: crawler_dead
+        - state: ai
+    - type: RandomSpawner
+      prototypes:
+        - MobArgocyteSkitter
+        - MobArgocyteSwiper
+        - MobArgocyteMolder
+        - MobArgocytePouncer
+        - MobArgocyteGlider
+        - MobArgocyteHarvester
+        - MobArgocyteCrawler
+        - MobArgocyteFounder # need to test they don't break out
+      rarePrototypes:
+        - MobArgocyteLeviathing # need to test they don't break out
+      rareChance: 0.10
+
+- type: entity
+  name: Watcher Spawner
+  id: WatcherAISpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Mobs/Aliens/Lavaland/watcher.rsi
+          state: dead
+        - state: ai
+    - type: RandomSpawner
+      prototypes:
+        - MobWatcherLavaland
+        - MobWatcherIcewing
+        - MobWatcherMagmawing
+      rarePrototypes:
+        - MobWatcherPride
+      rareChance: 0.10
+
+- type: entity
+  name: Space Creature Spawner
+  id: SpaceCreatureAISpawner
+  parent: MarkerBase
+  suffix: No Ghost Takeover
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Mobs/Animals/spacespider.rsi
+          state: spacespider_dead
+        - state: ai
+    - type: RandomSpawner
+      prototypes:
+        - MobBearSpaceNPC
+        - MobKangarooSpaceNPC
+        - MobSpiderSpaceNPC
+
+- type: entity
+  name: Arena Spawner
+  id: ArenaSpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Mobs/Animals/kangaroo.rsi
+          state: kangaroo-space-dead
+        - state: ai
+    - type: RandomSpawner
+      prototypes:
+        - SpaceCreatureAISpawner
+        - WatcherAISpawner
+        - ArgocyteAISpawner
+        - SpawnMobOreCrab
+      rarePrototypes:
+        - MobLaserRaptor
       rareChance: 0.10

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/space.yml
@@ -1,0 +1,33 @@
+# GhostTakeover
+
+- type: entity
+  name: space bear
+  id: MobBearSpace
+  parent: MobBearSpaceNPC
+  components:
+  - type: GhostTakeoverAvailable # Delta V: Moves here
+  - type: GhostRole
+    prob: 0.25
+    name: ghost-role-information-space-bear-name
+    description: ghost-role-information-space-bear-description
+
+- type: entity
+  name: space kangaroo
+  id: MobKangarooSpace
+  parent: MobKangarooSpaceNPC
+  components:
+  - type: GhostTakeoverAvailable # Delta V: Moves here
+  - type: GhostRole
+    prob: 0.25
+    name: ghost-role-information-space-kangaroo-name
+    description: ghost-role-information-space-kangaroo-description
+
+- type: entity
+  name: space spider
+  id: MobSpiderSpace
+  parent: MobSpiderSpaceNPC
+  components:
+  - type: GhostRole
+    prob: 0.30
+    name: ghost-role-information-space-spider-name
+    description: ghost-role-information-space-spider-description

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -35,6 +35,13 @@
   parent: MobXeno
   suffix: Player
   components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -43,6 +50,13 @@
   id: MobXenoPraetorian
   suffix: Player
   components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -51,6 +65,13 @@
   id: MobXenoDrone
   suffix: Player
   components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -59,6 +80,13 @@
   id: MobXenoQueen
   suffix: Player
   components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -67,6 +95,13 @@
   id: MobXenoRavager
   suffix: Player
   components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
   - type: GhostTakeoverAvailable
 
 - type: entity
@@ -75,17 +110,28 @@
   id: MobXenoRunner
   suffix: Player
   components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
   - type: GhostTakeoverAvailable
 
 - type: entity
   name: Rouny
-  parent: MobXenoRunner
+  parent: MobXenoRounyNPC
   id: MobXenoRouny
   components:
-  - type: Sprite
-    drawdepth: Mobs
-    sprite: Mobs/Aliens/Xenos/rouny.rsi
-    offset: 0,0.6
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
+  - type: GhostTakeoverAvailable
 
 - type: entity
   name: Spitter
@@ -93,4 +139,11 @@
   id: MobXenoSpitter
   suffix: Player
   components:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-xeno-name
+    description: ghost-role-information-xeno-description
+    rules: ghost-role-information-xeno-rules
   - type: GhostTakeoverAvailable


### PR DESCRIPTION
## About the PR
- Fixes Xeno showing up in Ghost Roles on Arena
- Fixes bears sometimes being ghost roles on Arena(will require pending Arena update)
- Adds spawners for Argocyte, Watcher, and new Space Creatures (These are primarily intended for Arena use, with potential for salvage chunks)
- Adds an Arena-specific spawner for maximum rng

## Why / Balance
More variety in the arena.

## Technical details
n/a

## Media
n/a

## Breaking changes
n/a

**Changelog**
n/a
