### PR TITLE
Blacklisted Syrinx Implant from Surplus Bundles

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
@@ -42,6 +42,7 @@
   - !type:BuyerSpeciesCondition
     whitelist:
     - Harpy
+  - !type:BuyerWhitelistCondition
     blacklist:
       components:
       - SurplusBundle

--- a/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
@@ -42,3 +42,6 @@
   - !type:BuyerSpeciesCondition
     whitelist:
     - Harpy
+    blacklist:
+      components:
+      - SurplusBundle


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Blacklisted Syrinx Implant from Surplus Bundles
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Doesn't make sense a species-only item is included in a general surplus crate.
**Changelog**

:cl:
- remove: Removed bionic syrinx implanter from surplus crate.