### PR TITLE
Trimming the bird emotes

### DIFF
--- a/Resources/Prototypes/DeltaV/SoundCollections/harpy.yml
+++ b/Resources/Prototypes/DeltaV/SoundCollections/harpy.yml
@@ -100,11 +100,6 @@
     - /Audio/Mecha/sound_mecha_hydraulic.ogg
 
 - type: soundCollection
-  id: HarpyBooms
-  files:
-    - /Audio/Effects/flash_bang.ogg
-
-- type: soundCollection
   id: HarpyRings
   files:
     - /Audio/Items/desk_bell_ring.ogg
@@ -130,7 +125,6 @@
     - /Audio/Effects/Arcade/player_attack.ogg
     - /Audio/Effects/Arcade/player_charge.ogg
     - /Audio/Effects/Arcade/player_heal.ogg
-    - /Audio/Magic/blink.ogg
     - /Audio/Magic/staff_animation.ogg
     - /Audio/Magic/staff_change.ogg
     - /Audio/Magic/staff_chaos.ogg
@@ -146,7 +140,6 @@
     - /Audio/Weapons/Guns/Gunshots/pistol.ogg
     - /Audio/Weapons/Guns/Gunshots/c-20r.ogg
     - /Audio/Items/snap.ogg
-    - /Audio/Machines/airlock_creaking.ogg
     - /Audio/Machines/blastdoor.ogg
     - /Audio/Machines/machine_vend.ogg
     - /Audio/Magic/disintegrate.ogg
@@ -240,3 +233,6 @@
   id: HarpyChirps
   files: 
     - /Audio/DeltaV/Voice/Harpy/chirp1.ogg
+    - /Audio/Voicce/Talk/pai.ogg
+    - /Audio/Voicce/Talk/pai_ask.ogg
+    - /Audio/Voicce/Talk/pai_exclaim.ogg

--- a/Resources/Prototypes/DeltaV/SoundCollections/harpy.yml
+++ b/Resources/Prototypes/DeltaV/SoundCollections/harpy.yml
@@ -233,6 +233,6 @@
   id: HarpyChirps
   files: 
     - /Audio/DeltaV/Voice/Harpy/chirp1.ogg
-    - /Audio/Voicce/Talk/pai.ogg
-    - /Audio/Voicce/Talk/pai_ask.ogg
-    - /Audio/Voicce/Talk/pai_exclaim.ogg
+    - /Audio/Voice/Talk/pai.ogg
+    - /Audio/Voice/Talk/pai_ask.ogg
+    - /Audio/Voice/Talk/pai_exclaim.ogg

--- a/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
@@ -28,8 +28,6 @@
       collection: HarpyGrowls
     Purr:
       collection: HarpyPurrs
-    Boom:
-      collection: HarpyBooms
     Ring:
       collection: HarpyRings
     HonkHarpy:

--- a/Resources/Prototypes/DeltaV/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emotes.yml
@@ -1,16 +1,5 @@
 # Harpy
 - type: emote
-  id: Boom
-  category: Vocal
-  chatMessages: [booms.]
-  chatTriggers:
-    - boom.
-    - booms.
-    - booms!
-    - booming.
-    - boomed.
-
-- type: emote
   id: HonkHarpy
   category: Vocal
   chatMessages: [honks.]


### PR DESCRIPTION
## About the PR
By request, some of the harpy emotes have been deemed too "Griefy" to qualify for the harpy emote lists, and have been trimmed. This includes the sound sfx for, ninja blink, dragons eating doors, and the flash bang sound. By extension, harpies will no longer have a "Boom" emote. Meaning they can no longer imitate any kind of grenade or bomb explosion. Per my own demands, I have replaced these emotes with adding new, less griefy sounds in the form of letting them imitate the PAI chirping.  

## Why / Balance
As a general rule of thumb for what sound effects are acceptable according to the Harpy design documents, sounds are to be excluded if they meet the following criteria:
- "Too Griefy"
- Too long
- Too loud
- Too spammable

## Technical details

In the future, I think I'm going to look into also adding a cool down to sound emotes in general, so as to address annoying spam. It's funny seeing Vulpkanin spamming bark at a mail courier exactly once, especially when three harpies decide to join in the barking. 

**Changelog**
:cl: VMSolidus
- tweak: Centcomm Geneticists have modified the Harpies so that they can no longer imitate flash bangs. Your eardrums are safe now. 
