### PR TITLE
Changes Reinforcement TC Cost

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -431,7 +431,7 @@
   productEntity: ReinforcementRadioSyndicate
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 16
+    Telecrystal: 10 # Delta-V - Lowers cost to 10, from 16.
   categories:
   - UplinkUtility
   conditions:
@@ -447,7 +447,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 16
+    Telecrystal: 15 # Delta-V Lowers cost to 15, from 16.
   categories:
   - UplinkUtility
   conditions:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- Drops the TC cost for Syndie Reinforcements to 10, Nukie to 15
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It's never used, primarily because the cost is outrageous especially for a ghostrole. If C4 capable mice are 3TC, why is a human 16? A department-destroying, most-of-the-time round ending bomb is 11TC. 
### The cost is so high, you can literally buy nothing of value for yourself or the person you summon, there's 0 incentive to buy this, even for gimmicks.
What's even the value of *buying* another Operative, who's not on the manifest and starts in the most conspicuous clothing available?
- This makes the Reinforcement *more* valuable while still keeping him too expensive for conventional strategies and *too* expensive for mass-abuse by Nukies.
- The Nukie Cost does *not* lower dramatically because every NukeOp buying a reinforcement could lead to disastrous results.

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: DangerRevolution
- tweak: Syndicate Reinforcement Cost has been lowered to 10TC, Nukie Reinforcement to 15.


