### PR TITLE
Prevent pseudoitems from being transferred between bags 

### DIFF
--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -31,6 +31,7 @@ public sealed partial class PseudoItemSystem : EntitySystem
         SubscribeLocalEvent<PseudoItemComponent, GettingPickedUpAttemptEvent>(OnGettingPickedUpAttempt);
         SubscribeLocalEvent<PseudoItemComponent, DropAttemptEvent>(OnDropAttempt);
         SubscribeLocalEvent<PseudoItemComponent, PseudoItemInsertDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<PseudoItemComponent, ContainerGettingInsertedAttemptEvent>(OnInsertAttempt);
     }
 
     private void AddInsertVerb(EntityUid uid, PseudoItemComponent component, GetVerbsEvent<InnateVerb> args)
@@ -156,5 +157,14 @@ public sealed partial class PseudoItemSystem : EntitySystem
         };
 
         _doAfter.TryStartDoAfter(args);
+    }
+
+    private void OnInsertAttempt(EntityUid uid, PseudoItemComponent component,
+        ContainerGettingInsertedAttemptEvent args)
+    {
+        if (!component.Active)
+            return;
+        // This hopefully shouldn't trigger, but this is a failsafe just in case so we dont bluespace them cats
+        args.Cancel();
     }
 }

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -1,18 +1,18 @@
-using System.Threading;
-using Content.Shared.Verbs;
-using Content.Shared.Item;
-using Content.Shared.Hands;
+using Content.Server.DoAfter;
+using Content.Server.Storage.EntitySystems;
 using Content.Shared.DoAfter;
+using Content.Shared.Hands;
 using Content.Shared.IdentityManagement;
+using Content.Shared.Item;
 using Content.Shared.Item.PseudoItem;
 using Content.Shared.Storage;
-using Content.Server.Storage.EntitySystems;
-using Content.Server.DoAfter;
 using Content.Shared.Tag;
+using Content.Shared.Verbs;
 using Robust.Shared.Containers;
 
 namespace Content.Server.Item.PseudoItem;
-public sealed partial class PseudoItemSystem : EntitySystem
+
+public sealed class PseudoItemSystem : EntitySystem
 {
     [Dependency] private readonly StorageSystem _storageSystem = default!;
     [Dependency] private readonly ItemSystem _itemSystem = default!;
@@ -98,7 +98,8 @@ public sealed partial class PseudoItemSystem : EntitySystem
         component.Active = false;
     }
 
-    private void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component, GettingPickedUpAttemptEvent args)
+    private void OnGettingPickedUpAttempt(EntityUid uid, PseudoItemComponent component,
+        GettingPickedUpAttemptEvent args)
     {
         if (args.User == args.Item)
             return;
@@ -112,6 +113,7 @@ public sealed partial class PseudoItemSystem : EntitySystem
         if (component.Active)
             args.Cancel();
     }
+
     private void OnDoAfter(EntityUid uid, PseudoItemComponent component, DoAfterEvent args)
     {
         if (args.Handled || args.Cancelled || args.Args.Used == null)
@@ -120,7 +122,8 @@ public sealed partial class PseudoItemSystem : EntitySystem
         args.Handled = TryInsert(args.Args.Used.Value, uid, component);
     }
 
-    public bool TryInsert(EntityUid storageUid, EntityUid toInsert, PseudoItemComponent component, StorageComponent? storage = null)
+    public bool TryInsert(EntityUid storageUid, EntityUid toInsert, PseudoItemComponent component,
+        StorageComponent? storage = null)
     {
         if (!Resolve(storageUid, ref storage))
             return false;
@@ -143,13 +146,15 @@ public sealed partial class PseudoItemSystem : EntitySystem
         Transform(storageUid).AttachToGridOrMap();
         return true;
     }
-    private void StartInsertDoAfter(EntityUid inserter, EntityUid toInsert, EntityUid storageEntity, PseudoItemComponent? pseudoItem = null)
+
+    private void StartInsertDoAfter(EntityUid inserter, EntityUid toInsert, EntityUid storageEntity,
+        PseudoItemComponent? pseudoItem = null)
     {
         if (!Resolve(toInsert, ref pseudoItem))
             return;
 
         var ev = new PseudoItemInsertDoAfterEvent();
-        var args = new DoAfterArgs(EntityManager, inserter, 5f, ev, toInsert, target: toInsert, used: storageEntity)
+        var args = new DoAfterArgs(EntityManager, inserter, 5f, ev, toInsert, toInsert, storageEntity)
         {
             BreakOnTargetMove = true,
             BreakOnUserMove = true,

--- a/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/PseudoItem/PseudoItemSystem.cs
@@ -143,7 +143,6 @@ public sealed class PseudoItemSystem : EntitySystem
         }
 
         component.Active = true;
-        Transform(storageUid).AttachToGridOrMap();
         return true;
     }
 

--- a/Content.Shared/Nyanotrasen/Item/Components/PseudoItemComponent.cs
+++ b/Content.Shared/Nyanotrasen/Item/Components/PseudoItemComponent.cs
@@ -1,5 +1,5 @@
 
-namespace Content.Server.Item.PseudoItem;
+namespace Content.Shared.Item.PseudoItem;
 
     /// <summary>
     /// For entities that behave like an item under certain conditions,

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Implants.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Item;
+using Content.Shared.Item.PseudoItem;
 using Content.Shared.Lock;
 using Content.Shared.Placeable;
 using Content.Shared.Popups;
@@ -441,6 +442,9 @@ public abstract class SharedStorageSystem : EntitySystem
 
         foreach (var entity in entities.ToArray())
         {
+            if (HasComp<PseudoItemComponent>(entity)) // Nyanotrasen - They dont transfer properly
+                continue;
+
             Insert(target, entity, out _, user: user, targetComp, playSound: false);
         }
 


### PR DESCRIPTION
## About the PR
Just a quick fix that stops people from having 50 felinids in their regular backpack because apparently nothing stops them from doing so.

A better fix might be finding out why pseudoitem doesnt respect the set item size, but this is easier