### PR TITLE
secret weight tweaks

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,9 +1,9 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Survival: 0.44
-    Nukeops: 0.14
-    Zombie: 0.03
-    Traitor: 0.39
+    Survival: 0.30
+    Nukeops: 0.20
+    Zombie: 0.10
+    Traitor: 0.40
     #Pirates: 0.15 #ahoy me bucko
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
new secret weights:
    Survival: 0.30
    Nukeops: 0.20
    Zombie: 0.10
    Traitor: 0.40
feel free to discuss these in the comments
## Why / Balance

survival is an overall boring round, antagonists are supposed to drive the round instead of it just degrading on its own, yeah theres a bunch of events but that happens in other game mods regardless. i get the point is to roleplay but traitors can also roleplay, and usually roleplay more interesting things like hostage taking

zombies is also just too rare, ive played over 1000 hours on wizden where zombies wight is also 10% and its still once in a blue moon, letting a rare game mode happen more often is fine

**Changelog**
:cl: JoeHammad
- tweak: Secret weights tweaked
- tweak: Traitor: 40%
- tweak: Survival: 30%
- tweak: Nukeops: 20%
- tweak: Zombie: 10%
