### PR TITLE
Uplink TC Rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -17,7 +17,7 @@
   description: uplink-revolver-python-desc
   productEntity: WeaponRevolverPythonAP
   cost:
-    Telecrystal: 8 # Originally was 13 TC but was not used due to high cost
+    Telecrystal: 7 # Originally was 13 TC but was not used due to high cost # DV changed from 8 to 7
   categories:
   - UplinkWeaponry
 
@@ -72,7 +72,7 @@
   icon: { sprite: /Textures/Objects/Storage/boxicons.rsi, state: throwing_knives }
   productEntity: ThrowingKnivesKit
   cost:
-    Telecrystal: 6
+    Telecrystal: 4 # DV - was 6
   categories:
     - UplinkWeaponry
 
@@ -108,7 +108,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Melee/e_shield.rsi, state: eshield-on }
   productEntity: EnergyShield
   cost:
-    Telecrystal: 8
+    Telecrystal: 10 # DV - Was 8
   categories:
   - UplinkWeaponry
   conditions:
@@ -124,7 +124,7 @@
   icon: { sprite: /Textures/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi, state: base }
   productEntity: BriefcaseSyndieSniperBundleFilled  
   cost:
-    Telecrystal: 12
+    Telecrystal: 10 # DV - was 12 changed because the Hristov is REALLY bad
   categories:
   - UplinkWeaponry
 
@@ -180,7 +180,7 @@
   description: uplink-explosive-grenade-desc
   productEntity: ExGrenade
   cost:
-    Telecrystal: 4
+    Telecrystal: 3 # DV - was 4
   categories:
   - UplinkExplosives
 
@@ -240,7 +240,7 @@
   description: uplink-penguin-grenade-desc
   productEntity: MobGrenadePenguin
   cost:
-    Telecrystal: 5
+    Telecrystal: 6 # DV - was 5
   categories:
     - UplinkExplosives
   conditions:
@@ -301,7 +301,7 @@
   icon: { sprite: /Textures/Objects/Misc/pens.rsi, state: pen }
   productEntity: PenExplodingBox
   cost:
-    Telecrystal: 4
+    Telecrystal: 3 # DV - was 4
   categories:
   - UplinkExplosives
 
@@ -311,7 +311,7 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 11
+    Telecrystal: 14 # DV - was 11, Syndicate bomb was way too powerful for the 11 TC cost
   categories:
     - UplinkExplosives
   restockTime: 1800
@@ -372,7 +372,7 @@
   description: uplink-emp-kit-desc
   productEntity: ElectricalDisruptionKit
   cost:
-    Telecrystal: 6
+    Telecrystal: 5 # DV - was 6
   categories:
     - UplinkExplosives
 
@@ -486,7 +486,7 @@
   icon: { sprite: /Textures/Objects/Fun/Darts/dart_red.rsi, state: icon }
   productEntity: HypoDartBox
   cost:
-    Telecrystal: 2
+    Telecrystal: 1 # DV - was 2
   categories:
   - UplinkChemicals
 
@@ -547,7 +547,7 @@
   description: uplink-combat-medipen-desc
   productEntity: CombatMedipen
   cost:
-    Telecrystal: 4
+    Telecrystal: 3 # DV - was 4
   categories:
   - UplinkChemicals
 
@@ -557,7 +557,7 @@
   description: uplink-stimpack-desc
   productEntity: Stimpack
   cost:
-    Telecrystal: 4
+    Telecrystal: 3 # DV - was 4
   categories:
   - UplinkChemicals
 
@@ -567,7 +567,7 @@
   description: uplink-stimkit-desc
   productEntity: StimkitFilled
   cost:
-    Telecrystal: 12
+    Telecrystal: 10 # DV - was 12
   categories:
   - UplinkChemicals
 
@@ -618,7 +618,7 @@
   description: uplink-stealth-box-desc
   productEntity: StealthBox
   cost:
-    Telecrystal: 5
+    Telecrystal: 3 # DV - was 5
   categories:
   - UplinkDeception
 
@@ -721,7 +721,7 @@
   description: uplink-exploding-syndicate-bomb-fake-desc
   productEntity: SyndicateBombFake
   cost:
-    Telecrystal: 4
+    Telecrystal: 3 # DV - was 4
   categories:
   - UplinkDeception
 
@@ -733,7 +733,7 @@
   description: uplink-emag-desc
   productEntity: Emag
   cost:
-    Telecrystal: 8
+    Telecrystal: 10 # DV was 8, rebalanced after discussion
   categories:
   - UplinkDisruption
 
@@ -824,7 +824,7 @@
   description: uplink-power-sink-desc
   productEntity: PowerSink
   cost:
-    Telecrystal: 8
+    Telecrystal: 6 # DV - was 8
   categories:
   - UplinkDisruption
   conditions:
@@ -872,7 +872,7 @@
       - SurplusBundle
 
 - type: listing
-  id: UplinkSingarityBeacon
+ id: UplinkSingarityBeacon
   name: uplink-singularity-beacon-name
   description: uplink-singularity-beacon-desc
   productEntity: SingularityBeacon
@@ -880,24 +880,32 @@
     Telecrystal: 12
   categories:
     - UplinkDisruption
+  conditions: #DV - Blacklists from traitor uplink and removes from surplus bundle
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
 
 # Allies
 
-#- type: listing
-#  id: UplinkHoloparaKit
-#  name: uplink-holopara-kit-name
-#  description: uplink-holopara-kit-desc
-#  icon: { sprite: /Textures/Objects/Misc/guardian_info.rsi, state: icon }
-#  productEntity: BoxHoloparasite
-#  cost:
-#    Telecrystal: 14
-#  categories:
-#  - UplinkAllies
-#  conditions:
-#  - !type:StoreWhitelistCondition
-#    blacklist:
-#      tags:
-#      - NukeOpsUplink
+- type: listing
+  id: UplinkHoloparaKit
+  name: uplink-holopara-kit-name
+  description: uplink-holopara-kit-desc
+  icon: { sprite: /Textures/Objects/Misc/guardian_info.rsi, state: icon }
+  productEntity: BoxHoloparasite
+  cost:
+    Telecrystal: 14
+  categories:#  - UplinkAllies
+  conditions:
+  - !type:StoreWhitelistCondition
+    blacklist:
+      tags:
+      - NukeOpsUplink
 
 - type: listing
   id: UplinkReinforcementRadioSyndicate
@@ -906,7 +914,7 @@
   productEntity: ReinforcementRadioSyndicate
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 16
+    Telecrystal: 14 # DV - was 16
   categories:
   - UplinkAllies
   conditions:
@@ -922,7 +930,7 @@
   productEntity: ReinforcementRadioSyndicateNukeops
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 16
+    Telecrystal: 20 # DV - Was 16
   categories:
   - UplinkAllies
   conditions:
@@ -1028,7 +1036,7 @@
   icon: { sprite: /Textures/Clothing/Back/Backpacks/backpack.rsi, state: icon }
   productEntity: StorageImplanter
   cost:
-    Telecrystal: 8
+    Telecrystal: 10 # DV - Was 8
   categories:
     - UplinkImplants
   conditions:
@@ -1044,7 +1052,7 @@
   icon: { sprite: /Textures/Actions/Implants/implants.rsi, state: freedom }
   productEntity: FreedomImplanter
   cost:
-    Telecrystal: 5
+    Telecrystal: 4 # DV - Was 5
   categories:
     - UplinkImplants
 
@@ -1055,7 +1063,7 @@
   icon: { sprite: /Textures/Structures/Specific/anomaly.rsi, state: anom4 }
   productEntity: ScramImplanter
   cost:
-    Telecrystal: 6 # it's a gamble that may kill you easily so 6 TC per 2 uses, second one more of a backup
+    Telecrystal: 4 # it's a gamble that may kill you easily so 6 TC per 2 uses, second one more of a backup # DV - Was 6
   categories:
     - UplinkImplants
 
@@ -1241,7 +1249,7 @@
   description: uplink-clothing-thieving-gloves-desc
   productEntity: ThievingGloves
   cost:
-    Telecrystal: 4
+    Telecrystal: 7 # DV - Was 4, 4TC was too cheap for the items power
   categories:
   - UplinkWearables
 
@@ -1504,13 +1512,14 @@
   description: uplink-gatfruit-seeds-desc
   productEntity: GatfruitSeeds
   cost:
-    Telecrystal: 6
+    Telecrystal: 5 # DV - Was 6
   categories:
   - UplinkJob
   conditions:
   - !type:BuyerJobCondition
     whitelist:
     - Botanist
+    - ServiceWorker # DV
 
 - type: listing
   id: uplinkRiggedBoxingGlovesPassenger
@@ -1647,6 +1656,7 @@
     - Botanist
     - Clown
     - Mime
+    - ServiceWorker # DV
 
 - type: listing
   id: UplinkChimpUpgradeKit

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -122,7 +122,7 @@
   name: uplink-sniper-bundle-name
   description: uplink-sniper-bundle-desc
   icon: { sprite: /Textures/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi, state: base }
-  productEntity: BriefcaseSyndieSniperBundleFilled  
+  productEntity: BriefcaseSyndieSniperBundleFilled
   cost:
     Telecrystal: 10 # DV - was 12 changed because the Hristov is REALLY bad
   categories:
@@ -872,7 +872,7 @@
       - SurplusBundle
 
 - type: listing
- id: UplinkSingarityBeacon
+  id: UplinkSingarityBeacon
   name: uplink-singularity-beacon-name
   description: uplink-singularity-beacon-desc
   productEntity: SingularityBeacon
@@ -900,7 +900,8 @@
   productEntity: BoxHoloparasite
   cost:
     Telecrystal: 14
-  categories:#  - UplinkAllies
+  categories:
+  - UplinkAllies
   conditions:
   - !type:StoreWhitelistCondition
     blacklist:
@@ -1012,7 +1013,7 @@
     Telecrystal: 6
   categories:
     - UplinkAllies
-  
+
 - type: listing
   id: UplinkSyndicatePersonalAI
   name: uplink-syndicate-pai-name


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Many, many uplink items have had their TC cost adjusted during admin discussion

## Why / Balance
To promote the use of less-used items and discourage playstyles and loadouts that dont provide any meaningful RP.
Emag, Syndicate Bomb, Thieving Gloves, were all too powerful for their TC cost, ontop of the Emag being unironicaly the most purchased item.

## Technical details
Changed the uplink catalogue

I also with close to 100% certainty fucked some syntax up **PLEASE YELL AT ME IF I DID**

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl: therealDLondon, Lyndomen, and Colin_Tel
- tweak: Fluctuations in the Syndicate Stock Market have changed the prices of various uplink items. Most cheaper, some more expensive.


