### PR TITLE
qol tweak: More context about how to access traitor uplink in character menu

### DIFF
--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-traitor.ftl
@@ -40,4 +40,4 @@ traitor-role-uplink-code =
 traitor-role-codewords-short =
     The codewords are:
     {$codewords}.
-traitor-role-uplink-code-short = Your uplink code is {$code}.
+traitor-role-uplink-code-short = Your uplink code is {$code}. Set your PDA ringtone to this to access uplink.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Add a bit more context about what the traitor codes actually mean to uplink menu

## Why / Balance
It's already displayed in the chat menu but from experience dumb people like me don't see the message or cannot read it because of reconnecting mid-round, or it is just so far up the chat log that it is sort of inconvenient to search for

My first traitor round I had to reconnect at the start of the game and so I spent the first 20 minutes of the round trying to figure out how to use the uplink code in the character menu; the PDA ringtone is, of course, easy to remember but not very intuitive for a new player - specifically adding it to the character menu clears a lot of confusion I feel, as it is the place that people go to to check antag status/tasks condensing useful information there seems to be the right thing to do

## Technical details

## Media

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
