### PR TITLE
Add Syndicate/generic radio implants, remove Syndicate encryption key from uplink

### DIFF
--- a/Content.Client/DeltaV/Implants/Radio/RadioImplantSystem.cs
+++ b/Content.Client/DeltaV/Implants/Radio/RadioImplantSystem.cs
@@ -2,6 +2,7 @@
 
 namespace Content.Client.DeltaV.Implants.Radio;
 
+/// <inheritdoc />
 public sealed class RadioImplantSystem : SharedRadioImplantSystem
 {
 }

--- a/Content.Client/DeltaV/Implants/Radio/RadioImplantSystem.cs
+++ b/Content.Client/DeltaV/Implants/Radio/RadioImplantSystem.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.DeltaV.Implants.Radio;
+
+namespace Content.Client.DeltaV.Implants.Radio;
+
+public sealed class RadioImplantSystem : SharedRadioImplantSystem
+{
+}

--- a/Content.Server/DeltaV/Implants/Radio/RadioImplantSystem.cs
+++ b/Content.Server/DeltaV/Implants/Radio/RadioImplantSystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Player;
 
 namespace Content.Server.DeltaV.Implants.Radio;
 
+/// <inheritdoc />
 public sealed class RadioImplantSystem : SharedRadioImplantSystem
 {
     [Dependency] private readonly INetManager _netManager = default!;

--- a/Content.Server/DeltaV/Implants/Radio/RadioImplantSystem.cs
+++ b/Content.Server/DeltaV/Implants/Radio/RadioImplantSystem.cs
@@ -47,11 +47,11 @@ public sealed class RadioImplantSystem : SharedRadioImplantSystem
             return;
 
         // does the implant have access to the channel the implantee is trying to speak on?
-        if (ent.Comp.Implant is { Valid: true }
-            && TryComp<RadioImplantComponent>(ent.Comp.Implant, out var radioImplantComponent)
+        if (ent.Comp.Implant is {} implant
+            && TryComp<RadioImplantComponent>(implant, out var radioImplantComponent)
             && radioImplantComponent.Channels.Contains(args.Channel.ID))
         {
-            _radioSystem.SendRadioMessage(ent, args.Message, args.Channel.ID, ent.Comp.Implant.Value);
+            _radioSystem.SendRadioMessage(ent, args.Message, args.Channel.ID, implant);
             // prevent other radios they might be wearing from sending the message again
             args.Channel = null;
         }

--- a/Content.Server/DeltaV/Implants/Radio/RadioImplantSystem.cs
+++ b/Content.Server/DeltaV/Implants/Radio/RadioImplantSystem.cs
@@ -1,0 +1,115 @@
+﻿using Content.Server.Chat.Systems;
+using Content.Server.Radio;
+using Content.Server.Radio.Components;
+using Content.Server.Radio.EntitySystems;
+using Content.Shared.DeltaV.Implants.Radio;
+using Content.Shared.Radio.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace Content.Server.DeltaV.Implants.Radio;
+
+public sealed class RadioImplantSystem : SharedRadioImplantSystem
+{
+    [Dependency] private readonly INetManager _netManager = default!;
+    [Dependency] private readonly RadioSystem _radioSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<RadioImplantComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<RadioImplantComponent, EntInsertedIntoContainerMessage>(OnInsertEncryptionKey);
+        SubscribeLocalEvent<RadioImplantComponent, EntRemovedFromContainerMessage>(OnRemoveEncryptionKey);
+        SubscribeLocalEvent<RadioImplantComponent, RadioReceiveEvent>(OnRadioReceive);
+        SubscribeLocalEvent<HasRadioImplantComponent, EntitySpokeEvent>(OnSpeak);
+    }
+
+    /// <summary>
+    /// Ensures implants with fixed channels work.
+    /// </summary>
+    private void OnMapInit(EntityUid uid, RadioImplantComponent component, MapInitEvent args)
+    {
+        UpdateRadioReception(uid, component);
+    }
+
+    /// <summary>
+    /// Handles the implantee's speech being forwarded onto the radio channel of the implant.
+    /// </summary>
+    private void OnSpeak(EntityUid uid, HasRadioImplantComponent hasRadioImplantComponent, EntitySpokeEvent args)
+    {
+        // not a radio message, or already handled by another radio
+        if (args.Channel is null)
+            return;
+
+        // does the implant have access to the channel the implantee is trying to speak on?
+        if (hasRadioImplantComponent.Implant is { Valid: true }
+            && TryComp<RadioImplantComponent>(hasRadioImplantComponent.Implant, out var radioImplantComponent)
+            && radioImplantComponent.Channels.Contains(args.Channel.ID))
+        {
+            _radioSystem.SendRadioMessage(uid, args.Message, args.Channel.ID, hasRadioImplantComponent.Implant.Value);
+            // prevent other radios they might be wearing from sending the message again
+            args.Channel = null;
+        }
+    }
+
+    /// <summary>
+    /// Handles receiving radio messages and forwarding them to the implantee.
+    /// </summary>
+    private void OnRadioReceive(EntityUid uid, RadioImplantComponent component, ref RadioReceiveEvent args)
+    {
+        if (TryComp(component.Implantee, out ActorComponent? actorComponent))
+            _netManager.ServerSendMessage(args.ChatMsg, actorComponent.PlayerSession.Channel);
+    }
+
+    /// <summary>
+    /// Handles the addition of an encryption key to the implant's storage.
+    /// </summary>
+    private void OnInsertEncryptionKey(EntityUid uid, RadioImplantComponent component, EntInsertedIntoContainerMessage args)
+    {
+        // check if the insertion is actually something getting inserted into the radio implant storage, since
+        // this evt also fires when the radio implant is being inserted into a person.
+        if (uid != args.Container.Owner
+            || !TryComp<EncryptionKeyComponent>(args.Entity, out var encryptionKeyComponent))
+            return;
+
+        // copy over the radio channels that can be accessed
+        component.Channels.Clear();
+        component.Channels.UnionWith(encryptionKeyComponent.Channels);
+        Dirty(uid, component);
+        UpdateRadioReception(uid, component);
+    }
+
+    /// <summary>
+    /// Handles the removal of an encryption key from the implant's storage.
+    /// </summary>
+    private void OnRemoveEncryptionKey(EntityUid uid, RadioImplantComponent component, EntRemovedFromContainerMessage args)
+    {
+        // check if the insertion is actually something getting inserted into the radio implant storage, since
+        // this evt also fires when the radio implant is being inserted into a person.
+        if (uid != args.Container.Owner
+            || !HasComp<EncryptionKeyComponent>(args.Entity))
+            return;
+
+        // clear the radio channels since there's no encryption key inserted anymore.
+        component.Channels.Clear();
+        Dirty(uid, component);
+        UpdateRadioReception(uid, component);
+    }
+
+    /// <summary>
+    /// Ensures that this thing can actually hear radio messages from channels the key provides.
+    /// </summary>
+    private void UpdateRadioReception(EntityUid uid, RadioImplantComponent component)
+    {
+        if (component.Channels.Count != 0)
+        {
+            // we need to add this comp to actually receive radio events.
+            EnsureComp<ActiveRadioComponent>(uid).Channels = new(component.Channels);
+        }
+        else
+        {
+            RemComp<ActiveRadioComponent>(uid);
+        }
+    }
+}

--- a/Content.Shared/DeltaV/Implants/Radio/HasRadioImplantComponent.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/HasRadioImplantComponent.cs
@@ -1,0 +1,16 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.DeltaV.Implants.Radio;
+
+/// <summary>
+/// This indicates this entity has a radio implant implanted into themselves.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedRadioImplantSystem))]
+public sealed partial class HasRadioImplantComponent : Component
+{
+    /// <summary>
+    /// The radio implant. We need this to be able to determine encryption keys.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? Implant { get; set; }
+}

--- a/Content.Shared/DeltaV/Implants/Radio/HasRadioImplantComponent.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/HasRadioImplantComponent.cs
@@ -12,5 +12,5 @@ public sealed partial class HasRadioImplantComponent : Component
     /// The radio implant. We need this to be able to determine encryption keys.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public EntityUid? Implant { get; set; }
+    public EntityUid? Implant;
 }

--- a/Content.Shared/DeltaV/Implants/Radio/RadioImplantComponent.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/RadioImplantComponent.cs
@@ -1,0 +1,21 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.DeltaV.Implants.Radio;
+
+/// <summary>
+/// This is used for radio implants.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedRadioImplantSystem))]
+public sealed partial class RadioImplantComponent : Component
+{
+    /// <summary>
+    /// The entity this implant got added to.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? Implantee { get; set; }
+    /// <summary>
+    /// The channels this implant can talk on.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<string> Channels { get; set; } = new();
+}

--- a/Content.Shared/DeltaV/Implants/Radio/RadioImplantComponent.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/RadioImplantComponent.cs
@@ -3,7 +3,7 @@
 namespace Content.Shared.DeltaV.Implants.Radio;
 
 /// <summary>
-/// This is used for radio implants.
+/// This is for radio implants. Might be Syndie, might not be Syndie, but either way, it's an implant.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedRadioImplantSystem))]
 public sealed partial class RadioImplantComponent : Component
@@ -13,6 +13,7 @@ public sealed partial class RadioImplantComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid? Implantee { get; set; }
+
     /// <summary>
     /// The channels this implant can talk on.
     /// </summary>

--- a/Content.Shared/DeltaV/Implants/Radio/RadioImplantComponent.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/RadioImplantComponent.cs
@@ -1,4 +1,6 @@
-﻿using Robust.Shared.GameStates;
+﻿using Content.Shared.Radio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.DeltaV.Implants.Radio;
 
@@ -12,11 +14,11 @@ public sealed partial class RadioImplantComponent : Component
     /// The entity this implant got added to.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public EntityUid? Implantee { get; set; }
+    public EntityUid? Implantee;
 
     /// <summary>
     /// The channels this implant can talk on.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public HashSet<string> Channels { get; set; } = new();
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new();
 }

--- a/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Content.Shared.Actions;
 using Content.Shared.Implants;
-using Content.Shared.Radio.Components;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;

--- a/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
@@ -11,14 +11,11 @@ namespace Content.Shared.DeltaV.Implants.Radio;
 /// </summary>
 public abstract class SharedRadioImplantSystem : EntitySystem
 {
-    [Dependency] private readonly SharedStorageSystem _storage = default!;
-
     /// <inheritdoc/>
     public override void Initialize()
     {
         SubscribeLocalEvent<RadioImplantComponent, ImplantImplantedEvent>(OnImplanted);
         SubscribeLocalEvent<RadioImplantComponent, EntGotRemovedFromContainerMessage>(OnPossiblyUnimplanted);
-        SubscribeLocalEvent<StorageComponent, OpenRadioImplantEvent>(OnOpenStorage);
     }
 
     /// <summary>
@@ -56,23 +53,4 @@ public abstract class SharedRadioImplantSystem : EntitySystem
             component.Implantee = null;
         }
     }
-
-    /// <summary>
-    /// Handles clicking the radio storage button by opening storage UI.
-    /// </summary>
-    private void OnOpenStorage(EntityUid uid, StorageComponent component, OpenRadioImplantEvent args)
-    {
-        if (args.Handled)
-            return;
-
-        _storage.OpenStorageUI(uid, args.Performer, component);
-        args.Handled = true;
-    }
-}
-
-/// <summary>
-/// Triggered when someone clicks the open radio implant action.
-/// </summary>
-public sealed partial class OpenRadioImplantEvent : InstantActionEvent
-{
 }

--- a/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
@@ -21,7 +21,7 @@ public abstract class SharedRadioImplantSystem : EntitySystem
     /// <summary>
     /// Handles implantation of the implant.
     /// </summary>
-    protected virtual void OnImplanted(EntityUid uid, RadioImplantComponent component, ImplantImplantedEvent args)
+    private void OnImplanted(EntityUid uid, RadioImplantComponent component, ImplantImplantedEvent args)
     {
         if (args.Implanted is not { Valid: true })
             return;

--- a/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
@@ -1,0 +1,79 @@
+﻿using Content.Shared.Actions;
+using Content.Shared.Implants;
+using Content.Shared.Radio.Components;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Containers;
+
+namespace Content.Shared.DeltaV.Implants.Radio;
+
+/// <summary>
+/// This handles radio implants, which you can implant to get access to a radio channel.
+/// </summary>
+public abstract class SharedRadioImplantSystem : EntitySystem
+{
+    [Dependency] private readonly SharedStorageSystem _storage = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<RadioImplantComponent, ImplantImplantedEvent>(OnImplanted);
+        SubscribeLocalEvent<RadioImplantComponent, EntGotRemovedFromContainerMessage>(OnPossiblyUnimplanted);
+        SubscribeLocalEvent<StorageComponent, OpenRadioImplantEvent>(OnOpenStorage);
+    }
+
+    /// <summary>
+    /// Handles implantation of the implant.
+    /// </summary>
+    private void OnImplanted(EntityUid uid, RadioImplantComponent component, ImplantImplantedEvent args)
+    {
+        if (args.Implanted is not { Valid: true })
+            return;
+
+        component.Implantee = args.Implanted.Value;
+        Dirty(uid, component);
+
+        // make sure the person entity gets slapped with a component so it can react to it talking.
+        var hasRadioImplantComponent = EnsureComp<HasRadioImplantComponent>(args.Implanted.Value);
+        hasRadioImplantComponent.Implant = uid;
+        Dirty(component.Implantee.Value, hasRadioImplantComponent);
+    }
+
+
+    /// <summary>
+    /// Handles removal of the implant from its containing mob.
+    /// </summary>
+    /// <remarks>Done via <see cref="EntGotRemovedFromContainerMessage"/> because there is no specific event for an implant being removed.</remarks>
+    private void OnPossiblyUnimplanted(EntityUid uid, RadioImplantComponent component, EntGotRemovedFromContainerMessage args)
+    {
+        if (Terminating(uid))
+            return;
+
+        // this gets fired if it gets removed from ANY container but really, we just want to know if it was removed from its owner...
+        // so check if the ent we got implanted into matches the container's owner (here, the container's owner is the entity)
+        if (component.Implantee is not null && component.Implantee == args.Container.Owner)
+        {
+            RemComp<HasRadioImplantComponent>(component.Implantee.Value);
+            component.Implantee = null;
+        }
+    }
+
+    /// <summary>
+    /// Handles clicking the radio storage button by opening storage UI.
+    /// </summary>
+    private void OnOpenStorage(EntityUid uid, StorageComponent component, OpenRadioImplantEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        _storage.OpenStorageUI(uid, args.Performer, component);
+        args.Handled = true;
+    }
+}
+
+/// <summary>
+/// Triggered when someone clicks the open radio implant action.
+/// </summary>
+public sealed partial class OpenRadioImplantEvent : InstantActionEvent
+{
+}

--- a/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
+++ b/Content.Shared/DeltaV/Implants/Radio/SharedRadioImplantSystem.cs
@@ -24,7 +24,7 @@ public abstract class SharedRadioImplantSystem : EntitySystem
     /// <summary>
     /// Handles implantation of the implant.
     /// </summary>
-    private void OnImplanted(EntityUid uid, RadioImplantComponent component, ImplantImplantedEvent args)
+    protected virtual void OnImplanted(EntityUid uid, RadioImplantComponent component, ImplantImplantedEvent args)
     {
         if (args.Implanted is not { Valid: true })
             return;

--- a/Resources/Locale/en-US/deltav/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/deltav/store/uplink-catalog.ftl
@@ -4,3 +4,12 @@ uplink-reinforcement-radio-nukie-mouse-desc = Calls in a specially trained mouse
 # Implants
 uplink-bionic-syrinx-implanter-name = Bionic Syrinx Implanter
 uplink-bionic-syrinx-implanter-desc = An implant that enhances a harpy's natural talent for mimicry to let you adjust your voice to whoever you can think of.
+
+uplink-syndicate-radio-implanter-name = Syndicate Radio Implanter
+uplink-syndicate-radio-implanter-desc = A cranial implant that lets you talk on the Syndicate radio channel (use :t).
+
+uplink-syndicate-radio-implanter-bundle-name = Syndicate Radio Implanter Bundle
+uplink-syndicate-radio-implanter-bundle-desc = Two implanters for the price of one and a half! Share it with your Syndicate friend.
+
+uplink-generic-radio-implanter-name = Generic Radio Implanter
+uplink-generic-radio-implanter-desc = A cranial implant with a bluespace compartment for a single encryption key (not included). Put in a key of your choice, and you can talk using it like you would with any headset.

--- a/Resources/Locale/en-US/deltav/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/deltav/store/uplink-catalog.ftl
@@ -9,7 +9,7 @@ uplink-syndicate-radio-implanter-name = Syndicate Radio Implanter
 uplink-syndicate-radio-implanter-desc = A cranial implant that lets you talk on the Syndicate radio channel (use :t).
 
 uplink-syndicate-radio-implanter-bundle-name = Syndicate Radio Implanter Bundle
-uplink-syndicate-radio-implanter-bundle-desc = Two implanters for the price of one and a half! Share it with your Syndicate friend.
+uplink-syndicate-radio-implanter-bundle-desc = Two implanters for the price of one and a half! Share one with your Syndicate friend.
 
 uplink-generic-radio-implanter-name = Generic Radio Implanter
 uplink-generic-radio-implanter-desc = A cranial implant with a bluespace compartment for a single encryption key (not included). Put in a key of your choice, and you can talk using it like you would with any headset.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -122,7 +122,7 @@
   name: uplink-sniper-bundle-name
   description: uplink-sniper-bundle-desc
   icon: { sprite: /Textures/Objects/Weapons/Guns/Snipers/heavy_sniper.rsi, state: base }
-  productEntity: BriefcaseSyndieSniperBundleFilled  
+  productEntity: BriefcaseSyndieSniperBundleFilled
   cost:
     Telecrystal: 12
   categories:
@@ -632,16 +632,17 @@
   categories:
   - UplinkDeception
 
-- type: listing
-  id: UplinkHeadsetEncryptionKey
-  name: uplink-encryption-key-name
-  description: uplink-encryption-key-desc
-  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
-  productEntity: BoxEncryptionKeySyndie # Two for the price of one
-  cost:
-    Telecrystal: 2
-  categories:
-  - UplinkDeception
+# Delta-V: replaced by syndicate radio implant
+#- type: listing
+#  id: UplinkHeadsetEncryptionKey
+#  name: uplink-encryption-key-name
+#  description: uplink-encryption-key-desc
+#  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
+#  productEntity: BoxEncryptionKeySyndie # Two for the price of one
+#  cost:
+#    Telecrystal: 2
+#  categories:
+#  - UplinkDeception
 
 - type: listing
   id: UplinkBinaryTranslatorKey
@@ -1004,7 +1005,7 @@
     Telecrystal: 6
   categories:
     - UplinkAllies
-  
+
 - type: listing
   id: UplinkSyndicatePersonalAI
   name: uplink-syndicate-pai-name

--- a/Resources/Prototypes/DeltaV/Actions/types.yml
+++ b/Resources/Prototypes/DeltaV/Actions/types.yml
@@ -1,0 +1,13 @@
+﻿- type: entity
+  id: ActionOpenRadioImplant
+  name: Open Radio Implant
+  description: Opens the bluespace key compartment of the radio implant embedded in your skull.
+  noSpawn: true
+  components:
+  - type: InstantAction
+    itemIconStyle: BigAction
+    priority: -20
+    icon:
+      sprite: Clothing/Ears/Headsets/base.rsi
+      state: icon
+    event: !type:OpenRadioImplantEvent

--- a/Resources/Prototypes/DeltaV/Actions/types.yml
+++ b/Resources/Prototypes/DeltaV/Actions/types.yml
@@ -10,4 +10,4 @@
     icon:
       sprite: Clothing/Ears/Headsets/base.rsi
       state: icon
-    event: !type:OpenRadioImplantEvent
+    event: !type:OpenStorageImplantEvent

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Boxes/general.yml
@@ -16,3 +16,18 @@
     whitelist:
       components:
       - EncryptionKey
+
+- type: entity
+  name: syndicate radio implanter box
+  parent: BoxCardboard
+  id: BoxSyndicateRadioImplanter
+  description: Contains cranial radio implants favored by Syndicate agents.
+  components:
+  - type: Sprite
+    layers:
+    - state: box_of_doom
+    - state: implant
+  - type: StorageFill
+    contents:
+    - id: SyndicateRadioImplanter
+      amount: 2

--- a/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
@@ -37,3 +37,37 @@
     Telecrystal: 4
   categories:
   - UplinkDeception
+
+- type: listing
+  id: UplinkSyndicateRadioImplanter
+  name: uplink-syndicate-radio-implanter-name
+  description: uplink-syndicate-radio-implanter-desc
+  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
+  productEntity: SyndicateRadioImplanter
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkImplants
+
+- type: listing
+  id: UplinkSyndicateRadioImplanterBundle
+  name: uplink-syndicate-radio-implanter-bundle-name
+  description: uplink-syndicate-radio-implanter-bundle-desc
+  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: synd_label }
+  productEntity: BoxSyndicateRadioImplanter
+  cost:
+    Telecrystal: 3
+  categories:
+  - UplinkImplants
+
+
+- type: listing
+  id: UplinkGenericRadioImplanter
+  name: uplink-generic-radio-implanter-name
+  description: uplink-generic-radio-implanter-desc
+  icon: { sprite: /Textures/Objects/Devices/encryption_keys.rsi, state: crypt_rusted }
+  productEntity: GenericRadioImplanter
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkImplants

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/implanters.yml
@@ -5,3 +5,19 @@
   components:
     - type: Implanter
       implant: BionicSyrinxImplant
+
+- type: entity
+  id: RadioImplanter
+  name: generic radio implanter
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+  - type: Implanter
+    implant: RadioImplant
+
+- type: entity
+  id: SyndicateRadioImplanter
+  name: syndicate radio implanter
+  parent: BaseImplantOnlyImplanterSyndi
+  components:
+  - type: Implanter
+    implant: SyndicateRadioImplant

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/implanters.yml
@@ -7,7 +7,7 @@
       implant: BionicSyrinxImplant
 
 - type: entity
-  id: RadioImplanter
+  id: GenericRadioImplanter
   name: generic radio implanter
   parent: BaseImplantOnlyImplanterSyndi
   components:

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
@@ -15,3 +15,42 @@
       tags:
         - SubdermalImplant
         - BionicSyrinxImplant
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: RadioImplant
+  name: generic radio implant
+  description: This implant contains a radio augmentation with a bluespace compartment for an encryption key. It allows its user to communicate on the key's channel.
+  noSpawn: true
+  components:
+  - type: SubdermalImplant
+    implantAction: ActionOpenRadioImplant
+    whitelist:
+      components:
+      - Hands # the user needs to have hands to actually insert or remove a key, much like the storage implant
+  - type: Storage
+    grid:
+      - 0,0,0,1
+    whitelist:
+      components:
+        - EncryptionKey # encryption keys only!
+  - type: ContainerContainer
+    containers:
+      storagebase: !type:Container
+        ents: [ ]
+  - type: UserInterface
+    interfaces:
+      enum.StorageUiKey.Key:
+        type: StorageBoundUserInterface
+  - type: RadioImplant
+
+- type: entity
+  parent: BaseSubdermalImplant
+  id: SyndicateRadioImplant
+  name: syndicate radio implant
+  description: This implant contains a radio augmentation that allows its user to communicate on the Syndicate channel.
+  noSpawn: true
+  components:
+  - type: RadioImplant
+    channels:
+    - Syndicate

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
@@ -20,7 +20,7 @@
   parent: BaseSubdermalImplant
   id: RadioImplant
   name: generic radio implant
-  description: This implant contains a radio augmentation with a bluespace compartment for an encryption key. It allows its user to communicate on the key's channel.
+  description: This implant contains a radio augmentation with a bluespace compartment for an encryption key. It allows its user to communicate on the key's channels.
   noSpawn: true
   components:
   - type: SubdermalImplant

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
@@ -28,6 +28,9 @@
     whitelist:
       components:
       - Hands # the user needs to have hands to actually insert or remove a key, much like the storage implant
+    blacklist:
+      components:
+      - BorgChassisComponent # borgs have "hands", but can't pick stuff up so the implant would be useless for them
   - type: Storage
     grid:
       - 0,0,0,1

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/subdermal_implants.yml
@@ -17,7 +17,7 @@
         - BionicSyrinxImplant
 
 - type: entity
-  parent: BaseSubdermalImplant
+  parent: StorageImplant
   id: RadioImplant
   name: generic radio implant
   description: This implant contains a radio augmentation with a bluespace compartment for an encryption key. It allows its user to communicate on the key's channel.
@@ -34,14 +34,6 @@
     whitelist:
       components:
         - EncryptionKey # encryption keys only!
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        ents: [ ]
-  - type: UserInterface
-    interfaces:
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
   - type: RadioImplant
 
 - type: entity


### PR DESCRIPTION
## About the PR

- Adds a generic radio implant for traitors. Adds an action button for accessing encryption key storage (acts like an encryption key only 1x2 storage implant), and lets you use the key that's inside to communicate on the key's radio channels.
- Adds a Syndicate radio implant for traitors. Allows the implanted player to use :t to talk on the Syndicate radio channel. The key is not removable.

As with any other implant you can only have one of each implanted.

## Why / Balance

### Syndicate radio implant (2 TC, or two implanters for 3 TC)

The Syndicate encryption key is in a bad place right now and too risky to use. If just one traitor using it gets compromised (which can happen during random searches in the worst case), sec has access to a key - and as per admin policy, they are allowed to use it with the CO giving permission. Even without express permission sec players might just use it anyway, even though it's against the rules, and it's hard to catch that happening. 

Making it an implant enables Syndicate cooperation and makes it more viable because you can mostly stop worrying about Syndicate comms being compromised. Sec would need to have a good reason to implant search someone, and it's harder to do solo since an implanter is needed. They need an even better reason to implant Syndicate tech into themselves. Still, a risk remains: You now have a spent, DNA-laden implanter instead of a key to worry about, and you can easily be compromised if that is found. And, of course, a caught Syndie can still rat you out too if they think it will lessen their sentence.

Ultimately this will allow for some fun opportunities that didn't exist before, like an imprisoned Syndie coordinating with another Syndie outside to organize a break-out, disclosing a stash, etc.

Nukies still use headsets with Syndicate encryption keys. This rewards the crew with a key to use if they can capture a nukie alive (or a dead one without an acidifier implant).

### Generic radio implant (4 TC)

This one felt like a logical addition to the above. As before you can use a regular headset for your stolen encryption keys, but spending 4 TC nets you the ability to keep your stolen key mostly hidden from searches, at least as long as the implanter isn't found. I think the price is probably fair since it doesn't come with a key, and you still have to deal with disposing the implanter and actually getting a key which can be risky, especially for command or sec keys. If it turns out to be too unbalanced the cost can be tweaked or it can be removed completely.

Any inserted encryption key will fall to the floor when the implant is extracted.

## Technical details

The generic radio uses the inventory system for encryption keys instead of EncryptionKeyHolder because the latter doesn't really work for implants.

More channel specific implants can be easily added if desired.

## Known issues

### Message duplication 

If you use encryption keys with channels that overlap with the the channels of the keys in your headset, received messages on those overlapping channels will be duplicated. 

I think realistically this is only an issue when someone uses the station master encryption key in it. Usually you would just insert a key you do not have in your headset (e.g. to listen in on sec communications as a scientist). The station master key has the Common channel included in it though, as well as department channels. If someone runs into this issue they can take off their headset or pop out its keys. ("Officer, I just took it off because comms were too noisy, my head hurts...")

This ultimately is something that needs to be fixed by Wizden because it would probably require pretty big changes to the chat system.

### Storage still accessible after extraction

If the storage window for the generic radio implant is still open after implant extraction, it can still be manipulated, though it won't let you gain radio access again unless reimplanted. 

The storage implanter also has this issue, I filed this on WizDen: https://github.com/space-wizards/space-station-14/issues/28309

## Media
![image](https://github.com/DeltaV-Station/Delta-v/assets/165581243/be0af7c2-53a3-46af-8d14-bb14f488752a)
![image](https://github.com/DeltaV-Station/Delta-v/assets/165581243/0e8c20f6-c2c3-496b-a45d-8f8b2ece7428)

## Breaking changes

None, the Syndicate key still exists but just can't be bought through the uplink anymore.

**Changelog**
:cl:
- remove: Syndicate encryption keys can no longer be purchased.
- add: Syndicate radio implants are now available in uplinks. After implanting, you can use it to speak on the Syndicate frequency like you would on a headset (":t Hi!"). No headset needed!
- add: Generic radio implants are now available in uplinks. After implanting, you can insert an encryption key into its bluespace storage space, and use it like you would use a headset.
