### PR TITLE
Glimmer Drain requires 5 crystal again

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Recipes/Construction/Graphs/structures/glimmerdevices.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Construction/Graphs/structures/glimmerdevices.yml
@@ -30,36 +30,36 @@
           conditions:
             - !type:EntityAnchored {}
           steps:
-            - tag: NormalityCrystal # DeltaV - Temporarily makes Drain only need 1 Crystal until Golemnization is implemented otherwise it's just imposible to craft
+            - tag: NormalityCrystal
               icon:
                 sprite: Nyanotrasen/Objects/Materials/materials.rsi
                 state: bluespace
               name: a normality crystal
               doAfter: 1
-            # - tag: NormalityCrystal
-            #   icon:
-            #     sprite: Nyanotrasen/Objects/Materials/materials.rsi
-            #     state: bluespace
-            #   name: a normality crystal
-            #   doAfter: 1
-            # - tag: NormalityCrystal
-            #   icon:
-            #     sprite: Nyanotrasen/Objects/Materials/materials.rsi
-            #     state: bluespace
-            #   name: a normality crystal
-            #   doAfter: 1
-            # - tag: NormalityCrystal
-            #   icon:
-            #     sprite: Nyanotrasen/Objects/Materials/materials.rsi
-            #     state: bluespace
-            #   name: a normality crystal
-            #   doAfter: 1
-            # - tag: NormalityCrystal
-            #   icon:
-            #     sprite: Nyanotrasen/Objects/Materials/materials.rsi
-            #     state: bluespace
-            #   name: a normality crystal
-            #   doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
+            - tag: NormalityCrystal
+              icon:
+                sprite: Nyanotrasen/Objects/Materials/materials.rsi
+                state: bluespace
+              name: a normality crystal
+              doAfter: 1
             - tool: Welding
               doAfter: 5
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Uncommented the previous requirement for drainers so it goes from 1 to 5 crystals again.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Before Glimmer Mite it was impossible to actually get ectoplasm before it was too late, now you can literally get *almost* 25u Ectoplasm per Glimmer Mite (if you draw their blood + grind them) and they spawn between 50 to 900 glimmer.

This makes it so you cannot just create 4 drainer with one mite and instead requires you to extract 2 mites to create 1 Drainer.

The Glimmer Drain was never meant to be easy to make AFAIK so yeah.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- tweak: Glimmer Drain now requires 5 Normality Crystals to craft.
