### PR TITLE
Vulpkanin's Deuteranopia

### DIFF
--- a/Content.Client/Nyanotrasen/Overlays/DogVisionSystem.cs
+++ b/Content.Client/Nyanotrasen/Overlays/DogVisionSystem.cs
@@ -1,13 +1,10 @@
 using Content.Shared.Abilities;
-using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
-using Robust.Client.Player;
 
 namespace Content.Client.Nyanotrasen.Overlays;
 
 public sealed partial class DogVisionSystem : EntitySystem
 {
-    [Dependency] private readonly IPlayerManager _player = default!;
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
 
     private DogVisionOverlay _overlay = default!;
@@ -19,28 +16,16 @@ public sealed partial class DogVisionSystem : EntitySystem
         SubscribeLocalEvent<DogVisionComponent, ComponentInit>(OnDogVisionInit);
         SubscribeLocalEvent<DogVisionComponent, ComponentShutdown>(OnDogVisionShutdown);
 
-        _player.LocalPlayerAttached += OnAttachedChanged;
-        _player.LocalPlayerDetached += OnAttachedChanged;
-
         _overlay = new();
-    }
-
-    private void OnAttachedChanged(EntityUid uid)
-    {
-        _overlayMan.AddOverlay(_overlay);
     }
 
     private void OnDogVisionInit(EntityUid uid, DogVisionComponent component, ComponentInit args)
     {
-        if (_player.LocalPlayer?.ControlledEntity == uid)
-            _overlayMan.AddOverlay(_overlay);
+        _overlayMan.AddOverlay(_overlay);
     }
 
     private void OnDogVisionShutdown(EntityUid uid, DogVisionComponent component, ComponentShutdown args)
     {
-        if (_player.LocalPlayer?.ControlledEntity == uid)
-        {
-            _overlayMan.RemoveOverlay(_overlay);
-        }
+        _overlayMan.RemoveOverlay(_overlay);
     }
 }

--- a/Content.Shared/DeltaV/Abilities/DefaultVisionSystem.cs
+++ b/Content.Shared/DeltaV/Abilities/DefaultVisionSystem.cs
@@ -15,5 +15,6 @@ public sealed partial class DefaultVisionSystem : EntitySystem
     private void OnDefaultVisionInit(EntityUid uid, DefaultVisionComponent component, ComponentInit args)
     {
         RemComp<UltraVisionComponent>(uid);
+        RemComp<DogVisionComponent>(uid);
     }
 }

--- a/Resources/Locale/en-US/deltav/traits/traits.ftl
+++ b/Resources/Locale/en-US/deltav/traits/traits.ftl
@@ -1,8 +1,15 @@
 trait-scottish-accent-name = Scottish Accent
 trait-scottish-accent-desc = Fer tha folk who come frae Hielan clan.
+
+trait-ultravision-name = Ultraviolet Vision
 trait-ultravision-desc = Whether through custom bionic eyes, random mutation,
                          or being a Harpy, you perceive the world with ultraviolet light.
 
+trait-dogvision-name = Deuteranopia
+trait-dogvision-desc = Whether through custom bionic eyes, random mutation,
+                       or being a Vulpkanin, you have red–green colour blindness.
+
+trait-defaultvision-name = Normal Vision
 trait-defaultvision-desc = You lack any vision variation from the norm for a non-human species.
 
 trait-uncloneable-name = Uncloneable

--- a/Resources/Locale/en-US/deltav/traits/traits.ftl
+++ b/Resources/Locale/en-US/deltav/traits/traits.ftl
@@ -5,9 +5,9 @@ trait-ultravision-name = Ultraviolet Vision
 trait-ultravision-desc = Whether through custom bionic eyes, random mutation,
                          or being a Harpy, you perceive the world with ultraviolet light.
 
-trait-dogvision-name = Deuteranopia
-trait-dogvision-desc = Whether through custom bionic eyes, random mutation,
-                       or being a Vulpkanin, you have red–green colour blindness.
+trait-deuteranopia-name = Deuteranopia
+trait-deuteranopia-desc = Whether through custom bionic eyes, random mutation,
+                          or being a Vulpkanin, you have red–green colour blindness.
 
 trait-defaultvision-name = Normal Vision
 trait-defaultvision-desc = You lack any vision variation from the norm for a non-human species.

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -96,6 +96,7 @@
       Male: MaleVulpkanin
       Female: FemaleVulpkanin
       Unsexed: MaleVulpkanin
+  - type: DogVision
 
 - type: entity
   save: false

--- a/Resources/Prototypes/DeltaV/Traits/altvision.yml
+++ b/Resources/Prototypes/DeltaV/Traits/altvision.yml
@@ -1,13 +1,20 @@
 - type: trait
   id: UltraVision
-  name: Ultraviolet Vision
+  name: trait-ultravision-name
   description: trait-ultravision-desc
   components:
     - type: UltraVision
 
 - type: trait
+  id: DogVision
+  name: trait-dogvision-name
+  description: trait-dogvision-desc
+  components:
+    - type: DogVision
+
+- type: trait
   id: DefaultVision
-  name: Normal Vision
+  name: trait-defaultvision-name
   description: trait-defaultvision-desc
   components:
     - type: DefaultVision

--- a/Resources/Prototypes/DeltaV/Traits/altvision.yml
+++ b/Resources/Prototypes/DeltaV/Traits/altvision.yml
@@ -7,8 +7,8 @@
 
 - type: trait
   id: DogVision
-  name: trait-dogvision-name
-  description: trait-dogvision-desc
+  name: trait-deuteranopia-name
+  description: trait-deuteranopia-desc
   components:
     - type: DogVision
 

--- a/Resources/Prototypes/Nyanotrasen/Traits/disabilities.yml
+++ b/Resources/Prototypes/Nyanotrasen/Traits/disabilities.yml
@@ -1,5 +1,0 @@
-- type: trait
-  id: Colorblindness
-  name: Colorblindness
-  components:
-    - type: DogVision


### PR DESCRIPTION
Everyone loves dog vision :trollface: 

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds Deuteranopia as a selectable trait.
Adds Deuteranopia to Vulpkanin by default. It can be reverted using the Normal Vision trait similarly to the Harpy UltraVision.
Make Normal Vision and Ultraviolet Vision trait names into locale.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Why not, Harpy gets a default vision and it make sense for Vulpkanins.
I'm sure a lot of people won't like it, even less when the Metempsychotic machine gets readded and they roll into a Vulpkanin.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
I don't think I *really* needed to remove all those funny lines but the UltraVision doesn't need em and since you can't really gain/lose Deuteranopia anyway outside of selecting the trait or being Vulpkanin...

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![ss (2024-02-15 at 11 41 31)](https://github.com/DeltaV-Station/Delta-v/assets/9823203/0110615d-9260-4db6-be08-511a30902e76)

- [yes] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added Deuteranopia trait.
- tweak: Vulpkanin now start with Deuteranopia by default which can be removed using the Normal Vision trait.
