### PR TITLE
Spare ID cabinet will no longer drop a card on destruction

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Command/safe.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Command/safe.yml
@@ -4,6 +4,23 @@
   name: spare id cabinet
   description: There is a small label that reads "For emergency use only".
   components:
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 300
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+      - trigger:
+          !type:DamageTrigger
+          damage: 50000 # Good luck lol
+        behaviors:
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalGlassBreak
     - type: Sprite
       sprite: DeltaV/Structures/Wallmounts/idcard_cabinet.rsi
       layers:

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Command/safe.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Command/safe.yml
@@ -4,23 +4,23 @@
   name: spare id cabinet
   description: There is a small label that reads "For emergency use only".
   components:
-  - type: Destructible
-    thresholds:
-      - trigger:
-          !type:DamageTrigger
-          damage: 300
-        behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-      - trigger:
-          !type:DamageTrigger
-          damage: 50000 # Good luck lol
-        behaviors:
-        - !type:DoActsBehavior
-          acts: [ "Destruction" ]
-        - !type:PlaySoundBehavior
-          sound:
-            collection: MetalGlassBreak
+    - type: Destructible
+      thresholds:
+        - trigger:
+            !type:DamageTrigger
+            damage: 300
+          behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+        - trigger:
+            !type:DamageTrigger
+            damage: 50000 # Good luck lol
+          behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]
+          - !type:PlaySoundBehavior
+            sound:
+              collection: MetalGlassBreak
     - type: Sprite
       sprite: DeltaV/Structures/Wallmounts/idcard_cabinet.rsi
       layers:


### PR DESCRIPTION
## About the PR
Also makes it take a lot of damage before it'll actually break

**Changelog**

:cl:
- fix: Fixed the spare ID safe being destructible 

