### PR TITLE
remove throw damage from mail

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -92,10 +92,6 @@
     damage:
       types:
         Blunt: 10
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Blunt: 5
 
 # This empty parcel is allowed to exist and evade the tests for the admin
 # mailto command.


### PR DESCRIPTION
## About the PR
disposals gets filled with mail + you flush and get instacrit from full health
that bad so no more mail damage, also ive actually accidentally crit people by opening mail on them because i didnt know it did any damage (Real)

**Changelog**
:cl:
- tweak: Mail no longer has throwing damage.
