### PR TITLE
Updates to Shoukou, Asterisk, and Edge

### DIFF
--- a/Resources/Maps/asterisk.yml
+++ b/Resources/Maps/asterisk.yml
@@ -2562,6 +2562,7 @@ entities:
             0: 9215
           -6,5:
             0: 255
+            4: 34816
           -5,5:
             0: 255
           -8,-9:
@@ -2574,10 +2575,10 @@ entities:
             0: 65280
           -5,-9:
             0: 65280
-            4: 128
+            4: 245
           -4,-9:
             0: 65504
-            4: 17
+            4: 21
           -3,-9:
             0: 65520
             4: 14
@@ -2586,17 +2587,19 @@ entities:
             4: 3
           -1,-9:
             0: 65296
-            4: 68
+            4: 69
           0,-9:
             0: 65280
           1,-9:
             0: 65280
+            4: 17
           2,-9:
             0: 65408
           3,-9:
             0: 65520
           4,-9:
             0: 65532
+            4: 3
           5,-9:
             0: 65535
           6,-9:
@@ -2619,6 +2622,7 @@ entities:
             0: 65535
           7,5:
             0: 8191
+            4: 8192
           -11,-2:
             0: 65535
           -11,-1:
@@ -2920,6 +2924,7 @@ entities:
             0: 4095
           7,6:
             0: 30464
+            4: 2
           7,7:
             0: 887
             4: 8
@@ -3035,6 +3040,7 @@ entities:
             0: 61440
           -7,6:
             0: 8738
+            4: 4108
           -7,7:
             0: 2
           -12,-8:
@@ -3087,10 +3093,12 @@ entities:
             0: 12544
           -10,6:
             0: 8738
+            4: 49153
           -10,7:
             0: 2
           -9,6:
             0: 34952
+            4: 28672
           8,6:
             0: 1
           9,6:
@@ -3108,13 +3116,13 @@ entities:
           -9,-10:
             4: 53248
           -4,-10:
-            4: 4096
+            4: 20480
           -1,-10:
-            4: 16384
+            4: 20480
           8,7:
             4: 1
           3,8:
-            4: 61167
+            4: 61439
           3,9:
             4: 3310
           -1,8:
@@ -3122,6 +3130,18 @@ entities:
           -1,9:
             4: 614
           4,8:
+            4: 8
+          -8,6:
+            4: 61440
+          -6,6:
+            4: 15
+          -5,-10:
+            4: 20480
+          4,-10:
+            4: 4352
+          -11,6:
+            4: 15
+          -9,7:
             4: 8
         uniqueMixes:
         - volume: 2500
@@ -4606,9 +4626,9 @@ entities:
     - pos: -41.5,-13.5
       parent: 2
       type: Transform
-- proto: AirlockChemistryLocked
+- proto: AirlockChemistryGlassLocked
   entities:
-  - uid: 4035
+  - uid: 381
     components:
     - pos: 23.5,-16.5
       parent: 2
@@ -5820,16 +5840,6 @@ entities:
     - pos: -49.5,2.5
       parent: 2
       type: Transform
-  - uid: 9061
-    components:
-    - pos: -16.5,9.5
-      parent: 2
-      type: Transform
-  - uid: 9062
-    components:
-    - pos: -17.5,4.5
-      parent: 2
-      type: Transform
   - uid: 9064
     components:
     - pos: -45.5,17.5
@@ -5838,6 +5848,18 @@ entities:
   - uid: 9065
     components:
     - pos: -40.5,17.5
+      parent: 2
+      type: Transform
+- proto: AirlockMaintSecurityLawyerLocked
+  entities:
+  - uid: 662
+    components:
+    - pos: -16.5,9.5
+      parent: 2
+      type: Transform
+  - uid: 665
+    components:
+    - pos: -17.5,4.5
       parent: 2
       type: Transform
 - proto: AirlockMaintServiceLocked
@@ -6006,6 +6028,13 @@ entities:
   - uid: 2471
     components:
     - pos: 26.5,-31.5
+      parent: 2
+      type: Transform
+- proto: AirlockMusicianLocked
+  entities:
+  - uid: 666
+    components:
+    - pos: 3.5,-26.5
       parent: 2
       type: Transform
 - proto: AirlockParamedicGlassLocked
@@ -6404,11 +6433,6 @@ entities:
       type: Transform
 - proto: AirlockTheatreLocked
   entities:
-  - uid: 3979
-    components:
-    - pos: 3.5,-26.5
-      parent: 2
-      type: Transform
   - uid: 3980
     components:
     - pos: -0.5,-27.5
@@ -7890,6 +7914,13 @@ entities:
   - uid: 2793
     components:
     - pos: -41.325523,14.524066
+      parent: 2
+      type: Transform
+- proto: BoxMouthSwab
+  entities:
+  - uid: 3979
+    components:
+    - pos: 15.109555,-20.140219
       parent: 2
       type: Transform
 - proto: BoxSyringe
@@ -25028,6 +25059,13 @@ entities:
     - pos: -30.5,-20.5
       parent: 2
       type: Transform
+- proto: CleanerDispenser
+  entities:
+  - uid: 9062
+    components:
+    - pos: -13.5,-3.5
+      parent: 2
+      type: Transform
 - proto: CloningPod
   entities:
   - uid: 2465
@@ -25173,6 +25211,11 @@ entities:
   - uid: 2904
     components:
     - pos: -13.5,-1.5
+      parent: 2
+      type: Transform
+  - uid: 4035
+    components:
+    - pos: 14.5,-9.5
       parent: 2
       type: Transform
 - proto: ClosetMaintenanceFilledRandom
@@ -26746,7 +26789,12 @@ entities:
   entities:
   - uid: 4153
     components:
-    - pos: 15.128561,-20.292566
+    - pos: -12.044842,-12.30005
+      parent: 2
+      type: Transform
+  - uid: 11102
+    components:
+    - pos: -11.992759,-12.48768
       parent: 2
       type: Transform
 - proto: DisposalBend
@@ -31485,6 +31533,13 @@ entities:
     components:
     - rot: 3.141592653589793 rad
       pos: 29.5,-31.5
+      parent: 2
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
+  - uid: 9061
+    components:
+    - pos: 14.5,-9.5
       parent: 2
       type: Transform
     - fixtures: {}
@@ -50594,6 +50649,13 @@ entities:
     - pos: 37.25989,-20.5
       parent: 2
       type: Transform
+- proto: LockerClown
+  entities:
+  - uid: 4201
+    components:
+    - pos: -1.5,-28.5
+      parent: 2
+      type: Transform
 - proto: LockerDetectiveFilled
   entities:
   - uid: 490
@@ -50688,6 +50750,13 @@ entities:
   - uid: 2205
     components:
     - pos: 37.5,-8.5
+      parent: 2
+      type: Transform
+- proto: LockerMime
+  entities:
+  - uid: 11101
+    components:
+    - pos: -3.5,-26.5
       parent: 2
       type: Transform
 - proto: LockerParamedicFilled
@@ -51328,11 +51397,6 @@ entities:
       type: Transform
 - proto: MopItem
   entities:
-  - uid: 662
-    components:
-    - pos: 14.668055,-9.521283
-      parent: 2
-      type: Transform
   - uid: 10064
     components:
     - pos: -38.551044,18.852169
@@ -53840,11 +53904,6 @@ entities:
   - uid: 290
     components:
     - pos: -29.5,7.5
-      parent: 2
-      type: Transform
-  - uid: 381
-    components:
-    - pos: 14.5,-9.5
       parent: 2
       type: Transform
   - uid: 609
@@ -58385,11 +58444,6 @@ entities:
     - pos: 12.5,-17.5
       parent: 2
       type: Transform
-  - uid: 9966
-    components:
-    - pos: 14.5,-19.5
-      parent: 2
-      type: Transform
   - uid: 9967
     components:
     - pos: 16.5,-17.5
@@ -61752,17 +61806,17 @@ entities:
       type: Transform
   - uid: 4200
     components:
-    - pos: -1.5,-28.5
-      parent: 2
-      type: Transform
-  - uid: 4201
-    components:
-    - pos: -3.5,-26.5
+    - pos: -3.5,-27.5
       parent: 2
       type: Transform
   - uid: 8971
     components:
     - pos: -29.5,-14.5
+      parent: 2
+      type: Transform
+  - uid: 9966
+    components:
+    - pos: -2.5,-28.5
       parent: 2
       type: Transform
   - uid: 10871
@@ -69627,19 +69681,14 @@ entities:
       type: Transform
 - proto: WetFloorSign
   entities:
-  - uid: 665
-    components:
-    - pos: 14.43368,-9.239837
-      parent: 2
-      type: Transform
-  - uid: 666
-    components:
-    - pos: 14.65243,-9.208566
-      parent: 2
-      type: Transform
   - uid: 10066
     components:
     - pos: -38.207294,18.445639
+      parent: 2
+      type: Transform
+  - uid: 11103
+    components:
+    - pos: 12.80534,-8.106109
       parent: 2
       type: Transform
 - proto: WindoorCargoLocked

--- a/Resources/Maps/edge.yml
+++ b/Resources/Maps/edge.yml
@@ -133,7 +133,7 @@ entities:
           version: 6
         -2,-1:
           ind: -2,-1
-          tiles: GwAAAAABGwAAAAABcwAAAAAAGwAAAAABGwAAAAAASAAAAAAASAAAAAAAcwAAAAAAGwAAAAAAGwAAAAADGwAAAAABGwAAAAADcwAAAAAAVAAAAAABVAAAAAACVAAAAAABGwAAAAABGwAAAAAAYgAAAAAAGwAAAAABGwAAAAADSAAAAAAASAAAAAAAcwAAAAAAGwAAAAABGwAAAAADGwAAAAABGwAAAAADcwAAAAAAcwAAAAAAYgAAAAAAYgAAAAAAGwAAAAAAGwAAAAACcwAAAAAAGwAAAAADGwAAAAACSAAAAAAASAAAAAAAcwAAAAAAGwAAAAAAGwAAAAACGwAAAAABGwAAAAABcwAAAAAAVAAAAAACKwAAAAAAVAAAAAAAGwAAAAACGwAAAAACcwAAAAAAGwAAAAACGwAAAAAASAAAAAAASAAAAAAAcwAAAAAAGwAAAAAAGwAAAAABGwAAAAAAGwAAAAADcwAAAAAAVAAAAAABVAAAAAADKwAAAAACcwAAAAAAcwAAAAAAcwAAAAAAGwAAAAAAGwAAAAAASAAAAAAASAAAAAAAcwAAAAAAGwAAAAADGwAAAAAAGwAAAAADGwAAAAADcwAAAAAAVAAAAAADVAAAAAABVAAAAAACGwAAAAACGwAAAAADGwAAAAADGwAAAAAAGwAAAAACcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAABVAAAAAACVAAAAAADGwAAAAACGwAAAAADGwAAAAAAGwAAAAABGwAAAAADYgAAAAAAGwAAAAABGwAAAAABGwAAAAAAGwAAAAAAGwAAAAADGwAAAAADcwAAAAAAVAAAAAABKwAAAAADVAAAAAAAGwAAAAADGwAAAAACGwAAAAAAGwAAAAAAGwAAAAAAYgAAAAAAGwAAAAADVAAAAAADVAAAAAACVAAAAAACVAAAAAACVAAAAAAAYgAAAAAAVAAAAAADVAAAAAAAKwAAAAAAGwAAAAACcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAGwAAAAAAVAAAAAABVAAAAAABVAAAAAAAVAAAAAABVAAAAAADcwAAAAAAVAAAAAABVAAAAAAAVAAAAAABGwAAAAADcwAAAAAAKwAAAAABKwAAAAABKwAAAAABcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAYgAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAYgAAAAAAGwAAAAABcwAAAAAAKwAAAAADKwAAAAACKwAAAAADcwAAAAAAVAAAAAABKwAAAAADVAAAAAAAVAAAAAAAVAAAAAACKwAAAAABcwAAAAAAVAAAAAADVAAAAAAAVAAAAAAAGwAAAAAAcwAAAAAAKwAAAAACKwAAAAADKwAAAAAAcwAAAAAAVAAAAAADVAAAAAABKwAAAAABKwAAAAADKwAAAAACVAAAAAAAYgAAAAAAVAAAAAAAKwAAAAAAVAAAAAACcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAAAKwAAAAAAVAAAAAACVAAAAAABVAAAAAADKwAAAAAAYgAAAAAAVAAAAAACVAAAAAADKwAAAAADcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAAAVAAAAAAAVAAAAAABVAAAAAADVAAAAAACVAAAAAABcwAAAAAAVAAAAAACVAAAAAACVAAAAAAAYwAAAAAAcwAAAAAAcwAAAAAAZAAAAAABcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAABVAAAAAAAVAAAAAAAZgAAAAACZgAAAAACcwAAAAAAZAAAAAAAcwAAAAAAYwAAAAAAKwAAAAABVAAAAAACVAAAAAADVAAAAAAAKwAAAAAAYgAAAAAAVAAAAAACVAAAAAABKwAAAAABVAAAAAAA
+          tiles: GwAAAAABGwAAAAABcwAAAAAAGwAAAAABGwAAAAAASAAAAAAASAAAAAAAcwAAAAAAGwAAAAAAGwAAAAADGwAAAAABGwAAAAADcwAAAAAAVAAAAAABVAAAAAACVAAAAAABGwAAAAABGwAAAAAAYgAAAAAAGwAAAAABGwAAAAADSAAAAAAASAAAAAAAcwAAAAAAGwAAAAABGwAAAAADGwAAAAABGwAAAAADcwAAAAAAcwAAAAAAYgAAAAAAYgAAAAAAGwAAAAAAGwAAAAACcwAAAAAAGwAAAAADGwAAAAACSAAAAAAASAAAAAAAcwAAAAAAGwAAAAAAGwAAAAACGwAAAAABGwAAAAABcwAAAAAAVAAAAAACKwAAAAAAVAAAAAAAGwAAAAACGwAAAAACcwAAAAAAGwAAAAACGwAAAAAASAAAAAAASAAAAAAAcwAAAAAAGwAAAAAAGwAAAAABGwAAAAAAGwAAAAADcwAAAAAAVAAAAAABVAAAAAADKwAAAAACcwAAAAAAcwAAAAAAcwAAAAAAGwAAAAAAGwAAAAAASAAAAAAASAAAAAAAcwAAAAAAGwAAAAADGwAAAAAAGwAAAAADGwAAAAADcwAAAAAAVAAAAAADVAAAAAABVAAAAAACGwAAAAACGwAAAAADGwAAAAADGwAAAAAAGwAAAAACcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAABVAAAAAACVAAAAAADGwAAAAACGwAAAAADGwAAAAAAGwAAAAABGwAAAAADYgAAAAAAGwAAAAABGwAAAAABGwAAAAAAGwAAAAAAGwAAAAADGwAAAAADcwAAAAAAVAAAAAABKwAAAAADVAAAAAAAGwAAAAADGwAAAAACGwAAAAAAGwAAAAAAGwAAAAAAYgAAAAAAGwAAAAADVAAAAAADVAAAAAACVAAAAAACVAAAAAACVAAAAAAAYgAAAAAAVAAAAAADVAAAAAAAKwAAAAAAGwAAAAACcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAGwAAAAAAVAAAAAABVAAAAAABVAAAAAAAVAAAAAABVAAAAAADcwAAAAAAVAAAAAABVAAAAAAAVAAAAAABGwAAAAADcwAAAAAAKwAAAAABKwAAAAABKwAAAAABcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAYgAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAYgAAAAAAGwAAAAABcwAAAAAAKwAAAAADKwAAAAACKwAAAAADcwAAAAAAVAAAAAABKwAAAAADVAAAAAAAVAAAAAAAVAAAAAACKwAAAAABcwAAAAAAVAAAAAADVAAAAAAAVAAAAAAAGwAAAAAAcwAAAAAAKwAAAAACKwAAAAADKwAAAAAAcwAAAAAAVAAAAAADVAAAAAABKwAAAAABKwAAAAADKwAAAAACVAAAAAAAYgAAAAAAVAAAAAAAKwAAAAAAVAAAAAACcwAAAAAAcwAAAAAAcwAAAAAAYwAAAAAAcwAAAAAAcwAAAAAAVAAAAAAAKwAAAAAAVAAAAAACVAAAAAABVAAAAAADKwAAAAAAYgAAAAAAVAAAAAACVAAAAAADKwAAAAADcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAAAVAAAAAAAVAAAAAABVAAAAAADVAAAAAACVAAAAAABcwAAAAAAVAAAAAACVAAAAAACVAAAAAAAYwAAAAAAcwAAAAAAcwAAAAAAZAAAAAABcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAABVAAAAAAAVAAAAAAAZgAAAAACZgAAAAACcwAAAAAAZAAAAAAAcwAAAAAAYwAAAAAAKwAAAAABVAAAAAACVAAAAAADVAAAAAAAKwAAAAAAYgAAAAAAVAAAAAACVAAAAAABKwAAAAABVAAAAAAA
           version: 6
         -2,0:
           ind: -2,0
@@ -8436,6 +8436,13 @@ entities:
       pos: -53.5,-6.5
       parent: 2
       type: Transform
+- proto: AirlockFreezerHydroponicsLocked
+  entities:
+  - uid: 290
+    components:
+    - pos: -16.5,10.5
+      parent: 2
+      type: Transform
 - proto: AirlockFreezerKitchenHydroLocked
   entities:
   - uid: 222
@@ -8810,13 +8817,6 @@ entities:
   - uid: 289
     components:
     - pos: -29.5,-14.5
-      parent: 2
-      type: Transform
-- proto: AirlockHydroGlassLocked
-  entities:
-  - uid: 290
-    components:
-    - pos: -16.5,10.5
       parent: 2
       type: Transform
 - proto: AirlockHydroponicsLocked
@@ -9251,14 +9251,22 @@ entities:
     - pos: -37.5,-21.5
       parent: 2
       type: Transform
-  - uid: 361
-    components:
-    - pos: -28.5,-16.5
-      parent: 2
-      type: Transform
   - uid: 362
     components:
     - pos: -22.5,-17.5
+      parent: 2
+      type: Transform
+  - uid: 366
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -44.5,-18.5
+      parent: 2
+      type: Transform
+- proto: AirlockMaintSecurityLawyerLocked
+  entities:
+  - uid: 361
+    components:
+    - pos: -28.5,-16.5
       parent: 2
       type: Transform
   - uid: 363
@@ -9268,7 +9276,7 @@ entities:
       type: Transform
   - uid: 364
     components:
-    - pos: -32.5,-3.5
+    - pos: -28.5,-3.5
       parent: 2
       type: Transform
   - uid: 365
@@ -9276,15 +9284,14 @@ entities:
     - pos: -35.5,-20.5
       parent: 2
       type: Transform
-  - uid: 366
-    components:
-    - rot: 3.141592653589793 rad
-      pos: -44.5,-18.5
-      parent: 2
-      type: Transform
   - uid: 367
     components:
     - pos: -37.5,-17.5
+      parent: 2
+      type: Transform
+  - uid: 12827
+    components:
+    - pos: -32.5,-3.5
       parent: 2
       type: Transform
 - proto: AirlockMaintServiceLocked
@@ -9413,6 +9420,13 @@ entities:
   - uid: 388
     components:
     - pos: 11.5,25.5
+      parent: 2
+      type: Transform
+- proto: AirlockMusicianLocked
+  entities:
+  - uid: 431
+    components:
+    - pos: -11.5,-8.5
       parent: 2
       type: Transform
 - proto: AirlockQuartermasterGlassLocked
@@ -9734,12 +9748,6 @@ entities:
   - uid: 430
     components:
     - pos: -34.5,8.5
-      parent: 2
-      type: Transform
-  - uid: 431
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -11.5,-8.5
       parent: 2
       type: Transform
 - proto: AirlockVirologyLocked
@@ -10617,11 +10625,6 @@ entities:
   - uid: 583
     components:
     - pos: -6.5,-16.5
-      parent: 2
-      type: Transform
-  - uid: 584
-    components:
-    - pos: 19.5,-13.5
       parent: 2
       type: Transform
   - uid: 585
@@ -38050,12 +38053,6 @@ entities:
       pos: -36.5,11.5
       parent: 2
       type: Transform
-  - uid: 5913
-    components:
-    - rot: -1.5707963267948966 rad
-      pos: -33.5,11.5
-      parent: 2
-      type: Transform
   - uid: 5914
     components:
     - pos: -33.5,14.5
@@ -38180,6 +38177,12 @@ entities:
     components:
     - rot: 3.0847128947549542 rad
       pos: -31.532867,-14.156494
+      parent: 2
+      type: Transform
+  - uid: 11939
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -34.5,10.5
       parent: 2
       type: Transform
 - proto: CheapLighter
@@ -38375,6 +38378,13 @@ entities:
   - uid: 5967
     components:
     - pos: -14.560801,-29.289936
+      parent: 2
+      type: Transform
+- proto: CleanerDispenser
+  entities:
+  - uid: 6245
+    components:
+    - pos: 2.5,10.5
       parent: 2
       type: Transform
 - proto: CloningPod
@@ -38592,6 +38602,11 @@ entities:
   - uid: 6008
     components:
     - pos: -0.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 6246
+    components:
+    - pos: 22.5,-13.5
       parent: 2
       type: Transform
 - proto: ClosetL3JanitorFilled
@@ -49600,6 +49615,13 @@ entities:
   - uid: 7681
     components:
     - pos: -58.25037,-3.1736562
+      parent: 2
+      type: Transform
+- proto: FuelDispenser
+  entities:
+  - uid: 12841
+    components:
+    - pos: -15.5,-27.5
       parent: 2
       type: Transform
 - proto: GasAnalyzer
@@ -78973,6 +78995,13 @@ entities:
     - pos: 8.5,18.5
       parent: 2
       type: Transform
+- proto: LockerClown
+  entities:
+  - uid: 12701
+    components:
+    - pos: -33.5,11.5
+      parent: 2
+      type: Transform
 - proto: LockerDetectiveFilled
   entities:
   - uid: 11789
@@ -79093,6 +79122,13 @@ entities:
   - uid: 11808
     components:
     - pos: 16.5,26.5
+      parent: 2
+      type: Transform
+- proto: LockerMime
+  entities:
+  - uid: 5913
+    components:
+    - pos: -38.5,11.5
       parent: 2
       type: Transform
 - proto: LockerParamedicFilled
@@ -79836,16 +79872,6 @@ entities:
   - uid: 11937
     components:
     - pos: -52.354904,-6.2620792
-      parent: 2
-      type: Transform
-  - uid: 11938
-    components:
-    - pos: 22.348795,-13.526395
-      parent: 2
-      type: Transform
-  - uid: 11939
-    components:
-    - pos: 22.661295,-13.573302
       parent: 2
       type: Transform
   - uid: 11940
@@ -84427,16 +84453,6 @@ entities:
     - pos: 22.5,-11.5
       parent: 2
       type: Transform
-  - uid: 12701
-    components:
-    - pos: 22.5,-13.5
-      parent: 2
-      type: Transform
-  - uid: 12702
-    components:
-    - pos: -38.5,11.5
-      parent: 2
-      type: Transform
   - uid: 12703
     components:
     - pos: 19.5,24.5
@@ -85136,13 +85152,11 @@ entities:
       type: Transform
 - proto: RandomInstruments
   entities:
-  - uid: 12827
+  - uid: 14915
     components:
-    - pos: -38.5,11.5
+    - pos: -33.5,10.5
       parent: 2
       type: Transform
-    - chance: 1
-      type: RandomSpawner
 - proto: RandomItem
   entities:
   - uid: 12828
@@ -85214,9 +85228,14 @@ entities:
       type: Transform
 - proto: RandomPosterAny
   entities:
-  - uid: 12841
+  - uid: 11938
     components:
-    - pos: 2.5,10.5
+    - pos: 2.5,12.5
+      parent: 2
+      type: Transform
+  - uid: 12702
+    components:
+    - pos: 0.5,13.5
       parent: 2
       type: Transform
   - uid: 12842
@@ -97252,6 +97271,11 @@ entities:
       type: Transform
 - proto: VendingMachineYouTool
   entities:
+  - uid: 584
+    components:
+    - pos: 19.5,-13.5
+      parent: 2
+      type: Transform
   - uid: 14777
     components:
     - flags: SessionSpecific
@@ -98038,11 +98062,6 @@ entities:
   - uid: 14914
     components:
     - pos: -19.5,-12.5
-      parent: 2
-      type: Transform
-  - uid: 14915
-    components:
-    - pos: -28.5,-3.5
       parent: 2
       type: Transform
   - uid: 14916

--- a/Resources/Maps/edge.yml
+++ b/Resources/Maps/edge.yml
@@ -45383,19 +45383,6 @@ entities:
         metamorphicSprite:
           sprite: Objects/Consumable/Drinks/gintonicglass.rsi
           state: icon
-        footstepSound: !type:SoundCollectionSpecifier
-          params:
-            variation: null
-            playoffset: 0
-            loop: False
-            referenceDistance: 1
-            rolloffFactor: 1
-            maxdistance: 25
-            busname: Master
-            pitchscale: 1
-            volume: 0
-            attenuation: Default
-          collection: FootstepWater
         flavor: gintonic
         flavorMinimum: 0.1
         slippery: False
@@ -45486,19 +45473,6 @@ entities:
         metamorphicSprite:
           sprite: Objects/Consumable/Drinks/whiskeycolaglass.rsi
           state: icon
-        footstepSound: !type:SoundCollectionSpecifier
-          params:
-            variation: null
-            playoffset: 0
-            loop: False
-            referenceDistance: 1
-            rolloffFactor: 1
-            maxdistance: 25
-            busname: Master
-            pitchscale: 1
-            volume: 0
-            attenuation: Default
-          collection: FootstepWater
         flavor: whiskeycola
         flavorMinimum: 0.1
         slippery: False

--- a/Resources/Maps/shoukou.yml
+++ b/Resources/Maps/shoukou.yml
@@ -91,7 +91,7 @@ entities:
           version: 6
         0,-2:
           ind: 0,-2
-          tiles: bwAAAAADcwAAAAAAbwAAAAADbwAAAAACZwAAAAADbwAAAAABbwAAAAACbwAAAAACcwAAAAAAbwAAAAACbwAAAAABcwAAAAAAcAAAAAACcAAAAAABcAAAAAABcAAAAAABcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAAYgAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAASAAAAAAAcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAADbwAAAAAAbwAAAAADcwAAAAAAbwAAAAADZwAAAAADbwAAAAACcwAAAAAAbwAAAAACbwAAAAADbwAAAAABbwAAAAACcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAAAbwAAAAAAKwAAAAACYgAAAAAAZwAAAAACZwAAAAADZwAAAAADYgAAAAAAbwAAAAAAbwAAAAAAbwAAAAADbwAAAAADcwAAAAAAcAAAAAAAcAAAAAABcAAAAAABcAAAAAACbwAAAAACKwAAAAABSAAAAAAAbwAAAAADZwAAAAAAbwAAAAADcwAAAAAAbwAAAAADbwAAAAAAbwAAAAADbwAAAAABcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAACbwAAAAACbwAAAAAASAAAAAAAbwAAAAABZwAAAAAAbwAAAAAAcwAAAAAAbwAAAAABbwAAAAAAbwAAAAAAbwAAAAABcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAASAAAAAAAcwAAAAAAYgAAAAAAYAAAAAADYAAAAAACYAAAAAACYAAAAAAAYAAAAAADYAAAAAADYAAAAAACYAAAAAABYAAAAAACVAAAAAACSAAAAAAAYAAAAAACYAAAAAAAYAAAAAACVAAAAAAAWQAAAAABWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAACWQAAAAAAWQAAAAABWQAAAAABWQAAAAADVAAAAAACYgAAAAAAWQAAAAACWQAAAAADWQAAAAABWQAAAAACWQAAAAADYAAAAAABYAAAAAAAYAAAAAADYAAAAAABYAAAAAABYAAAAAACYAAAAAAAYAAAAAABYAAAAAACVAAAAAAASAAAAAAAYAAAAAACXAAAAAABWQAAAAAAXAAAAAADYAAAAAADYgAAAAAAcwAAAAAASAAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAACYQAAAAACWQAAAAACYQAAAAADVAAAAAADRwAAAAACPwAAAAAAPwAAAAAAcwAAAAAAVAAAAAACVAAAAAACVAAAAAADcwAAAAAAYwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAAYgAAAAAASAAAAAAAcwAAAAAARwAAAAAAPwAAAAAAPwAAAAAAcwAAAAAAVAAAAAADVAAAAAACVAAAAAADcwAAAAAAYwAAAAAAcwAAAAAAZAAAAAABcwAAAAAAYQAAAAADWQAAAAACYQAAAAADcwAAAAAARwAAAAABPwAAAAAAPwAAAAAAcwAAAAAAVAAAAAAAVAAAAAAAVAAAAAACcwAAAAAAYwAAAAAAcwAAAAAAZAAAAAAAcwAAAAAAYQAAAAADWQAAAAACYQAAAAABcwAAAAAARwAAAAACPwAAAAAAPwAAAAAAcwAAAAAAVAAAAAADVAAAAAAAVAAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAYQAAAAAAWQAAAAABYQAAAAACcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAYwAAAAAAcwAAAAAAcwAAAAAALQAAAAAAYQAAAAADWQAAAAAAYQAAAAABcwAAAAAA
+          tiles: bwAAAAADcwAAAAAAbwAAAAADbwAAAAACZwAAAAADbwAAAAABbwAAAAACbwAAAAACcwAAAAAAbwAAAAACbwAAAAABcwAAAAAAcAAAAAACcAAAAAABcAAAAAABcAAAAAABcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAAYgAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAASAAAAAAAcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAADbwAAAAAAbwAAAAADcwAAAAAAbwAAAAADZwAAAAADbwAAAAACcwAAAAAAbwAAAAACbwAAAAADbwAAAAABbwAAAAACcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAAAbwAAAAAAKwAAAAACYgAAAAAAZwAAAAACZwAAAAADZwAAAAADYgAAAAAAbwAAAAAAbwAAAAAAbwAAAAADbwAAAAADcwAAAAAAcAAAAAAAcAAAAAABcAAAAAABcAAAAAACbwAAAAACKwAAAAABSAAAAAAAbwAAAAADZwAAAAAAbwAAAAADcwAAAAAAbwAAAAADbwAAAAAAbwAAAAADbwAAAAABcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAACbwAAAAACbwAAAAAASAAAAAAAbwAAAAABZwAAAAAAbwAAAAAAcwAAAAAAbwAAAAABbwAAAAAAbwAAAAAAbwAAAAABcwAAAAAAPAAAAAAAPAAAAAAAPAAAAAAAcAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAASAAAAAAAcwAAAAAAYgAAAAAAYAAAAAADYAAAAAACYAAAAAACYAAAAAAAYAAAAAADYAAAAAADYAAAAAACYAAAAAABYAAAAAACVAAAAAACSAAAAAAAYAAAAAACYAAAAAAAYAAAAAACVAAAAAAAWQAAAAABWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAACWQAAAAAAWQAAAAABWQAAAAABWQAAAAADVAAAAAACYgAAAAAAWQAAAAACWQAAAAADWQAAAAABWQAAAAACWQAAAAADYAAAAAABYAAAAAAAYAAAAAADYAAAAAABYAAAAAABYAAAAAACYAAAAAAAYAAAAAABYAAAAAACVAAAAAAASAAAAAAAYAAAAAACXAAAAAABWQAAAAAAXAAAAAADYAAAAAADYgAAAAAAcwAAAAAASAAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAACYQAAAAACWQAAAAACYQAAAAADVAAAAAADRwAAAAACPwAAAAAAPwAAAAAAcwAAAAAAZAAAAAAAVAAAAAACVAAAAAADcwAAAAAAYwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAAYgAAAAAASAAAAAAAcwAAAAAARwAAAAAAPwAAAAAAPwAAAAAAcwAAAAAAZAAAAAAAVAAAAAACVAAAAAADcwAAAAAAYwAAAAAAcwAAAAAAZAAAAAABcwAAAAAAYQAAAAADWQAAAAACYQAAAAADcwAAAAAARwAAAAABPwAAAAAAPwAAAAAAcwAAAAAAZAAAAAAAVAAAAAAAVAAAAAACcwAAAAAAYwAAAAAAcwAAAAAAZAAAAAAAcwAAAAAAYQAAAAADWQAAAAACYQAAAAABcwAAAAAARwAAAAACPwAAAAAAPwAAAAAAcwAAAAAAZAAAAAAAVAAAAAAAVAAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAYQAAAAAAWQAAAAABYQAAAAACcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAYwAAAAAAcwAAAAAAcwAAAAAALQAAAAAAYQAAAAADWQAAAAAAYQAAAAABcwAAAAAA
           version: 6
         -1,-2:
           ind: -1,-2
@@ -179,7 +179,7 @@ entities:
           version: 6
         2,-1:
           ind: 2,-1
-          tiles: cwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAZAAAAAACYwAAAAAAcwAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAVAAAAAACVAAAAAABVAAAAAADcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAASAAAAAAASAAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAAAAAAAAAVAAAAAADVAAAAAACVAAAAAACcwAAAAAAJAAAAAADJAAAAAACYgAAAAAAVAAAAAACVAAAAAACVAAAAAAAVAAAAAADSAAAAAAAJAAAAAABJAAAAAAAcwAAAAAAAAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAJAAAAAAAJAAAAAACSAAAAAAARwAAAAAAVAAAAAACVAAAAAADRwAAAAAAYgAAAAAAJAAAAAACJAAAAAABcwAAAAAAAAAAAAAAGwAAAAABJAAAAAACJAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAARwAAAAACVAAAAAAAVAAAAAACRwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcgAAAAAAGwAAAAADGwAAAAAAJAAAAAADcwAAAAAAJAAAAAAAJAAAAAADYgAAAAAAVAAAAAAARwAAAAACRwAAAAABVAAAAAACSAAAAAAAJAAAAAABJAAAAAABcwAAAAAAAAAAAAAAGwAAAAABGwAAAAAAJAAAAAABcwAAAAAAJAAAAAADJAAAAAAASAAAAAAAVAAAAAABRwAAAAADRwAAAAAAVAAAAAABYgAAAAAAJAAAAAACJAAAAAABcwAAAAAAAAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAARwAAAAABVAAAAAADVAAAAAADRwAAAAABcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcgAAAAAANwAAAAAANwAAAAAANwAAAAAAcwAAAAAAJAAAAAACJAAAAAAAYgAAAAAARwAAAAABVAAAAAAAVAAAAAAARwAAAAABSAAAAAAAJAAAAAACJAAAAAACcwAAAAAAcgAAAAAANwAAAAAANwAAAAAANwAAAAAAcwAAAAAAJAAAAAADJAAAAAADSAAAAAAAVAAAAAACVAAAAAAAVAAAAAACVAAAAAAAYgAAAAAAJAAAAAADJAAAAAADcwAAAAAAcgAAAAAANwAAAAAANwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAAYgAAAAAAYgAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAADSAAAAAAASAAAAAAAPgAAAAAAPgAAAAAASAAAAAAARwAAAAADVAAAAAADRwAAAAAAVAAAAAACRwAAAAAAVAAAAAAAcwAAAAAAcAAAAAACcAAAAAADcAAAAAACVAAAAAABVAAAAAAAYgAAAAAAGwAAAAACGwAAAAABYgAAAAAAVAAAAAADVAAAAAAAVAAAAAACVAAAAAABVAAAAAAAVAAAAAABYgAAAAAAcAAAAAACcAAAAAAAcAAAAAABVAAAAAABVAAAAAADSAAAAAAAPgAAAAAAPgAAAAAASAAAAAAARwAAAAAAVAAAAAAARwAAAAABVAAAAAABRwAAAAACVAAAAAACSAAAAAAAcAAAAAAAcAAAAAACcAAAAAADVAAAAAABVAAAAAABcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAVAAAAAABVAAAAAABVAAAAAABSAAAAAAAcAAAAAADcAAAAAABcAAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAOwAAAAAAOwAAAAAAOwAAAAAAOwAAAAAAcwAAAAAAVAAAAAABRwAAAAABVAAAAAABSAAAAAAAcAAAAAABcAAAAAACcAAAAAAD
+          tiles: cwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAZAAAAAACYwAAAAAAcwAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAcgAAAAAAAAAAAAAAVAAAAAACVAAAAAABVAAAAAADcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAASAAAAAAASAAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAAAAAAAAAVAAAAAADVAAAAAACVAAAAAACcwAAAAAAJAAAAAADJAAAAAACYgAAAAAAVAAAAAACVAAAAAACVAAAAAAAVAAAAAADSAAAAAAAJAAAAAABJAAAAAAAcwAAAAAAAAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAJAAAAAAAJAAAAAACSAAAAAAARwAAAAAAVAAAAAACVAAAAAADRwAAAAAAYgAAAAAAJAAAAAACJAAAAAABcwAAAAAAAAAAAAAAGwAAAAABJAAAAAACJAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAARwAAAAACVAAAAAAAVAAAAAACRwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcgAAAAAAGwAAAAADGwAAAAAAJAAAAAADcwAAAAAAJAAAAAAAJAAAAAADYgAAAAAAVAAAAAAARwAAAAACRwAAAAABVAAAAAACSAAAAAAAJAAAAAABJAAAAAABcwAAAAAAAAAAAAAAGwAAAAABGwAAAAAAJAAAAAABcwAAAAAAJAAAAAADJAAAAAAASAAAAAAAVAAAAAABRwAAAAADRwAAAAAAVAAAAAABYgAAAAAAJAAAAAACJAAAAAABcwAAAAAAAAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAARwAAAAABVAAAAAADVAAAAAADRwAAAAABcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcgAAAAAANwAAAAAANwAAAAAANwAAAAAAcwAAAAAAJAAAAAACJAAAAAAAYgAAAAAARwAAAAABVAAAAAAAVAAAAAAARwAAAAABSAAAAAAAJAAAAAACJAAAAAACcwAAAAAAcgAAAAAANwAAAAAANwAAAAAANwAAAAAAcwAAAAAAJAAAAAADJAAAAAADSAAAAAAAVAAAAAACVAAAAAAAVAAAAAACVAAAAAAAYgAAAAAAJAAAAAADJAAAAAADcwAAAAAAcgAAAAAANwAAAAAANwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAASAAAAAAAYgAAAAAAYgAAAAAASAAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAVAAAAAADSAAAAAAASAAAAAAAPgAAAAAAPgAAAAAASAAAAAAARwAAAAADVAAAAAADRwAAAAAAVAAAAAACRwAAAAAAVAAAAAAAcwAAAAAAcAAAAAACcAAAAAADcAAAAAACVAAAAAABVAAAAAAAYgAAAAAAGwAAAAACGwAAAAABYgAAAAAAVAAAAAADVAAAAAAAVAAAAAACVAAAAAABVAAAAAAAVAAAAAABYgAAAAAAcAAAAAACcAAAAAAAcAAAAAABVAAAAAABVAAAAAADSAAAAAAAPgAAAAAAPgAAAAAASAAAAAAARwAAAAAAVAAAAAAARwAAAAABVAAAAAABRwAAAAACVAAAAAACSAAAAAAAcAAAAAAAcAAAAAACcAAAAAADVAAAAAABVAAAAAABcwAAAAAAcwAAAAAAcwAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAVAAAAAABVAAAAAABVAAAAAABSAAAAAAAcAAAAAADcAAAAAABcAAAAAAAcwAAAAAAYgAAAAAAcwAAAAAAcwAAAAAAOwAAAAAAOwAAAAAAOwAAAAAAOwAAAAAAcwAAAAAAVAAAAAABRwAAAAABVAAAAAABSAAAAAAAcAAAAAABcAAAAAACcAAAAAAD
           version: 6
         2,0:
           ind: 2,0
@@ -1800,11 +1800,12 @@ entities:
           -4,-3:
             0: 65535
           -4,-2:
-            0: 4607
-            1: 60928
+            1: 1
+            0: 4606
+            2: 60928
           -4,-1:
             0: 65521
-            1: 14
+            2: 14
           -3,-4:
             0: 65535
           -3,-3:
@@ -1934,7 +1935,8 @@ entities:
           -5,-3:
             0: 65535
           -5,-2:
-            0: 65535
+            0: 32767
+            3: 32768
           -5,-1:
             0: 65535
           0,-8:
@@ -2125,14 +2127,14 @@ entities:
             0: 65535
           -10,-12:
             0: 61951
-            2: 3584
+            4: 3584
           -10,-11:
             0: 61945
-            3: 6
-            4: 3584
+            5: 6
+            6: 3584
           -10,-10:
             0: 65521
-            5: 14
+            7: 14
           -10,-9:
             0: 65535
           -9,-12:
@@ -2201,12 +2203,12 @@ entities:
             0: 65535
           -13,-12:
             0: 65529
-            2: 6
+            4: 6
           -13,-11:
             0: 65535
           -13,-10:
             0: 65487
-            2: 48
+            4: 48
           -12,-5:
             0: 65535
           -11,-5:
@@ -2599,7 +2601,7 @@ entities:
             0: 10239
           10,-7:
             0: 7171
-            2: 57344
+            4: 57344
           9,2:
             0: 12846
           10,2:
@@ -2726,14 +2728,14 @@ entities:
             0: 63095
           10,-6:
             0: 3089
-            2: 238
+            4: 238
           11,-8:
             0: 3151
           11,-7:
             0: 18368
-            2: 47104
+            4: 47104
           11,-6:
-            2: 2235
+            4: 2235
             0: 51012
           8,3:
             0: 4352
@@ -2791,9 +2793,9 @@ entities:
             0: 19
           12,-7:
             0: 3312
-            2: 62208
+            4: 62208
           12,-6:
-            2: 1023
+            4: 1023
             0: 64512
           13,-8:
             0: 55040
@@ -2938,10 +2940,40 @@ entities:
           - 0
           - 0
         - volume: 2500
+          temperature: 293.15
+          moles:
+          - 23.57087
+          - 88.67137
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
           temperature: 235
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 20.078888
+          - 75.53487
           - 0
           - 0
           - 0
@@ -4295,21 +4327,61 @@ entities:
     - pos: -23.5,-41.5
       parent: 34
       type: Transform
+    - links:
+      - 11768
+      - 11682
+      type: DeviceLinkSink
+    - linkedPorts:
+        11682:
+        - DoorStatus: DoorBolt
+        11768:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 11682
     components:
     - pos: -26.5,-42.5
       parent: 34
       type: Transform
+    - links:
+      - 11911
+      - 1802
+      type: DeviceLinkSink
+    - linkedPorts:
+        1802:
+        - DoorStatus: DoorBolt
+        11911:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 11768
     components:
     - pos: -26.5,-41.5
       parent: 34
       type: Transform
+    - links:
+      - 11911
+      - 1802
+      type: DeviceLinkSink
+    - linkedPorts:
+        11911:
+        - DoorStatus: DoorBolt
+        1802:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 11911
     components:
     - pos: -23.5,-42.5
       parent: 34
       type: Transform
+    - links:
+      - 11768
+      - 11682
+      type: DeviceLinkSink
+    - linkedPorts:
+        11682:
+        - DoorStatus: DoorBolt
+        11768:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
 - proto: AirlockExternalGlassLocked
   entities:
   - uid: 1120
@@ -4317,21 +4389,49 @@ entities:
     - pos: -54.5,-40.5
       parent: 34
       type: Transform
+    - links:
+      - 2439
+      type: DeviceLinkSink
+    - linkedPorts:
+        2439:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 1497
     components:
     - pos: -52.5,-44.5
       parent: 34
       type: Transform
+    - links:
+      - 1498
+      type: DeviceLinkSink
+    - linkedPorts:
+        1498:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 1498
     components:
     - pos: -51.5,-42.5
       parent: 34
       type: Transform
+    - links:
+      - 1497
+      type: DeviceLinkSink
+    - linkedPorts:
+        1497:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 2439
     components:
     - pos: -53.5,-37.5
       parent: 34
       type: Transform
+    - links:
+      - 1120
+      type: DeviceLinkSink
+    - linkedPorts:
+        1120:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 3189
     components:
     - pos: 13.5,-48.5
@@ -4352,26 +4452,64 @@ entities:
     - pos: -25.5,6.5
       parent: 34
       type: Transform
+    - links:
+      - 7072
+      - 7071
+      type: DeviceLinkSink
+    - linkedPorts:
+        7071:
+        - DoorStatus: DoorBolt
+        7072:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 7071
     components:
     - pos: -24.5,8.5
       parent: 34
       type: Transform
+    - links:
+      - 7070
+      type: DeviceLinkSink
+    - linkedPorts:
+        7070:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 7072
     components:
     - pos: -27.5,8.5
       parent: 34
       type: Transform
+    - links:
+      - 7070
+      type: DeviceLinkSink
+    - linkedPorts:
+        7070:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 9347
     components:
     - pos: 34.5,-43.5
       parent: 34
       type: Transform
+    - links:
+      - 9348
+      type: DeviceLinkSink
+    - linkedPorts:
+        9348:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
   - uid: 9348
     components:
     - pos: 36.5,-46.5
       parent: 34
       type: Transform
+    - links:
+      - 9347
+      type: DeviceLinkSink
+    - linkedPorts:
+        9347:
+        - DoorStatus: DoorBolt
+      type: DeviceLinkSource
 - proto: AirlockExternalGlassShuttleEmergencyLocked
   entities:
   - uid: 3360
@@ -4862,17 +5000,19 @@ entities:
       type: Transform
 - proto: AirlockMaintSecLocked
   entities:
-  - uid: 1923
-    components:
-    - pos: 33.5,-15.5
-      parent: 34
-      type: Transform
   - uid: 8115
     components:
     - pos: 22.5,2.5
       parent: 34
       type: Transform
-  - uid: 8116
+- proto: AirlockMaintSecurityLawyerLocked
+  entities:
+  - uid: 78
+    components:
+    - pos: 33.5,-15.5
+      parent: 34
+      type: Transform
+  - uid: 160
     components:
     - pos: 33.5,-0.5
       parent: 34
@@ -4953,6 +5093,13 @@ entities:
   - uid: 3415
     components:
     - pos: 5.5,-41.5
+      parent: 34
+      type: Transform
+- proto: AirlockMusicianLocked
+  entities:
+  - uid: 175
+    components:
+    - pos: 6.5,-8.5
       parent: 34
       type: Transform
 - proto: AirlockQuartermasterGlassLocked
@@ -5256,13 +5403,6 @@ entities:
       type: Transform
 - proto: AirlockTheatreLocked
   entities:
-  - uid: 312
-    components:
-    - name: musician's room
-      type: MetaData
-    - pos: 6.5,-8.5
-      parent: 34
-      type: Transform
   - uid: 1021
     components:
     - name: clown/mime room
@@ -5626,11 +5766,11 @@ entities:
       type: Transform
 - proto: AppraisalTool
   entities:
-  - uid: 8035
+  - uid: 895
     components:
     - flags: InContainer
       type: MetaData
-    - parent: 6144
+    - parent: 431
       type: Transform
     - canCollide: False
       type: Physics
@@ -6958,9 +7098,9 @@ entities:
       type: Transform
 - proto: BoxColoredLighttube
   entities:
-  - uid: 11623
+  - uid: 245
     components:
-    - pos: 6.5195274,-18.1113
+    - pos: 6.7010136,-18.662865
       parent: 34
       type: Transform
 - proto: BoxFolderBlue
@@ -7129,6 +7269,16 @@ entities:
       type: Transform
 - proto: Bucket
   entities:
+  - uid: 3076
+    components:
+    - pos: -17.8019,2.7929726
+      parent: 34
+      type: Transform
+  - uid: 3307
+    components:
+    - pos: -17.6769,2.4594078
+      parent: 34
+      type: Transform
   - uid: 4715
     components:
     - pos: 37.16463,5.0502324
@@ -26617,9 +26767,9 @@ entities:
     - pos: -1.5,-28.5
       parent: 34
       type: Transform
-  - uid: 5248
+  - uid: 12338
     components:
-    - pos: -16.5,-6.5
+    - pos: -16.5,-3.5
       parent: 34
       type: Transform
 - proto: ChemDispenser
@@ -26810,6 +26960,13 @@ entities:
   - uid: 12277
     components:
     - pos: -33.5,-19.5
+      parent: 34
+      type: Transform
+- proto: CleanerDispenser
+  entities:
+  - uid: 3387
+    components:
+    - pos: 7.5,-18.5
       parent: 34
       type: Transform
 - proto: CloningPod
@@ -27006,9 +27163,21 @@ entities:
     - pos: -15.5,-31.5
       parent: 34
       type: Transform
+- proto: ClosetJanitorFilled
+  entities:
+  - uid: 1923
+    components:
+    - pos: 6.5,-17.5
+      parent: 34
+      type: Transform
+  - uid: 3727
+    components:
+    - pos: -15.5,2.5
+      parent: 34
+      type: Transform
 - proto: ClosetL3JanitorFilled
   entities:
-  - uid: 10449
+  - uid: 230
     components:
     - pos: 4.5,-18.5
       parent: 34
@@ -27373,9 +27542,9 @@ entities:
       type: Transform
 - proto: ClothingHeadHatPurplesoftFlipped
   entities:
-  - uid: 11399
+  - uid: 5568
     components:
-    - pos: 6.5752983,-17.455265
+    - pos: 4.7426805,-18.214638
       parent: 34
       type: Transform
 - proto: ClothingHeadHatPwig
@@ -28094,6 +28263,10 @@ entities:
       pos: -29.5,-6.5
       parent: 34
       type: Transform
+    - linkedPorts:
+        49:
+        - ArtifactAnalyzerSender: ArtifactAnalyzerReceiver
+      type: DeviceLinkSource
 - proto: ComputerBroken
   entities:
   - uid: 11374
@@ -28718,9 +28891,9 @@ entities:
       type: EntityStorage
 - proto: CrateHydroponics
   entities:
-  - uid: 6144
+  - uid: 431
     components:
-    - pos: -15.5,-7.5
+    - pos: -16.5,-4.5
       parent: 34
       type: Transform
     - air:
@@ -28746,7 +28919,7 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 8035
+          - 895
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -28754,29 +28927,11 @@ entities:
       type: ContainerContainer
 - proto: CrateHydroSecure
   entities:
-  - uid: 11381
+  - uid: 254
     components:
     - pos: -14.5,-7.5
       parent: 34
       type: Transform
-    - air:
-        volume: 200
-        immutable: False
-        temperature: 293.14957
-        moles:
-        - 4.3114347
-        - 16.219208
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-      type: EntityStorage
 - proto: CrateMedicalSecure
   entities:
   - uid: 2693
@@ -28834,9 +28989,9 @@ entities:
       type: EntityStorage
 - proto: CrateNPCHamster
   entities:
-  - uid: 5952
+  - uid: 5248
     components:
-    - pos: 1.5,-20.5
+    - pos: -1.5,-18.5
       parent: 34
       type: Transform
 - proto: CratePrivateSecure
@@ -34622,8 +34777,20 @@ entities:
     - pos: -14.575876,-3.3837485
       parent: 34
       type: Transform
+- proto: FuelDispenser
+  entities:
+  - uid: 5540
+    components:
+    - pos: -27.5,6.5
+      parent: 34
+      type: Transform
 - proto: GasAnalyzer
   entities:
+  - uid: 239
+    components:
+    - pos: -15.333032,-7.4604254
+      parent: 34
+      type: Transform
   - uid: 10908
     components:
     - pos: 37.73635,-27.41521
@@ -55370,16 +55537,6 @@ entities:
     - pos: -18.5,-4.5
       parent: 34
       type: Transform
-  - uid: 895
-    components:
-    - pos: -16.5,-4.5
-      parent: 34
-      type: Transform
-  - uid: 3307
-    components:
-    - pos: -16.5,-3.5
-      parent: 34
-      type: Transform
   - uid: 4706
     components:
     - pos: 36.5,4.5
@@ -55393,6 +55550,31 @@ entities:
   - uid: 4709
     components:
     - pos: 36.5,3.5
+      parent: 34
+      type: Transform
+  - uid: 12332
+    components:
+    - pos: -19.5,-3.5
+      parent: 34
+      type: Transform
+  - uid: 12333
+    components:
+    - pos: -19.5,-4.5
+      parent: 34
+      type: Transform
+  - uid: 12334
+    components:
+    - pos: -19.5,-5.5
+      parent: 34
+      type: Transform
+  - uid: 12335
+    components:
+    - pos: -18.5,-5.5
+      parent: 34
+      type: Transform
+  - uid: 12336
+    components:
+    - pos: -17.5,-5.5
       parent: 34
       type: Transform
 - proto: Igniter
@@ -55892,6 +56074,13 @@ entities:
     - pos: 9.5,-34.5
       parent: 34
       type: Transform
+- proto: LockerClown
+  entities:
+  - uid: 312
+    components:
+    - pos: -0.5,-20.5
+      parent: 34
+      type: Transform
 - proto: LockerDetectiveFilled
   entities:
   - uid: 10872
@@ -56032,6 +56221,13 @@ entities:
   - uid: 8019
     components:
     - pos: 7.5,-29.5
+      parent: 34
+      type: Transform
+- proto: LockerMime
+  entities:
+  - uid: 12329
+    components:
+    - pos: 1.5,-20.5
       parent: 34
       type: Transform
 - proto: LockerParamedicFilled
@@ -56183,6 +56379,9 @@ entities:
     - pos: -25.5,-5.5
       parent: 34
       type: Transform
+    - links:
+      - 404
+      type: DeviceLinkSink
 - proto: MachineFrame
   entities:
   - uid: 1162
@@ -56699,28 +56898,6 @@ entities:
       type: Transform
 - proto: MopItem
   entities:
-  - uid: 3075
-    components:
-    - pos: 6.3304253,-17.420143
-      parent: 34
-      type: Transform
-  - uid: 3076
-    components:
-    - pos: 6.6533422,-17.607773
-      parent: 34
-      type: Transform
-  - uid: 5569
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -15.355621,2.5086179
-      parent: 34
-      type: Transform
-  - uid: 5570
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: -15.605621,2.414803
-      parent: 34
-      type: Transform
   - uid: 7411
     components:
     - pos: -49.63304,-18.481379
@@ -61047,11 +61224,6 @@ entities:
     - pos: -14.5,-4.5
       parent: 34
       type: Transform
-  - uid: 431
-    components:
-    - pos: 6.5,-17.5
-      parent: 34
-      type: Transform
   - uid: 618
     components:
     - pos: -35.5,-11.5
@@ -61268,11 +61440,6 @@ entities:
   - uid: 5556
     components:
     - pos: -15.5,4.5
-      parent: 34
-      type: Transform
-  - uid: 5568
-    components:
-    - pos: -15.5,2.5
       parent: 34
       type: Transform
   - uid: 5875
@@ -61817,6 +61984,11 @@ entities:
     - pos: 18.5,6.5
       parent: 34
       type: Transform
+  - uid: 5569
+    components:
+    - pos: -1.5,-3.5
+      parent: 34
+      type: Transform
 - proto: RandomArtifactSpawner
   entities:
   - uid: 957
@@ -62318,6 +62490,11 @@ entities:
     - pos: 8.5,-35.5
       parent: 34
       type: Transform
+  - uid: 3075
+    components:
+    - pos: -2.5,9.5
+      parent: 34
+      type: Transform
   - uid: 7151
     components:
     - pos: -36.5,-12.5
@@ -62471,6 +62648,16 @@ entities:
   - uid: 12197
     components:
     - pos: 24.5,-8.5
+      parent: 34
+      type: Transform
+  - uid: 12330
+    components:
+    - pos: 3.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 12331
+    components:
+    - pos: 6.5,7.5
       parent: 34
       type: Transform
 - proto: RandomSnacks
@@ -65742,14 +65929,6 @@ entities:
       pos: 23.494371,-25.253572
       parent: 34
       type: Transform
-- proto: SignDirectionalJanitor
-  entities:
-  - uid: 10381
-    components:
-    - rot: 3.141592653589793 rad
-      pos: 6.5,-21.5
-      parent: 34
-      type: Transform
 - proto: SignDirectionalMed
   entities:
   - uid: 153
@@ -65991,6 +66170,13 @@ entities:
   - uid: 4885
     components:
     - pos: 27.5,-15.5
+      parent: 34
+      type: Transform
+- proto: SignJanitor
+  entities:
+  - uid: 3728
+    components:
+    - pos: 6.5,-21.5
       parent: 34
       type: Transform
 - proto: SignLawyer
@@ -67065,6 +67251,11 @@ entities:
       type: Transform
 - proto: SpawnPointJanitor
   entities:
+  - uid: 240
+    components:
+    - pos: 5.5,-19.5
+      parent: 34
+      type: Transform
   - uid: 12179
     components:
     - pos: 5.5,-18.5
@@ -67573,6 +67764,12 @@ entities:
       type: Transform
 - proto: Stool
   entities:
+  - uid: 1108
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 34
+      type: Transform
   - uid: 2728
     components:
     - rot: -1.5707963267948966 rad
@@ -70908,31 +71105,17 @@ entities:
       type: Transform
     - chance: 1
       type: RandomSpawner
-  - uid: 10829
+  - uid: 12327
     components:
-    - pos: -1.5,-18.5
+    - pos: -0.5,-19.5
       parent: 34
       type: Transform
-    - chance: 1
-      type: RandomSpawner
 - proto: TrainingBomb
   entities:
   - uid: 8685
     components:
     - rot: 1.5707963267948966 rad
       pos: 32.5,-6.5
-      parent: 34
-      type: Transform
-- proto: TrashBag
-  entities:
-  - uid: 3727
-    components:
-    - pos: 6.7647095,-17.550875
-      parent: 34
-      type: Transform
-  - uid: 3728
-    components:
-    - pos: 6.6813755,-17.519604
       parent: 34
       type: Transform
 - proto: TwoWayLever
@@ -71072,15 +71255,6 @@ entities:
     - flags: SessionSpecific
       type: MetaData
     - pos: -19.5,-18.5
-      parent: 34
-      type: Transform
-- proto: VendingMachineChang
-  entities:
-  - uid: 10370
-    components:
-    - flags: SessionSpecific
-      type: MetaData
-    - pos: -1.5,-3.5
       parent: 34
       type: Transform
 - proto: VendingMachineChapel
@@ -71705,21 +71879,6 @@ entities:
     - pos: -17.5,5.5
       parent: 34
       type: Transform
-  - uid: 78
-    components:
-    - pos: 3.5,9.5
-      parent: 34
-      type: Transform
-  - uid: 160
-    components:
-    - pos: 5.5,9.5
-      parent: 34
-      type: Transform
-  - uid: 175
-    components:
-    - pos: 4.5,9.5
-      parent: 34
-      type: Transform
   - uid: 213
     components:
     - pos: -22.5,-36.5
@@ -71740,16 +71899,6 @@ entities:
     - pos: -23.5,-33.5
       parent: 34
       type: Transform
-  - uid: 223
-    components:
-    - pos: -4.5,9.5
-      parent: 34
-      type: Transform
-  - uid: 230
-    components:
-    - pos: -4.5,7.5
-      parent: 34
-      type: Transform
   - uid: 235
     components:
     - pos: -11.5,6.5
@@ -71763,16 +71912,6 @@ entities:
   - uid: 237
     components:
     - pos: -9.5,6.5
-      parent: 34
-      type: Transform
-  - uid: 239
-    components:
-    - pos: -3.5,9.5
-      parent: 34
-      type: Transform
-  - uid: 240
-    components:
-    - pos: -4.5,8.5
       parent: 34
       type: Transform
   - uid: 241
@@ -71798,11 +71937,6 @@ entities:
   - uid: 251
     components:
     - pos: -4.5,6.5
-      parent: 34
-      type: Transform
-  - uid: 254
-    components:
-    - pos: 2.5,9.5
       parent: 34
       type: Transform
   - uid: 255
@@ -72673,11 +72807,6 @@ entities:
   - uid: 1074
     components:
     - pos: -28.5,-38.5
-      parent: 34
-      type: Transform
-  - uid: 1108
-    components:
-    - pos: 10.5,9.5
       parent: 34
       type: Transform
   - uid: 1117
@@ -73703,11 +73832,6 @@ entities:
   - uid: 3385
     components:
     - pos: -51.5,-37.5
-      parent: 34
-      type: Transform
-  - uid: 3387
-    components:
-    - pos: 9.5,9.5
       parent: 34
       type: Transform
   - uid: 3390
@@ -75515,11 +75639,6 @@ entities:
     - pos: 34.5,-39.5
       parent: 34
       type: Transform
-  - uid: 5540
-    components:
-    - pos: 11.5,9.5
-      parent: 34
-      type: Transform
   - uid: 5576
     components:
     - pos: -28.5,5.5
@@ -75840,19 +75959,9 @@ entities:
     - pos: 6.5,12.5
       parent: 34
       type: Transform
-  - uid: 6130
-    components:
-    - pos: 6.5,9.5
-      parent: 34
-      type: Transform
   - uid: 6131
     components:
     - pos: 9.5,12.5
-      parent: 34
-      type: Transform
-  - uid: 6141
-    components:
-    - pos: 7.5,9.5
       parent: 34
       type: Transform
   - uid: 6149
@@ -76530,11 +76639,6 @@ entities:
     - pos: -14.5,-32.5
       parent: 34
       type: Transform
-  - uid: 11437
-    components:
-    - pos: -1.5,9.5
-      parent: 34
-      type: Transform
   - uid: 11438
     components:
     - pos: -1.5,12.5
@@ -76605,11 +76709,6 @@ entities:
     - pos: -22.5,-35.5
       parent: 34
       type: Transform
-  - uid: 11715
-    components:
-    - pos: 1.5,9.5
-      parent: 34
-      type: Transform
   - uid: 11764
     components:
     - pos: -29.5,-40.5
@@ -76620,11 +76719,6 @@ entities:
     - pos: -48.5,-23.5
       parent: 34
       type: Transform
-  - uid: 11786
-    components:
-    - pos: -2.5,9.5
-      parent: 34
-      type: Transform
   - uid: 11788
     components:
     - pos: 1.5,12.5
@@ -76633,16 +76727,6 @@ entities:
   - uid: 11791
     components:
     - pos: 2.5,15.5
-      parent: 34
-      type: Transform
-  - uid: 11807
-    components:
-    - pos: 6.5,6.5
-      parent: 34
-      type: Transform
-  - uid: 11810
-    components:
-    - pos: -0.5,9.5
       parent: 34
       type: Transform
   - uid: 11824
@@ -76713,21 +76797,6 @@ entities:
   - uid: 12218
     components:
     - pos: -23.5,-43.5
-      parent: 34
-      type: Transform
-  - uid: 12231
-    components:
-    - pos: 6.5,5.5
-      parent: 34
-      type: Transform
-  - uid: 12238
-    components:
-    - pos: 6.5,8.5
-      parent: 34
-      type: Transform
-  - uid: 12240
-    components:
-    - pos: 6.5,7.5
       parent: 34
       type: Transform
   - uid: 12255
@@ -78647,6 +78716,11 @@ entities:
     - pos: 34.5,-45.5
       parent: 34
       type: Transform
+  - uid: 5570
+    components:
+    - pos: 3.5,9.5
+      parent: 34
+      type: Transform
   - uid: 5626
     components:
     - pos: -38.5,0.5
@@ -78667,6 +78741,11 @@ entities:
     - pos: 6.5,4.5
       parent: 34
       type: Transform
+  - uid: 5952
+    components:
+    - pos: 5.5,9.5
+      parent: 34
+      type: Transform
   - uid: 6108
     components:
     - pos: 11.5,4.5
@@ -78675,6 +78754,21 @@ entities:
   - uid: 6127
     components:
     - pos: 6.5,2.5
+      parent: 34
+      type: Transform
+  - uid: 6130
+    components:
+    - pos: 4.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 6141
+    components:
+    - pos: -4.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 6144
+    components:
+    - pos: -4.5,7.5
       parent: 34
       type: Transform
   - uid: 6147
@@ -78697,6 +78791,16 @@ entities:
     - pos: 16.5,-42.5
       parent: 34
       type: Transform
+  - uid: 8035
+    components:
+    - pos: -3.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 8116
+    components:
+    - pos: -4.5,8.5
+      parent: 34
+      type: Transform
   - uid: 8413
     components:
     - pos: 14.5,-38.5
@@ -78710,6 +78814,21 @@ entities:
   - uid: 9289
     components:
     - pos: -52.5,-10.5
+      parent: 34
+      type: Transform
+  - uid: 10370
+    components:
+    - pos: 2.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 10381
+    components:
+    - pos: 10.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 10449
+    components:
+    - pos: 9.5,9.5
       parent: 34
       type: Transform
   - uid: 10572
@@ -78732,6 +78851,11 @@ entities:
     - pos: 14.5,-39.5
       parent: 34
       type: Transform
+  - uid: 10829
+    components:
+    - pos: 11.5,9.5
+      parent: 34
+      type: Transform
   - uid: 11202
     components:
     - pos: 23.5,12.5
@@ -78745,6 +78869,56 @@ entities:
   - uid: 11263
     components:
     - pos: 28.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 11381
+    components:
+    - pos: 6.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 11399
+    components:
+    - pos: 7.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 11437
+    components:
+    - pos: -1.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 11623
+    components:
+    - pos: 1.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 11715
+    components:
+    - pos: -2.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 11786
+    components:
+    - pos: 6.5,6.5
+      parent: 34
+      type: Transform
+  - uid: 11807
+    components:
+    - pos: -0.5,9.5
+      parent: 34
+      type: Transform
+  - uid: 11810
+    components:
+    - pos: 6.5,5.5
+      parent: 34
+      type: Transform
+  - uid: 12231
+    components:
+    - pos: 6.5,8.5
+      parent: 34
+      type: Transform
+  - uid: 12238
+    components:
+    - pos: 6.5,7.5
       parent: 34
       type: Transform
 - proto: WallSolidRust
@@ -79387,9 +79561,15 @@ entities:
     - pos: -19.5,-2.5
       parent: 34
       type: Transform
-- proto: WindoorKitchenHydroponicsLocked
+  - uid: 12240
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -13.5,-8.5
+      parent: 34
+      type: Transform
+- proto: WindoorKitchenLocked
   entities:
-  - uid: 245
+  - uid: 223
     components:
     - rot: 1.5707963267948966 rad
       pos: -13.5,-8.5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Asterisk, Edge, Shoukou:
Musician airlocks, clown/mime lockers, custodian lockers in service rooms, sec/law maintenance hatches, space cleaner dispensers in janitor rooms.

Asterisk:
Added swabs to common botany room, added box of swabs to hydroponics.

Shoukou:
Linked many external airlocks.
Replaced food dispenser in bar with an arcade cabinet and stool.
Added more trays to hydroponics, gave them a gas analyzer, and made the shared table a set of two windoors.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

As far as botany on Shoukou, the aesthetic of having the trays in the corner where you have a free path of travel around them is nice and all, but it was a common complaint having so few trays for botanists to work with.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media

![image](https://github.com/DeltaV-Station/Delta-v/assets/113523727/1ae036ea-3594-426b-99c2-e082f9e73352)
