### PR TITLE
Remove "Become Psionic" Objective 

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
+++ b/Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
@@ -9,28 +9,29 @@
     stealGroup: AntiPsychicKnife
     owner: job-name-mantis
 
-- type: entity
-  id: BecomePsionicObjective
-  parent: BaseTraitorObjective
-  name: Become psionic
-  description: We need you to acquire psionics and keep them until your mission is complete.
-  noSpawn: true
-  components:
-  - type: NotJobsRequirement
-    jobs:
-      - Mime
-      - ForensicMantis
-  - type: Objective
-    difficulty: 2.5
-    #unique: false
-    icon:
-      sprite: Nyanotrasen/Icons/psi.rsi
-      state: psi
-  - type: ObjectiveBlacklistRequirement
-    blacklist:
-      components:
-      - BecomeGolemCondition
-  - type: BecomePsionicCondition
+# /-- This objective does not encourage antagonism, thus 1984
+#- type: entity
+# id: BecomePsionicObjective
+#  parent: BaseTraitorObjective
+#  name: Become psionic
+#  description: We need you to acquire psionics and keep them until your mission is complete.
+#  noSpawn: true
+#  components:
+#  - type: NotJobsRequirement
+#    jobs:
+#      - Mime
+#      - ForensicMantis
+#  - type: Objective
+#    difficulty: 2.5
+#    #unique: false
+#    icon:
+#      sprite: Nyanotrasen/Icons/psi.rsi
+#     state: psi
+#  - type: ObjectiveBlacklistRequirement
+#    blacklist:
+#      components:
+#      - BecomeGolemCondition
+#  - type: BecomePsionicCondition
 
 #- type: entity
 #  id: BecomeGolemObjective

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -39,7 +39,7 @@
     EscapeShuttleObjective: 1
     # DieObjective: 0.05 # DeltaV - Disable the lrp objective aka murderbone justification
     #HijackShuttleObjective: 0.02
-    BecomePsionicObjective: 1 # Nyanotrasen - Become Psionic objective, see Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
+    #BecomePsionicObjective: 1 # Nyanotrasen - Become Psionic objective, see Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
     #BecomeGolemObjective: 0.5 # Nyanotrasen - Become a golem objective, see Resources/Prototypes/Nyanotrasen/Objectives/traitor.yml
 
 - type: weightedRandom


### PR DESCRIPTION
## About the PR
Syndicate Agents will no longer receive the "Become Psionic" objective. 

## Why / Balance
This objective has always sucked. It doesn't encourage our antagonists to be antagonistic, and contributes to stale rounds. This will require review from Fox, but I'm pretty sure we have achieved consensus that this should go. 

## Technical details
I commented out the bit that I think weighs the objectives, but left basically everything else about this Objective- should we wish to re-add it. 

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Shouldn't break anything! I copied what was done with the golem objective :)

**Changelog**
:cl:
- tweak: Syndicate Agents will no longer receive the "Become Psionic" objective. 


