### PR TITLE
Fixes screens not showing ETA/ETD for evac shuttles

### DIFF
--- a/Resources/Maps/Shuttles/DeltaV/NTES_BC20.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_BC20.yml
@@ -74,6 +74,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Box.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Box.yml
@@ -61,6 +61,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Centipede.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Centipede.yml
@@ -84,6 +84,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Delta.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Delta.yml
@@ -68,6 +68,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Kaeri.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Kaeri.yml
@@ -61,6 +61,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Lox.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Lox.yml
@@ -66,6 +66,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Propeller.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Propeller.yml
@@ -93,6 +93,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Right.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Right.yml
@@ -81,6 +81,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_Seal.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Seal.yml
@@ -70,6 +70,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/NTES_UCLB.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_UCLB.yml
@@ -74,6 +74,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/Shuttles/DeltaV/sub_escape_pod.yml
+++ b/Resources/Maps/Shuttles/DeltaV/sub_escape_pod.yml
@@ -52,6 +52,10 @@ entities:
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
     - type: DecalGrid
       chunkCollection:
         version: 2


### PR DESCRIPTION
## About the PR
Adds missing comp to evac shuttles

## Why / Balance
ETA/ETD will now display on station and shuttle announcement screens

**Changelog**
:cl: Velcroboy
- fix: Fixed announcement screens not showing ETA/ETD of evac shuttles