### PR TITLE
Add magnet pickup system from Frontier

### DIFF
--- a/Content.Shared/Frontier/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
+++ b/Content.Shared/Frontier/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
@@ -1,0 +1,20 @@
+namespace Content.Server.Storage.Components;
+
+/// <summary>
+/// Applies an ongoing pickup area around the attached entity.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MaterialReclaimerMagnetPickupComponent : Component
+{
+    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    public TimeSpan NextScan = TimeSpan.Zero;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("range")]
+    public float Range = 1f;
+
+    /// <summary>
+    /// Frontier - Is the magnet currently enabled?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("magnetEnabled")]
+    public bool MagnetEnabled = false;
+}

--- a/Content.Shared/Frontier/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
+++ b/Content.Shared/Frontier/Storage/Components/MaterialReclaimerMagnetPickupComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Server.Storage.Components;
+namespace Content.Shared.Frontier.Storage.Components;
 
 /// <summary>
 /// Applies an ongoing pickup area around the attached entity.

--- a/Content.Shared/Frontier/Storage/Components/MaterialStorageMagnetPickupComponent.cs
+++ b/Content.Shared/Frontier/Storage/Components/MaterialStorageMagnetPickupComponent.cs
@@ -1,0 +1,20 @@
+namespace Content.Server.Storage.Components;
+
+/// <summary>
+/// Applies an ongoing pickup area around the attached entity.
+/// </summary>
+[RegisterComponent]
+public sealed partial class MaterialStorageMagnetPickupComponent : Component
+{
+    [ViewVariables(VVAccess.ReadWrite), DataField("nextScan")]
+    public TimeSpan NextScan = TimeSpan.Zero;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField("range")]
+    public float Range = 1f;
+
+    /// <summary>
+    /// Frontier - Is the magnet currently enabled?
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("magnetEnabled")]
+    public bool MagnetEnabled = false;
+}

--- a/Content.Shared/Frontier/Storage/Components/MaterialStorageMagnetPickupComponent.cs
+++ b/Content.Shared/Frontier/Storage/Components/MaterialStorageMagnetPickupComponent.cs
@@ -1,4 +1,4 @@
-namespace Content.Server.Storage.Components;
+namespace Content.Shared.Frontier.Storage.Components;
 
 /// <summary>
 /// Applies an ongoing pickup area around the attached entity.

--- a/Content.Shared/Frontier/Storage/EntitySystems/MaterialReclaimerMagnetPickupSystem.cs
+++ b/Content.Shared/Frontier/Storage/EntitySystems/MaterialReclaimerMagnetPickupSystem.cs
@@ -1,0 +1,118 @@
+using Content.Server.Storage.Components;
+using Content.Shared.Materials;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+using Content.Shared.Examine;   // Frontier
+using Content.Shared.Hands.Components;  // Frontier
+using Content.Shared.Verbs;     // Frontier
+using Robust.Shared.Utility;    // Frontier
+
+namespace Content.Shared.Storage.EntitySystems;
+
+/// <summary>
+/// <see cref="MaterialReclaimerMagnetPickupComponent"/>
+/// </summary>
+public sealed class MaterialReclaimerMagnetPickupSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedMaterialReclaimerSystem _storage = default!;
+
+    private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
+
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, MapInitEvent>(OnMagnetMapInit);
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, EntityUnpausedEvent>(OnMagnetUnpaused);
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, ExaminedEvent>(OnExamined);  // Frontier
+        SubscribeLocalEvent<MaterialReclaimerMagnetPickupComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleMagnetVerb);    // Frontier
+    }
+
+    private void OnMagnetUnpaused(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, ref EntityUnpausedEvent args)
+    {
+        component.NextScan += args.PausedTime;
+    }
+
+    private void OnMagnetMapInit(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, MapInitEvent args)
+    {
+        component.NextScan = _timing.CurTime + TimeSpan.FromSeconds(1); // Need to add 1 sec to fix a weird time bug with it that make it never start the magnet
+    }
+
+    // Frontier, used to add the magnet toggle to the context menu
+    private void AddToggleMagnetVerb(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (!HasComp<HandsComponent>(args.User))
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Act = () =>
+            {
+                ToggleMagnet(uid, component);
+            },
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+            Text = Loc.GetString("magnet-pickup-component-toggle-verb"),
+            Priority = 3
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    // Frontier, used to show the magnet state on examination
+    private void OnExamined(EntityUid uid, MaterialReclaimerMagnetPickupComponent component, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("magnet-pickup-component-on-examine-main",
+                        ("stateText", Loc.GetString(component.MagnetEnabled
+                        ? "magnet-pickup-component-magnet-on"
+                        : "magnet-pickup-component-magnet-off"))));
+    }
+
+    // Frontier, used to toggle the magnet on the ore bag/box
+    public bool ToggleMagnet(EntityUid uid, MaterialReclaimerMagnetPickupComponent comp)
+    {
+        var query = EntityQueryEnumerator<MaterialReclaimerMagnetPickupComponent>();
+        comp.MagnetEnabled = !comp.MagnetEnabled;
+
+        return comp.MagnetEnabled;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var query = EntityQueryEnumerator<MaterialReclaimerMagnetPickupComponent, MaterialReclaimerComponent, TransformComponent>();
+        var currentTime = _timing.CurTime;
+
+        while (query.MoveNext(out var uid, out var comp, out var storage, out var xform))
+        {
+            if (comp.NextScan < currentTime)
+                continue;
+
+            comp.NextScan += ScanDelay;
+
+            // Frontier - magnet disabled
+            if (!comp.MagnetEnabled)
+                continue;
+
+            var parentUid = xform.ParentUid;
+
+            foreach (var near in _lookup.GetEntitiesInRange(uid, comp.Range, LookupFlags.Dynamic | LookupFlags.Sundries))
+            {
+                if (!_physicsQuery.TryGetComponent(near, out var physics) || physics.BodyStatus != BodyStatus.OnGround)
+                    continue;
+
+                if (near == parentUid)
+                    continue;
+
+                if (!_storage.TryStartProcessItem(uid, near))
+                    continue;
+            }
+        }
+    }
+}

--- a/Content.Shared/Frontier/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
+++ b/Content.Shared/Frontier/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
@@ -1,0 +1,118 @@
+using Content.Server.Storage.Components;
+using Content.Shared.Materials;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+using Content.Shared.Examine;   // Frontier
+using Content.Shared.Hands.Components;  // Frontier
+using Content.Shared.Verbs;     // Frontier
+using Robust.Shared.Utility;    // Frontier
+
+namespace Content.Shared.Storage.EntitySystems;
+
+/// <summary>
+/// <see cref="MaterialStorageMagnetPickupComponent"/>
+/// </summary>
+public sealed class MaterialStorageMagnetPickupSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedMaterialStorageSystem _storage = default!;
+
+    private static readonly TimeSpan ScanDelay = TimeSpan.FromSeconds(1);
+
+    private EntityQuery<PhysicsComponent> _physicsQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _physicsQuery = GetEntityQuery<PhysicsComponent>();
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, MapInitEvent>(OnMagnetMapInit);
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, EntityUnpausedEvent>(OnMagnetUnpaused);
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, ExaminedEvent>(OnExamined);  // Frontier
+        SubscribeLocalEvent<MaterialStorageMagnetPickupComponent, GetVerbsEvent<AlternativeVerb>>(AddToggleMagnetVerb);    // Frontier
+    }
+
+    private void OnMagnetUnpaused(EntityUid uid, MaterialStorageMagnetPickupComponent component, ref EntityUnpausedEvent args)
+    {
+        component.NextScan += args.PausedTime;
+    }
+
+    private void OnMagnetMapInit(EntityUid uid, MaterialStorageMagnetPickupComponent component, MapInitEvent args)
+    {
+        component.NextScan = _timing.CurTime + TimeSpan.FromSeconds(1); // Need to add 1 sec to fix a weird time bug with it that make it never start the magnet
+    }
+
+    // Frontier, used to add the magnet toggle to the context menu
+    private void AddToggleMagnetVerb(EntityUid uid, MaterialStorageMagnetPickupComponent component, GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (!HasComp<HandsComponent>(args.User))
+            return;
+
+        AlternativeVerb verb = new()
+        {
+            Act = () =>
+            {
+                ToggleMagnet(uid, component);
+            },
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
+            Text = Loc.GetString("magnet-pickup-component-toggle-verb"),
+            Priority = 3
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    // Frontier, used to show the magnet state on examination
+    private void OnExamined(EntityUid uid, MaterialStorageMagnetPickupComponent component, ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("magnet-pickup-component-on-examine-main",
+                        ("stateText", Loc.GetString(component.MagnetEnabled
+                        ? "magnet-pickup-component-magnet-on"
+                        : "magnet-pickup-component-magnet-off"))));
+    }
+
+    // Frontier, used to toggle the magnet on the ore bag/box
+    public bool ToggleMagnet(EntityUid uid, MaterialStorageMagnetPickupComponent comp)
+    {
+        var query = EntityQueryEnumerator<MaterialStorageMagnetPickupComponent>();
+        comp.MagnetEnabled = !comp.MagnetEnabled;
+
+        return comp.MagnetEnabled;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var query = EntityQueryEnumerator<MaterialStorageMagnetPickupComponent, MaterialStorageComponent, TransformComponent>();
+        var currentTime = _timing.CurTime;
+
+        while (query.MoveNext(out var uid, out var comp, out var storage, out var xform))
+        {
+            if (comp.NextScan < currentTime)
+                continue;
+
+            comp.NextScan += ScanDelay;
+
+            // Frontier - magnet disabled
+            if (!comp.MagnetEnabled)
+                continue;
+
+            var parentUid = xform.ParentUid;
+
+            foreach (var near in _lookup.GetEntitiesInRange(uid, comp.Range, LookupFlags.Dynamic | LookupFlags.Sundries))
+            {
+                if (!_physicsQuery.TryGetComponent(near, out var physics) || physics.BodyStatus != BodyStatus.OnGround)
+                    continue;
+
+                if (near == parentUid)
+                    continue;
+
+                if (!_storage.TryInsertMaterialEntity(uid, near, uid, storage))
+                    continue;
+            }
+        }
+    }
+}

--- a/Content.Shared/Frontier/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
+++ b/Content.Shared/Frontier/Storage/EntitySystems/MaterialStorageMagnetPickupSystem.cs
@@ -1,4 +1,4 @@
-using Content.Server.Storage.Components;
+using Content.Shared.Frontier.Storage.Components;
 using Content.Shared.Materials;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Timing;
@@ -7,7 +7,7 @@ using Content.Shared.Hands.Components;  // Frontier
 using Content.Shared.Verbs;     // Frontier
 using Robust.Shared.Utility;    // Frontier
 
-namespace Content.Shared.Storage.EntitySystems;
+namespace Content.Shared.Frontier.Storage.EntitySystems;
 
 /// <summary>
 /// <see cref="MaterialStorageMagnetPickupComponent"/>
@@ -45,17 +45,16 @@ public sealed class MaterialStorageMagnetPickupSystem : EntitySystem
     // Frontier, used to add the magnet toggle to the context menu
     private void AddToggleMagnetVerb(EntityUid uid, MaterialStorageMagnetPickupComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.CanAccess || !args.CanInteract)
-            return;
-
-        if (!HasComp<HandsComponent>(args.User))
+        if (!HasComp<HandsComponent>(args.User)
+            || !args.CanInteract
+            || !args.CanAccess)
             return;
 
         AlternativeVerb verb = new()
         {
             Act = () =>
             {
-                ToggleMagnet(uid, component);
+                component.MagnetEnabled = !component.MagnetEnabled;
             },
             Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/Spare/poweronoff.svg.192dpi.png")),
             Text = Loc.GetString("magnet-pickup-component-toggle-verb"),
@@ -72,15 +71,6 @@ public sealed class MaterialStorageMagnetPickupSystem : EntitySystem
                         ("stateText", Loc.GetString(component.MagnetEnabled
                         ? "magnet-pickup-component-magnet-on"
                         : "magnet-pickup-component-magnet-off"))));
-    }
-
-    // Frontier, used to toggle the magnet on the ore bag/box
-    public bool ToggleMagnet(EntityUid uid, MaterialStorageMagnetPickupComponent comp)
-    {
-        var query = EntityQueryEnumerator<MaterialStorageMagnetPickupComponent>();
-        comp.MagnetEnabled = !comp.MagnetEnabled;
-
-        return comp.MagnetEnabled;
     }
 
     public override void Update(float frameTime)
@@ -110,8 +100,7 @@ public sealed class MaterialStorageMagnetPickupSystem : EntitySystem
                 if (near == parentUid)
                     continue;
 
-                if (!_storage.TryInsertMaterialEntity(uid, near, uid, storage))
-                    continue;
+                _storage.TryInsertMaterialEntity(uid, near, uid, storage);
             }
         }
     }

--- a/Resources/Locale/en-US/frontier/storage/components/magnet-pickup-components.ftl
+++ b/Resources/Locale/en-US/frontier/storage/components/magnet-pickup-components.ftl
@@ -1,0 +1,4 @@
+magnet-pickup-component-toggle-verb = Toggle magnet
+magnet-pickup-component-on-examine-main = The magnet appears to be {$stateText}.
+magnet-pickup-component-magnet-on = [color=darkgreen]on[/color]
+magnet-pickup-component-magnet-off =  [color=darkred]off[/color]

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1180,6 +1180,11 @@
         - IngotGold30
         - IngotSilver30
         - MaterialBananium10
+    - type: MaterialStorageMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
+      range: 0.30
+      whitelist:
+        tags:
+          - Ore # Delta V - End Magnet Pull
 
 - type: entity
   parent: OreProcessor

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1211,9 +1211,6 @@
       - IngotGold30
       - IngotSilver30
       - MaterialBananium10
-  - type: MaterialStorageMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
-    magnetEnabled: True
-    range: 0.30 # Delta V - End Magnet Pull
 
 - type: entity
   parent: BaseLathe

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1181,10 +1181,8 @@
         - IngotSilver30
         - MaterialBananium10
     - type: MaterialStorageMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
-      range: 0.30
-      whitelist:
-        tags:
-          - Ore # Delta V - End Magnet Pull
+      magnetEnabled: True
+      range: 0.30 # Delta V - End Magnet Pull
 
 - type: entity
   parent: OreProcessor

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1211,6 +1211,9 @@
       - IngotGold30
       - IngotSilver30
       - MaterialBananium10
+  - type: MaterialStorageMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
+    magnetEnabled: True
+    range: 0.30 # Delta V - End Magnet Pull
 
 - type: entity
   parent: BaseLathe

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -103,3 +103,19 @@
     solution: output
   - type: StaticPrice
     price: 500
+  - type: MaterialReclaimerMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
+    range: 0.30
+    whitelist:
+      components:
+      - PhysicalComposition
+      - SpaceGarbage
+      tags:
+      - Trash
+      - Recyclable
+    blacklist:
+      components:
+      - Material
+      - Pda
+      - IdCard
+      tags:
+      - HighRiskItem # Delta V - End Magnet Pull

--- a/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/material_reclaimer.yml
@@ -104,18 +104,5 @@
   - type: StaticPrice
     price: 500
   - type: MaterialReclaimerMagnetPickup # Delta V - Summary: Adds magnet pull from Frontier
-    range: 0.30
-    whitelist:
-      components:
-      - PhysicalComposition
-      - SpaceGarbage
-      tags:
-      - Trash
-      - Recyclable
-    blacklist:
-      components:
-      - Material
-      - Pda
-      - IdCard
-      tags:
-      - HighRiskItem # Delta V - End Magnet Pull
+    magnetEnabled: True
+    range: 0.30 # Delta V - End Magnet Pull


### PR DESCRIPTION
## About the PR
- Title: Machines will automatically pull in tagged items for processing, allowing to set them up on conveyor belts.
- Adds to Ore Processors
- Adds to Material Reclaimer

## Why / Balance
Better gameplay and Factorio mapping

## Technical details
n/a

## Media
https://github.com/DeltaV-Station/Delta-v/assets/107660393/defb8724-acaf-4897-9d5a-4edb5ba17edd

https://github.com/DeltaV-Station/Delta-v/assets/107660393/725a74a3-3978-4097-bdf4-d84ff2f55f38



- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- add: Added magnet pickup to Ore Processors and Material Reclaimer