### PR TITLE
Salvage loses their shuttle

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -17,6 +17,7 @@
       - id: SeismicCharge
         amount: 2
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
+      - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
       - id: OreBag
         prob: 0.5
       - id: Flare
@@ -44,6 +45,7 @@
       - id: SeismicCharge
         amount: 2
       - id: ClothingShoesBootsWinterMiner #Delta V: Add departmental winter boots
+      - id: JetpackMiniFilled # DeltaV - Salv lost their shuttle
       - id: OreBag
         prob: 0.5
       - id: Flare

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -76,9 +76,9 @@
         cargo:
           paths:
           - /Maps/Shuttles/cargo_core.yml
-        mining:
-          paths:
-          - /Maps/Shuttles/mining.yml
+#        mining:
+#          paths:
+#          - /Maps/Shuttles/mining.yml
         ruins:
           hide: true
           nameGrid: true


### PR DESCRIPTION
I've had it with powergaming salvage, last round was the final straw. If they cant behave, I wont even bother trying to nerf their shuttle because I know they'll find ways around it.

Shipyards wyci.

:cl:
- remove: The salvage shuttle has been completely removed
- tweak: Salvage specialists now start with a mini jetpack in their locker
