### PR TITLE
Allows non-wizden species to wear the new markings.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/gauze.yml
@@ -2,7 +2,7 @@
   id: GauzeLefteyePatch
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Harpy, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Vulpkanin
   coloring:
     default:
       type:
@@ -16,7 +16,7 @@
   id: GauzeLefteyeTape
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Harpy, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Vulpkanin
   coloring:
     default:
       type:
@@ -30,7 +30,7 @@
   id: GauzeRighteyePatch
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Harpy, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Vulpkanin
   coloring:
     default:
       type:
@@ -44,7 +44,7 @@
   id: GauzeRighteyeTape
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Harpy, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Vulpkanin
   coloring:
     default:
       type:
@@ -58,7 +58,7 @@
   id: GauzeShoulder
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Harpy, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Vulpkanin
   coloring:
     default:
       type:
@@ -72,7 +72,7 @@
   id: GauzeStomach
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Harpy, Vulpkanin] # Delta V - Felinid, Oni, Harpy, Vulpkanin
   coloring:
     default:
       type:
@@ -86,7 +86,7 @@
   id: GauzeUpperArmRight
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
   coloring:
     default:
       type:
@@ -100,7 +100,7 @@
   id: GauzeLowerArmRight
   bodyPart: RArm, RHand
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
   coloring:
     default:
       type:
@@ -114,7 +114,7 @@
   id: GauzeLeftArm
   bodyPart: LArm, LHand
   markingCategory: Arms
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
   coloring:
     default:
       type:
@@ -128,7 +128,7 @@
   id: GauzeLowerLegLeft
   bodyPart: LFoot
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
   coloring:
     default:
       type:
@@ -142,7 +142,7 @@
   id: GauzeUpperLegLeft
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
   coloring:
     default:
       type:
@@ -156,7 +156,7 @@
   id: GauzeUpperLegRight
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
   coloring:
     default:
       type:
@@ -170,7 +170,7 @@
   id: GauzeLowerLegRight
   bodyPart: RFoot
   markingCategory: Legs
-  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson]
+  speciesRestriction: [Moth, Dwarf, Human, Reptilian, Arachnid, SlimePerson, Felinid, Oni, Vulpkanin] # Delta V - Felinid, Oni, Vulpkanin
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/scars.yml
@@ -2,7 +2,7 @@
   id: ScarEyeRight
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni] # Delta V - Felinid, Oni
   coloring:
     default:
       type:
@@ -16,7 +16,7 @@
   id: ScarEyeLeft
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Human, Dwarf]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni] # Delta V - Felinid, Oni
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -2,7 +2,7 @@
   id: TattooHiveChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:
@@ -16,7 +16,7 @@
   id: TattooNightlingChest
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:
@@ -30,7 +30,7 @@
   id: TattooSilverburghLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:
@@ -44,7 +44,7 @@
   id: TattooSilverburghRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:
@@ -58,7 +58,7 @@
   id: TattooCampbellLeftArm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Felinid, Oni]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni] # Delta V - Felinid, Oni
   coloring:
     default:
       type:
@@ -72,7 +72,7 @@
   id: TattooCampbellRightArm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Felinid, Oni]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni] # Delta V - Felinid, Oni
   coloring:
     default:
       type:
@@ -86,7 +86,7 @@
   id: TattooCampbellLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:
@@ -100,7 +100,7 @@
   id: TattooCampbellRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:
@@ -114,7 +114,7 @@
   id: TattooEyeRight
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:
@@ -128,7 +128,7 @@
   id: TattooEyeLeft
   bodyPart: Eyes
   markingCategory: Head
-  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy]
+  speciesRestriction: [Human, SlimePerson, Reptilian, Dwarf, Felinid, Oni, Harpy] # Delta V - Felinid, Oni, Harpy
   coloring:
     default:
       type:


### PR DESCRIPTION
I do have to note that I did remember to not put arms and even just incase, legs markings on harpys. Also added notes since well. those were changed on a wizden file and not notin it isnt the way, atleast I think so.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Added species to the allowance of what species can have them.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
To ensure that all species have the markings... well not all but still

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/DeltaV-Station/Delta-v/assets/144424013/457b8323-df07-4331-b794-70453796374d)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: Fixed non-wizden species not having markings.

