### PR TITLE
Species vision fixes

### DIFF
--- a/Content.Client/DeltaV/Overlays/UltraVisionOverlay.cs
+++ b/Content.Client/DeltaV/Overlays/UltraVisionOverlay.cs
@@ -23,22 +23,29 @@ public sealed partial class UltraVisionOverlay : Overlay
         _ultraVisionShader = _prototypeManager.Index<ShaderPrototype>("UltraVision").Instance().Duplicate();
     }
 
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (_playerManager.LocalEntity is not { Valid: true } player
+            || !_entityManager.HasComponent<UltraVisionComponent>(player))
+        {
+            return false;
+        }
+
+        return base.BeforeDraw(in args);
+    }
+
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (ScreenTexture == null)
-            return;
-        if (_playerManager.LocalPlayer?.ControlledEntity is not {Valid: true} player)
-            return;
-        if (!_entityManager.HasComponent<UltraVisionComponent>(player))
+        if (ScreenTexture is null)
             return;
 
-        _ultraVisionShader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-
+        _ultraVisionShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
 
         var worldHandle = args.WorldHandle;
         var viewport = args.WorldBounds;
         worldHandle.SetTransform(Matrix3.Identity);
         worldHandle.UseShader(_ultraVisionShader);
         worldHandle.DrawRect(viewport, Color.White);
+        worldHandle.UseShader(null); // important - as of writing, construction overlay breaks without this
     }
 }

--- a/Content.Client/Nyanotrasen/Overlays/DogVisionOverlay.cs
+++ b/Content.Client/Nyanotrasen/Overlays/DogVisionOverlay.cs
@@ -23,22 +23,29 @@ public sealed partial class DogVisionOverlay : Overlay
         _dogVisionShader = _prototypeManager.Index<ShaderPrototype>("DogVision").Instance().Duplicate();
     }
 
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (_playerManager.LocalEntity is not { Valid: true } player
+            || !_entityManager.HasComponent<DogVisionComponent>(player))
+        {
+            return false;
+        }
+
+        return base.BeforeDraw(in args);
+    }
+
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (ScreenTexture == null)
-            return;
-        if (_playerManager.LocalPlayer?.ControlledEntity is not {Valid: true} player)
-            return;
-        if (!_entityManager.HasComponent<DogVisionComponent>(player))
+        if (ScreenTexture is null)
             return;
 
-        _dogVisionShader?.SetParameter("SCREEN_TEXTURE", ScreenTexture);
-
+        _dogVisionShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
 
         var worldHandle = args.WorldHandle;
         var viewport = args.WorldBounds;
         worldHandle.SetTransform(Matrix3.Identity);
         worldHandle.UseShader(_dogVisionShader);
         worldHandle.DrawRect(viewport, Color.White);
+        worldHandle.UseShader(null); // important - as of writing, construction overlay breaks without this
     }
 }

--- a/Content.Client/Nyanotrasen/Overlays/DogVisionSystem.cs
+++ b/Content.Client/Nyanotrasen/Overlays/DogVisionSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Abilities;
 using Content.Shared.DeltaV.CCVars;
 using Robust.Client.Graphics;
 using Robust.Shared.Configuration;
+using Robust.Shared.Player;
 
 namespace Content.Client.Nyanotrasen.Overlays;
 
@@ -9,6 +10,7 @@ public sealed partial class DogVisionSystem : EntitySystem
 {
     [Dependency] private readonly IOverlayManager _overlayMan = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly ISharedPlayerManager _playerMan = default!;
 
     private DogVisionOverlay _overlay = default!;
 
@@ -18,6 +20,8 @@ public sealed partial class DogVisionSystem : EntitySystem
 
         SubscribeLocalEvent<DogVisionComponent, ComponentInit>(OnDogVisionInit);
         SubscribeLocalEvent<DogVisionComponent, ComponentShutdown>(OnDogVisionShutdown);
+        SubscribeLocalEvent<DogVisionComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<DogVisionComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
 
         Subs.CVar(_cfg, DCCVars.NoVisionFilters, OnNoVisionFiltersChanged);
 
@@ -26,11 +30,23 @@ public sealed partial class DogVisionSystem : EntitySystem
 
     private void OnDogVisionInit(EntityUid uid, DogVisionComponent component, ComponentInit args)
     {
-        if (!_cfg.GetCVar(DCCVars.NoVisionFilters))
+        if (uid == _playerMan.LocalEntity && !_cfg.GetCVar(DCCVars.NoVisionFilters))
             _overlayMan.AddOverlay(_overlay);
     }
 
     private void OnDogVisionShutdown(EntityUid uid, DogVisionComponent component, ComponentShutdown args)
+    {
+        if (uid == _playerMan.LocalEntity)
+            _overlayMan.RemoveOverlay(_overlay);
+    }
+
+    private void OnPlayerAttached(EntityUid uid, DogVisionComponent component, LocalPlayerAttachedEvent args)
+    {
+        if (!_cfg.GetCVar(DCCVars.NoVisionFilters))
+            _overlayMan.AddOverlay(_overlay);
+    }
+
+    private void OnPlayerDetached(EntityUid uid, DogVisionComponent component, LocalPlayerDetachedEvent args)
     {
         _overlayMan.RemoveOverlay(_overlay);
     }


### PR DESCRIPTION
## About the PR
Fixes both issues described in #1148 for vulps and harpies. Closes #1148. (Also this PR's changeset is MIT licensed)

## Breaking changes
None

**Changelog**
:cl:
- fix: Vulpkanins or harpies getting gibbed/meatspiked no longer cures the colorblindness of vulpkanins/harpies nearby.
- fix: Species vision filters no longer break the construction overlay. Vulp and harpy engineers rejoice!
