### PR TITLE
Remove cargo gambling

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -198,12 +198,12 @@
   category: Fun
   group: market
 
-- type: cargoProduct
-  id: FunCrateGambling
-  icon:
-    sprite: Objects/Economy/cash.rsi
-    state: cash_1000000
-  product: CrateCargoGambling
-  cost: 10000
-  category: Fun
-  group: market
+#- type: cargoProduct
+#  id: FunCrateGambling
+#  icon:
+#    sprite: Objects/Economy/cash.rsi
+#    state: cash_1000000
+#  product: CrateCargoGambling
+#  cost: 10000
+#  category: Fun
+#  group: market


### PR DESCRIPTION
## About the PR
This doesn't really have a place in an MRP enviroment, and it just results in cargo gambeling away all money after the recent Liltenhead video