### PR TITLE
Fix to cyborgs being able to spawn with nearsighted.

### DIFF
--- a/Resources/Prototypes/SimpleStation14/Traits/disabilities.yml
+++ b/Resources/Prototypes/SimpleStation14/Traits/disabilities.yml
@@ -5,4 +5,7 @@
   traitGear: ClothingEyesGlasses
   components:
     - type: Nearsighted
+  whitelist: # Delta V fix to borgs spawning with it.
+    components:
+      - Blindable
 


### PR DESCRIPTION
I absolutely hate that I failed to find the fix until I asked someone.
Fixes #274 

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->


## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
To make it more convenient.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- fix: Fixes cyborgs spawning with nearsighted trait.

