### PR TITLE
fix nukie planet whitelist

### DIFF
--- a/Resources/Maps/Nonstations/nukieplanet.yml
+++ b/Resources/Maps/Nonstations/nukieplanet.yml
@@ -29,10 +29,6 @@ entities:
       name: Syndicate Outpost
     - type: Transform
       parent: 1295
-    - type: FTLDestination
-      whitelist:
-        tags:
-        - Syndicate
     - type: MapGrid
       chunks:
         -1,-1:
@@ -1636,6 +1632,10 @@ entities:
     - type: MetaData
     - type: Transform
     - type: Map
+    - type: FTLDestination
+      whitelist:
+        tags:
+        - Syndicate
     - type: PhysicsMap
     - type: Broadphase
     - type: OccluderTree


### PR DESCRIPTION
## About the PR
cargo can no longer see nukie planet in ftl list

## Why / Balance
le metagaming bad

## Technical details
it was on wrong entity no idea who moved it or why

## Media
nukeops rule added and cargo shuttle spawned
![19:30:44](https://github.com/DeltaV-Station/Delta-v/assets/39013340/eab938cb-7f93-49e9-9ac0-e5217996c202)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed cargo being able to metagame the nukie outpost existing.
