### PR TITLE
Give HoP lawyer access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -47,7 +47,7 @@
 #  - Detective
 #  - Salvage
 #  - Security # NoooOoOo!! My HoPcurity!1
-#  - Brig
+  - Brig # Lawyer access
 #  - Cargo
 #  - Atmospherics
 #  - Medical


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

inb4 someone looks at it and asks "you gave them brig access? Isn't that bad?!"

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Head of Personnel now has the access that lawyers have.
