### PR TITLE
fix: let chaplain pda have a glimmer monitor

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -297,7 +297,7 @@
 
 - type: entity
   name: chaplain PDA
-  parent: BasePDA
+  parent: SciencePDA # DeltaV - Chaplain is part of episetmics
   id: ChaplainPDA
   description: God's chosen PDA.
   components:


### PR DESCRIPTION
## About the PR
Chaplain now gets a glimmer monitor like the rest of Epistemics.

## Why / Balance
Fixes #575.

## Technical details
Chaplain PDA now has the epistemics PDA as a parent.

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
![image](https://github.com/DeltaV-Station/Delta-v/assets/8277780/bb696889-4971-4b48-9f1d-9926d0bf6e4d)


## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Chaplain now gets a glimmer monitor app on their PDA like the rest of epistemics.
