### PR TITLE
Make periapsis only have 10 non-whitelisted slots, and make whitelist not shit

### DIFF
--- a/Content.Server/Connection/ConnectionManager.cs
+++ b/Content.Server/Connection/ConnectionManager.cs
@@ -31,9 +31,13 @@ namespace Content.Server.Connection
         [Dependency] private readonly ILocalizationManager _loc = default!;
         [Dependency] private readonly ServerDbEntryManager _serverDbEntry = default!;
 
+        private List<NetUserId> _connectedWhitelistedPlayers = new(); // DeltaV - Soft whitelist improvements
+
         public void Initialize()
         {
             _netMgr.Connecting += NetMgrOnConnecting;
+            _netMgr.Connected += OnConnected; // DeltaV - Soft whitelist improvements
+            _netMgr.Disconnect += OnDisconnected; // DeltaV - Soft whitelist improvements
             _netMgr.AssignUserIdCallback = AssignUserIdCallback;
             // Approval-based IP bans disabled because they don't play well with Happy Eyeballs.
             // _netMgr.HandleApprovalCallback = HandleApproval;
@@ -169,7 +173,8 @@ namespace Content.Server.Connection
                 return (ConnectionDenyReason.Ban, message, bans);
             }
 
-            if (_cfg.GetCVar(CCVars.WhitelistEnabled))
+            // DeltaV - Replace existing softwhitelist implementation
+            if (false) //_cfg.GetCVar(CCVars.WhitelistEnabled))
             {
                 var min = _cfg.GetCVar(CCVars.WhitelistMinPlayers);
                 var max = _cfg.GetCVar(CCVars.WhitelistMaxPlayers);
@@ -182,6 +187,28 @@ namespace Content.Server.Connection
                     // was the whitelist playercount changed?
                     if (min > 0 || max < int.MaxValue)
                         msg += "\n" + Loc.GetString("whitelist-playercount-invalid", ("min", min), ("max", max));
+                    return (ConnectionDenyReason.Whitelist, msg, null);
+                }
+            }
+
+            // DeltaV - Soft whitelist improvements
+            if (_cfg.GetCVar(CCVars.WhitelistEnabled))
+            {
+                var connectedPlayers = _plyMgr.PlayerCount;
+                var connectedWhitelist = _connectedWhitelistedPlayers.Count;
+
+                var slots = _cfg.GetCVar(CCVars.WhitelistMinPlayers);
+
+                var nonWhitelistAllowed = slots > 0 && slots < connectedPlayers - connectedWhitelist;
+
+                if (nonWhitelistAllowed && await _db.GetWhitelistStatusAsync(userId) == false
+                                     && adminData is null)
+                {
+                    var msg = Loc.GetString(_cfg.GetCVar(CCVars.WhitelistReason));
+
+                    if (slots > 0)
+                        msg += "\n" + Loc.GetString("whitelist-playercount-invalid", ("min", slots), ("max", _cfg.GetCVar(CCVars.SoftMaxPlayers)));
+
                     return (ConnectionDenyReason.Whitelist, msg, null);
                 }
             }
@@ -205,6 +232,32 @@ namespace Content.Server.Connection
             var assigned = new NetUserId(Guid.NewGuid());
             await _db.AssignUserIdAsync(name, assigned);
             return assigned;
+        }
+
+        /// <summary>
+        ///     DeltaV - Soft whitelist improvements
+        ///     Handles a completed connection, and stores the player if they're whitelisted and the whitelist is enabled
+        /// </summary>
+        private async void OnConnected(object? sender, NetChannelArgs e)
+        {
+            var userId = e.Channel.UserId;
+
+            if (_cfg.GetCVar(CCVars.WhitelistEnabled) && await _db.GetWhitelistStatusAsync(userId))
+            {
+                _connectedWhitelistedPlayers.Add(userId);
+            }
+        }
+
+        /// <summary>
+        ///     DeltaV - Soft whitelist improvements
+        ///     Handles a disconnection, and removes a stored player from the count if the whitelist is enabled
+        /// </summary>
+        private async void OnDisconnected(object? sender, NetChannelArgs e)
+        {
+            if (_cfg.GetCVar(CCVars.WhitelistEnabled))
+            {
+                _connectedWhitelistedPlayers.Remove(e.Channel.UserId);
+            }
         }
     }
 }

--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -11,9 +11,9 @@ preset_enabled = true
 map_enabled = true
 
 [whitelist]
-enabled     = false
-reason      = "whitelist-not-whitelisted"
-min_players = 40
+enabled     = true
+reason      = "whitelist-not-whitelisted-peri"
+min_players = 10
 
 [ooc]
 enable_during_round = true

--- a/Resources/Locale/en-US/deltav/connection-messages.ftl
+++ b/Resources/Locale/en-US/deltav/connection-messages.ftl
@@ -1,0 +1,1 @@
+﻿whitelist-not-whitelisted-peri = You are not whitelisted. To become whitelisted, apply on our forum. It can be found at https://forum.delta-v.org/


### PR DESCRIPTION
## About the PR
Another server is coming to replace it

Inspired by Cosmatic drift's system, but in my own way

## Technical details
Whitelist now works based on slots instead of the hard player count. The `whitelist.max_players` is now ignored, and `whitelist.min_players` decides how many slots there are.

If it is set to 10, 10 non-whitelisted players will always be able to join, regardless of how many whitelisted players there are. With the execption being there is still space within the soft player cap

**Changelog**
:cl:
- tweak: Whitelist to join now works based on slots instead of player count
- tweak: Periapsis now has only 10 non-whitelisted slots
