### PR TITLE
Increased security PDAs' cartridge slots by 2

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/pda.yml
@@ -20,7 +20,8 @@
       map: [ "enum.PdaVisualLayers.IdLight" ]
       shader: "unshaded"
       visible: false
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -173,7 +173,8 @@
     accentVColor: "#A32D26"
   - type: Icon
     state: pda-interncadet
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -431,7 +432,8 @@
     borderColor: "#6f6192"
   - type: Icon
     state: pda-lawyer
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -645,7 +647,8 @@
     accentHColor: "#447987"
   - type: Icon
     state: pda-hos
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -667,7 +670,8 @@
     accentVColor: "#949137"
   - type: Icon
     state: pda-warden
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -688,7 +692,8 @@
     borderColor: "#A32D26"
   - type: Icon
     state: pda-security
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -984,7 +989,8 @@
     borderColor: "#774705"
   - type: Icon
     state: pda-detective
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -1007,7 +1013,8 @@
     accentVColor: "#d7d7d0"
   - type: Icon
     state: pda-brigmedic
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
@@ -1099,7 +1106,8 @@
     accentVColor: "#DFDFDF"
   - type: Icon
     state: pda-seniorofficer
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
@@ -32,7 +32,8 @@
     accentVColor: "#DFDFDF"
   - type: Icon
     state: pda-security
-  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch
+  - type: CartridgeLoader # DeltaV - Crime Assist + SecWatch, increased diskSpace by 2 to fit them
+    diskSpace: 7
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Increased cartridge slots for all security PDAs to compensate for SecWatch and CrimeAssist. Now security can once again install other programs.

Closes https://github.com/DeltaV-Station/Delta-v/issues/1259

## Why / Balance
Couldn't install LogProbe or any other program on any security PDA after the addition of SecWatch and CrimeAssist. Huge disadvantage for detective.

:cl:
- tweak: Cartridge slots in all security PDAs were increased by 2 to compensate for the addition of SecWatch and CrimeAssist.

