### PR TITLE
Fix psionic invisiblity to others

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -204,6 +204,10 @@
   - type: GuideHelp
     guides:
       - Cyborgs
+  - type: Eye
+    visMask:
+      - PsionicInvisibility
+      - Normal
 
 - type: entity
   id: BaseBorgChassisNT

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -4,6 +4,12 @@
   name: admin observer
   noSpawn: true
   components:
+  - type: Eye
+    visMask:
+      - TelegnosticProjection
+      - PsionicInvisibility
+      - Ghost
+      - Normal
   - type: ContentEye
     maxZoom: 8.916104, 8.916104
   - type: Tag

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -27,6 +27,11 @@
         - GhostImpassable
   - type: Eye
     drawFov: false
+    visMask:
+      - TelegnosticProjection
+      - PsionicInvisibility
+      - Ghost
+      - Normal
   - type: Input
     context: "ghost"
   - type: Examiner

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -69,6 +69,10 @@
   - type: Tag
     tags:
       - ShoesRequiredStepTriggerImmune
+  - type: Eye
+    visMask:
+      - PsionicInvisibility
+      - Normal
 
 - type: entity
   name: drone


### PR DESCRIPTION
## About the PR
Fix https://github.com/DeltaV-Station/Delta-v/issues/647

## Technical details
Set Visibility Flags to cyborgs and ghost, to see players with PsionicInvisibility power.

## Media
What see user with power
![514e8d41522854c1](https://github.com/DeltaV-Station/Delta-v/assets/42233446/7e68b3a0-003d-4be0-bd26-224cfef241e2)

What see human (any race)
![f4ba0938260a7a6c](https://github.com/DeltaV-Station/Delta-v/assets/42233446/47b2e20a-3a4d-4df5-b744-b168456593c7)

What see cyborgs/silicons
![fc6e5be076cb2f17](https://github.com/DeltaV-Station/Delta-v/assets/42233446/b50f4c75-c2fd-45e9-8a9b-aad27c616e6c)

What see ghost
![1256ad070ef73104](https://github.com/DeltaV-Station/Delta-v/assets/42233446/478111d2-6173-432e-a4a0-7a975b484c39)

Also its show telegnostic projection for ghost now
![изображение](https://github.com/DeltaV-Station/Delta-v/assets/42233446/80c97ace-b346-4fb0-bc01-ec39df74b2da)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl:
- fix: Entities that are psionically invisible now show for ghosts and borgs

