### PR TITLE
Senior ID cards get a custom job name

### DIFF
--- a/Content.Server/Access/Components/PresetIdCardComponent.cs
+++ b/Content.Server/Access/Components/PresetIdCardComponent.cs
@@ -11,4 +11,7 @@ public sealed partial class PresetIdCardComponent : Component
 
     [DataField("name")]
     public string? IdName;
+
+    [DataField("customJob")]
+    public string? CustomJobName;
 }

--- a/Content.Server/Access/Components/PresetIdCardComponent.cs
+++ b/Content.Server/Access/Components/PresetIdCardComponent.cs
@@ -12,6 +12,9 @@ public sealed partial class PresetIdCardComponent : Component
     [DataField("name")]
     public string? IdName;
 
+    /// <summary>
+    /// DeltaV: Allow changing the job title, even if it'd be otherwise set by the JobPrototype
+    /// </summary>
     [DataField("customJob")]
     public string? CustomJobName;
 }

--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -17,7 +17,7 @@ public sealed class PresetIdCardSystem : EntitySystem
     [Dependency] private readonly IdCardSystem _cardSystem = default!;
     [Dependency] private readonly SharedAccessSystem _accessSystem = default!;
     [Dependency] private readonly StationSystem _stationSystem = default!;
-    [Dependency] private readonly StationRecordsSystem _record = default!;
+    [Dependency] private readonly StationRecordsSystem _record = default!; // DeltaV - Allow changing the job title within the prototype
 
     public override void Initialize()
     {
@@ -41,7 +41,7 @@ public sealed class PresetIdCardSystem : EntitySystem
 
             SetupIdAccess(uid, card, true);
             SetupIdName(uid, card);
-            SetupIdJob(uid, card);
+            SetupIdJob(uid, card); // DeltaV - Allow changing the job title within the prototype
         }
     }
 
@@ -61,7 +61,7 @@ public sealed class PresetIdCardSystem : EntitySystem
 
         SetupIdAccess(uid, id, extended);
         SetupIdName(uid, id);
-        SetupIdJob(uid, id);
+        SetupIdJob(uid, id); // DeltaV - Allow changing the job title within the prototype
     }
 
     private void SetupIdName(EntityUid uid, PresetIdCardComponent id)
@@ -71,6 +71,7 @@ public sealed class PresetIdCardSystem : EntitySystem
         _cardSystem.TryChangeFullName(uid, id.IdName);
     }
 
+    // DeltaV - Allow changing the job title within the prototype
     private void SetupIdJob(EntityUid uid, PresetIdCardComponent id)
     {
         if (id.CustomJobName == null)
@@ -87,6 +88,7 @@ public sealed class PresetIdCardSystem : EntitySystem
         record.JobTitle = id.CustomJobName;
         _record.Synchronize(key);
     }
+    // End of DeltaV code
 
     private void SetupIdAccess(EntityUid uid, PresetIdCardComponent id, bool extended)
     {

--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -2,8 +2,10 @@ using Content.Server.Access.Components;
 using Content.Server.GameTicking;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
+using Content.Server.StationRecords.Systems;
 using Content.Shared.Access.Systems;
 using Content.Shared.Roles;
+using Content.Shared.StationRecords;
 using Content.Shared.StatusIcon;
 using Robust.Shared.Prototypes;
 
@@ -15,6 +17,7 @@ public sealed class PresetIdCardSystem : EntitySystem
     [Dependency] private readonly IdCardSystem _cardSystem = default!;
     [Dependency] private readonly SharedAccessSystem _accessSystem = default!;
     [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly StationRecordsSystem _record = default!;
 
     public override void Initialize()
     {
@@ -73,6 +76,16 @@ public sealed class PresetIdCardSystem : EntitySystem
         if (id.CustomJobName == null)
             return;
         _cardSystem.TryChangeJobTitle(uid, id.CustomJobName);
+
+        // The following code is taken from IdCardConsoleSystem
+        if (!TryComp<StationRecordKeyStorageComponent>(uid, out var keyStorage)
+            || keyStorage.Key is not { } key
+            || !_record.TryGetRecord<GeneralStationRecord>(key, out var record))
+        {
+            return;
+        }
+        record.JobTitle = id.CustomJobName;
+        _record.Synchronize(key);
     }
 
     private void SetupIdAccess(EntityUid uid, PresetIdCardComponent id, bool extended)

--- a/Content.Server/Access/Systems/PresetIdCardSystem.cs
+++ b/Content.Server/Access/Systems/PresetIdCardSystem.cs
@@ -38,6 +38,7 @@ public sealed class PresetIdCardSystem : EntitySystem
 
             SetupIdAccess(uid, card, true);
             SetupIdName(uid, card);
+            SetupIdJob(uid, card);
         }
     }
 
@@ -57,6 +58,7 @@ public sealed class PresetIdCardSystem : EntitySystem
 
         SetupIdAccess(uid, id, extended);
         SetupIdName(uid, id);
+        SetupIdJob(uid, id);
     }
 
     private void SetupIdName(EntityUid uid, PresetIdCardComponent id)
@@ -64,6 +66,13 @@ public sealed class PresetIdCardSystem : EntitySystem
         if (id.IdName == null)
             return;
         _cardSystem.TryChangeFullName(uid, id.IdName);
+    }
+
+    private void SetupIdJob(EntityUid uid, PresetIdCardComponent id)
+    {
+        if (id.CustomJobName == null)
+            return;
+        _cardSystem.TryChangeJobTitle(uid, id.CustomJobName);
     }
 
     private void SetupIdAccess(EntityUid uid, PresetIdCardComponent id, bool extended)

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -818,6 +818,8 @@
     layers:
     - state: default
     - state: idseniorengineer
+  - type: PresetIdCard
+    customJob: Senior Engineer
 
 - type: entity
   parent: ResearchIDCard
@@ -828,6 +830,8 @@
     layers:
     - state: default
     - state: idseniorresearcher
+  - type: PresetIdCard
+    customJob: Senior Researcher
 
 - type: entity
   parent: MedicalIDCard
@@ -838,6 +842,8 @@
     layers:
     - state: default
     - state: idseniorphysician
+  - type: PresetIdCard
+    customJob: Senior Physician
 
 - type: entity
   parent: SecurityIDCard
@@ -848,3 +854,5 @@
     layers:
     - state: default
     - state: idseniorofficer
+  - type: PresetIdCard
+    customJob: Senior Officer

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -818,7 +818,7 @@
     layers:
     - state: default
     - state: idseniorengineer
-  - type: PresetIdCard
+  - type: PresetIdCard # DeltaV - Change senior job titles
     customJob: Senior Engineer
 
 - type: entity
@@ -830,7 +830,7 @@
     layers:
     - state: default
     - state: idseniorresearcher
-  - type: PresetIdCard
+  - type: PresetIdCard # DeltaV - Change senior job titles
     customJob: Senior Researcher
 
 - type: entity
@@ -842,7 +842,7 @@
     layers:
     - state: default
     - state: idseniorphysician
-  - type: PresetIdCard
+  - type: PresetIdCard # DeltaV - Change senior job titles
     customJob: Senior Physician
 
 - type: entity
@@ -854,5 +854,5 @@
     layers:
     - state: default
     - state: idseniorofficer
-  - type: PresetIdCard
+  - type: PresetIdCard # DeltaV - Change senior job titles
     customJob: Senior Officer


### PR DESCRIPTION
## About the PR
Makes it actually worth taking, as it isn't just a resprite in the loadout

**Changelog**
:cl:
- tweak: Senior PDA's now have an ID card with a custom job title
