### PR TITLE
Change collision mask of canisters to allow passing through cargo flaps

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -74,7 +74,7 @@
             bounds: "-0.25,-0.25,0.25,0.25"
           density: 190
           mask:
-          - MachineMask
+          - SmallMobMask # Delta V - Allow to pass under cargo flaps
           layer:
           - MachineLayer
     - type: AtmosDevice


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Frequently requested feature/QoL

**Changelog**
:cl: Velcroboy
- tweak: Tweaked canisters can pass through cargo flaps now. 