### PR TITLE
Courier PDA Fix

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Cargo/courier.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Cargo/courier.yml
@@ -14,6 +14,5 @@
 - type: startingGear
   id: CourierGear
   equipment:
-    id: MailCarrierPDA
     ears: ClothingHeadsetCargo
     belt: CourierBag


### PR DESCRIPTION
## About the PR
Fixes #1242 by removing the ID equipment defined in the job prototype.

## Why / Balance
Just a fix of a bug.

## Media
- [X] This PR does not require an ingame showcase.

**Changelog**
Shouldn't require one.