### PR TITLE
Bureaucratic error changes

### DIFF
--- a/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
+++ b/Content.Server/StationEvents/Events/BureaucraticErrorRule.cs
@@ -33,12 +33,14 @@ public sealed class BureaucraticErrorRule : StationEventSystem<BureaucraticError
         {
             var chosenJob = RobustRandom.PickAndTake(jobList);
             _stationJobs.MakeJobUnlimited(chosenStation.Value, chosenJob); // INFINITE chaos.
+            /* DeltaV - don't close all other jobs
             foreach (var job in jobList)
             {
                 if (_stationJobs.IsJobUnlimited(chosenStation.Value, job))
                     continue;
                 _stationJobs.TrySetJobSlot(chosenStation.Value, job, 0);
             }
+            */
         }
         else
         {

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -43,17 +43,17 @@
     minimumPlayers: 15
   - type: BreakerFlipRule
 
- - type: entity
-   id: BureaucraticError
-   parent: BaseGameRule
-   noSpawn: true
-   components:
-   - type: StationEvent
-     startAnnouncement: station-event-bureaucratic-error-announcement
-     minimumPlayers: 25
-     weight: 5
-     duration: 1
-   - type: BureaucraticErrorRule
+- type: entity
+  id: BureaucraticError
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-bureaucratic-error-announcement
+    minimumPlayers: 25
+    weight: 5
+    duration: 1
+  - type: BureaucraticErrorRule
 
 #- type: entity
 #  parent: BaseGameRule # DeltaV - this shit is busted most of the time

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -43,17 +43,17 @@
     minimumPlayers: 15
   - type: BreakerFlipRule
 
-# - type: entity
-#   id: BureaucraticError # DeltaV - Prevent the BureaucraticError event to happen.
-#   parent: BaseGameRule
-#   noSpawn: true
-#   components:
-#   - type: StationEvent
-#     startAnnouncement: station-event-bureaucratic-error-announcement
-#     minimumPlayers: 25
-#     weight: 5
-#     duration: 1
-#   - type: BureaucraticErrorRule
+ - type: entity
+   id: BureaucraticError
+   parent: BaseGameRule
+   noSpawn: true
+   components:
+   - type: StationEvent
+     startAnnouncement: station-event-bureaucratic-error-announcement
+     minimumPlayers: 25
+     weight: 5
+     duration: 1
+   - type: BureaucraticErrorRule
 
 #- type: entity
 #  parent: BaseGameRule # DeltaV - this shit is busted most of the time


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
reenables bureaucratic error event and changes it to a bit less chaos -- no more closing all jobs except a single unlimited one

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Some budget cuts were made in HR department, expect more bureaucratic errors in near future.