### PR TITLE
Disable cognizine ghost roles for humanoids.

### DIFF
--- a/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
+++ b/Content.Server/Chemistry/ReagentEffects/MakeSentient.cs
@@ -4,6 +4,7 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Mind.Components;
 using Robust.Shared.Prototypes;
 using Content.Server.Psionics; //Nyano - Summary: pulls in the ability for the sentient creature to become psionic.
+using Content.Shared.Humanoid; //Delta-V - Banning humanoids from becoming ghost roles.
 
 namespace Content.Server.Chemistry.ReagentEffects;
 
@@ -31,6 +32,15 @@ public sealed partial class MakeSentient : ReagentEffect
 
         // Don't add a ghost role to things that already have ghost roles
         if (entityManager.TryGetComponent(uid, out GhostRoleComponent? ghostRole))
+        {
+            return;
+        }
+
+        // Delta-V: Do not allow humanoids to become sentient. Intended to stop people from
+        // repeatedly cloning themselves and using cognizine on their bodies.
+        // HumanoidAppearanceComponent is common to all player species, and is also used for the
+        // Ripley pilot whitelist, so there's a precedent for using it for this kind of check.
+        if (entityManager.HasComponent<HumanoidAppearanceComponent>(uid))
         {
             return;
         }


### PR DESCRIPTION
## About the PR
Disables cognizine for humanoids.

## Why / Balance
Fixes #449.

## Technical details
Adds a check in ReagentEffects/MakeSentient.cs to disable adding ghost roles if the target has a `HumanoidAppearanceComponent`, which is common to all player species and are not used for anyone else. This component is also used for the Ripley pilot whitelist, so there's a precedent for using it for this kind of check.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
N/A

**Changelog**
N/A

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
