### PR TITLE
Add prisoner latejoin cryopod

### DIFF
--- a/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ContainerSpawnPointSystem.cs
@@ -26,8 +26,8 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
         if (args.SpawnResult != null)
             return;
 
-        // DeltaV - Prevent spawnpoint overrides from being ignored
-        if (args.DesiredSpawnPointType != null && args.DesiredSpawnPointType != SpawnPointType.Unset)
+        // DeltaV - Ignore these two desired spawn types
+        if (args.DesiredSpawnPointType is SpawnPointType.Observer or SpawnPointType.LateJoin)
             return;
 
         var query = EntityQueryEnumerator<ContainerSpawnPointComponent, ContainerManagerComponent, TransformComponent>();
@@ -37,6 +37,16 @@ public sealed class ContainerSpawnPointSystem : EntitySystem
         {
             if (args.Station != null && _station.GetOwningStation(uid, xform) != args.Station)
                 continue;
+
+            // DeltaV - Custom override for override spawnpoints, only used for prisoners currently. This shouldn't run for any other jobs
+            if (args.DesiredSpawnPointType == SpawnPointType.Job)
+            {
+                if (spawnPoint.SpawnType != SpawnPointType.Job || spawnPoint.Job != args.Job?.Prototype)
+                    continue;
+
+                possibleContainers.Add((uid, spawnPoint, container, xform));
+                continue;
+            }
 
             // If it's unset, then we allow it to be used for both roundstart and midround joins
             if (spawnPoint.SpawnType == SpawnPointType.Unset)

--- a/Resources/Prototypes/DeltaV/Entities/Structures/cryopod.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/cryopod.yml
@@ -1,0 +1,9 @@
+﻿- type: entity
+  parent: CryogenicSleepUnit
+  id: CryogenicSleepUnitSpawnerPrisoner
+  suffix: Spawner, Prisoner
+  components:
+    - type: ContainerSpawnPoint
+      containerId: storage
+      spawnType: Job
+      job: Prisoner


### PR DESCRIPTION
## About the PR
A special cryopod that only allows prisoners to pop out of it.

## Why / Balance
Why not, if Velcro wants the prison to have a cryopod we might aswell

## Technical details
Alters the containerspawn code even more to ensure that when the preferred spawnpoint is overwritten to job it'll prioritize cryopods that have the same job, while still ignoring any that don't meet those exact requirements.

# IMPORTANT
This doesn't mean you can skip mapping prisoner latejoin spots. If you do, its very likely they'll spawn at the latejoin spawnpoints if all cryopods are in use.

ContainerSpawnSystem will only spawn someone in a cryopod if there isn't someone inside it already.

## Breaking changes
Hopefully doesnt break shit, but I have no idea what I'm doing so who knows

**Changelog**

:cl:
- tweak: Prisoners can now spawn from a special cryopod that can be put in security, instead of magically appearing in a cell.
