### PR TITLE
Re-adds PDA variety to PDA boxes

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Boxes/pda.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Boxes/pda.yml
@@ -7,9 +7,9 @@
   - type: StorageFill
     contents:
       - id: SecurityPDA
-        amount: 2
       - id: DetectivePDA
       - id: WardenPDA
+      - id: SeniorOfficerPDA
 
 - type: entity
   name: prisoner PDA box
@@ -31,9 +31,9 @@
   - type: StorageFill
     contents:
       - id: MedicalPDA
-        amount: 2
       - id: ChemistryPDA
       - id: ParamedicPDA
+      - id: SeniorPhysicianPDA
 
 - type: entity
   name: epistemics PDA box
@@ -44,9 +44,9 @@
   - type: StorageFill
     contents:
       - id: SciencePDA
-        amount: 2
       - id: ForensicMantisPDA
       - id: ChaplainPDA
+      - id: SeniorResearcherPDA
 
 - type: entity
   name: engineering PDA box
@@ -57,8 +57,9 @@
   - type: StorageFill
     contents:
       - id: EngineerPDA
-        amount: 3
       - id: AtmosPDA
+      - id: SeniorEngineerPDA
+      - id: TechnicalAssistantPDA
 
 - type: entity
   name: logistics PDA box
@@ -71,6 +72,4 @@
       - id: CargoPDA
         amount: 2
       - id: SalvagePDA
-        amount: 1
       - id: MailCarrierPDA
-        amount: 1


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds Senior role PDAs back where they belong.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The purpose of the PDA box is to give heads the option to promote people to different jobs, like the senior roles. This was the only way of becoming "senior" until they were removed in the gridinv update.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/DeltaV-Station/Delta-v/assets/113523727/d5782e88-6ab0-4c82-bb10-1c3bcc288247)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- fix: Re-added Senior PDAs in the PDA boxes that heads have in their lockers. Bug your superior for a promotion today!
