### PR TITLE
Make salvage corpses unrevivable

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/human.yml
@@ -64,6 +64,7 @@
         Asphyxiation: 76
         Slash: 56
         Blunt: 19
+        Radiation: 1984 # DV: Unrevivable due to prolonged exposure to space.
   - type: Inventory
     templateId: corpse
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Make salvage corpses unrevivable by giving them a ton of radiation damage, a damage type that can not be healed on dead people, and also makes thematic sense with the prolonged exposure to space they presumably have undergone.

## Why / Balance
Related to #449, if cognizine shouldn't work on salvage corpses, it'd be best if you can't revive them either.

## Technical details
N/A

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
