### PR TITLE
reduce atmos antag advantage

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -3,7 +3,7 @@
   name: job-name-atmostech
   description: job-description-atmostech
   playTimeTracker: JobAtmosphericTechnician
-  antagAdvantage: 10 # DeltaV - Reduced TC: External Access + Fireaxe + Free Hardsuit
+  antagAdvantage: 2 # DeltaV - Reduced TC: Engineering
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering


### PR DESCRIPTION
## About the PR
#804 but atmos only because its very annoying

10 tc -> 18 tc, 4 bonus fish

## Why / Balance
because you only had 10 tc your stealth options were extremely limited, you can get 1 thing like a storage implant then a soap or some shit, for no good reason
- plasma is limited so plasmaflooding like old days is both not allowed and infeasible
- axe has no helpful use so running around with it makes you valid
- firesuits are all over the station

**Changelog**
:cl:
- tweak: Traitor atmos technicians now get 18 TC instead of 10 TC.