### PR TITLE
Allow nuclear operatives to buy deswords

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -95,11 +95,11 @@
     Telecrystal: 16 # DeltaV - Originally 20 but no one bought it due to it's high cost.
   categories:
   - UplinkWeapons
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink
+# conditions:
+#   - !type:StoreWhitelistCondition
+#     blacklist:
+#       tags:
+#         - NukeOpsUplink
 
 - type: listing
   id: UplinkDisposableTurret

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -95,7 +95,7 @@
     Telecrystal: 16 # DeltaV - Originally 20 but no one bought it due to it's high cost.
   categories:
   - UplinkWeapons
-# conditions:
+# conditions:      # DeltaV - Desword is a bit nerfed here
 #   - !type:StoreWhitelistCondition
 #     blacklist:
 #       tags:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
allows nuclear operatives to buy deswords.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Our deswords can only reflect energy stuff, and the original reason desword was removed on nukie uplink upstream was because of it's original reflection. You'll still die to a shotgun if security decides to shoot you.

This is also more interesting than just using a fire axe to constantly pry up tiles and space stuff.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Just commented out the original code that disallowed it from nukie uplink
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added double bladed energy swords to Nuclear Operative Uplinks
-->
:cl: tryded
- add: Added double bladed energy swords to Nuclear Operative Uplinks
