### PR TITLE
Added Drain on Pebble

### DIFF
--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -35095,6 +35095,13 @@ entities:
       type: Transform
     - fixtures: {}
       type: Fixtures
+  - uid: 7946
+    components:
+    - pos: -16.5,13.5
+      parent: 2
+      type: Transform
+    - fixtures: {}
+      type: Fixtures
 - proto: FloorLavaEntity
   entities:
   - uid: 5452


### PR DESCRIPTION
## About the PR
Added a drain on Pebble Map

Got Carolyn's approval

## Why / Balance
Forgot to add it on the PR#662 adding the ChemVend to Pebble.

## Technical details
None...

## Media
![image](https://github.com/DeltaV-Station/Delta-v/assets/45323530/1dd7ee3a-c529-4af2-a2ff-4808cc98fbff)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None.

**Changelog**
- tweak: Added a drain on Pebble inside of the Chemistry laboratory