### PR TITLE
Brings back the clown hardsuit.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -954,6 +954,9 @@
     node: clownHardsuit
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitClown
+  - type: ContainerContainer # Delta V-Brings back clownsuit but make it make sense
+    containers:
+      toggleable-clothing: !type:ContainerSlot {}
 
 #Mime Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -924,7 +924,7 @@
 #MISC. HARDSUITS
 #Clown Hardsuit
 - type: entity
-  parent: ClothingOuterHardsuitBase
+  parent: ClothingOuterEVASuitBase # Delta V-Brings back clownsuit but make it make sense
   id: ClothingOuterHardsuitClown
   name: clown hardsuit
   description: A custom-made clown hardsuit.
@@ -936,22 +936,22 @@
   - type: PressureProtection
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
-  - type: ExplosionResistance
-    damageCoefficient: 0.9
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Caustic: 0.8
+  #- type: ExplosionResistance # Delta V-Brings back clownsuit but make it make sense
+  #  damageCoefficient: 0.9
+  #- type: Armor
+  #  modifiers:
+  #    coefficients:
+  #      Blunt: 0.9
+  #      Slash: 0.9
+  #      Piercing: 0.9
+  #      Caustic: 0.8
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
   - type: HeldSpeedModifier
-  #- type: Construction # DeltaV - Prevent clowns from making the hardsuit
-  #   graph: ClownHardsuit
-  #   node: clownHardsuit
+  - type: Construction
+    graph: ClownHardsuit
+    node: clownHardsuit
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitClown
 

--- a/Resources/Prototypes/Recipes/Construction/clothing.yml
+++ b/Resources/Prototypes/Recipes/Construction/clothing.yml
@@ -1,13 +1,13 @@
-# - type: construction # DeltaV - Prevent clowns from making the hardsuit
-#   name: clown hardsuit
-#   id: ClownHardsuit
-#   graph: ClownHardsuit
-#   startNode: start
-#   targetNode: clownHardsuit
-#   category: construction-category-clothing
-#   description: A modified hardsuit fit for a clown.
-#   icon: { sprite: Clothing/OuterClothing/Hardsuits/clown.rsi, state: icon }
-#   objectType: Item
+- type: construction
+  name: clown hardsuit
+  id: ClownHardsuit
+  graph: ClownHardsuit
+  startNode: start
+  targetNode: clownHardsuit
+  category: construction-category-clothing
+  description: A modified hardsuit fit for a clown.
+  icon: { sprite: Clothing/OuterClothing/Hardsuits/clown.rsi, state: icon }
+  objectType: Item
 
 #- type: construction # DeltaV - No mimes either
 #  name: mime hardsuit


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
I bring it back *but* it aint no straight upgrade to EVA by slappin crayons on it
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Its unique enough and it does feel like it would be somethin that clown would do in their attic.
Not the mime tho. The mime at best should have an transparent hardsuit :blunt:
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:

- tweak: Clown hardsuit is craftable once again.

