### PR TITLE
Bags of holding recipe tweak

### DIFF
--- a/devices.yml
+++ b/devices.yml
@@ -1,0 +1,189 @@
+- type: latheRecipe
+  id: TimerTrigger
+  result: TimerTrigger
+  completetime: 2
+  materials:
+    Steel: 300
+    Plastic: 200
+
+- type: latheRecipe
+  id: SignalTrigger
+  result: SignalTrigger
+  completetime: 2
+  materials:
+    Steel: 300
+    Plastic: 200
+
+- type: latheRecipe
+  id: VoiceTrigger
+  result: VoiceTrigger
+  completetime: 2
+  materials:
+    Steel: 300
+    Plastic: 200
+
+- type: latheRecipe
+  id: Igniter
+  result: Igniter
+  completetime: 2
+  materials:
+    Steel: 300
+    Plastic: 100
+    Glass: 100
+
+- type: latheRecipe
+  id: ChemicalPayload
+  result: ChemicalPayload
+  completetime: 2
+  materials:
+    Steel: 200
+    Plastic: 300
+
+- type: latheRecipe
+  id: FlashPayload
+  result: FlashPayload
+  completetime: 2
+  materials:
+    Steel: 50
+    Plastic: 100
+    Glass: 50
+    #one fourth of what making a flash would cost
+
+- type: latheRecipe
+  id: ExplosivePayload
+  result: ExplosivePayload
+  completetime: 4
+  materials:
+    Steel: 100
+    Plastic: 100
+    Glass: 50
+    Plasma: 50
+    Silver: 50
+
+- type: latheRecipe
+  id: Signaller
+  result: RemoteSignaller
+  completetime: 2
+  materials:
+    Steel: 100
+    Plastic: 200
+    Glass: 100
+
+- type: latheRecipe
+  id: AnomalyLocator
+  result: AnomalyLocatorEmpty
+  completetime: 3
+  materials:
+    Steel: 400
+    Glass: 100
+
+- type: latheRecipe
+  id: AnomalyLocatorWide
+  result: AnomalyLocatorWideEmpty
+  completetime: 3
+  materials:
+    Steel: 400
+    Glass: 100
+
+- type: latheRecipe
+  id: AnomalyScanner
+  result: AnomalyScanner
+  completetime: 2
+  materials:
+    Plastic: 200
+    Glass: 150
+
+- type: latheRecipe
+  id: WeaponPistolCHIMP
+  result: WeaponPistolCHIMP
+  completetime: 5
+  materials:
+    Steel: 500
+    Glass: 400
+
+- type: latheRecipe
+  id: ClothingBackpackHolding
+  result: ClothingBackpackHolding
+  completetime: 5
+  materials:
+    Steel: 2000
+    Silver: 750
+    Plasma: 1250 
+    Uranium: 150
+    Bluespace: 300 #DeltaV: Bluespace Exists
+
+- type: latheRecipe
+  id: ClothingBackpackSatchelHolding
+  result: ClothingBackpackSatchelHolding
+  completetime: 5
+  materials:
+    Steel: 2000
+    Silver: 750
+    Plasma: 1250 
+    Uranium: 150
+    Bluespace: 300 #DeltaV: Bluespace Exists
+
+- type: latheRecipe
+  id: ClothingBackpackDuffelHolding
+  result: ClothingBackpackDuffelHolding
+  completetime: 5
+  materials:
+    Steel: 2000
+    Silver: 750
+    Plasma: 1250 
+    Uranium: 150
+    Bluespace: 300 #DeltaV: Bluespace Exists
+
+- type: latheRecipe
+  id: WeaponCrusher
+  result: WeaponCrusher
+  completetime: 5
+  materials:
+    Steel: 1000
+    Glass: 250
+    Plastic: 100
+
+- type: latheRecipe
+  id: WeaponCrusherDagger
+  result: WeaponCrusherDagger
+  completetime: 5
+  materials:
+    Steel: 500
+    Glass: 250
+    Plastic: 50
+
+#- type: latheRecipe #DeltaV - LRP
+#  id: WeaponForceGun
+#  result: WeaponForceGun
+#  completetime: 5
+#  materials:
+#    Steel: 500
+#    Glass: 400
+#    Silver: 200
+
+- type: latheRecipe
+  id: WeaponProtoKineticAccelerator
+  result: WeaponProtoKineticAccelerator
+  completetime: 5
+  materials:
+    Steel: 1000
+    Glass: 500
+    Silver: 100
+
+#- type: latheRecipe #DeltaV - LRP
+#  id: WeaponTetherGun
+#  result: WeaponTetherGun
+#  completetime: 5
+#  materials:
+#    Steel: 500
+#    Glass: 400
+#    Silver: 100
+
+#- type: latheRecipe #DeltaV - LRP
+#  id: WeaponGrapplingGun
+#  result: WeaponGrapplingGun
+#  completetime: 5
+#  materials:
+#    Steel: 500
+#    Glass: 400
+#    Gold: 100


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Modified the base cost of the three bag of holding, namely:
-Increased plasma cost from 750 to 1250
-Reduced bluespace crystals cost from 5 to 3

## Why / Balance
Five crystals is, in both my personnal opinion and the people I asked a bit too much, considering the only source is the oracle and even if made to be inconsistent to keep the bag's rarity, would be better off reduced, with of course a counter balance through the increased plasma cost.

Point is overall, to make the bags not a thing you unlock when playing EPI and at most keep to yourself but rather something that is, hard to make but not too hard, so namely salvagers could get their hands on it too as this is something I haven't seen once despite them being basically the back bone of EPI's fund, most of the time.

**Changelog**

:cl:

- tweak: Tweaked bags of holding cost to be more consistent.

