### PR TITLE
Stop nukies from spawning with species vision filters

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -30,6 +30,7 @@ using Content.Server.Store.Components;
 using Content.Server.Store.Systems;
 using Content.Shared.CCVar;
 using Content.Shared.Dataset;
+using Content.Shared.DeltaV.Abilities;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Mind;
@@ -907,6 +908,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
     {
         _metaData.SetEntityName(mob, name);
         EnsureComp<NukeOperativeComponent>(mob);
+        EnsureComp<DefaultVisionComponent>(mob); // DeltaV - Ensures Vulps and Harpies dont spawn with their respective vision filter
 
         if (profile != null)
         {


### PR DESCRIPTION
## About the PR
There are real, good reasons to not have these enabled by default, and I'm not a fan of stuff like this being on the species itself instead of a trait you have to opt in to, but it is what it is.

Ensures nukies dont start with ultravision or dog vision, or any future filters that'd be part of DefaultVision
This still doesn't fix the numerous other instances where these traits can be forced onto a mob with no regard to traits. I might make this an accessibility feature instead

**Changelog**
:cl:
- tweak: Nuclear operatives no longer start with vision altering traits

