### PR TITLE
make midround antag spawn code better

### DIFF
--- a/Content.Server/Nyanotrasen/StationEvents/Components/MidRoundAntagRuleComponent.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Components/MidRoundAntagRuleComponent.cs
@@ -6,12 +6,9 @@ namespace Content.Server.StationEvents.Components;
 [RegisterComponent, Access(typeof(MidRoundAntagRule))]
 public sealed partial class MidRoundAntagRuleComponent : Component
 {
-    [DataField("antags")]
-    public List<EntProtoId> MidRoundAntags = new()
-    {
-        "SpawnPointGhostRatKing",
-        //"SpawnPointGhostVampSpider",
-        //"SpawnPointGhostFugitive",
-        "SpawnPointGhostParadoxAnomaly"
-    };
+    /// <summary>
+    /// Spawner to create at a random mid round antag marker.
+    /// </summary>
+    [DataField(required: true)]
+    public EntProtoId Spawner = string.Empty;
 }

--- a/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
@@ -16,7 +16,7 @@ public sealed class MidRoundAntagRule : StationEventSystem<MidRoundAntagRuleComp
         var spawnLocations = FindSpawns(station.Value);
         if (spawnLocations.Count == 0)
         {
-            Log.Warn("Couldn't find any midround antag spawners or vent critter spawners, not spawning an antag.");
+            Log.Warning("Couldn't find any midround antag spawners or vent critter spawners, not spawning an antag.");
             return;
         }
 

--- a/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
@@ -1,5 +1,6 @@
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents.Components;
+using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 

--- a/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/MidRoundAntagRule.cs
@@ -16,7 +16,7 @@ public sealed class MidRoundAntagRule : StationEventSystem<MidRoundAntagRuleComp
         var spawnLocations = FindSpawns(station.Value);
         if (spawnLocations.Count == 0)
         {
-            Log.Error("Couldn't find any midround antag spawners or vent critter spawners, not spawning an antag.");
+            Log.Warn("Couldn't find any midround antag spawners or vent critter spawners, not spawning an antag.");
             return;
         }
 

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -12,18 +12,34 @@
       earliestStart: 15
     - type: NoosphericStormRule
 
-# Rat king and paradox anomaly.
+# Mid round antag spawns
 - type: entity
-  id: MidRoundAntag
+  abstract: true
   parent: BaseGameRule
-  noSpawn: true
+  id: BaseMidRoundAntag
   components:
-    - type: StationEvent
-      weight: 7
-      reoccurrenceDelay: 5
-      minimumPlayers: 15
-      earliestStart: 25
-    - type: MidRoundAntagRule
+  - type: StationEvent
+    weight: 7
+    reoccurrenceDelay: 5
+    minimumPlayers: 15
+    earliestStart: 25
+  - type: MidRoundAntagRule
+
+- type: entity
+  noSpawn: true
+  parent: BaseMidRoundAntag
+  id: RatKingSpawn
+  components:
+  - type: MidRoundAntagRule
+    spawner: SpawnPointGhostRatKing
+
+- type: entity
+  noSpawn: true
+  parent: BaseMidRoundAntag
+  id: ParadoxAnomalySpawn
+  components:
+  - type: MidRoundAntagRule
+    spawner: SpawnPointGhostParadoxAnomaly
 
 # Base glimmer event
 - type: entity


### PR DESCRIPTION
## About the PR
title

## Why / Balance
fixes #899

## Technical details
- will only use spawners on the target station and not fall back with centcom
- logging so if a map has no midround spawners its easy to find out (should probably have a test too but eh)
- no linq and using EntityQueryEnumerator so a bit more efficient
- rat king and paradox anomaly get their own rules instead of le hardcoded list

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
MidRoundAntagRule is for spawning a single antag per rule not a hardcoded list of them

**Changelog**
:cl:
- fix: Fixed midround antags sometimes spawning on CentComm.
