### PR TITLE
Update Salvage Vend

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -144,7 +144,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockSalvageEquipmentFilled
-  cost: 1000
+  cost: 1660 # DeltaV
   category: Engineering
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/salvage.yml
@@ -1,6 +1,13 @@
 ﻿- type: vendingMachineInventory
   id: SalvageEquipmentInventory
   startingInventory:
+    ClothingBackpackSalvage: 3 # DeltaV
+    ClothingBackpackSatchelSalvage: 3 # DeltaV
+    ClothingBackpackDuffelSalvage: 3 # DeltaV
+    ClothingUniformJumpsuitSalvageSpecialist: 3 # DeltaV
+    ClothingShoesBootsSalvage: 3 # DeltaV
+    ClothingMaskGasExplorer: 4 # DeltaV
+    ClothingBeltSalvageWebbing: 5 # DeltaV
     Crowbar: 2
     Pickaxe: 4
     OreBag: 4


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Updated Salvage's vend machine to offer proper gear, as there's currently no in-game way of getting salvage gear other than it being mapped in. Gear added to salvage's vending machine is 3 of each bag type, 4 tactical gas masks, 3 salvage boots, and 5 salvage webbing.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Gives salvage proper gear that doesn't require map-ins.

**Changelog**

:cl:
- add: Added salvage gear to salvage vending machine.