### PR TITLE
Revert "Allow nuclear operatives to buy deswords"

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -95,11 +95,11 @@
     Telecrystal: 16 # DeltaV - Originally 20 but no one bought it due to it's high cost.
   categories:
   - UplinkWeapons
-# conditions:      # DeltaV - Desword is a bit nerfed here
-#   - !type:StoreWhitelistCondition
-#     blacklist:
-#       tags:
-#         - NukeOpsUplink
+  conditions:
+    - !type:StoreWhitelistCondition
+      blacklist:
+        tags:
+          - NukeOpsUplink
 
 - type: listing
   id: UplinkDisposableTurret


### PR DESCRIPTION
Reverts DeltaV-Station/Delta-v#472

It has proven to be way too overpowered.