### PR TITLE
Unlocked Booze-O-Mat

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Machines/vending_machines.yml
@@ -48,3 +48,11 @@
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
     access: [["Mail"]]
+
+- type: entity
+  parent: VendingMachineBooze
+  id: VendingMachineBoozeUnlocked
+  suffix: Unlocked
+  components:
+  - type: AccessReader
+    enabled: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds a Booze-O-Mat variant that has no access requirements. Mainly for the perma one in Sub, and it would be useful for the maints bars where it has to be hacked *every* time.

NOTE: I hereby release all changes made in this PR under MIT license.

**Changelog**
:cl:
- add: Added a variant Booze-O-Mat that starts unlocked.
