### PR TITLE
Gamemode votes

### DIFF
--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -6,6 +6,10 @@ soft_max_players = 50
 rules_file   = "Rules.txt"
 rules_header = "ui-rules-header"
 
+[vote]
+preset_enabled = true
+map_enabled = true
+
 [whitelist]
 enabled     = false
 reason      = "whitelist-not-whitelisted"

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -3,7 +3,7 @@
   alias:
     - survival
   name: survival-title
-  showInVote: false # secret
+  showInVote: true # secret # DeltaV - Me when the survival. Used for periapsis.
   description: survival-description
   rules:
     - RampingStationEventScheduler
@@ -14,7 +14,7 @@
   - extended
   - shittersafari
   name: extended-title
-  showInVote: false #2boring2vote
+  showInVote: true #2boring2vote # DeltaV - I'd like to disagree, used for periapsis.
   description: extended-description
   rules:
   - BasicStationEventScheduler


### PR DESCRIPTION
Just allows people to vote for extended, survival or secret. These votes literally never get called anyways so might aswell use them to let people choose on the low pop server. Also maps. Dunno why they're disabled by default but I guess we'll find out.

**Changelog**
:cl:
- tweak: Enabled gamerule voting on periapsis
- tweak: Enabled map voting on periapsis
