### PR TITLE
Uncomments MidRoundAntag

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -198,9 +198,11 @@
       prob: 0.02
     - id: MobMouse2
       prob: 0.02
-    specialEntries:
-    - id: SpawnPointGhostRatKing
-      prob: 0.005
+    # DeltaV - Rat King spawns under MidRoundAntag - Comment out Rat King from spawning with MouseMigration gamerule
+    # specialEntries:
+    # - id: SpawnPointGhostRatKing
+    #   prob: 0.005
+    # End of modified code
 
 - type: entity
   id: CockroachMigration

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -12,18 +12,18 @@
       earliestStart: 15
     - type: NoosphericStormRule
 
-# Rat king, paradox anomaly, fugitive, oneiro, etc.
-#- type: entity
-#  id: MidRoundAntag
-#  parent: BaseGameRule
-#  noSpawn: true
-#  components:
-#    - type: StationEvent
-#      weight: 7
-#      reoccurrenceDelay: 5
-#      minimumPlayers: 15
-#      earliestStart: 25
-#    - type: MidRoundAntagRule
+# Rat king and paradox anomaly.
+- type: entity
+  id: MidRoundAntag
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+    - type: StationEvent
+      weight: 7
+      reoccurrenceDelay: 5
+      minimumPlayers: 15
+      earliestStart: 25
+    - type: MidRoundAntagRule
 
 # Base glimmer event
 - type: entity


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
Fixes #868 

## About the PR
<!-- What did you change in this PR? -->
Uncomments MidRoundAntag in the Nyanotrasen files.

Honestly we could just give paradox its own event but eh this seems to work.
It will probably need the funny "mid round spawner" things mapped

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
It allows the spawning of Paradox Anomalies. Also more rat kings.