### PR TITLE
Revert AME buff

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -182,7 +182,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
         // Fuel is squared so more fuel vastly increases power and efficiency
         // We divide by the number of cores so a larger AME is less efficient at the same fuel settings
         // this results in all AMEs having the same efficiency at the same fuel-per-core setting
-        return 2000000f * fuel * fuel / cores;
+        return 20000f * fuel * fuel / cores; // Delt V - Revert upstream buff for normal AME operation
     }
 
     public int GetTotalStability()


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Wizden has different motivations for power gen that don't currently align with ours making this an unnecessary change for us. It has completely broken the power generation aspect of engineering. 

**Changelog**
:cl: Velcroboy
- tweak: Reverted AME buff.