### PR TITLE
Make loadacts more user friendly

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using Content.Shared.Actions;
+using Content.Shared.Mapping;
 using JetBrains.Annotations;
 using Robust.Client.Player;
 using Robust.Shared.ContentPack;
@@ -294,6 +295,70 @@ namespace Content.Client.Actions
 
                 if (map.TryGet<ValueDataNode>("name", out var nameNode))
                     _metaData.SetEntityName(actionId, nameNode.Value);
+
+                if (!map.TryGet("assignments", out var assignmentNode))
+                    continue;
+
+                var nodeAssignments = _serialization.Read<List<(byte Hotbar, byte Slot)>>(assignmentNode, notNullableOverride: true);
+
+                foreach (var index in nodeAssignments)
+                {
+                    var assignment = new SlotAssignment(index.Hotbar, index.Slot, actionId);
+                    assignments.Add(assignment);
+                }
+            }
+
+            AssignSlot?.Invoke(assignments);
+        }
+
+        /// <summary>
+        ///     Load actions and their toolbar assignments from a file.
+        ///     DeltaV - Load from an existing yaml stream instead
+        /// </summary>
+        public void LoadActionAssignments(YamlStream stream)
+        {
+            if (_playerManager.LocalEntity is not { } user)
+                return;
+
+            if (stream.Documents[0].RootNode.ToDataNode() is not SequenceDataNode sequence)
+                return;
+
+            ClearAssignments?.Invoke();
+
+            var assignments = new List<SlotAssignment>();
+            var existingActions = GetClientActions();
+            var existingActionsList = existingActions.ToList();
+
+            foreach (var entry in sequence.Sequence)
+            {
+                if (entry is not MappingDataNode map)
+                    continue;
+
+                if (!map.TryGet("action", out var actionNode))
+                    continue;
+
+                if (!map.TryGet<ValueDataNode>("name", out var nameNode))
+                    continue;
+
+                var action = _serialization.Read<BaseActionComponent>(actionNode, notNullableOverride: true);
+
+                // Prevent spawning actions multiple times
+                var existing = existingActionsList.FirstOrNull(a =>
+                    Name(a.Id) == nameNode.Value);
+
+                EntityUid actionId;
+                if (existing == null)
+                {
+                    actionId = Spawn(null);
+                    AddComp(actionId, action);
+                    _metaData.SetEntityName(actionId, nameNode.Value);
+                    DirtyEntity(actionId);
+                    AddActionDirect(user, actionId);
+                }
+                else
+                {
+                    actionId = existing.Value.Id;
+                }
 
                 if (!map.TryGet("assignments", out var assignmentNode))
                     continue;


### PR DESCRIPTION
## About the PR
Helps Velcro out, and makes it easy for mappers to use his acts without having to do anything complicated.

To load from a file stream, the entries must be laid out like this
```yaml
- action: !type:WhateverActionComponent
  assignments:
  - 0: SLOT
  name: Action's Name
```
If an action lacks a name, it wont work through the open file dialogue, but it'll still work if the file name is passed directly. No additional checks are done to make sure the action is valid