### PR TITLE
Map Hotfixes

### DIFF
--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -53946,9 +53946,9 @@ entities:
       pos: 42.5,-59.5
       parent: 6747
       type: Transform
-  - uid: 17770
+  - uid: 17611
     components:
-    - pos: 51.086426,9.452867
+    - pos: 50.5,9.5
       parent: 6747
       type: Transform
   - uid: 23562
@@ -57558,6 +57558,11 @@ entities:
     components:
     - rot: -1.5707963267948966 rad
       pos: -9.5,-5.5
+      parent: 6747
+      type: Transform
+  - uid: 17785
+    components:
+    - pos: 51.5,8.5
       parent: 6747
       type: Transform
 - proto: ComputerMassMedia
@@ -128631,7 +128636,7 @@ entities:
           maxVol: 25
           reagents:
           - data: null
-            ReagentId: Codeine
+            ReagentId: Bananadine
             Quantity: 15
       type: SolutionContainerManager
     - canCollide: False
@@ -129655,6 +129660,13 @@ entities:
     - pos: 32.5,-95.5
       parent: 6747
       type: Transform
+- proto: PottedPlant29
+  entities:
+  - uid: 17770
+    components:
+    - pos: 52.691494,9.715378
+      parent: 6747
+      type: Transform
 - proto: PottedPlant3
   entities:
   - uid: 4758
@@ -129970,11 +129982,6 @@ entities:
   - uid: 12020
     components:
     - pos: 55.5,25.5
-      parent: 6747
-      type: Transform
-  - uid: 17785
-    components:
-    - pos: 50.5,9.5
       parent: 6747
       type: Transform
   - uid: 18623
@@ -151114,8 +151121,8 @@ entities:
       type: Transform
   - uid: 19076
     components:
-    - rot: -1.5707963267948966 rad
-      pos: 51.73348,8.584921
+    - rot: 1.5707963267948966 rad
+      pos: 50.514412,8.652139
       parent: 6747
       type: Transform
 - proto: SubstationWallBasic
@@ -155250,12 +155257,6 @@ entities:
     components:
     - rot: 1.5707963267948966 rad
       pos: 50.5,8.5
-      parent: 6747
-      type: Transform
-  - uid: 17611
-    components:
-    - rot: 1.5707963267948966 rad
-      pos: 51.5,8.5
       parent: 6747
       type: Transform
 - proto: TaikoInstrument

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -119025,6 +119025,27 @@ entities:
       pos: -75.31066,9.590001
       parent: 1
       type: Transform
+- proto: MagazineShotgun
+  entities:
+  - uid: 25842
+    components:
+    - pos: 76.59831,15.676351
+      parent: 1
+      type: Transform
+- proto: MagazineShotgunBeanbag
+  entities:
+  - uid: 25841
+    components:
+    - pos: 76.34831,15.645079
+      parent: 1
+      type: Transform
+- proto: MagazineShotgunSlug
+  entities:
+  - uid: 25843
+    components:
+    - pos: 76.78581,15.624231
+      parent: 1
+      type: Transform
 - proto: MagicDiceBag
   entities:
   - uid: 3889


### PR DESCRIPTION
## About the PR
Arena
- Fixes pill containing obsolete reagent
- Adds ID computer in CE office

The Hive
- Gives HoS some ammo