### PR TITLE
Add WorksOnTheDead property to ReagentPrototype

### DIFF
--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -172,7 +172,8 @@ namespace Content.Server.Body.Systems
                     // still remove reagents
                     if (EntityManager.TryGetComponent<MobStateComponent>(solutionEntityUid.Value, out var state))
                     {
-                        if (_mobStateSystem.IsDead(solutionEntityUid.Value, state))
+                        // Delta-V: Add WorksOnTheDead check.
+                        if (_mobStateSystem.IsDead(solutionEntityUid.Value, state) && !proto.WorksOnTheDead)
                             continue;
                     }
 

--- a/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
+++ b/Content.Shared/Chemistry/Reagent/ReagentPrototype.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Text.Json.Serialization;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body.Prototypes;
@@ -101,6 +101,12 @@ namespace Content.Shared.Chemistry.Reagent
         /// </summary>
         [DataField("viscosity")]
         public float Viscosity = 0;
+
+        /// <summary>
+        /// Delta-V: Should this reagent work on the dead?
+        /// </summary>
+        [DataField("worksOnTheDead")]
+        public bool WorksOnTheDead = false;
 
         [DataField("metabolisms", serverOnly: true, customTypeSerializer: typeof(PrototypeIdDictionarySerializer<ReagentEffectsEntry, MetabolismGroupPrototype>))]
         public Dictionary<string, ReagentEffectsEntry>? Metabolisms = null;


### PR DESCRIPTION
## About the PR
Add a WorksOnTheDead property to ReagentPrototype.

## Why / Balance
TBD. This is intended as a starting point for Adrian to work on some cryo changes.

## Technical details
Adds a WorksOnTheDead field to ReagentPrototype defaulting to false, and checks if that's `true` before skipping reagent effects in MetabolizerSystem.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
TBD

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
