### PR TITLE
Remove mimic event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -558,13 +558,14 @@
     duration: 1
   - type: IonStormRule
 
-- type: entity
-  id: MimicVendorRule
-  parent: BaseGameRule
-  noSpawn: true
-  components:
-    - type: StationEvent
-      earliestStart: 0
-      minimumPlayers: 20
-      weight: 5
-    - type: MobReplacementRule
+# DeltaV - Disable Mimic event. It causes a ton of heisentests, and does practially nothing in game
+#- type: entity
+#  id: MimicVendorRule
+#  parent: BaseGameRule
+#  noSpawn: true
+#  components:
+#    - type: StationEvent
+#      earliestStart: 0
+#      minimumPlayers: 20
+#      weight: 5
+#    - type: MobReplacementRule


### PR DESCRIPTION
Does nothing except create heisentests.

I know I told @DangerRevolution that I don't want to remove this without replacing it with something else, or would prefer the system to be fixed. But at this point its just a massive fucking joke of an event. I reran tests on 1 pr 4 times and its STILL failing. There isn't anything lost by removing it because the in game stuff is broken anyways