### PR TITLE
Reduce inventory of unlocked Booze-O-Mats

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
@@ -1,0 +1,37 @@
+- type: vendingMachineInventory
+  id: BoozeOMatUnlockedInventory
+  startingInventory:
+    DrinkGlass: 10 #Kept glasses at top for ease to differentiate from booze.
+    DrinkShotGlass: 5
+    DrinkGlassCoupeShaped: 5
+    DrinkVacuumFlask: 1
+    DrinkFlaskBar: 1
+    DrinkShaker: 4
+    CustomDrinkJug: 2 #to allow for custom drinks in the soda/booze dispensers
+    DrinkAleBottleFull: 8
+    DrinkBeerBottleFull: 8
+    DrinkBeerCan: 8
+    DrinkWineCan: 8
+    DrinkSolDryCan: 8
+    DrinkWineBottleFull: 3
+    DrinkSojuBottleFull: 1
+    DrinkSakeBottleFull: 1
+    DrinkGinBottleFull: 3
+    DrinkRumBottleFull: 3
+    DrinkTequilaBottleFull: 3
+    DrinkVodkaBottleFull: 3
+    DrinkWhiskeyBottleFull: 3
+    #Mixers
+    DrinkColaBottleFull: 4
+    DrinkCreamCarton: 5
+    DrinkGrenadineBottleFull: 2
+    DrinkJuiceLimeCarton: 3
+    DrinkJuiceOrangeCarton: 3
+    DrinkJuiceTomatoCarton: 3
+    DrinkCoffeeLiqueurBottleFull: 1
+    DrinkSodaWaterCan: 8
+    DrinkSpaceMountainWindBottleFull: 3
+    DrinkSpaceUpBottleFull: 3
+    DrinkTonicWaterCan: 8
+    DrinkVermouthBottleFull: 4
+  #emaggedInventory:

--- a/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
@@ -1,7 +1,7 @@
 - type: vendingMachineInventory
   id: BoozeOMatUnlockedInventory
   startingInventory:
-    DrinkGlass: 10 #Kept glasses at top for ease to differentiate from booze.
+    DrinkGlass: 15 #Kept glasses at top for ease to differentiate from booze.
     DrinkShotGlass: 5
     DrinkGlassCoupeShaped: 5
     DrinkVacuumFlask: 1

--- a/Resources/Prototypes/DeltaV/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Machines/vending_machines.yml
@@ -56,10 +56,5 @@
   components:
   - type: VendingMachine
     pack: BoozeOMatUnlockedInventory
-    offState: off
-    brokenState: broken
-    normalState: normal-unshaded
-    denyState: deny-unshaded
-    loopDeny: false
   - type: AccessReader
     enabled: false

--- a/Resources/Prototypes/DeltaV/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Machines/vending_machines.yml
@@ -54,5 +54,12 @@
   id: VendingMachineBoozeUnlocked
   suffix: Unlocked
   components:
+  - type: VendingMachine
+    pack: BoozeOMatUnlockedInventory
+    offState: off
+    brokenState: broken
+    normalState: normal-unshaded
+    denyState: deny-unshaded
+    loopDeny: false
   - type: AccessReader
     enabled: false


### PR DESCRIPTION
## About the PR
Reduced the inventories of Booze-O-Mats to primarily basic booze, beer, wine, and mixers. (It does increase the amount of beer/wine cans and bottles though)

## Why / Balance
These are mostly mapped in maints bars and, in perma on Submarine. Partially this reduces the amount of free booze around the station, but more importantly, forces players to seek out the "real" bar for the more specialty drinks.

**Changelog**
:cl: Velcroboy
- tweak: Tweaked the inventories of unlocked Booze-O-Mats