### PR TITLE
Tweak event weights

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -73,7 +73,7 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 10
+    weight: 8 # DeltaV - was 10
     duration: 1
     minimumPlayers: 10
   - type: RandomEntityStorageSpawnRule
@@ -87,9 +87,9 @@
   - type: StationEvent
     weight: 1 # DeltaV - was 5
     duration: 1
-    earliestStart: 45
+    earliestStart: 60 # DeltaV - was 45
     reoccurrenceDelay: 60
-    minimumPlayers: 20
+    minimumPlayers: 45 # DeltaV - was 20
   - type: RandomSpawnRule
     prototype: SpawnPointGhostDragon
 
@@ -99,9 +99,9 @@
   noSpawn: true
   components:
   - type: StationEvent
-    weight: 3 # DeltaV - was 10
+    weight: 5 # DeltaV - was 10
     duration: 1
-    earliestStart: 45 # DeltaV - was 30
+    earliestStart: 30
     reoccurrenceDelay: 60
     minimumPlayers: 40
   - type: NinjaSpawnRule
@@ -152,7 +152,7 @@
   components:
   - type: StationEvent
     earliestStart: 15
-    minimumPlayers: 15
+    minimumPlayers: 10 # DeltaV - Was 15
     weight: 5
     startDelay: 50
     duration: 240
@@ -187,8 +187,8 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     startDelay: 10
-    earliestStart: 30
-    minimumPlayers: 35
+    earliestStart: 20 #DeltaV - was 30
+    minimumPlayers: 25 #DeltaV - was 35
     weight: 5
     duration: 50
   - type: VentCrittersRule
@@ -280,7 +280,7 @@
     - Security
     - Service
     - Supply
-    extraCount: 2
+    extraCount: 3 # DeltaV - was 2
     lightBreakChancePerSecond: 0.0003
     doorToggleChancePerSecond: 0.001
 
@@ -306,9 +306,9 @@
     startAnnouncement: station-event-vent-clog-start-announcement
     startAudio:
       path: /Audio/Announcements/ventclog.ogg # DeltaV - custom announcer
-    earliestStart: 15
+    earliestStart: 20 # DeltaV - was 15
     minimumPlayers: 15
-    weight: 5
+    weight: 7.5 # DeltaV - was 5
     startDelay: 50
     duration: 60
   - type: VentClogRule
@@ -378,24 +378,24 @@
     - id: MobGiantSpiderAngry
       prob: 0.05
 
-# - type: entity # DeltaV - Prevent normal spawning of MobClownSpider
-#  id: SpiderClownSpawn
-#  parent: BaseGameRule
-#  noSpawn: true
-#  components:
-#  - type: StationEvent
-#    startAnnouncement: station-event-vent-creatures-start-announcement
-#    startAudio:
-#      path: /Audio/Announcements/attention.ogg
-#    startDelay: 10
-#    earliestStart: 20
-#    minimumPlayers: 15
-#    weight: 1
-#    duration: 60
-#  - type: VentCrittersRule
-#    entries:
-#    - id: MobClownSpider
-#      prob: 0.05
+ - type: entity 
+  id: SpiderClownSpawn
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    startAnnouncement: station-event-vent-creatures-start-announcement
+    startAudio:
+      path: /Audio/Announcements/attention.ogg
+    startDelay: 10
+    earliestStart: 45 # DeltaV - was 20
+    minimumPlayers: 30 # DeltaV - was 15
+    weight: 1
+    duration: 60
+  - type: VentCrittersRule
+    entries:
+    - id: MobClownSpider
+      prob: 0.03 # DeltaV - was 0.05
 
 - type: entity
   id: ZombieOutbreak
@@ -411,7 +411,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ InitialInfected ]
-      max: 3
+      max: 4 # DeltaV - was 3
       playerRatio: 10
       blacklist:
         components:
@@ -438,8 +438,8 @@
   components:
   - type: StationEvent
     earliestStart: 60 # DeltaV - was 45
-    weight: 3 # DeltaV - was 5
-    minimumPlayers: 20
+    weight: 3.5 # DeltaV - was 5
+    minimumPlayers: 30 # DeltaV - was 20
     reoccurrenceDelay: 30
     duration: 1
   - type: LoadMapRule
@@ -501,7 +501,7 @@
     duration: 150
     maxDuration: 300
   - type: MassHallucinationsRule
-    minTimeBetweenIncidents: 0.1
+    minTimeBetweenIncidents: 30 # DeltaV - was 0.1
     maxTimeBetweenIncidents: 300
     maxSoundDistance: 7
     sounds:
@@ -554,7 +554,7 @@
   components:
   - type: StationEvent
     weight: 10
-    reoccurrenceDelay: 20
+    reoccurrenceDelay: 30 #DeltaV - Was 20 #20 mins feels too short, and can scramble borgs way too much
     duration: 1
   - type: IonStormRule
 

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -378,7 +378,7 @@
     - id: MobGiantSpiderAngry
       prob: 0.05
 
- - type: entity 
+- type: entity 
   id: SpiderClownSpawn
   parent: BaseGameRule
   noSpawn: true
@@ -386,7 +386,7 @@
   - type: StationEvent
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
-      path: /Audio/Announcements/attention.ogg
+    path: /Audio/Announcements/attention.ogg
     startDelay: 10
     earliestStart: 45 # DeltaV - was 20
     minimumPlayers: 30 # DeltaV - was 15

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -386,7 +386,7 @@
   - type: StationEvent
     startAnnouncement: station-event-vent-creatures-start-announcement
     startAudio:
-    path: /Audio/Announcements/attention.ogg
+      path: /Audio/Announcements/attention.ogg
     startDelay: 10
     earliestStart: 45 # DeltaV - was 20
     minimumPlayers: 30 # DeltaV - was 15


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Slightly edited event weights to fit the current meta and balance

## Why / Balance
Various minplayers, mintimes, and weights were changed

## Technical details

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
**Changelog**

:cl:
- tweak: Tweaked event balance. The vents spew sludge more often now!
- tweak: Mid-Round zombie outbreaks cause 1 more initial infected
- add: Added the dreaded clown spiders

