### PR TITLE
deep frier slice fix

### DIFF
--- a/Content.Server/DeltaV/Nutrition/Events.cs
+++ b/Content.Server/DeltaV/Nutrition/Events.cs
@@ -1,0 +1,34 @@
+namespace Content.Server.Nutrition;
+
+/// <summary>
+/// Raised on a food being sliced.
+/// Used by deep frier to apply friedness to slices (e.g. deep fried pizza)
+/// </summary>
+public sealed class SliceFoodEvent : EntityEventArgs
+{
+    /// <summary>
+    /// Who did the slicing?
+    /// <summary>
+    public EntityUid User;
+
+    /// <summary>
+    /// What has been sliced?
+    /// <summary>
+    /// <remarks>
+    /// This could soon be deleted if there was not enough food left to
+    /// continue slicing.
+    /// </remarks>
+    public EntityUid Food;
+
+    /// <summary>
+    /// What is the slice?
+    /// <summary>
+    public EntityUid Slice;
+
+    public SliceFoodEvent(EntityUid user, EntityUid food, EntityUid slice)
+    {
+        User = user;
+        Food = food;
+        Slice = slice;
+    }
+}

--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Nutrition; // DeltaV
 using Content.Server.Nutrition.Components;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.Components.SolutionManager;
@@ -76,12 +77,6 @@ namespace Content.Server.Nutrition.EntitySystems
 
             component.Count--;
 
-            //Nyano - Summary: Begin Nyano Code to tell us we've sliced something for Fryer --
-
-            var sliceEvent = new SliceFoodEvent(user, usedItem, uid, sliceUid);
-            RaiseLocalEvent(uid, sliceEvent);
-            //Nyano - End Nyano Code. 
-
             // If someone makes food proto with 1 slice...
             if (component.Count < 1)
             {
@@ -123,6 +118,11 @@ namespace Content.Server.Nutrition.EntitySystems
                 _containerSystem.AttachParentToContainerOrGrid((sliceUid, xform));
                 xform.LocalRotation = 0;
             }
+
+            // DeltaV - Begin deep frier related code
+            var sliceEvent = new SliceFoodEvent(user, uid, sliceUid);
+            RaiseLocalEvent(uid, sliceEvent);
+            // DeltaV - End deep frier related code
 
             return sliceUid;
         }
@@ -166,40 +166,4 @@ namespace Content.Server.Nutrition.EntitySystems
             args.PushMarkup(Loc.GetString("sliceable-food-component-on-examine-remaining-slices-text", ("remainingCount", component.Count)));
         }
     }
-    //Nyano - Summary: Begin Nyano Code for the sliced food event. 
-    public sealed class SliceFoodEvent : EntityEventArgs
-    {
-        /// <summary>
-        /// Who did the slicing?
-        /// <summary>
-        public EntityUid User;
-
-        /// <summary>
-        /// What did the slicing?
-        /// <summary>
-        public EntityUid Tool;
-
-        /// <summary>
-        /// What has been sliced?
-        /// <summary>
-        /// <remarks>
-        /// This could soon be deleted if there was not enough food left to
-        /// continue slicing.
-        /// </remarks>
-        public EntityUid Food;
-
-        /// <summary>
-        /// What is the slice?
-        /// <summary>
-        public EntityUid Slice;
-
-        public SliceFoodEvent(EntityUid user, EntityUid tool, EntityUid food, EntityUid slice)
-        {
-            User = user;
-            Tool = tool;
-            Food = food;
-            Slice = slice;
-        }
-    }
-    //End Nyano Code. 
 }

--- a/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.cs
+++ b/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.cs
@@ -23,6 +23,7 @@ using Content.Server.Fluids.EntitySystems;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Kitchen.Components;
 using Content.Server.NPC.Components;
+using Content.Server.Nutrition;
 using Content.Server.Nutrition.Components;
 using Content.Server.Nutrition.EntitySystems;
 using Content.Server.Paper;


### PR DESCRIPTION
## About the PR
moves old slice event raising into new `Slice` method which is easier to keep compatible in the future, if upstream adds a new thing that causes it to be sliced it will still inherit deep frying instead of needing to add a copypaste event raise

moved the `SliceFoodEvent` into deltav directory and removed `Tool` field since nothing used it and it would mean modifying `Slice` method to add it (maybe it should be in nyanotrasen directory instead idk)

fixes #439

https://github.com/DeltaV-Station/Delta-v/assets/39013340/e7f43140-a405-4abb-9c01-e163c18e3d8b


(every slice is burned even the last one)