### PR TITLE
Increase nuclear operative playtime requirements.

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -9,7 +9,7 @@
     time: 108000 # DeltaV - 30 hours
   - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
     department: Security
-    time: 36000 # DeltaV - 10 hours
+    time: 54000 # DeltaV - 15 hours
 
 - type: antag
   id: NukeopsMedic
@@ -19,10 +19,14 @@
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 108000 # DeltaV - 30 hours
+    time: 162000 # DeltaV - 45 hours
   - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
     department: Medical
+    time: 54000 # DeltaV - 15 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
+    department: Security  
     time: 36000 # DeltaV - 10 hours
+  - !type:WhitelistRequirement # DeltaV - Whitelist requirement
 
 - type: antag
   id: NukeopsCommander
@@ -35,8 +39,11 @@
     time: 216000 # DeltaV - 60 hours
   - !type:DepartmentTimeRequirement # DeltaV - Security dept time requirement
     department: Security
+    time: 108000 # DeltaV - 30 hours
+  - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
+    department: Medical
     time: 36000 # DeltaV - 10 hours
   - !type:DepartmentTimeRequirement # DeltaV - Command dept time requirement
     department: Command
-    time: 36000 # DeltaV - 10 hours
+    time: 54000 # DeltaV - 15 hours
   - !type:WhitelistRequirement # DeltaV - Whitelist requirement


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Here are the changes made to nukie requirements in this PR.

Nuclear Operative:
General Playtime: 30h > 30h
Security Playtime: 10h > 15h
Whitelist Needed: No > No

Nuclear Operative Agent:
General Playtime: 30h > 45h
Security Playtime: 0h > 10h
Medical Playtime: 10h > 15h
Whitelist Needed: No > Yes

Nuclear Operative Commander:
General Playtime: 60h > 60h
Security Playtime: 10h > 30h
Medical Playtime: 0h > 10h
Command Playtime: 10h > 15h
Whitelist Needed: Yes > Yes

## Why / Balance
Some tweaks were done to need a few more hours for commander and regular nukie, but over all these are solid as is.
However the main issue in my opinion is the nuclear operative agent/medic. Too many people simply turn it on because "More chance for me to play nukie" but when they actually get it, completely neglect their responsibility to play the teams healer and prepare meds for that task, sometimes even asking others to take over the role, hardsuit, and hypospray entirely. As such, I gave its requirements a drastic boost, including needing a whitelist to play, in the hope that those with a whitelist are smart enough to turn off nukie medic if they don't want to play as the nukies MEDIC, or do not know enough to do so.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up. -->
:cl:
- tweak: Cybersun has raised the requirements for those attempting to sign up for the elite division of Syndicate Nuclear Operatives, especially for agents/medics.

