### PR TITLE
bluespace ore bag use bluespace

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -141,8 +141,8 @@
   materials:
     Steel: 2000
     Silver: 750
-    Plasma: 1500
-    Uranium: 150
+    Plasma: 1000 #DeltaV: Bluespace Exists so less plasma used, no uranium
+    Bluespace: 200 #DeltaV: Bluespace Exists
 
 - type: latheRecipe
   id: WeaponCrusher


### PR DESCRIPTION
## About the PR
use 2 bluespace, no uranium and a little less plasma

## Why / Balance
bluespace

since it doesnt need uranium theres a good chance that it might be got when shitsalv isnt mining any uranium

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Ore Bags of Holding now use bluespace crystals instead of uranium.