### PR TITLE
Prevent zombies from becoming psionic

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/DispelPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/DispelPowerSystem.cs
@@ -53,12 +53,20 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.DispelActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+            {
                 psionic.PsionicAbility = component.DispelActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
         }
 
         private void OnShutdown(EntityUid uid, DispelPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.DispelActionEntity);
+
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnPowerUsed(DispelPowerActionEvent args)

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MetapsionicPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MetapsionicPowerSystem.cs
@@ -36,13 +36,21 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.MetapsionicActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
-                psionic.PsionicAbility = component.MetapsionicActionEntity; 
-                
+            {
+                psionic.PsionicAbility = component.MetapsionicActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
+
         }
 
         private void OnShutdown(EntityUid uid, MetapsionicPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.MetapsionicActionEntity);
+
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnPowerUsed(EntityUid uid, MetapsionicPowerComponent component, MetapsionicPowerActionEvent args)

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -49,12 +49,19 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.MindSwapActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+            {
                 psionic.PsionicAbility = component.MindSwapActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
         }
 
         private void OnShutdown(EntityUid uid, MindSwapPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.MindSwapActionEntity);
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnPowerUsed(MindSwapPowerActionEvent args)
@@ -166,7 +173,7 @@ namespace Content.Server.Abilities.Psionics
                 targetMind = null;
             };
             //This is a terrible way to 'unattach' minds. I wanted to use UnVisit but in TransferTo's code they say
-            //To unnatch the minds, do it like this. 
+            //To unnatch the minds, do it like this.
             //Have to unnattach the minds before we reattach them via transfer. Still feels weird, but seems to work well.
             _mindSystem.TransferTo(performerMindId, null);
             _mindSystem.TransferTo(targetMindId, null);

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/NoosphericZapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/NoosphericZapPowerSystem.cs
@@ -38,12 +38,19 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.NoosphericZapActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+            {
                 psionic.PsionicAbility = component.NoosphericZapActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
         }
 
         private void OnShutdown(EntityUid uid, NoosphericZapPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.NoosphericZapActionEntity);
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnPowerUsed(NoosphericZapPowerActionEvent args)

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PsionicInvisibilityPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PsionicInvisibilityPowerSystem.cs
@@ -46,12 +46,19 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.PsionicInvisibilityActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+            {
                 psionic.PsionicAbility = component.PsionicInvisibilityActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
         }
 
         private void OnShutdown(EntityUid uid, PsionicInvisibilityPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.PsionicInvisibilityActionEntity);
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnPowerUsed(EntityUid uid, PsionicInvisibilityPowerComponent component, PsionicInvisibilityPowerActionEvent args)

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PsionicRegenerationPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PsionicRegenerationPowerSystem.cs
@@ -57,7 +57,10 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.PsionicRegenerationActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+            {
                 psionic.PsionicAbility = component.PsionicRegenerationActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
         }
 
         private void OnPowerUsed(EntityUid uid, PsionicRegenerationPowerComponent component, PsionicRegenerationPowerActionEvent args)
@@ -84,6 +87,11 @@ namespace Content.Server.Abilities.Psionics
         private void OnShutdown(EntityUid uid, PsionicRegenerationPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.PsionicRegenerationActionEntity);
+
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnDispelled(EntityUid uid, PsionicRegenerationPowerComponent component, DispelledEvent args)

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PyrokinesisPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/PyrokinesisPowerSystem.cs
@@ -35,12 +35,19 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.PyrokinesisActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+            {
                 psionic.PsionicAbility = component.PyrokinesisActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
         }
 
         private void OnShutdown(EntityUid uid, PyrokinesisPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.PyrokinesisActionEntity);
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnPowerUsed(PyrokinesisPowerActionEvent args)

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/TelegnosisPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/TelegnosisPowerSystem.cs
@@ -35,12 +35,19 @@ namespace Content.Server.Abilities.Psionics
             if (actionData is { UseDelay: not null })
                 _actions.StartUseDelay(component.TelegnosisActionEntity);
             if (TryComp<PsionicComponent>(uid, out var psionic) && psionic.PsionicAbility == null)
+            {
                 psionic.PsionicAbility = component.TelegnosisActionEntity;
+                psionic.ActivePowers.Add(component);
+            }
         }
 
         private void OnShutdown(EntityUid uid, TelegnosisPowerComponent component, ComponentShutdown args)
         {
             _actions.RemoveAction(uid, component.TelegnosisActionEntity);
+            if (TryComp<PsionicComponent>(uid, out var psionic))
+            {
+                psionic.ActivePowers.Remove(component);
+            }
         }
 
         private void OnPowerUsed(EntityUid uid, TelegnosisPowerComponent component, TelegnosisPowerActionEvent args)

--- a/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericStormRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericStormRule.cs
@@ -30,7 +30,7 @@ internal sealed class NoosphericStormRule : StationEventSystem<NoosphericStormRu
                 continue;
 
             // Skip over those who are already psionic or those who are insulated, or zombies.
-            if (HasComp<PsionicComponent>(potentialPsionic) || HasComp<PsionicInsulationComponent>(potentialPsionic) && !HasComp<ZombieComponent>(potentialPsionic))
+            if (HasComp<PsionicComponent>(potentialPsionic) || HasComp<PsionicInsulationComponent>(potentialPsionic) || HasComp<ZombieComponent>(potentialPsionic))
                 continue;
 
             validList.Add(potentialPsionic);

--- a/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericStormRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericStormRule.cs
@@ -6,6 +6,7 @@ using Content.Server.Psionics;
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Psionics.Glimmer;
+using Content.Shared.Zombies;
 
 namespace Content.Server.StationEvents.Events;
 
@@ -28,8 +29,8 @@ internal sealed class NoosphericStormRule : StationEventSystem<NoosphericStormRu
             if (_mobStateSystem.IsDead(potentialPsionic))
                 continue;
 
-            // Skip over those who are already psionic or those who are insulated.
-            if (HasComp<PsionicComponent>(potentialPsionic) || HasComp<PsionicInsulationComponent>(potentialPsionic))
+            // Skip over those who are already psionic or those who are insulated, or zombies.
+            if (HasComp<PsionicComponent>(potentialPsionic) || HasComp<PsionicInsulationComponent>(potentialPsionic) && !HasComp<ZombieComponent>(potentialPsionic))
                 continue;
 
             validList.Add(potentialPsionic);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -1,3 +1,4 @@
+using Content.Server.Actions;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Components;
 using Content.Server.Chat;
@@ -15,6 +16,7 @@ using Content.Server.NPC.Systems;
 using Content.Server.Roles;
 using Content.Server.Speech.Components;
 using Content.Server.Temperature.Components;
+using Content.Shared.Abilities.Psionics;
 using Content.Shared.CombatMode;
 using Content.Shared.CombatMode.Pacification;
 using Content.Shared.Damage;
@@ -59,6 +61,7 @@ namespace Content.Server.Zombies
         [Dependency] private readonly SharedRoleSystem _roles = default!;
         [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
+        [Dependency] private readonly ActionsSystem _actions = default!; // DeltaV - No psionic zombies
 
         /// <summary>
         /// Handles an entity turning into a zombie when they die or go into crit
@@ -102,8 +105,21 @@ namespace Content.Server.Zombies
             RemComp<BarotraumaComponent>(target);
             RemComp<HungerComponent>(target);
             RemComp<ThirstComponent>(target);
-            RemComp<ReproductiveComponent>(target); 
+            RemComp<ReproductiveComponent>(target);
             RemComp<ReproductivePartnerComponent>(target);
+
+            if (TryComp<PsionicComponent>(target, out var psionic)) // DeltaV - Prevent psionic zombies
+            {
+                if (psionic.ActivePowers.Count > 0)
+                {
+                    foreach (var power in psionic.ActivePowers)
+                    {
+                        RemComp(target, power);
+                    }
+                    psionic.ActivePowers.Clear();
+                }
+                RemComp<PsionicComponent>(target);
+            }
 
             //funny voice
             var accentType = "zombie";

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/PsionicComponent.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/PsionicComponent.cs
@@ -13,5 +13,8 @@ namespace Content.Shared.Abilities.Psionics
         /// </summary>
         [DataField("removable")]
         public bool Removable = true;
+
+        [DataField("activePowers")]
+        public HashSet<Component> ActivePowers = new();
     }
 }


### PR DESCRIPTION
## About the PR
They're braindead, and people just use it to bypass chat restrictions

## Why / Balance
Some arguments got made against removing it, and while I do think they're good, people won't roleplay those out except in very rare cases. I already don't like zombies, and I don't think changing how people play them is very possible. So this is the next best thing

## Technical details
PsionicComponent now tracks which powers all got added. For whatever reason, you can have multiple powers, but PsionicAbility only accounts for one and wont resolve to the component that needs to be removed. 

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- remove: Zombies can no longer be psionic
