### PR TITLE
give revs a chance

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -81,7 +81,8 @@
   noSpawn: true
   components:
   - type: RevolutionaryRule
-    maxHeadRevs: 1 # DeltaV
+    maxHeadRevs: 2 # DeltaV
+    playersPerHeadRev: 30 # DeltaV - need highpop readied up for multiple headrevs
 
 - type: entity
   id: Sandbox


### PR DESCRIPTION
## About the PR
increase headrevs from 1 max to 2 max with 60 people readied up, to give them a slight chance of winning

## Why / Balance
i dont recall a single time revs took over the station, though its been close with certain good headrevs, being alone is crippling on highpop. since it requires a lot of people readying up it'll still usually be 1 headrev, though on 100p its quite possible to have 2 now.

ideally theyd be told who other headrevs are roundstart to coordinate with them instead of having the round ruined by someone flashing in hallways 5 seconds into the round and instantly alerting everyone, but thats for upstream

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: On very high pop revolution rounds, there can be 2 head revolutionaries.