### PR TITLE
Felinids are in your plants: The reckoning.

### DIFF
--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemComponent.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Server.Item.PseudoItem;
 public sealed partial class PseudoItemComponent : Component
 {
     [DataField("size")]
-    public int Size = 120;
+    public int Size = 100;
 
     public bool Active = false;
 }

--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -19,6 +19,11 @@
         density: 190
         mask:
         - Impassable
+  - type: Storage # Delta V - Felinid in plant
+    capacity: 150
+    whitelist:
+      components:
+        - Felinid # Delta V - Felinid in plant till here
   - type: Sprite
     drawdepth: Overdoors
     offset: "0.0,0.3"


### PR DESCRIPTION
Due to implementation of not being able to shoot in any storage being extremely well implemented, it automaticly applies to this, allowin this to be an amazin gimmick like the duffelbag.


Code made by: Leander from Nyano.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
To make the cat in bag mechanic be more than just haha cat in duffelbag.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Felinids now can be in plants.
- tweak: Felinids are now size 100

