### PR TITLE
Change Survival Event Weights

### DIFF
--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -9,7 +9,7 @@
       path: /Audio/Announcements/aliens.ogg
     earliestStart: 20
     minimumPlayers: 15
-    weight: 1
+    weight: 2.5
     duration: 60
   - type: VentCrittersRule
     entries:
@@ -30,21 +30,21 @@
     - id: MobXenoQueen
       prob: 0.005
 
-- type: entity
-  id: MothroachSpawn
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    id: VentCritters
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 4
-    duration: 60
-  - type: VentCrittersRule
-    entries:
-    - id: MobMothroach
-      prob: 0.05
+# - type: entity
+#   id: MothroachSpawn
+#   parent: BaseGameRule
+#   noSpawn: true
+#   components:
+#   - type: StationEvent
+#     id: VentCritters
+#     earliestStart: 15
+#     minimumPlayers: 15
+#     weight: 4
+#     duration: 60
+#   - type: VentCrittersRule
+#     entries:
+#     - id: MobMothroach
+#       prob: 0.05
 
 - type: entity # Delta-V : Midround Syndie Listening Station Spawn
   id: PirateRadioSpawn

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -85,7 +85,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 1 # DeltaV - was 5
+    weight: 2.5 # DeltaV - was 5
     duration: 1
     earliestStart: 45
     reoccurrenceDelay: 60
@@ -99,7 +99,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 3 # DeltaV - was 10
+    weight: 7.5 # DeltaV - was 10
     duration: 1
     earliestStart: 45 # DeltaV - was 30
     reoccurrenceDelay: 60
@@ -112,7 +112,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 7.5
+    weight: 3 # DeltaV - was 10
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -177,52 +177,52 @@
     startDelay: 30
   - type: MeteorSwarmRule
 
-- type: entity
-  id: MouseMigration
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    startDelay: 10
-    earliestStart: 30
-    minimumPlayers: 35
-    weight: 5
-    duration: 50
-  - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
+# - type: entity # Delta-V: Commented out uninteresting events
+#   id: MouseMigration
+#   parent: BaseGameRule
+#   noSpawn: true
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-vent-creatures-start-announcement
+#     startAudio:
+#       path: /Audio/Announcements/attention.ogg
+#     startDelay: 10
+#     earliestStart: 30
+#     minimumPlayers: 35
+#     weight: 5
+#     duration: 50
+#   - type: VentCrittersRule
+#     entries:
+#     - id: MobMouse
+#       prob: 0.02
+#     - id: MobMouse1
+#       prob: 0.02
+#     - id: MobMouse2
+#       prob: 0.02
     # DeltaV - Rat King spawns under MidRoundAntag - Comment out Rat King from spawning with MouseMigration gamerule
     # specialEntries:
     # - id: SpawnPointGhostRatKing
     #   prob: 0.005
     # End of modified code
 
-- type: entity
-  id: CockroachMigration
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    startDelay: 10
-    weight: 5
-    duration: 50
-  - type: VentCrittersRule
-    entries:
-    - id: MobCockroach
-      prob: 0.03
-    - id: MobMothroach
-      prob: 0.008
+# - type: entity # Delta-V: Commented out uninteresting events
+#   id: CockroachMigration
+#   parent: BaseGameRule
+#   noSpawn: true
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-vent-creatures-start-announcement
+#     startAudio:
+#       path: /Audio/Announcements/attention.ogg
+#     startDelay: 10
+#     weight: 5
+#     duration: 50
+#   - type: VentCrittersRule
+#     entries:
+#     - id: MobCockroach
+#       prob: 0.03
+#     - id: MobMothroach
+#       prob: 0.008
 
 - type: entity
   id: PowerGridCheck
@@ -312,28 +312,28 @@
     duration: 60
   - type: VentClogRule
 
-- type: entity
-  id: VentCritters
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    startAnnouncement: station-event-vent-creatures-start-announcement
-    startAudio:
-      path: /Audio/Announcements/attention.ogg
-    startDelay: 10
-    earliestStart: 15
-    minimumPlayers: 15
-    weight: 5
-    duration: 60
-  - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
+# - type: entity # Delta-V: Commented out uninteresting events
+#   id: VentCritters
+#   parent: BaseGameRule
+#   noSpawn: true
+#   components:
+#   - type: StationEvent
+#     startAnnouncement: station-event-vent-creatures-start-announcement
+#     startAudio:
+#       path: /Audio/Announcements/attention.ogg
+#     startDelay: 10
+#     earliestStart: 15
+#     minimumPlayers: 15
+#     weight: 5
+#     duration: 60
+#   - type: VentCrittersRule
+#     entries:
+#     - id: MobMouse
+#       prob: 0.02
+#     - id: MobMouse1
+#       prob: 0.02
+#     - id: MobMouse2
+#       prob: 0.02
 
 - type: entity
   id: SlimesSpawn
@@ -426,21 +426,21 @@
     duration: 1
   - type: LoneOpsSpawnRule
 
-- type: entity
-  id: MassHallucinations
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 10
-    duration: 150
-    maxDuration: 300
-  - type: MassHallucinationsRule
-    minTimeBetweenIncidents: 0.1
-    maxTimeBetweenIncidents: 300
-    maxSoundDistance: 7
-    sounds:
-      collection: Paracusia
+# - type: entity # DeltaV - commented out uninterested events
+#   id: MassHallucinations
+#   parent: BaseGameRule
+#   noSpawn: true
+#   components:
+#   - type: StationEvent
+#     weight: 10
+#     duration: 150
+#     maxDuration: 300
+#   - type: MassHallucinationsRule
+#     minTimeBetweenIncidents: 0.1
+#     maxTimeBetweenIncidents: 300
+#     maxSoundDistance: 7
+#     sounds:
+#       collection: Paracusia
 
 #- type: entity # DeltaV - Why does this exist??
 #  id: ImmovableRodSpawn


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Changed some weights:

- Ninja is more likely (3 --> 7.5) because it is by far the most interesting survival antag and its a shame it doesn't show up very often. Still lower than upstream, which is 10.
- Dragon is slightly more likely (1 --> 2.5) because I think I've maybe seen a dragon spawn that wasn't a ninja call-in... oooonce??? Still lower than upstream, which is 5.
- Revenant is less likely (7.5 --> 3) as it is currently not very interesting and happens way too often. I have no idea why upstream would put this at 10, maybe because all the other interesting deadly shit is also 10.
- XenoVents is slightly more likely (1 --> 2.5) because, like Dragon, it seems to be *extremely* rare right now. I remember back when it was 4 it was WAY too often but now its a little too rare IMO. Even modified, its still half the weight of spiders & slimes.
- MouseMigration was commented out because it is Literally Nothing and wastes the slot of a potentially more interesting event.
- CockroachMigration, ditto above.
- MothroachSpawn, ditto above.
- VentCritters (??!) was commented out FOR BEING IDENTICAL TO MOUSEMIGRATION. God, no fucking wonder the mouse one seemed to be the most common event, it was DUPLICATED.
- MassHallucinations was commented out, also an uninteresting one. You hear a zombie groan or something and for a moment think this round might *actually* be interesting, but nope! Just pick the paracusia trait if you want this to happen.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Tweaked survival event weights to be more fun.