### PR TITLE
add prison headsets to secdrobe and prison lockers

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -13,6 +13,7 @@
        - id: ClothingShoesColorBlack
          amount: 2
        - id: ClothingMaskMuzzle
+       - id: ClothingHeadsetPrison
 
 #- type: entity
 #  id: WardrobePajamaFilled

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -17,6 +17,7 @@
     ClothingUniformJumpsuitSecBlue: 3
     ClothingUniformJumpskirtSecBlue: 3 # DeltaV - new skirt sprited, added to secdrobe
     ClothingHeadsetSecurity: 3
+    ClothingHeadsetPrison: 3 # DeltaV - prison headsets in secdrobe
     ClothingOuterWinterSec: 2
     ClothingOuterCoatGreatcoat: 2 # DeltaV - added greatcoats to SecDrobe. Surplus, reminds the officers of the good times.
 ##    ClothingOuterArmorBasic: 2 # DeltaV - moved body armour from SecDrobe to SecTech


### PR DESCRIPTION
## About the PR
3 of them

## Why / Balance
theres no actual way to get them before this

## Technical details
no

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: The SecDrobe now has Prison Headsets. Prisoners have rights too!
