### PR TITLE
Add the Salvage Expedition board to research

### DIFF
--- a/Resources/Prototypes/DeltaV/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Lathes/electronics.yml
@@ -1,0 +1,8 @@
+- type: latheRecipe
+  id: SalvageExpeditionsComputerCircuitboard
+  result: SalvageExpeditionsComputerCircuitboard
+  completetime: 4
+  materials:
+     Steel: 100
+     Glass: 900
+     Silver: 100

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -388,6 +388,7 @@
 #      - MetempsychoticMachineCircuitboard
       - DeepFryerMachineCircuitboard
     # End Nyano additions
+      - SalvageExpeditionsComputerCircuitboard # DeltaV
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -13,6 +13,7 @@
   - MiningDrill
   - BorgModuleMining
   - OreProcessorMachineCircuitboard
+  - SalvageExpeditionsComputerCircuitboard # DeltaV 
 
 - type: technology
   id: AdvancedPowercells

--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -118,3 +118,4 @@ In the following special circumstances, lethal force may be used by Security:
     - Executions must be for a capital crime, used only as a last resort, and MUST be authorized by the highest ranking member of Security, who will answer to the use of execution.
     - Detainees in the brig have the right to know what they are being charged with.
 
+[color=#a4885c]16.[/color] Command members besides the Logistics Officer are not permitted to leave the station on salvage expeditions.


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->

Allows the crew to research and produce Salvage Expedition computer boards by way of adding a recipe for the board, then locking it behind the "Salvage Equipment" tier 1 industrial technology.

Also adds a new entry to the rules.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

A lot of the growing pains of the rebase have been addressed and fixed. It's good fun and I think it's worth testing more broadly. We can always revert this if it doesn't work out, and go about it some other way.

## Media

![image](https://github.com/DeltaV-Station/Delta-v/assets/113523727/2173c4aa-7443-4c65-be7b-82f21b02b090)
![image](https://github.com/DeltaV-Station/Delta-v/assets/113523727/0ac72f39-7adc-4fe5-9c3d-aa916f7e2730)
![image](https://github.com/DeltaV-Station/Delta-v/assets/113523727/bb49fa9b-2e8c-4fb7-af76-64cb36be1cd5)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Salvage Expedition computer boards can now be researched by Epistemics and produced in circuit imprinters.
