### PR TITLE
Adds "Armory Commander" job for Hammurabi specific role

### DIFF
--- a/Resources/Locale/en-US/deltav/job/job-description.ftl
+++ b/Resources/Locale/en-US/deltav/job/job-description.ftl
@@ -1,1 +1,2 @@
 job-description-medical-borg = Half-human, Half-machine. Follow your laws, serve the crew, and assist the medical department.
+job-description-armory-commander = Hammurabi specific role. Your job is to manage the jail, man the front desk, monitor CCTV, and control the armory.

--- a/Resources/Locale/en-US/deltav/job/job-names.ftl
+++ b/Resources/Locale/en-US/deltav/job/job-names.ftl
@@ -1,1 +1,2 @@
 job-name-medical-borg = Medical Cyborg
+job-name-armory-commander = Armory Commander

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -33,7 +33,7 @@
       amount: 2
     - id: MagazineLightRifle
       amount: 4
-      
+
 - type: entity
   parent: GunSafe
   id: GunSafeAdjutantShotgun
@@ -45,7 +45,7 @@
       amount: 2
     - id: MagazineShotgun
       amount: 4
-      
+
 - type: entity
   parent: GunSafe
   id: GunSafeEnergyGun
@@ -55,7 +55,7 @@
     contents:
     - id: WeaponEnergyGun
       amount: 3
-      
+
 - type: entity
   parent: GunSafe
   id: GunSafeEnergyGunMini
@@ -65,3 +65,26 @@
     contents:
     - id: WeaponEnergyGunMini
       amount: 3
+
+- type: entity
+  id: LockerArmoryCommanderFilledHardsuit
+  suffix: Filled, Hardsuit, Hammurabi Only
+  parent: LockerWarden
+  components:
+  - type: StorageFill
+    contents:
+      - id: FlashlightSeclite
+      - id: WeaponDisabler
+        prob: 0.3
+      - id: ClothingBeltSecurityFilled
+      - id: Flash
+      - id: ClothingEyesGlassesSecurity
+      - id: ClothingHeadsetAltSecurity
+      - id: ClothingHandsGlovesCombat
+      - id: ClothingShoesBootsJack
+      # - id: ClothingOuterCoatWarden #Replace???
+      - id: DoorRemoteArmory
+      - id: ClothingOuterHardsuitWarden
+      - id: HoloprojectorSecurity
+      - id: LunchboxSecurityFilledRandom
+        prob: 0.3

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/jobs.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/jobs.yml
@@ -13,3 +13,16 @@
       state: medical
     - sprite: Mobs/Silicon/chassis.rsi
       state: medical_e
+
+- type: entity
+  id: SpawnPointArmoryCommander
+  parent: SpawnPointJobBase
+  name: armory commander
+  suffix: Hammurabi
+  components:
+  - type: SpawnPoint
+    job_id: ArmoryCommander
+  - type: Sprite
+    layers:
+      - state: green
+      - state: warden #here??

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/ArmoryCommander.yaml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/ArmoryCommander.yaml
@@ -1,11 +1,11 @@
 - type: job
   id: ArmoryCommander
   parent: Warden
-  name: job-name-warden #here
-  description: job-description-warden  #here
+  name: job-name-armory-commander
+  description: job-description-armory-commander
   playTimeTracker: JobArmoryCommander
   startingGear: ArmoryCommanderGear
-  icon: "JobIconWarden"
+  icon: "JobIconWarden" #here???
 
 - type: startingGear
   id: ArmoryCommanderGear

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/ArmoryCommander.yaml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/ArmoryCommander.yaml
@@ -1,0 +1,25 @@
+- type: job
+  id: ArmoryCommander
+  parent: Warden
+  name: job-name-warden #here
+  description: job-description-warden  #here
+  playTimeTracker: JobArmoryCommander
+  startingGear: ArmoryCommanderGear
+  icon: "JobIconWarden"
+
+- type: startingGear
+  id: ArmoryCommanderGear
+  equipment:
+    head: ClothingHeadHatWarden  #here
+    jumpsuit: ClothingUniformJumpsuitWarden  #here
+    back: ClothingBackpackSecurityFilled
+    shoes: ClothingShoesBootsCombatFilled
+    eyes: ClothingEyesGlassesSecurity
+    outerClothing: ClothingOuterCoatWarden  #here
+    id: WardenPDA  #here
+    ears: ClothingHeadsetSecurity
+    belt: ClothingBeltSecurityFilled
+    pocket1: WeaponPistolMk58Nonlethal
+  innerClothingSkirt: ClothingUniformJumpskirtWarden  #here
+  satchel: ClothingBackpackSatchelSecurityFilled
+  duffelbag: ClothingBackpackDuffelSecurityFilled

--- a/Resources/Prototypes/DeltaV/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/DeltaV/Roles/play_time_trackers.yml
@@ -3,3 +3,6 @@
 
 - type: playTimeTracker
   id: JobMedicalBorg
+
+- type: playTimeTracker
+  id: JobArmoryCommander

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -91,6 +91,7 @@
   - Warden
   - PrisonGuard # Nyanotrasen - PrisonGuard, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
   - Brigmedic # DeltaV - Brigmedic, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+  - ArmoryCommander # DeltaV - ArmoryCommander, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/armorycommander.yml
 
 - type: department
   id: Epistemics # DeltaV - Epistemics Department replacing Science
@@ -118,4 +119,5 @@
   - Gladiator # Nyanotrasen - Gladiator, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
   - Prisoner # Nyanotrasen - Prisoner, see Resrouces/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
   - Brigmedic # DeltaV - Corpsman, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+  - ArmoryCommander # DeltaV - ArmoryCommander, see Resources/Prototypes/DeltaV/Roles/Jobs/Security/armorycommander.yml
   primary: false


### PR DESCRIPTION
## About the PR
Basically title. Adds the role, gear, and items for a "second warden" to help manage the additional workload of the prison station.

## TODO

- [x] Add Role/Time Tracker
- [x] Add Locker
- [x] Add Spawnpoint
- [ ] Add Icon/ID Card/PDA
- [x] Add Strings
- [ ] Add Jumpsuit/skirt
- [ ] Add hat
- [ ] Add Outer Coat
- [ ] Map AC
- [ ] Update Map Prototype 

## Why / Balance
Based on several discussions, this seems like a popular way to address the issues of sec command being spread too thin on this station. The idea is that the Warden remains in the prison to manage the prisoners and the armory commander takes over the main station sec dept. Duties would include managing the standard jail, manning the front desk, monitoring CCTV/sec comms, and controlling the armory. 

## Technical details
n/a

## Media
- [x] I have added screenshots/videos to this PR showcasing its changes in-game, **or** this PR does not require an in-game showcase

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- add: Added the Armory Commander to Hammurabi Prison Station. The cavalry is here!
