### PR TITLE
Fixes security hud going blank

### DIFF
--- a/Resources/Prototypes/DeltaV/StatusEffects/job.yml
+++ b/Resources/Prototypes/DeltaV/StatusEffects/job.yml
@@ -2,5 +2,5 @@
   parent: JobIcon
   id: JobIconMedicalBorg
   icon:
-    sprite: DeltaV/Interface/Misc/job_icons.rsi
+    sprite: /Textures/DeltaV/Interface/Misc/job_icons.rsi
     state: MedicalBorg

--- a/Resources/Prototypes/Nyanotrasen/StatusEffects/job.yml
+++ b/Resources/Prototypes/Nyanotrasen/StatusEffects/job.yml
@@ -2,33 +2,33 @@
   parent: JobIcon
   id: JobIconGladiator
   icon:
-    sprite: DeltaV/Interface/Misc/job_icons.rsi
+    sprite: /Textures/DeltaV/Interface/Misc/job_icons.rsi
     state: nyanoGladiator
 
 - type: statusIcon
   parent: JobIcon
   id: JobIconPrisonGuard
   icon:
-    sprite: DeltaV/Interface/Misc/job_icons.rsi
+    sprite: /Textures/DeltaV/Interface/Misc/job_icons.rsi
     state: nyanoPrisonGuard
 
 - type: statusIcon
   parent: JobIcon
   id: JobIconMailCarrier
   icon:
-    sprite: DeltaV/Interface/Misc/job_icons.rsi
+    sprite: /Textures/DeltaV/Interface/Misc/job_icons.rsi
     state: nyanoMailCarrier
 
 - type: statusIcon
   parent: JobIcon
   id: JobIconMartialArtist
   icon:
-    sprite: DeltaV/Interface/Misc/job_icons.rsi
+    sprite: /Textures/DeltaV/Interface/Misc/job_icons.rsi
     state: nyanoMartialArtist
 
 - type: statusIcon
   parent: JobIcon
   id: JobIconForensicMantis
   icon:
-    sprite: DeltaV/Interface/Misc/job_icons.rsi
+    sprite: /Textures/DeltaV/Interface/Misc/job_icons.rsi
     state: nyanoMantis


### PR DESCRIPTION
Someone forgot to put Textures in the path
Basicly security hud stopped working when either nyano or delta V job came by, this fixes it.

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
