### PR TITLE
Edge FIX: cursed steel

### DIFF
--- a/Resources/Maps/edge.yml
+++ b/Resources/Maps/edge.yml
@@ -7820,6 +7820,58 @@ entities:
         - DoorStatus: DoorBolt
         170:
         - DoorStatus: DoorBolt
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -51.5,19.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -51.5,11.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -51.5,13.5
+      parent: 2
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -51.5,21.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 41.5,-3.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 41.5,-9.5
+      parent: 2
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 41.5,-17.5
+      parent: 2
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 41.5,-19.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 41.5,-11.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 41.5,-1.5
+      parent: 2
 - proto: AirlockExternalGlassAtmosphericsLocked
   entities:
   - uid: 172
@@ -7896,58 +7948,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-33.5
-      parent: 2
-- proto: AirlockExternalGlassEasyPry
-  entities:
-  - uid: 179
-    components:
-    - type: Transform
-      pos: -51.5,19.5
-      parent: 2
-  - uid: 180
-    components:
-    - type: Transform
-      pos: -51.5,11.5
-      parent: 2
-  - uid: 181
-    components:
-    - type: Transform
-      pos: -51.5,13.5
-      parent: 2
-  - uid: 182
-    components:
-    - type: Transform
-      pos: -51.5,21.5
-      parent: 2
-  - uid: 183
-    components:
-    - type: Transform
-      pos: 41.5,-3.5
-      parent: 2
-  - uid: 184
-    components:
-    - type: Transform
-      pos: 41.5,-9.5
-      parent: 2
-  - uid: 185
-    components:
-    - type: Transform
-      pos: 41.5,-17.5
-      parent: 2
-  - uid: 186
-    components:
-    - type: Transform
-      pos: 41.5,-19.5
-      parent: 2
-  - uid: 187
-    components:
-    - type: Transform
-      pos: 41.5,-11.5
-      parent: 2
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 41.5,-1.5
       parent: 2
 - proto: AirlockExternalGlassLocked
   entities:
@@ -89087,15 +89087,6 @@ entities:
     - type: Transform
       pos: 12.552183,-10.534737
       parent: 2
-  - uid: 13535
-    components:
-    - type: Transform
-      pos: -0.5,27.5
-      parent: 2
-    - type: Stack
-      count: 10
-    - type: Item
-      size: 10
 - proto: SheetSteel1
   entities:
   - uid: 13536
@@ -89128,6 +89119,11 @@ entities:
       parent: 2
 - proto: SheetSteel10
   entities:
+  - uid: 13535
+    components:
+    - type: Transform
+      pos: -0.48492527,27.537094
+      parent: 2
   - uid: 13541
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
thanos snapped the cursed steel stack and replaced it with a holy water blessed version
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
bug = bad

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
Cursed steel stack dating back to oldinv snapped, put the modern and non broken one instead