### PR TITLE
Shortens more beacon names

### DIFF
--- a/Resources/Locale/en-US/deltav/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/deltav/navmap-beacons/station-beacons.ftl
@@ -2,31 +2,31 @@ station-beacon-epistemics = Epistemics
 station-beacon-mystagogue = Mystagogue
 
 station-beacon-logistics = Logistics
-station-beacon-logistics-reception = Logistics Reception
+station-beacon-logistics-reception = Logistics
 station-beacon-lo = LO
 
 station-beacon-conference-room = Conference Room
 
 station-beacon-virology = Virology
 station-beacon-metempsychosis = Metempsychosis
-station-beacon-exam = Exam Room
+station-beacon-exam = Exam
 station-beacon-med-outpost = Med Outpost
-station-beacon-psych = Psychologist
+station-beacon-psych = Psych
 
-station-beacon-glimmer-prober = Glimmer Prober
-station-beacon-forensic-mantis = Forensic Mantis
+station-beacon-glimmer-prober = Prober
+station-beacon-forensic-mantis = Mantis
 
 station-beacon-mailroom = Mail
 
 station-beacon-engi-outpost = Engi Outpost
 
 station-beacon-janitor-office = Jani Office
-station-beacon-janitor-closet = Jani closet
+station-beacon-janitor-closet = Jani Closet
 station-beacon-reporter = Reporter
 
-station-beacon-camera-servers = Camera Servers
+station-beacon-camera-servers = Cameras
 
-station-beacon-boxing-ring = Boxing Ring
+station-beacon-boxing-ring = Boxing
 station-beacon-park = Park
 
 station-beacon-corpsman = Corpsman


### PR DESCRIPTION
## About the PR
Shortens some map beacon names and fixes casing for jani closet

## Why / Balance
Some were just too long, taking up too much space. And typo is typo.