### PR TITLE
Fix deep fryer divide by zero

### DIFF
--- a/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.cs
+++ b/Content.Server/Nyanotrasen/Kitchen/EntitySystems/DeepFryerSystem.cs
@@ -181,6 +181,7 @@ public sealed partial class DeepFryerSystem : SharedDeepfryerSystem
     /// </summary>
     public FixedPoint2 GetOilPurity(EntityUid uid, DeepFryerComponent component)
     {
+        if (component.Solution.Volume == 0) return 0;
         return GetOilVolume(uid, component) / component.Solution.Volume;
     }
 


### PR DESCRIPTION
## About the PR
Someday I'm going to rip all this code up and replace it with better code. For now, fixes a divide by zero. Verified by running the deep fryer all the way to empty, while listening to the debugger. 

## Why / Balance
Bad Math

![image](https://github.com/DeltaV-Station/Delta-v/assets/16548818/aa404065-c6f7-4c97-9b2f-f7275963bd1c)
