### PR TITLE
Update cargo_armory.yml

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Cargo/cargo_armory.yml
@@ -45,3 +45,5 @@
     state: icon
   product: CrateArmoryEnergyGunMini
   cost: 3500
+  category: Armory
+  group: market


### PR DESCRIPTION
Categorize mini energy gun crates as 'Armory' on the market.
Closes #522 