### PR TITLE
Remove Head Clothing From Uniform Printer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -968,20 +968,20 @@
       - ClothingUniformJumpskirtColorGrey
       - ClothingUniformJumpsuitBartender
       - ClothingUniformJumpskirtBartender
-      - ClothingHeadHatCapcap
-      - ClothingHeadHatCaptain
-      - ClothingUniformJumpsuitCaptain
-      - ClothingUniformJumpskirtCaptain
-      - ClothingUniformJumpsuitCapFormal
-      - ClothingUniformJumpskirtCapFormalDress
+      #- ClothingHeadHatCapcap # Delta V - remove head clothing from uniform printer
+      #- ClothingHeadHatCaptain
+      #- ClothingUniformJumpsuitCaptain
+      #- ClothingUniformJumpskirtCaptain
+      #- ClothingUniformJumpsuitCapFormal
+      #- ClothingUniformJumpskirtCapFormalDress
       - ClothingUniformJumpsuitCargo
       - ClothingUniformJumpskirtCargo
       - ClothingUniformJumpsuitSalvageSpecialist
       - ClothingHeadHatBeretEngineering
-      - ClothingUniformJumpsuitChiefEngineer
-      - ClothingUniformJumpskirtChiefEngineer
-      - ClothingUniformJumpsuitChiefEngineerTurtle
-      - ClothingUniformJumpskirtChiefEngineerTurtle
+      #- ClothingUniformJumpsuitChiefEngineer # Delta V - remove head clothing from uniform printer
+      #- ClothingUniformJumpskirtChiefEngineer
+      #- ClothingUniformJumpsuitChiefEngineerTurtle
+      #- ClothingUniformJumpskirtChiefEngineerTurtle
       - ClothingUniformJumpsuitChaplain
       - ClothingUniformJumpskirtChaplain
       - ClothingUniformJumpsuitChef
@@ -989,9 +989,9 @@
       - ClothingUniformJumpsuitChemistry
       - ClothingUniformJumpskirtChemistry
       - ClothingUniformJumpsuitClown
-      - ClothingHeadHatBeretCmo
-      - ClothingUniformJumpsuitCMO
-      - ClothingUniformJumpskirtCMO
+      #- ClothingHeadHatBeretCmo # Delta V - remove head clothing from uniform printer
+      #- ClothingUniformJumpsuitCMO
+      #- ClothingUniformJumpskirtCMO
       - ClothingUniformJumpsuitDetective
       - ClothingUniformJumpskirtDetective
       - ClothingUniformJumpsuitEngineering
@@ -1001,22 +1001,18 @@
       - ClothingHeadHatHopcap
       - ClothingUniformJumpsuitHoP
       - ClothingUniformJumpskirtHoP
-      - ClothingHeadHatBeretHoS
-      - ClothingHeadHatHoshat
-      - ClothingUniformJumpsuitHoS
-      - ClothingUniformJumpskirtHoS
-      - ClothingUniformJumpsuitHoSBlue # DeltaV - alternate sec uniforms
-      - ClothingUniformJumpskirtHoSBlue # DeltaV - alternate sec uniforms
-      - ClothingUniformJumpsuitHoSGrey # DeltaV - alternate sec uniforms
-      - ClothingUniformJumpskirtHoSGrey # DeltaV - alternate sec uniforms
-      - ClothingUniformJumpsuitHosFormal
-      - ClothingUniformJumpskirtHosFormal
-      - ClothingUniformJumpsuitHoSAlt
-      - ClothingUniformJumpskirtHoSAlt
-      - ClothingUniformJumpsuitHoSBlue
-      - ClothingUniformJumpsuitHoSGrey
-      - ClothingUniformJumpsuitHoSParadeMale
-      - ClothingUniformJumpskirtHoSParadeMale
+      #- ClothingHeadHatBeretHoS # Delta V - remove head clothing from uniform printer
+      #- ClothingHeadHatHoshat
+      #- ClothingUniformJumpsuitHoS
+      #- ClothingUniformJumpskirtHoS
+      #- ClothingUniformJumpsuitHosFormal
+      #- ClothingUniformJumpskirtHosFormal
+      #- ClothingUniformJumpsuitHoSAlt
+      #- ClothingUniformJumpskirtHoSAlt
+      #- ClothingUniformJumpsuitHoSBlue
+      #- ClothingUniformJumpsuitHoSGrey
+      #- ClothingUniformJumpsuitHoSParadeMale
+      #- ClothingUniformJumpskirtHoSParadeMale
       - ClothingUniformJumpsuitHydroponics
       - ClothingUniformJumpskirtHydroponics
       - ClothingUniformJumpsuitJanitor
@@ -1042,16 +1038,16 @@
       - ClothingUniformJumpskirtSeniorOfficer
       - ClothingUniformJumpsuitPrisoner
       - ClothingUniformJumpskirtPrisoner
-      - ClothingHeadHatQMsoft
-      - ClothingHeadHatBeretQM
-      - ClothingUniformJumpsuitQM
-      - ClothingUniformJumpskirtQM
-      - ClothingUniformJumpsuitQMTurtleneck
-      - ClothingUniformJumpskirtQMTurtleneck
-      - ClothingUniformJumpsuitQMFormal
-      - ClothingHeadHatBeretRND
-      - ClothingUniformJumpsuitResearchDirector
-      - ClothingUniformJumpskirtResearchDirector
+      #- ClothingHeadHatQMsoft # Delta V - remove head clothing from uniform printer
+      #- ClothingHeadHatBeretQM
+      #- ClothingUniformJumpsuitQM
+      #- ClothingUniformJumpskirtQM
+      #- ClothingUniformJumpsuitQMTurtleneck
+      #- ClothingUniformJumpskirtQMTurtleneck
+      #- ClothingUniformJumpsuitQMFormal
+      #- ClothingHeadHatBeretRND
+      #- ClothingUniformJumpsuitResearchDirector
+      #- ClothingUniformJumpskirtResearchDirector
       - ClothingUniformJumpsuitScientist
       - ClothingUniformJumpskirtScientist
       - ClothingUniformJumpsuitSeniorResearcher
@@ -1076,21 +1072,21 @@
       - ClothingUniformJumpskirtWardenGrey # DeltaV - alternate sec uniforms
       - ClothingHeadHatParamedicsoft
       # Winter outfits
-      - ClothingOuterWinterCap
-      - ClothingOuterWinterCE
-      - ClothingOuterWinterCMO
+      #- ClothingOuterWinterCap # Delta V - remove head clothing from uniform printer
+      #- ClothingOuterWinterCE
+      #- ClothingOuterWinterCMO
       - ClothingOuterWinterHoP
       - ClothingOuterWinterHoSUnarmored
       - ClothingOuterWinterWardenUnarmored
-      - ClothingOuterWinterQM
-      - ClothingOuterWinterRD
-      - ClothingNeckMantleCap
-      - ClothingNeckMantleCE
-      - ClothingNeckMantleCMO
+      #- ClothingOuterWinterQM # Delta V - remove head clothing from uniform printer
+      #- ClothingOuterWinterRD
+      #- ClothingNeckMantleCap
+      #- ClothingNeckMantleCE
+      #- ClothingNeckMantleCMO
       - ClothingNeckMantleHOP
-      - ClothingNeckMantleHOS
-      - ClothingNeckMantleRD
-      - ClothingNeckMantleQM
+      #- ClothingNeckMantleHOS
+      #- ClothingNeckMantleRD
+      #- ClothingNeckMantleQM
       - ClothingOuterStasecSweater # DeltaV - added stasec sweater to uniform printer.
       - ClothingOuterWinterMusician
       - ClothingOuterWinterClown


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Request from AJ to stop common HOP issue of them handing out cap uniform to random crew.


**Changelog**
:cl:
- tweak: HoP's Uniform printer can no longer print the clothing of all other heads. HoP's clothing can still be printed.
