### PR TITLE
Move paramedic windoor to Delta V directory

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Windoors/windoor.yml
@@ -13,3 +13,11 @@
   components:
   - type: AccessReader
     access: [["Mail"]]
+
+- type: entity
+  parent: WindoorSecure
+  id: WindoorSecureParamedicLocked
+  suffix: Paramedic, Locked
+  components:
+  - type: AccessReader
+    access: [["Paramedic"]]

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -231,11 +231,3 @@
   components:
   - type: AccessReader
     access: [["Atmospherics"]]
-
-- type: entity
-  parent: WindoorSecure
-  id: WindoorSecureParamedicLocked
-  suffix: Paramedic, Locked
-  components:
-  - type: AccessReader
-    access: [["Paramedic"]]


### PR DESCRIPTION
## About the PR
- Preemptively moves the Paramed windoor to DV directory since it was removed upstrea,

## Why / Balance
Wizden just removed it, but since we'll need/use it, this adds it back.
https://github.com/space-wizards/space-station-14/pull/22400/files 
