### PR TITLE
Security Access Adjustments

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -17,6 +17,7 @@
   - Maintenance
   #- Service # DeltaV
   - Detective
+  - Cryogenics
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -15,9 +15,9 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  #- Service # DeltaV
+  #- Service # Delta V: Access adjustments 02June2024
   - Detective
-  - Cryogenics # DeltaV
+  - Cryogenics # Delta V: Access adjustments 02June2024
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -15,9 +15,9 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  #- Service # Delta V: Access adjustments 02June2024
+  #- Service # Delta V: Access adjustments
   - Detective
-  - Cryogenics # Delta V: Access adjustments 02June2024
+  - Cryogenics # Delta V: Access adjustments
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -17,7 +17,7 @@
   - Maintenance
   #- Service # DeltaV
   - Detective
-  - Cryogenics
+  - Cryogenics # DeltaV
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -15,7 +15,7 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  - Service
+  #- Service # DeltaV
   - Detective
   special:
   - !type:AddImplantSpecial

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -29,7 +29,7 @@
   - Security
   - Armory
   - Maintenance
-  #- Service # DeltaV
+  #- Service # Delta V: Access adjustments 02June2024
   - External
   - Detective
   - Corpsman # DeltaV - added Corpsman access

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -29,7 +29,7 @@
   - Security
   - Armory
   - Maintenance
-  #- Service # Delta V: Access adjustments 02June2024
+  #- Service # Delta V: Access adjustments
   - External
   - Detective
   - Corpsman # DeltaV - added Corpsman access

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -29,7 +29,7 @@
   - Security
   - Armory
   - Maintenance
-  - Service
+  #- Service # DeltaV
   - External
   - Detective
   - Corpsman # DeltaV - added Corpsman access

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -18,9 +18,9 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  #- Service # Delta V: Access adjustments 02June2024
+  #- Service # Delta V: Access adjustments
   - External
-  #- Cryogenics # Delta V: Access adjustments 02June2024
+  #- Cryogenics # Delta V: Access adjustments
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -18,7 +18,7 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  - Service
+  #- Service # DeltaV
   - External
   - Cryogenics
   special:

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -18,9 +18,9 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  #- Service # DeltaV
+  #- Service # Delta V: Access adjustments 02June2024
   - External
-  - Cryogenics
+  #- Cryogenics # Delta V: Access adjustments 02June2024
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -15,7 +15,7 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  - Service
+  #- Service # DeltaV
   - External
   - Cryogenics
   special:

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -15,9 +15,9 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  #- Service # Delta V: Access adjustments 02June2024
+  #- Service # Delta V: Access adjustments
   - External
-  #- Cryogenics # Delta V: Access adjustments 02June2024
+  #- Cryogenics # Delta V: Access adjustments
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_officer.yml
@@ -15,9 +15,9 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  #- Service # DeltaV
+  #- Service # Delta V: Access adjustments 02June2024
   - External
-  - Cryogenics
+  #- Cryogenics # Delta V: Access adjustments 02June2024
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -20,7 +20,7 @@
   #- Brig # Delta V: Removed
   - Armory
   - Maintenance
-  #- Service # DeltaV
+  #- Service # Delta V: Access adjustments 02June2024
   - External
   - Detective
   - Cryogenics

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -20,7 +20,7 @@
   #- Brig # Delta V: Removed
   - Armory
   - Maintenance
-  #- Service # Delta V: Access adjustments 02June2024
+  #- Service # Delta V: Access adjustments
   - External
   - Detective
   - Cryogenics

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -20,7 +20,7 @@
   #- Brig # Delta V: Removed
   - Armory
   - Maintenance
-  - Service
+  #- Service # DeltaV
   - External
   - Detective
   - Cryogenics


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

sec can no longer whack service workers in their job areas without breaking down the wall
also detective gains cryogenic access while cadets and secoffs lose it

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

There isn't much of a reason for sec to be able to barge into service-locked rooms willy nilly. If there's a reason, they can fetch someone with the access (i.e. command) or get assigned the access with an ID computer.

Detective should have cryogenics access to obtain things stored in cryosleep beds, a task that security cadets are already trusted with. Regular officers and cadets shouldn't be encouraged to sift through cryosleepers.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- remove: Security personnel no longer have service access by default.