### PR TITLE
SlowOnDamage lessened + Moth buff

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -89,8 +89,8 @@
     species: Human
   - type: SlowOnDamage
     speedModifierThresholds:
-      60: 0.7
-      80: 0.5
+      60: 0.8
+      80: 0.6
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -90,7 +90,7 @@
   - type: SlowOnDamage
     speedModifierThresholds:
       60: 0.8 # DV - Was 0.7
-      80: 0.6 # DV - Was 0.6
+      80: 0.6 # DV - Was 0.5
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -89,8 +89,8 @@
     species: Human
   - type: SlowOnDamage
     speedModifierThresholds:
-      60: 0.8
-      80: 0.6
+      60: 0.8 # DV - Was 0.7
+      80: 0.6 # DV - Was 0.6
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -54,7 +54,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 1.5 # moths burn more easily
+        Heat: 4 # moths burn more easily
   - type: Temperature # Moths hate the heat and thrive in the cold.
     heatDamageThreshold: 320
     coldDamageThreshold: 230

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -54,7 +54,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 4.5 # moths burn more easily
+        Heat: 1.5 # moths burn more easily
   - type: Temperature # Moths hate the heat and thrive in the cold.
     heatDamageThreshold: 320
     coldDamageThreshold: 230

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -54,7 +54,7 @@
   - type: Flammable
     damage:
       types:
-        Heat: 4 # moths burn more easily
+        Heat: 4 # DV - Reduced by .5
   - type: Temperature # Moths hate the heat and thrive in the cold.
     heatDamageThreshold: 320
     coldDamageThreshold: 230


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## The Changes Are:
SlowOnDamage values changed from
_60dmg 0.7 -> 0.8
80dmg 0.5 -> 0.6_

Moth Heat weakness lessened from
_4.5 -> 4_

## Why / Balance
SlowOnDamage values are changed to the much older Nyano balance changes, this was one of the most well received balance changes, it is a simple change in speed but helps assist in making death spiral moments feel considerably better. Players have a number of sources to be slowed down by already, and this allows melee combat to be a bit more engaging.

~

~Moth heat weakness used to be 2, for some reason it's cranked up to 4.5 of all things. Players would complain about the old 2 modifier, and with how damage is dealt with Heat currently this means there's some comical ways to take out Moth players. A 1.5 weakness is still **plenty** but should allow the on fire moth a little bit more wiggle room in having someone douse them if they catch fire. _(Or when getting shot at by a laser gun...)_~

~

These changes are bundled together due to being both simple yml changes in the same folder, as well as also balance changes of a similar vein (improving the play experience of the players)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase




:cl: ODJ
- tweak: Moth's now take less heat dmg.
- tweak: You now move a little faster when hurt than previously


