### PR TITLE
Added Head ID cards to lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -24,6 +24,7 @@
       - id: BoxEncryptionKeyCargo
       - id: SpaceCashLuckyBill # DeltaV - LO steal objective, see Resources/Prototypes/DeltaV/Entities/Objects/Misc/first_bill.yml
       - id: BoxPDACargo # Delta-V
+      - id: QuartermasterIDCard # Delta-V
 
 - type: entity
   id: LockerCaptainFilledHardsuit
@@ -166,6 +167,7 @@
       - id: BoxEncryptionKeyEngineering
       - id: AccessConfigurator
       - id: BoxPDAEngineering # Delta-V
+      - id: CEIDCard # Delta-V
 
 - type: entity
   id: LockerChiefEngineerFilled
@@ -189,6 +191,7 @@
       - id: BoxEncryptionKeyEngineering
       - id: AccessConfigurator
       - id: BoxPDAEngineering # Delta-V
+      - id: CEIDCard # Delta-V
 
 - type: entity
   id: LockerChiefMedicalOfficerFilledHardsuit
@@ -215,6 +218,7 @@
       - id: BoxEncryptionKeyMedical
       - id: BoxPDAMedical # Delta-V
       - id: ClothingBeltMilitaryWebbingCMO # DeltaV - add webbing for CMO. ON THIS STATION, IT'S DRIP OR [die], CAPTAIN!
+      - id: CMOIDCard # Delta-V
 
 - type: entity
   id: LockerChiefMedicalOfficerFilled
@@ -240,6 +244,7 @@
       - id: BoxEncryptionKeyMedical
       - id: BoxPDAMedical # Delta-V
       - id: ClothingBeltMilitaryWebbingCMO # DeltaV - add webbing for CMO. ON THIS STATION, IT'S DRIP OR [die], CAPTAIN!
+      - id: CMOIDCard # Delta-V
 
 - type: entity
   id: LockerResearchDirectorFilledHardsuit
@@ -263,6 +268,7 @@
       - id: ClothingHeadsetAltScience
       - id: BoxEncryptionKeyScience
       - id: BoxPDAScience # Delta-V
+      - id: RDIDCard # Delta-V
 
 - type: entity
   id: LockerResearchDirectorFilled
@@ -285,6 +291,7 @@
       - id: ClothingHeadsetAltScience
       - id: BoxEncryptionKeyScience
       - id: BoxPDAScience # Delta-V
+      - id: RDIDCard # Delta-V
 
 - type: entity
   id: LockerHeadOfSecurityFilledHardsuit
@@ -319,6 +326,7 @@
       - id: HoloprojectorSecurity
       - id: BookSecretDocuments
       - id: BoxPDASecurity # Delta-V
+      - id: HoSIDCard # Delta-V
 
 - type: entity
   id: LockerHeadOfSecurityFilled
@@ -350,3 +358,4 @@
       - id: HoloprojectorSecurity
       - id: BookSecretDocuments
       - id: BoxPDASecurity # Delta-V
+      - id: HoSIDCard # Delta-V


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Added the ID cards for heads in their respective lockers, because sometimes you have the locker, but not the guy who owns it.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

On some occasions, players are missing a head of their department, and aren't able to promote people easily. With this change, if you're able to access the head's locker, you can simply use their spare ID card to grant yourself access. The alternative requires having a captain, which is not always a guarantee, while *this* is.

## Media

![image](https://github.com/DeltaV-Station/Delta-v/assets/113523727/1e9b13fa-8354-4e82-886a-c4befc9e9370)

**Changelog**
:cl:
- add: Head lockers now contain their respective head's spare ID card where they didn't already.
