### PR TITLE
Remove non-salvage testing map from pool

### DIFF
--- a/Resources/Prototypes/Maps/salvage.yml
+++ b/Resources/Prototypes/Maps/salvage.yml
@@ -107,10 +107,10 @@
 
 # """Large""" maps
 
-- type: salvageMap
-  id: StationStation
-  name: "StationStation"
-  mapPath: /Maps/Salvage/stationstation.yml
+#- type: salvageMap #DeltaV: Remove non-salvage testing map from pool
+#  id: StationStation
+#  name: "StationStation"
+#  mapPath: /Maps/Salvage/stationstation.yml
 
 - type: salvageMap
   id: AsteroidBase

--- a/Resources/Prototypes/Maps/salvage.yml
+++ b/Resources/Prototypes/Maps/salvage.yml
@@ -107,10 +107,10 @@
 
 # """Large""" maps
 
-#- type: salvageMap #DeltaV: Remove non-salvage testing map from pool
-#  id: StationStation
-#  name: "StationStation"
-#  mapPath: /Maps/Salvage/stationstation.yml
+- type: salvageMap
+  id: StationStation
+  name: "StationStation"
+  mapPath: /Maps/Salvage/stationstation.yml
 
 - type: salvageMap
   id: AsteroidBase


### PR DESCRIPTION
## About the PR
- Remove testing map from pool.

## Why / Balance
It's not meant for the salvage pool and contains several items that shouldn't be mapped in them.