### PR TITLE
prevent shock collar clock

### DIFF
--- a/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarSystem.cs
+++ b/Content.Server/Nyanotrasen/Item/ShockCollar/ShockCollarSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Mobs.Components;
+using Content.Shared.Timing;
 using Content.Server.Explosion.EntitySystems; // Why is trigger under explosions by the way? Even doors already use it.
 using Content.Server.Electrocution;
 using Robust.Shared.Containers;
@@ -9,6 +10,8 @@ public sealed partial class ShockCollarSystem : EntitySystem
 {
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly ElectrocutionSystem _electrocutionSystem = default!;
+    [Dependency] private readonly UseDelaySystem _useDelay = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -24,6 +27,13 @@ public sealed partial class ShockCollarSystem : EntitySystem
 
         if (!HasComp<MobStateComponent>(containerEnt)) // If it's not a mob we don't care
             return;
+
+        // DeltaV: prevent clocks from instantly killing people
+        TryComp<UseDelayComponent>(uid, out var useDelay);
+        if (_useDelay.ActiveDelay(uid, useDelay))
+            return;
+
+        _useDelay.BeginDelay(uid, useDelay);
 
         _electrocutionSystem.TryDoElectrocution(containerEnt, null, 5, TimeSpan.FromSeconds(2), true);
     }

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/shock_collar.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/shock_collar.yml
@@ -2,13 +2,15 @@
   parent: ClothingNeckBase
   id: ShockCollar
   name: shock collar
-  description: Shocking. Placeholder sprite.
+  description: Shocking. # DeltaV: sprite is fine
   components:
   - type: Sprite
     sprite: Nyanotrasen/Clothing/Neck/Misc/shock.rsi
   - type: Clothing
     sprite: Nyanotrasen/Clothing/Neck/Misc/shock.rsi
   - type: ShockCollar
+  - type: UseDelay
+    delay: 3 # DeltaV: prevent clocks instakilling people
   - type: TriggerOnSignal
   - type: DeviceNetwork
     deviceNetId: Wireless


### PR DESCRIPTION
## About the PR
give shock collar 3s delay between shocks

also remove placeholder sprite from the desc since imo it looks fine

## Why / Balance
while i think its funny to make a clock collar and instantly suicide it could be abused by shitter felinids / traitors who just buy thieving gloves to instantly round remove their kill targets

so thats no longer a thing you have to actually wait a good amount of time for them to die

## Technical details
its use delay

## Media
trust

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
only me and like 2 people even know how to use shock collars :trollface: