### PR TITLE
Adjust book spawner

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/books.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/books.yml
@@ -5,6 +5,8 @@
   placement:
     mode: PlaceFree # want to be able to free place books for stacks, etc.
   components:
+  - type: Transform
+    anchored: false
   - type: Sprite
     layers:
       - sprite: Objects/Misc/books.rsi


### PR DESCRIPTION
## About the PR
Just a quick adjustment that allows for the book spawner to be mapped freely as it was intended in the last PR. 