### PR TITLE
New defib rule

### DIFF
--- a/Resources/ServerInfo/Rules.txt
+++ b/Resources/ServerInfo/Rules.txt
@@ -57,7 +57,7 @@ If you have any questions about these rules, please use the admin help menu by h
 
 [color=#a4885c]3.[/color] Follow the new-life rules:
  - If a player dies and is brought back by way of cloning or borging, they forget the last five minutes leading up to their death and cannot describe who or what killed them.
- - Players that are revived by using a defibrillator CAN recall the circumstances of their death and do not have any forgetfulness/amnesia about what happened while they were conscious and awake.
+ - Players that are revived by using a defibrillator can only recall vague details about their death, such as "Someone shot me" or "I was set ablaze" but they cannot recall details beyond that.[color=#ff0000]Please report players who break this rule[/color]
  - In either case, characters do not have any knowledge of what happened while they were dead (i.e. ghosted/observing).
 
 [color=#a4885c]4.[/color] Follow naming conventions:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Changed the new life rule concerning revivial via defib, as discussed and agreed upon during the June 1st Admin meeting

## Why / Balance
For a very long time players would just blurt out war and peace explaning every detail about their murder when they were defib revived, and antags were compelled to round-remove targets and witnesses just to keep themselves from being caught. It also generally devalued the lives of the crew in general, so to make death more impactful, this rule was agreed upon.

## Technical details
Changed rules.txt

## Media
- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes

**Changelog**

:cl: Delta-V Admin Team
- tweak: Changed the rules concerning being revived by defib in Rule 3


