### PR TITLE
Move cat ears out of the Syndicate Uplink into AutoDrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -72,6 +72,7 @@
     ClothingCostumeMioSkirt: 1 # Nyano - Clothing addition
     ClothingCostumeNaota: 1 # Nyano - Clothing addition
     ClothingUniformJumpsuitSober: 1 # DeltaV - Clothing addition
+    ClothingHeadHatCatEars: 2 # DeltaV - Move cat ears out of syndicate uplink into the AutoDrobe
   emaggedInventory:
     ClothingShoesBling: 1
     ClothingOuterDogi: 1

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1274,15 +1274,15 @@
   categories:
   - UplinkPointless
 
-- type: listing
-  id: UplinkCatEars
-  name: uplink-cat-ears-name
-  description: uplink-cat-ears-desc
-  productEntity: ClothingHeadHatCatEars
-  cost:
-    Telecrystal: 4 # Nyanotrasen - Make Cat Ears 4TC instead of 26TC
-  categories:
-  - UplinkPointless
+# - type: listing # DeltaV - Move cat ears out of syndicate uplink into the AutoDrobe
+#   id: UplinkCatEars
+#   name: uplink-cat-ears-name
+#   description: uplink-cat-ears-desc
+#   productEntity: ClothingHeadHatCatEars
+#   cost:
+#     Telecrystal: 4 # Nyanotrasen - Make Cat Ears 4TC instead of 26TC
+#   categories:
+#   - UplinkPointless
 
 - type: listing
   id: UplinkOutlawHat


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Moves the cat ears out of the Syndicate Uplink and into AutoDrobe. Two units of cat ears. (Up to discussion)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Leo wants this.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
N/A

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
N/A

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Cat Ears have been moved from the Syndicate Uplink into the AutoDrobe.
