### PR TITLE
Gives martial artist the same access and time reqs as boxer

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/martialartist.yml
@@ -3,15 +3,18 @@
   name: job-name-martialartist
   description: job-description-martialartist
   playTimeTracker: JobMartialArtist
+  requirements:
+    - !type:OverallPlaytimeRequirement
+      time: 7200 #2 hours
   startingGear: MartialArtistGear
   icon: "JobIconMartialArtist"
   supervisors: job-supervisors-hop
   setPreference: true
 #  whitelistRequired: true
   access:
-  - Service
-  extendedAccess:
   - Maintenance
+  - Theatre # DeltaV - Add Theatre access
+  - Boxer # DeltaV - Add Boxer access
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
## About the PR
Title 

## Why / Balance
MA is the same as Boxer just specific to Shoukou Station. This aligns them with the same accesses and time requirements. 

:cl: Velcroboy
- fix: Fixed martial artist access
