### PR TITLE
Bags of holding recipe tweak

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -110,7 +110,7 @@
     Silver: 750
     Plasma: 1250 #Higher Plasma due to it needing less bluespace
     Uranium: 150
-    Bluespace: 30 #DeltaV: Bluespace Exists
+    Bluespace: 300 #DeltaV: Bluespace Exists
 
 - type: latheRecipe
   id: ClothingBackpackSatchelHolding

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -108,9 +108,9 @@
   materials:
     Steel: 2000
     Silver: 750
-    Plasma: 750 #Lower Plasma due to it needing bluespace
+    Plasma: 1250 #Higher Plasma due to it needing less bluespace
     Uranium: 150
-    Bluespace: 500 #DeltaV: Bluespace Exists
+    Bluespace: 30 #DeltaV: Bluespace Exists
 
 - type: latheRecipe
   id: ClothingBackpackSatchelHolding
@@ -119,9 +119,9 @@
   materials:
     Steel: 2000
     Silver: 750
-    Plasma: 750 #Lower Plasma due to it needing bluespace
+    Plasma: 1250 #Higher Plasma due to it needing less bluespace
     Uranium: 150
-    Bluespace: 500 #DeltaV: Bluespace Exists
+    Bluespace: 300 #DeltaV: Bluespace Exists
 
 - type: latheRecipe
   id: ClothingBackpackDuffelHolding
@@ -130,9 +130,9 @@
   materials:
     Steel: 2000
     Silver: 750
-    Plasma: 750 #Lower Plasma due to it needing bluespace
+    Plasma: 1250 #Higher Plasma due to it needing less bluespace
     Uranium: 150
-    Bluespace: 500 #DeltaV: Bluespace Exists
+    Bluespace: 300 #DeltaV: Bluespace Exists
 
 - type: latheRecipe
   id: WeaponCrusher


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Change the costs of bags of holding:
- Increase plasma cost (750 -> 1250)
- Decreased bluespace crystals cost (5 -> 3)

## Why / Balance
Goal is to make bluespace bags more consistent, like they used to be but still with a decent BP crystal cost.

**Changelog**

:cl:
- tweak: Changed bags of holding cost to be more consistent.
