### PR TITLE
Port frontier station 14's sizeattribute system

### DIFF
--- a/Content.Server/_NF/Cloning/ITransferredByCloning.cs
+++ b/Content.Server/_NF/Cloning/ITransferredByCloning.cs
@@ -1,0 +1,8 @@
+namespace Content.Server._NF.Cloning;
+
+/// <summary>
+///   Indicates that this Component should be transferred to the new entity when the entity is cloned (for example, using a cloner)
+/// </summary>
+public interface ITransferredByCloning
+{
+}

--- a/Content.Server/_NF/SizeAttribute/SizeAttributeComponent.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeComponent.cs
@@ -1,0 +1,14 @@
+using Content.Server._NF.Cloning;
+
+namespace Content.Server._NF.SizeAttribute
+{
+    [RegisterComponent]
+    public sealed partial class SizeAttributeComponent : Component, ITransferredByCloning
+    {
+        [DataField("short")]
+        public bool Short = false;
+
+        [DataField("tall")]
+        public bool Tall = false;
+    }
+}

--- a/Content.Server/_NF/SizeAttribute/SizeAttributeSystem.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeSystem.cs
@@ -1,0 +1,95 @@
+using System.Numerics;
+using Content.Server.SizeAttribute;
+using Robust.Server.GameObjects;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Collision.Shapes;
+using Robust.Shared.Physics.Systems;
+using Content.Shared.Item.PseudoItem;
+using Content.Shared.Nyanotrasen.Item.PseudoItem;
+
+namespace Content.Server._NF.SizeAttribute
+{
+    public sealed class SizeAttributeSystem : EntitySystem
+    {
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+        [Dependency] private readonly AppearanceSystem _appearance = default!;
+        [Dependency] private readonly FixtureSystem _fixtures = default!;
+        public override void Initialize()
+        {
+            base.Initialize();
+            SubscribeLocalEvent<SizeAttributeComponent, ComponentInit>(OnComponentInit);
+        }
+
+        private void OnComponentInit(EntityUid uid, SizeAttributeComponent component, ComponentInit args)
+        {
+            if (!TryComp<SizeAttributeWhitelistComponent>(uid, out var whitelist))
+                return;
+
+            if (whitelist.Tall && component.Tall)
+            {
+                Scale(uid, component, whitelist.TallScale, whitelist.TallDensity, whitelist.TallCosmeticOnly);
+                PseudoItem(uid, component, whitelist.TallPseudoItem);
+            }
+            else if (whitelist.Short && component.Short)
+            {
+                Scale(uid, component, whitelist.ShortScale, whitelist.ShortDensity, whitelist.ShortCosmeticOnly);
+                // deltav: added PseudoItemShape
+                PseudoItem(uid, component, whitelist.ShortPseudoItem, whitelist.PseudoItemShape);
+            }
+        }
+
+        // deltav: added a shape argument and refactored the method
+        private void PseudoItem(EntityUid uid, SizeAttributeComponent component, bool active, List<Box2i>? shape = null)
+        {
+            if (active)
+            {
+                var pseudoItem = EnsureComp<PseudoItemComponent>(uid);
+                pseudoItem.Shape = shape;
+            }
+            else
+            {
+                if (!TryComp<PseudoItemComponent>(uid, out var pseudoI))
+                    return;
+                RemComp(uid, pseudoI);
+            }
+        }
+
+        private void Scale(EntityUid uid, SizeAttributeComponent component, float scale, float density, bool cosmeticOnly)
+        {
+            if (scale <= 0f && density <= 0f)
+                return;
+
+            _entityManager.EnsureComponent<ScaleVisualsComponent>(uid);
+
+            var appearanceComponent = _entityManager.EnsureComponent<AppearanceComponent>(uid);
+            if (!_appearance.TryGetData<Vector2>(uid, ScaleVisuals.Scale, out var oldScale, appearanceComponent))
+                oldScale = Vector2.One;
+
+            _appearance.SetData(uid, ScaleVisuals.Scale, oldScale * scale, appearanceComponent);
+
+            if (!cosmeticOnly && _entityManager.TryGetComponent(uid, out FixturesComponent? manager))
+            {
+                foreach (var (id, fixture) in manager.Fixtures)
+                {
+                    if (!fixture.Hard || fixture.Density <= 1f)
+                        continue; // This will skip the flammable fixture and any other fixture that is not supposed to contribute to mass
+
+                    switch (fixture.Shape)
+                    {
+                        case PhysShapeCircle circle:
+                            _physics.SetPositionRadius(uid, id, fixture, circle, circle.Position * scale, circle.Radius * scale, manager);
+                            break;
+                        default:
+                            throw new NotImplementedException();
+                    }
+
+                    _physics.SetDensity(uid, id, fixture, density);
+                }
+            }
+        }
+    }
+
+    [ByRefEvent]
+    public readonly record struct ScaleEntityEvent(EntityUid Uid) { }
+}

--- a/Content.Server/_NF/SizeAttribute/SizeAttributeWhitelistComponent.cs
+++ b/Content.Server/_NF/SizeAttribute/SizeAttributeWhitelistComponent.cs
@@ -1,0 +1,48 @@
+using Robust.Shared.Physics.Collision.Shapes;
+
+namespace Content.Server.SizeAttribute
+{
+    [RegisterComponent]
+    public sealed partial class SizeAttributeWhitelistComponent : Component
+    {
+        // Short
+        [DataField("short")]
+        public bool Short = false;
+
+        [DataField("shortscale")]
+        public float ShortScale = 0f;
+
+        [DataField("shortDensity")]
+        public float ShortDensity = 0f;
+
+        [DataField("shortPseudoItem")]
+        public bool ShortPseudoItem = false;
+
+        [DataField("shortCosmeticOnly")]
+        public bool ShortCosmeticOnly = true;
+
+        // Delta-v: added custom pseudo-item shape
+        /// <summary>
+        /// An optional override for the shape of the item within the grid storage.
+        /// If null, a default shape will be used based on <see cref="Size"/>.
+        /// </summary>
+        [DataField("pseudoItemShape")]
+        public List<Box2i>? PseudoItemShape;
+
+        // Tall
+        [DataField("tall")]
+        public bool Tall = false;
+
+        [DataField("tallscale")]
+        public float TallScale = 0f;
+
+        [DataField("tallDensity")]
+        public float TallDensity = 0f;
+
+        [DataField("tallPseudoItem")]
+        public bool TallPseudoItem = false;
+
+        [DataField("tallCosmeticOnly")]
+        public bool TallCosmeticOnly = true;
+    }
+}

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -102,6 +102,7 @@
     shortscale: 0.8
     shortDensity: 140
     shortPseudoItem: true
+    shortCosmeticOnly: false
     pseudoItemShape: # Delta-v - custom pseudo-item shape
     - 0,0,1,4
     - 0,2,3,4

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -97,6 +97,15 @@
       Female: FemaleVulpkanin
       Unsexed: MaleVulpkanin
   - type: DogVision
+  - type: SizeAttributeWhitelist # Frontier - tall/short traits
+    short: true
+    shortscale: 0.8
+    shortDensity: 140
+    shortPseudoItem: true
+    pseudoItemShape: # Delta-v - custom pseudo-item shape
+    - 0,0,1,4
+    - 0,2,3,4
+    - 4,0,5,4
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -59,6 +59,9 @@
       types:
         Heat : 1.5 #per second, scales with temperature & other constants
   - type: Wagging
+  - type: SizeAttributeWhitelist # Frontier - tall/short traits (cosmetic-only)
+    tall: true
+    tallscale: 1.2
 
 - type: entity
   parent: BaseSpeciesDummy

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -64,6 +64,9 @@
       Unsexed: MaleFelinid
   - type: Felinid
   - type: NoShoesSilentFootsteps
+  - type: SizeAttributeWhitelist # Frontier - tall/short traits (cosmetic-only, but does remove pseudo-item)
+    tall: true
+    tallscale: 1
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_NF/Traits/sizeattribute.yml
+++ b/Resources/Prototypes/_NF/Traits/sizeattribute.yml
@@ -1,0 +1,25 @@
+- type: trait
+  id: Tall
+  name: Tall
+  whitelist:
+    components:
+    - SizeAttributeWhitelist
+  blacklist:
+    components:
+    - SizeAttribute
+  components:
+  - type: SizeAttribute
+    tall: true
+
+- type: trait
+  id: Short
+  name: Short
+  whitelist:
+    components:
+    - SizeAttributeWhitelist
+  blacklist:
+    components:
+    - SizeAttribute
+  components:
+  - type: SizeAttribute
+    short: true


### PR DESCRIPTION
## About the PR
Frontier station has a sizeattribute system that allows **certain species** to change their size via two traits: small and tall.

This PR fully ports it, with some minor changes to adapt it for deltav.

Only 3 species are currently affected:
- Catgirls can become tall, becoming on par with humans, although losing the ability to fit in bags. Other than that, this change is cosmetic-only.
- Lizards can become tall, this is purely cosmetic
- Vulps can become small, which makes them on par with felinids. They can fit in bags, they get a smaller collision fixture, they get smaller mass (so harder to push things around).

## Why / Balance
This system, albeit being far from ideal, allows for some more additional character customization and should hopefully benefit roleplay. These changes should HOPEFULLY not have any noticable impact on the balance.

The tall trait is cosmetic-only for lizards and cats because it used to breed a lot of powergaming when it had effect on character's stats. Although mass contests are no longer a thing, it's still not a very good idea to give people a "make me stronger" button.

## Technical details
First off, the code sucks a lot (it was written by a rather newbie coder). But it worked for months on frontier, and I'd rather not touch something that works already. A few adjustments were made, though.

1. Every species that are supposed to be able to use the tall/small traits must have a SizeAttributeWhitelistComponent attached to them. The component specifies what changes are to be done to the character if they choose either of the two traits.
2. Choosing one of the traits adds a SizeAttributeComponent to your character. The SizeAttributeSystem then checks if the whitelist allows it, and does the neccessary changes, which currently can include:
    - Scaling the character (either just cosmetically, or, if shortCosmeticOnly/tallCosmeticOnly are false, then also physically - their fixture is also scaled, affecting their mass)
    - Changing the density of the character's collision fixture, affecting their mass (if non-cosmetic)
    - Adding or removing the pseudoitem comp to/from the character

Also this includes a new interface for components - ITransferredByCloning. Here, it's only used to transfer the SizeAttributeComponent when the person is cloned (because, for some reason, without this cloning doesn't preserve these traits correctly, causing, for example, small vulps to come out of the cloning pod normal-sized). However, it can be added to any other component to make it carry over when the person with it is cloned. This introduces a couple new lines to upstream's cloning system.

## Media
Github won't allow me to upload a 20 mb recording, so here's it uploaded to discord: https://cdn.discordapp.com/attachments/732665247302942730/1217934790528077925/weeee-2024-03-14_23.09.08.mp4?ex=6605d52a&is=65f3602a&hm=2b16795e3cae09aad16ec70a69742918a24efe5018822f207ec1a46db776ad12&

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None? I hope.

**Changelog**

:cl:
- add: Two new traits were added: "short" and "tall". Currently, only the Vulpkanin can become shorter, and only Felinids and Reptillians can become taller.