### PR TITLE
Fix SpareIdCabinet prototypes

### DIFF
--- a/Resources/Maps/asterisk.yml
+++ b/Resources/Maps/asterisk.yml
@@ -57413,7 +57413,7 @@ entities:
       pos: -10.5,-23.5
       parent: 2
       type: Transform
-- proto: SpareIdCabinet
+- proto: SpareIdCabinetFilled
   entities:
   - uid: 11105
     components:

--- a/Resources/Maps/edge.yml
+++ b/Resources/Maps/edge.yml
@@ -91218,7 +91218,7 @@ entities:
     - pos: -49.5,-12.5
       parent: 2
       type: Transform
-- proto: SpareIdCabinet
+- proto: SpareIdCabinetFilled
   entities:
   - uid: 16973
     components:

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -139139,7 +139139,7 @@ entities:
       pos: 91.5,13.5
       parent: 1
       type: Transform
-- proto: SpareIdCabinet
+- proto: SpareIdCabinetFilled
   entities:
   - uid: 25840
     components:


### PR DESCRIPTION
These are all one line changes done by directly editing the map file.

If it creates merge conflicts, just find and replace `SpareIdCabinet` with `SpareIdCabinetFilled` in your map file.