### PR TITLE
Fix syrinx voice mask not working over radio

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -67,6 +67,10 @@ public sealed class RadioSystem : EntitySystem
             ? mask.VoiceName
             : MetaData(messageSource).EntityName;
 
+        // Delta-V: Support syrinx voice mask on radio.
+        if (TryComp(messageSource, out SyrinxVoiceMaskComponent? syrinx) && syrinx.Enabled)
+            name = syrinx.VoiceName;
+
         name = FormattedMessage.EscapeText(name);
 
         var speech = _chat.GetSpeechVerb(messageSource, message);


### PR DESCRIPTION
## About the PR
Fixes #460, syrinx voice mask not working over radio.

## Why / Balance
Syrinx voice mask should work over radio just like regular voice mask.

## Technical details
Late in the previous PR, when the syrinx duplicated some voice mask code to deconflict the two, I forgot that the radio code explicitly checks the VoiceMaskComponent for what name is being used. This PR adds a two-line check to upstream radio code to see if there's a SyrinxVoiceMaskComponent in play as well.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/DeltaV-Station/Delta-v/assets/8277780/019651cc-4872-490e-9207-56f7d3738bdc)


## Breaking changes
N/A

**Changelog**
<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: The Syrinx implant now lets you mask your voice over radio as intended.
-->
