### PR TITLE
Expand valid character names

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -407,7 +407,16 @@ namespace Content.Shared.Preferences
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             if (configManager.GetCVar(CCVars.RestrictedNames))
             {
-                name = Regex.Replace(name, @"[^A-Z,a-z,0-9, -]", string.Empty);
+                name = Regex.Replace(name, @"[^\u0030-\u0039,\u0041-\u005A,\u0061-\u007A,\u00C0-\u00D6,\u00D8-\u00F6,\u00F8-\u00FF,\u0100-\u017F, '.,-]", string.Empty);
+                /*
+                 * 0030-0039  Basic Latin: ASCII Digits
+                 * 0041-005A  Basic Latin: Uppercase Latin Alphabet
+                 * 0061-007A  Basic Latin: Lowercase Latin Alphabet
+                 * 00C0-00D6  Latin-1 Supplement: Letters I
+                 * 00D8-00F6  Latin-1 Supplement: Letters II
+                 * 00F8-00FF  Latin-1 Supplement: Letters III
+                 * 0100-017F  Latin Extended A: European Latin
+                 */
             }
 
             if (configManager.GetCVar(CCVars.ICNameCase))


### PR DESCRIPTION
## About the PR
This PR brings over an updated version of [Delta-v-Legacy: Adjust character name validation #14](https://github.com/DeltaV-Station/Delta-v-Legacy/pull/14).

The following has been changed from the original PR:
- Numeric digits have _not_ been removed in order to accommodate things like IPCs and other silicon characters.
- `,` and `.` are permitted because some people's names necessarily include affixes such as `Name, Sr.` or `Name, Jr.`.
- `'` is permitted to accommodate certain Diona names such as `The Bird's Song` and similar.

## Why / Balance
This change was lost during the rebase, and several characters have had their names stripped of non-ASCII letters as a consequence.

## Technical details
The permitted Unicode blocks are documented below the regex string that controls the allowed glyphs in a character's name.

## Media
![image](https://github.com/DeltaV-Station/Delta-v/assets/20689511/c387d306-a2db-419d-85a6-e9082a60199e)

**Changelog**
:cl:
- tweak: Character name restrictions are more permissive.
