### PR TITLE
Prevent probers from being unachored by gorilla gauntlets

### DIFF
--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -330,7 +330,7 @@ namespace Content.Server.Psionics.Glimmer
 
             _lightning.ShootRandomLightnings(uid, 10, 2, "SuperchargedLightning", 2, false);
 
-            // check if the transform parent of args.thing is alive
+            // Check if the parent of the user is alive, which will be the case if the user is an item and is being held.
             var zapTarget = _transformSystem.GetParentUid(args.User);
             if (TryComp<MindContainerComponent>(zapTarget, out _))
                 _electrocutionSystem.TryDoElectrocution(zapTarget, uid, 5, TimeSpan.FromSeconds(3), true,

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -16,6 +16,9 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Damage;
 using Content.Shared.Destructible;
 using Content.Shared.Construction.Components;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Weapons.Melee.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
@@ -62,6 +65,7 @@ namespace Content.Server.Psionics.Glimmer
             SubscribeLocalEvent<SharedGlimmerReactiveComponent, DamageChangedEvent>(OnDamageChanged);
             SubscribeLocalEvent<SharedGlimmerReactiveComponent, DestructionEventArgs>(OnDestroyed);
             SubscribeLocalEvent<SharedGlimmerReactiveComponent, UnanchorAttemptEvent>(OnUnanchorAttempt);
+            SubscribeLocalEvent<SharedGlimmerReactiveComponent, AttemptMeleeThrowOnHitEvent>(OnMeleeThrowOnHitAttempt);
         }
 
         /// <summary>
@@ -312,6 +316,25 @@ namespace Content.Server.Psionics.Glimmer
 
             // Wasn't able to get a grid or a free tile, so explode.
             _destructibleSystem.DestroyEntity(uid);
+        }
+
+        private void OnMeleeThrowOnHitAttempt(Entity<SharedGlimmerReactiveComponent> ent, ref AttemptMeleeThrowOnHitEvent args)
+        {
+            var (uid, _) = ent;
+
+            if (_glimmerSystem.GetGlimmerTier() < GlimmerTier.Dangerous)
+                return;
+
+            args.Cancelled = true;
+            args.Handled = true;
+
+            _lightning.ShootRandomLightnings(uid, 10, 2, "SuperchargedLightning", 2, false);
+
+            // check if the transform parent of args.thing is alive
+            var zapTarget = _transformSystem.GetParentUid(args.User);
+            if (TryComp<MindContainerComponent>(zapTarget, out _))
+                _electrocutionSystem.TryDoElectrocution(zapTarget, uid, 5, TimeSpan.FromSeconds(3), true,
+                    ignoreInsulation: true);
         }
 
         private void Reset(RoundRestartCleanupEvent args)

--- a/Content.Shared/Weapons/Melee/Components/MeleeThrowOnHitComponent.cs
+++ b/Content.Shared/Weapons/Melee/Components/MeleeThrowOnHitComponent.cs
@@ -101,9 +101,10 @@ public sealed partial class MeleeThrownComponent : Component
 /// <summary>
 /// Event raised before an entity is thrown by <see cref="MeleeThrowOnHitComponent"/> to see if a throw is allowed.
 /// If not handled, the enabled field on the component will be used instead.
+/// Delta-V modification: Added User field, since it is now also raised on the entity being hit
 /// </summary>
 [ByRefEvent]
-public record struct AttemptMeleeThrowOnHitEvent(EntityUid Hit, bool Cancelled = false, bool Handled = false);
+public record struct AttemptMeleeThrowOnHitEvent(EntityUid Hit, Entity<MeleeThrowOnHitComponent> User, bool Cancelled = false, bool Handled = false);
 
 [ByRefEvent]
 public record struct MeleeThrowOnHitStartEvent(EntityUid User, EntityUid Used);

--- a/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
+++ b/Content.Shared/Weapons/Melee/MeleeThrowOnHitSystem.cs
@@ -104,9 +104,14 @@ public sealed class MeleeThrowOnHitSystem : EntitySystem
     {
         var (uid, comp) = ent;
 
-        var ev = new AttemptMeleeThrowOnHitEvent(target);
-        RaiseLocalEvent(uid, ref ev);
+        var ev = new AttemptMeleeThrowOnHitEvent(target, ent);
 
+        // Delta-V modification: Also raise on the entity being hit, in case it wants to object
+        RaiseLocalEvent(target, ref ev);
+        if (ev.Handled)
+            return !ev.Cancelled;
+
+        RaiseLocalEvent(uid, ref ev);
         if (ev.Handled)
             return !ev.Cancelled;
 


### PR DESCRIPTION
## About the PR
Does what it says on the tin. If you try punting a prober, it'll shock you and some random shit around it

## Why / Balance
Dangerous probers should stay dangerous unless destroyed or if glimmer is lowered.

## Technical details
This makes it so `AttemptMeleeThrowOnHitEvent` is also raised on the entity thats getting thrown, and `GlimmerReactiveSystem` will cancel this event if glimmer is high enough, along with shocking the player and shooting (mostly harmless) lightning

**Changelog**
:cl:
- tweak: Glimmer probers now react violently to being hit by gorilla gauntlets if glimmer is above 500
