### PR TITLE
Modify antagAdvantage values.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -12,7 +12,6 @@
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"
   supervisors: job-supervisors-rd
-  antagAdvantage: 5 # DeltaV - From 4 to 5
   canBeAntag: true # DeltaV - Mantis is no longer a Detective
   # whitelistRequired: true
   access:

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -3,7 +3,6 @@
   name: job-name-cargotech
   description: job-description-cargotech
   playTimeTracker: JobCargoTechnician
-  antagAdvantage: 2 # DeltaV - Reduced TC: External Access
   startingGear: CargoTechGear
   icon: "JobIconCargoTechnician"
   supervisors: job-supervisors-qm

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -3,7 +3,7 @@
   name: job-name-salvagespec
   description: job-description-salvagespec
   playTimeTracker: JobSalvageSpecialist
-  antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Free hardsuit and weapons
+  antagAdvantage: 2 # DeltaV - Reduced TC: Free hardsuit and weapons
   requirements:
     - !type:DepartmentTimeRequirement
       department: Logistics # DeltaV - Logistics Department replacing Cargo

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -10,7 +10,6 @@
   icon: "JobIconServiceWorker"
   supervisors: job-supervisors-service
   canBeAntag: true # DeltaV - Can be antagonist
-  antagAdvantage: 1 # DeltaV - Reduced TC: Accesses
   access:
   - Service
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -3,7 +3,7 @@
   name: job-name-atmostech
   description: job-description-atmostech
   playTimeTracker: JobAtmosphericTechnician
-  antagAdvantage: 10 # DeltaV - Reduced TC: External Access + Fireaxe + Free Hardsuit
+  antagAdvantage: 3 # DeltaV - Reduced TC: Free Hardsuit + Engineering + Atmospherics
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -3,7 +3,7 @@
   name: job-name-engineer
   description: job-description-engineer
   playTimeTracker: JobStationEngineer
-  antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
+  antagAdvantage: 2 # DeltaV - Reduced TC: Free Hardsuit + Engineering
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -3,7 +3,7 @@
   name: job-name-technical-assistant
   description: job-description-technical-assistant
   playTimeTracker: JobTechnicalAssistant
-  antagAdvantage: 3 # DeltaV - Reduced TC: External Access + Engineering
+  antagAdvantage: 2 # DeltaV - Reduced TC: Free Hardsuit + Engineering
   requirements:
   - !type:OverallPlaytimeRequirement # DeltaV - to prevent griefers from taking the role.
       time: 14400 # 4 hours

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -3,7 +3,7 @@
   name: job-name-paramedic
   description: job-description-paramedic
   playTimeTracker: JobParamedic
-  antagAdvantage: 2 # DeltaV - Reduced TC: External Access
+  antagAdvantage: 1 # DeltaV - Reduced TC: Handheld crew monitor
   requirements:
     # - !type:RoleTimeRequirement # DeltaV - No Medical Doctor time requirement
     #   role: JobMedicalDoctor


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Reduced or removed antagAdvantage values for several roles.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
For several roles, antagAdvantage is too high as their job advantages either aren't actually used, or are not true advantages.
<details>
  <summary>More details, originally posted on Discord, https://discord.com/channels/968983104247185448/1150555473699934370/1205366269851996250. </summary>
  So, going through the list
 Psionic Mantis has an advantage of 5. No other epi role has an antag, the special things the mantis gets are
- psi knife
 - 10 slash 5 holy, sure, but afaik you don't take holy if you aren't "evil" so it's only 10 slash, and you have a 30% chance to electrocute yourself on every attack if the target isn't psionic, making it useless in most pvp fights
- psibreaker gun 
 - it comes with mindbreaker rounds, which deal 3 blunt and inject mindbreaker toxin. Getting lethal rounds from sec feels about as easy as just getting a whole gun.
- permission to mindbreak, and potentially slip in other drugs too?
 - this feels moot, since doctors also have this and they have no advantage

Cargo tech has an advantage of 2, with the comment saying it's cause externals access.
This is completely moot since techs don't have externals. Mats and autolathe (free tools) is pretty good, but it's not great and I think the full 20tc is deserved.

Salv tech has an advantage of 3, "External Access + Free hardsuit and weapons". The salvage weapons aren't ideal for pvp imo, I don't think externals is much of an advantage, I don't remember any cases of ex. a body being hidden in space, however, the weapons and similar contraband they can get definitely are. Maybe reduce to 2 advantage?

Lawyer, advantage of 2, "Security Radio and Access", having many more opportunities to steal sec stuff is pretty fair, and sec comms is very helpful.

Service worker, advantage of 1, "access", they just get service, and no other service role has an advantage, they should get 20tc. Seems to be a hold over from nyano.

Station engineer/Tech assistant, advantage of 3, "External Access + Engineering", you're trusted in a lot of higher security areas now, like substations, which imo is the main advantage, as tools are fairly easy to acquire, barring insuls and engi goggles. Maybe drop it to 2 instead?

Atmos tech, advantage of 10. "External Access + Fireaxe + Free Hardsuit", this is *definetly* too high, the axe's only purpose is as a weapon now, since any engineer can space floors, and the axe doesn't anymore. The only thing you gain from atmos access is *maybe* being able to do atmos sabotage, but that is disallowed since that generally affects large parts of the station. Your other advantages, such as being trusted some high security areas, are shared with the other engi roles. The advantage should be 2/3/4, I'm leaning towards 3.

Paramedic, advantage of 2, "External Access", I've said that I don't think it is worth the tc reduction, and whatever it is, it should definetly be lower than salv. Didn't realise they had the handheld monitor still, advantage of 1 for that.
</details>
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- tweak: Reduced or removed TC penalty for several roles.