### PR TITLE
Update Asterisk & map protos

### DIFF
--- a/Resources/Maps/asterisk.yml
+++ b/Resources/Maps/asterisk.yml
@@ -7871,13 +7871,6 @@ entities:
     - pos: -45.5,-25.5
       parent: 2
       type: Transform
-- proto: BoxLightMixed
-  entities:
-  - uid: 1389
-    components:
-    - pos: -13.321652,-1.3277344
-      parent: 2
-      type: Transform
 - proto: BoxMagazineLightRiflePractice
   entities:
   - uid: 2817
@@ -7890,13 +7883,6 @@ entities:
   - uid: 2793
     components:
     - pos: -41.325523,14.524066
-      parent: 2
-      type: Transform
-- proto: BoxMaintenanceLightbulb
-  entities:
-  - uid: 1386
-    components:
-    - pos: -13.676224,-1.250433
       parent: 2
       type: Transform
 - proto: BoxSyringe
@@ -8041,9 +8027,9 @@ entities:
       type: Transform
 - proto: BurnAutoInjector
   entities:
-  - uid: 825
+  - uid: 11049
     components:
-    - pos: 28.449654,-11.5423765
+    - pos: 28.121563,-11.653111
       parent: 2
       type: Transform
 - proto: CableApcExtension
@@ -15816,6 +15802,11 @@ entities:
   - uid: 11028
     components:
     - pos: -43.5,-19.5
+      parent: 2
+      type: Transform
+  - uid: 11047
+    components:
+    - pos: 28.5,28.5
       parent: 2
       type: Transform
 - proto: CableApcStack
@@ -24661,6 +24652,12 @@ entities:
     - pos: -12.5,-18.5
       parent: 2
       type: Transform
+  - uid: 11043
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -0.5,18.5
+      parent: 2
+      type: Transform
 - proto: ChairOfficeLight
   entities:
   - uid: 143
@@ -25164,6 +25161,13 @@ entities:
     - pos: 41.5,-8.5
       parent: 2
       type: Transform
+- proto: ClosetJanitorFilled
+  entities:
+  - uid: 2904
+    components:
+    - pos: -13.5,-1.5
+      parent: 2
+      type: Transform
 - proto: ClosetMaintenanceFilledRandom
   entities:
   - uid: 7004
@@ -25238,9 +25242,9 @@ entities:
       pos: 6.5,16.5
       parent: 2
       type: Transform
-  - uid: 9860
+  - uid: 11044
     components:
-    - pos: -0.5,15.5
+    - pos: -1.5,15.5
       parent: 2
       type: Transform
 - proto: ClothingBackpackDuffelSurgeryFilled
@@ -25399,6 +25403,13 @@ entities:
   - uid: 3724
     components:
     - pos: -13.35745,-29.37157
+      parent: 2
+      type: Transform
+- proto: ClothingUniformJumpskirtJanimaidmini
+  entities:
+  - uid: 3802
+    components:
+    - pos: -12.319212,0.73165154
       parent: 2
       type: Transform
 - proto: Cobweb1
@@ -26334,6 +26345,11 @@ entities:
       type: Transform
 - proto: CrateEmptySpawner
   entities:
+  - uid: 951
+    components:
+    - pos: -0.5,14.5
+      parent: 2
+      type: Transform
   - uid: 3765
     components:
     - pos: 10.5,11.5
@@ -26392,11 +26408,6 @@ entities:
   - uid: 4152
     components:
     - pos: -4.5,13.5
-      parent: 2
-      type: Transform
-  - uid: 4153
-    components:
-    - pos: -1.5,14.5
       parent: 2
       type: Transform
   - uid: 4155
@@ -26576,9 +26587,9 @@ entities:
     - pos: -46.5,7.5
       parent: 2
       type: Transform
-- proto: CrateTrashCart
+- proto: CrateTrashCartJani
   entities:
-  - uid: 3802
+  - uid: 1109
     components:
     - pos: -13.5,-0.5
       parent: 2
@@ -26722,6 +26733,13 @@ entities:
   - uid: 8889
     components:
     - pos: -48.32532,-19.424814
+      parent: 2
+      type: Transform
+- proto: DiseaseSwab
+  entities:
+  - uid: 4153
+    components:
+    - pos: 15.128561,-20.292566
       parent: 2
       type: Transform
 - proto: DisposalBend
@@ -29033,9 +29051,9 @@ entities:
     - pos: -21.5,19.5
       parent: 2
       type: Transform
-  - uid: 2938
+  - uid: 9860
     components:
-    - pos: -39.5,15.5
+    - pos: -38.5,15.5
       parent: 2
       type: Transform
 - proto: Dresser
@@ -29096,16 +29114,6 @@ entities:
       type: Transform
 - proto: DrinkCafeLatte
   entities:
-  - uid: 951
-    components:
-    - pos: -4.510326,5.617763
-      parent: 2
-      type: Transform
-  - uid: 952
-    components:
-    - pos: -4.239493,5.722001
-      parent: 2
-      type: Transform
   - uid: 9545
     components:
     - pos: -48.22356,-11.293325
@@ -29113,6 +29121,16 @@ entities:
       type: Transform
 - proto: DrinkCoffee
   entities:
+  - uid: 1369
+    components:
+    - pos: -4.1824093,5.628996
+      parent: 2
+      type: Transform
+  - uid: 1373
+    components:
+    - pos: -4.46366,5.5143323
+      parent: 2
+      type: Transform
   - uid: 9544
     components:
     - pos: -48.69231,-11.043152
@@ -29170,14 +29188,24 @@ entities:
       type: Transform
 - proto: DrinkEnergyDrinkCan
   entities:
-  - uid: 803
+  - uid: 825
     components:
-    - pos: 28.158022,-11.179657
+    - pos: 28.590313,-11.194461
       parent: 2
       type: Transform
   - uid: 10771
     components:
     - pos: 48.667942,-10.733177
+      parent: 2
+      type: Transform
+  - uid: 11045
+    components:
+    - pos: 0.5437088,19.767643
+      parent: 2
+      type: Transform
+  - uid: 11046
+    components:
+    - pos: 0.7520422,19.60086
       parent: 2
       type: Transform
 - proto: DrinkGlass
@@ -29390,6 +29418,11 @@ entities:
       type: Transform
 - proto: EmergencyLight
   entities:
+  - uid: 952
+    components:
+    - pos: 1.5,14.5
+      parent: 2
+      type: Transform
   - uid: 4315
     components:
     - rot: 1.5707963267948966 rad
@@ -29584,11 +29617,6 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -49.5,-6.5
-      parent: 2
-      type: Transform
-  - uid: 9482
-    components:
-    - pos: -0.5,14.5
       parent: 2
       type: Transform
   - uid: 9624
@@ -44913,6 +44941,8 @@ entities:
       pos: -43.5,6.5
       parent: 2
       type: Transform
+    - targetPressure: 4500
+      type: GasPressurePump
     - color: '#FF8800FF'
       type: AtmosPipeColor
   - uid: 4622
@@ -49177,6 +49207,11 @@ entities:
     - pos: -53.5,1.5
       parent: 2
       type: Transform
+  - uid: 8363
+    components:
+    - pos: -0.5,15.5
+      parent: 2
+      type: Transform
   - uid: 8596
     components:
     - pos: 48.5,-8.5
@@ -49824,16 +49859,16 @@ entities:
       type: Transform
 - proto: HydroponicsToolClippers
   entities:
-  - uid: 2904
+  - uid: 1377
     components:
-    - pos: -36.352306,15.338483
+    - pos: -36.71838,15.610928
       parent: 2
       type: Transform
 - proto: HydroponicsToolMiniHoe
   entities:
-  - uid: 2906
+  - uid: 1378
     components:
-    - pos: -36.522217,15.541486
+    - pos: -36.34338,15.725592
       parent: 2
       type: Transform
 - proto: hydroponicsTray
@@ -49883,14 +49918,14 @@ entities:
     - pos: 13.5,-16.5
       parent: 2
       type: Transform
-  - uid: 2898
-    components:
-    - pos: -38.5,15.5
-      parent: 2
-      type: Transform
   - uid: 2899
     components:
     - pos: -37.5,15.5
+      parent: 2
+      type: Transform
+  - uid: 2906
+    components:
+    - pos: -36.5,15.5
       parent: 2
       type: Transform
 - proto: IDComputerCircuitboard
@@ -50124,6 +50159,14 @@ entities:
       pos: 20.5,26.5
       parent: 2
       type: Transform
+- proto: JanitorialTrolley
+  entities:
+  - uid: 661
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -13.5,-2.5
+      parent: 2
+      type: Transform
 - proto: JetpackMiniFilled
   entities:
   - uid: 1881
@@ -50195,6 +50238,11 @@ entities:
   - uid: 558
     components:
     - pos: -2.5,-16.5
+      parent: 2
+      type: Transform
+  - uid: 1368
+    components:
+    - pos: -39.5,15.5
       parent: 2
       type: Transform
   - uid: 1399
@@ -50300,13 +50348,6 @@ entities:
   - uid: 2432
     components:
     - pos: 1.7242026,-29.565796
-      parent: 2
-      type: Transform
-- proto: LightReplacer
-  entities:
-  - uid: 1388
-    components:
-    - pos: -13.671011,-1.4744892
       parent: 2
       type: Transform
 - proto: LockerAtmosphericsFilledHardsuit
@@ -50671,11 +50712,6 @@ entities:
     - pos: 40.5,-10.5
       parent: 2
       type: Transform
-  - uid: 10294
-    components:
-    - pos: 41.5,-16.5
-      parent: 2
-      type: Transform
   - uid: 10298
     components:
     - pos: -40.5,19.5
@@ -50719,6 +50755,11 @@ entities:
   - uid: 10313
     components:
     - pos: 54.5,-5.5
+      parent: 2
+      type: Transform
+  - uid: 11048
+    components:
+    - pos: 40.5,-14.5
       parent: 2
       type: Transform
 - proto: MaintenancePlantSpawner
@@ -51080,14 +51121,9 @@ entities:
       type: Transform
 - proto: MopBucketFull
   entities:
-  - uid: 1373
+  - uid: 1388
     components:
-    - pos: -11.619304,-2.5068288
-      parent: 2
-      type: Transform
-  - uid: 1374
-    components:
-    - pos: -11.275554,-2.0481763
+    - pos: -10.712365,-2.1862
       parent: 2
       type: Transform
   - uid: 10065
@@ -51097,19 +51133,9 @@ entities:
       type: Transform
 - proto: MopItem
   entities:
-  - uid: 661
-    components:
-    - pos: -13.713254,-2.4941702
-      parent: 2
-      type: Transform
   - uid: 662
     components:
     - pos: 14.668055,-9.521283
-      parent: 2
-      type: Transform
-  - uid: 1377
-    components:
-    - pos: -13.338254,-2.4941702
       parent: 2
       type: Transform
   - uid: 10064
@@ -51424,6 +51450,27 @@ entities:
   - uid: 2593
     components:
     - pos: -14.679,-26.60409
+      parent: 2
+      type: Transform
+- proto: PillCanisterDylovene
+  entities:
+  - uid: 11051
+    components:
+    - pos: -25.163912,20.668972
+      parent: 2
+      type: Transform
+- proto: PillCanisterHyronalin
+  entities:
+  - uid: 11050
+    components:
+    - pos: -25.300356,20.85865
+      parent: 2
+      type: Transform
+- proto: PillCanisterTricordrazine
+  entities:
+  - uid: 1374
+    components:
+    - pos: 28.079897,-11.371667
       parent: 2
       type: Transform
 - proto: PillMindbreakerToxin
@@ -53677,16 +53724,6 @@ entities:
     - pos: -42.5,11.5
       parent: 2
       type: Transform
-  - uid: 1368
-    components:
-    - pos: -13.5,-2.5
-      parent: 2
-      type: Transform
-  - uid: 1369
-    components:
-    - pos: -13.5,-1.5
-      parent: 2
-      type: Transform
   - uid: 1405
     components:
     - pos: -41.5,11.5
@@ -53758,11 +53795,6 @@ entities:
   - uid: 2698
     components:
     - pos: -24.5,17.5
-      parent: 2
-      type: Transform
-  - uid: 2901
-    components:
-    - pos: -36.5,15.5
       parent: 2
       type: Transform
   - uid: 2946
@@ -54194,6 +54226,21 @@ entities:
       type: Transform
 - proto: RandomPosterLegit
   entities:
+  - uid: 1387
+    components:
+    - pos: -21.5,-26.5
+      parent: 2
+      type: Transform
+  - uid: 1389
+    components:
+    - pos: -17.5,-17.5
+      parent: 2
+      type: Transform
+  - uid: 2898
+    components:
+    - pos: -26.5,-25.5
+      parent: 2
+      type: Transform
   - uid: 10240
     components:
     - pos: 9.5,-13.5
@@ -54297,6 +54344,11 @@ entities:
   - uid: 10264
     components:
     - pos: 43.5,-14.5
+      parent: 2
+      type: Transform
+  - uid: 10294
+    components:
+    - pos: -22.5,-15.5
       parent: 2
       type: Transform
   - uid: 10323
@@ -54439,6 +54491,11 @@ entities:
     - pos: -11.5,-33.5
       parent: 2
       type: Transform
+  - uid: 11042
+    components:
+    - pos: -36.5,-23.5
+      parent: 2
+      type: Transform
 - proto: RandomSnacks
   entities:
   - uid: 2873
@@ -54458,6 +54515,26 @@ entities:
       type: Transform
 - proto: RandomSpawner
   entities:
+  - uid: 803
+    components:
+    - pos: -23.5,-2.5
+      parent: 2
+      type: Transform
+  - uid: 1386
+    components:
+    - pos: -20.5,0.5
+      parent: 2
+      type: Transform
+  - uid: 2901
+    components:
+    - pos: -18.5,-2.5
+      parent: 2
+      type: Transform
+  - uid: 9482
+    components:
+    - pos: -20.5,-2.5
+      parent: 2
+      type: Transform
   - uid: 9701
     components:
     - pos: -16.5,-13.5
@@ -56214,11 +56291,6 @@ entities:
   - uid: 3336
     components:
     - pos: -47.609417,7.24538
-      parent: 2
-      type: Transform
-  - uid: 8363
-    components:
-    - pos: -12.5785,0.4221762
       parent: 2
       type: Transform
 - proto: SecBreachingHammer
@@ -58575,9 +58647,9 @@ entities:
     - pos: -12.820137,0.6810938
       parent: 2
       type: Transform
-  - uid: 1382
+  - uid: 2938
     components:
-    - pos: -12.611803,0.85830045
+    - pos: -12.673379,0.5017892
       parent: 2
       type: Transform
   - uid: 9602
@@ -59980,6 +60052,11 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: -0.5,19.5
+      parent: 2
+      type: Transform
+  - uid: 1382
+    components:
+    - pos: -38.5,15.5
       parent: 2
       type: Transform
   - uid: 1806
@@ -61444,6 +61521,8 @@ entities:
     - pos: -6.5,-26.5
       parent: 2
       type: Transform
+    - chance: 1
+      type: RandomSpawner
   - uid: 10874
     components:
     - pos: -8.5,-27.5
@@ -61459,13 +61538,6 @@ entities:
   - uid: 3323
     components:
     - pos: -49.5,4.5
-      parent: 2
-      type: Transform
-- proto: TrashBag
-  entities:
-  - uid: 1387
-    components:
-    - pos: -12.348348,0.5902637
       parent: 2
       type: Transform
 - proto: TwoWayLever
@@ -67513,11 +67585,6 @@ entities:
     - pos: -19.5,1.5
       parent: 2
       type: Transform
-  - uid: 1109
-    components:
-    - pos: -0.5,15.5
-      parent: 2
-      type: Transform
   - uid: 1113
     components:
     - pos: -17.5,-2.5
@@ -69311,16 +69378,6 @@ entities:
     - pos: 14.65243,-9.208566
       parent: 2
       type: Transform
-  - uid: 1376
-    components:
-    - pos: -13.176681,-2.2839673
-      parent: 2
-      type: Transform
-  - uid: 1378
-    components:
-    - pos: -13.582931,-2.26312
-      parent: 2
-      type: Transform
   - uid: 10066
     components:
     - pos: -38.207294,18.445639
@@ -69818,6 +69875,11 @@ entities:
   - uid: 1351
     components:
     - pos: -6.5,-20.5
+      parent: 2
+      type: Transform
+  - uid: 1376
+    components:
+    - pos: -0.5,15.5
       parent: 2
       type: Transform
   - uid: 1468

--- a/Resources/Prototypes/Maps/asterisk.yml
+++ b/Resources/Prototypes/Maps/asterisk.yml
@@ -3,7 +3,7 @@
   mapName: 'Asterisk'
   mapPath: /Maps/asterisk.yml
   minPlayers: 0
-  maxPlayers: 55
+  maxPlayers: 60
   stations:
     Asterisk:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -3,7 +3,7 @@
   mapName: 'Shōkō'
   mapPath: /Maps/shoukou.yml
   minPlayers: 0
-  maxPlayers: 65
+  maxPlayers: 60
   stations:
     Shoukou:
       stationProto: StandardNanotrasenStation
@@ -42,9 +42,9 @@
           #Medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Paramedic: [ 1, 2 ]
-            MedicalDoctor: [ 3, 5 ]
+            MedicalDoctor: [ 3, 3 ]
             Chemist: [ 1, 2 ]
-            MedicalIntern: [ 2, 4 ]
+            MedicalIntern: [ 2, 3 ]
           #Security
             HeadOfSecurity: [ 1, 1 ]
             SecurityOfficer: [ 2, 4 ]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

asterisk qol changes, made asterisk and shoukou 60 player maps

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Asterisk can handle more people, Shoukou less so; there wasn't much reason to have such a discrepancy in the max population.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Adjusted Asterisk and Shoukou's min/max population to 0/60.