### PR TITLE
Fix Crime Assist incorrect entires and add a test

### DIFF
--- a/Content.IntegrationTests/Tests/DeltaV/CrimeassistTest.cs
+++ b/Content.IntegrationTests/Tests/DeltaV/CrimeassistTest.cs
@@ -1,0 +1,94 @@
+﻿using System.Linq;
+using Content.Shared.DeltaV.CartridgeLoader.Cartridges;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.DeltaV;
+
+[TestFixture]
+public sealed class CrimeAssistTest
+{
+    [Test]
+    public async Task CrimeAssistValid()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        await server.WaitIdleAsync();
+
+        var mapManager = server.ResolveDependency<IMapManager>();
+        var prototypeManager = server.ResolveDependency<IPrototypeManager>();
+
+        var testMap = await pair.CreateTestMap();
+
+        // Get all CrimeAssistPage
+        var allProtos = prototypeManager.EnumeratePrototypes<CrimeAssistPage>().ToArray();
+
+        await server.WaitAssertion(() =>
+        {
+            foreach (var proto in allProtos)
+            {
+                // Assert that ID is unique, and not present a second time in allProtos
+                Assert.That(allProtos.Count(p => p.ID == proto.ID), Is.EqualTo(1),
+                    $"CrimeAssistPage {proto.ID} is not unique!");
+
+                if (proto.LocKey != null)
+                {
+                    Assert.That(Loc.TryGetString(proto.LocKey, out var _),
+                        $"CrimeAssistPage {proto.ID} has invalid LocKey {proto.LocKey}!");
+                }
+
+                if (proto.LocKeyTitle != null)
+                {
+                    Assert.That(Loc.TryGetString(proto.LocKeyTitle, out var _),
+                        $"CrimeAssistPage {proto.ID} has invalid LocKeyTitle {proto.LocKeyTitle}!");
+                }
+
+                if (proto.LocKeyDescription != null)
+                {
+                    Assert.That(Loc.TryGetString(proto.LocKeyDescription, out var _),
+                        $"CrimeAssistPage {proto.ID} has invalid LocKeyDescription {proto.LocKeyDescription}!");
+                }
+
+                if (proto.LocKeySeverity != null)
+                {
+                    Assert.That(Loc.TryGetString(proto.LocKeySeverity, out var _),
+                        $"CrimeAssistPage {proto.ID} has invalid LocKeySeverity {proto.LocKeySeverity}!");
+                }
+
+                if (proto.LocKeyPunishment != null)
+                {
+                    Assert.That(Loc.TryGetString(proto.LocKeyPunishment, out var _),
+                        $"CrimeAssistPage {proto.ID} has invalid LocKeyPunishment {proto.LocKeyPunishment}!");
+                }
+
+                if (proto.OnStart != null)
+                {
+                    Assert.That(allProtos.Any(p => p.ID == proto.OnStart),
+                        $"CrimeAssistPage {proto.ID} has invalid OnStart {proto.OnStart}!");
+                }
+
+                if (proto.OnYes != null)
+                {
+                    Assert.That(allProtos.Any(p => p.ID == proto.OnYes),
+                        $"CrimeAssistPage {proto.ID} has invalid OnYes {proto.OnYes}!");
+                }
+
+                if (proto.OnNo != null)
+                {
+                    Assert.That(allProtos.Any(p => p.ID == proto.OnNo),
+                        $"CrimeAssistPage {proto.ID} has invalid OnNo {proto.OnNo}!");
+                }
+            }
+
+            // Because Server/Client pairs can be re-used between Tests, we
+            // need to clean up anything that might affect other tests,
+            // otherwise this pair cannot be considered clean, and the
+            // CleanReturnAsync call would need to be removed.
+            mapManager.DeleteMap(testMap.MapId);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/DeltaV/CrimeassistTest.cs
+++ b/Content.IntegrationTests/Tests/DeltaV/CrimeassistTest.cs
@@ -17,22 +17,13 @@ public sealed class CrimeAssistTest
         var server = pair.Server;
         await server.WaitIdleAsync();
 
-        var mapManager = server.ResolveDependency<IMapManager>();
         var prototypeManager = server.ResolveDependency<IPrototypeManager>();
-
-        var testMap = await pair.CreateTestMap();
-
-        // Get all CrimeAssistPage
         var allProtos = prototypeManager.EnumeratePrototypes<CrimeAssistPage>().ToArray();
 
         await server.WaitAssertion(() =>
         {
             foreach (var proto in allProtos)
             {
-                // Assert that ID is unique, and not present a second time in allProtos
-                Assert.That(allProtos.Count(p => p.ID == proto.ID), Is.EqualTo(1),
-                    $"CrimeAssistPage {proto.ID} is not unique!");
-
                 if (proto.LocKey != null)
                 {
                     Assert.That(Loc.TryGetString(proto.LocKey, out var _),
@@ -81,12 +72,6 @@ public sealed class CrimeAssistTest
                         $"CrimeAssistPage {proto.ID} has invalid OnNo {proto.OnNo}!");
                 }
             }
-
-            // Because Server/Client pairs can be re-used between Tests, we
-            // need to clean up anything that might affect other tests,
-            // otherwise this pair cannot be considered clean, and the
-            // CleanReturnAsync call would need to be removed.
-            mapManager.DeleteMap(testMap.MapId);
         });
 
         await pair.CleanReturnAsync();

--- a/Resources/Prototypes/DeltaV/cartridges/crimeassistflow.yml
+++ b/Resources/Prototypes/DeltaV/cartridges/crimeassistflow.yml
@@ -120,7 +120,7 @@
 - type: crimeAssistPage
   id: "questionWasCrimeSexualInNature"
   locKey: "crime-assist-question-wascrimesexualinnature"
-  onYes: "resultSexualHarrassment"
+  onYes: "resultSexualHarassment"
   onNo: "questionWasSuspectANuisance"
 
 - type: crimeAssistPage
@@ -279,11 +279,18 @@
   locKeyPunishment: "crime-assist-crimepunishment-contemptofcourt"
 
 - type: crimeAssistPage
-  id: "resultPerjuryOrFalseReport"
-  locKeyTitle: "crime-assist-crime-perjuryorfalsereport"
-  locKeyDescription: "crime-assist-crimedetail-perjuryorfalsereport"
+  id: "resultBlackMarketeering"
+  locKeyTitle: "crime-assist-crime-blackmarketeering"
+  locKeyDescription: "crime-assist-crimedetail-blackmarketeering"
   locKeySeverity: "crime-assist-crimetype-felony"
-  locKeyPunishment: "crime-assist-crimepunishment-perjuryorfalsereport"
+  locKeyPunishment: "crime-assist-crimepunishment-blackmarketeering"
+
+- type: crimeAssistPage
+  id: "resultPerjuryOrFalseReport"
+  locKeyTitle: "crime-assist-crime-perjuryfalsereport"
+  locKeyDescription: "crime-assist-crimedetail-perjuryfalsereport"
+  locKeySeverity: "crime-assist-crimetype-felony"
+  locKeyPunishment: "crime-assist-crimepunishment-perjuryfalsereport"
 
 - type: crimeAssistPage
   id: "resultObstructionOfJustice"
@@ -335,8 +342,8 @@
   locKeyPunishment: "crime-assist-crimepunishment-sedition"
 
 - type: crimeAssistPage
-  id: "resultSexualHarrassment"
-  locKeyTitle: "crime-assist-crime-sexualharrassment"
-  locKeyDescription: "crime-assist-crimedetail-sexualharrassment"
+  id: "resultSexualHarassment"
+  locKeyTitle: "crime-assist-crime-sexualharassment"
+  locKeyDescription: "crime-assist-crimedetail-sexualharassment"
   locKeySeverity: "crime-assist-crimetype-capital"
-  locKeyPunishment: "crime-assist-crimepunishment-sexualharrassment"
+  locKeyPunishment: "crime-assist-crimepunishment-sexualharassment"


### PR DESCRIPTION
## About the PR
This adds a test that ensures all CrimeAssistPage's are valid, and will prevent any future issues where the program can display locstrings or get stuck on a page and error out.