### PR TITLE
Make flatpacks mappable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -129,8 +129,8 @@
   id: TeslaGeneratorFlatpack
   name: tesla generator flatpack
   description: A flatpack used for constructing a tesla generator.
-  #categories:  #Delta V - No Tesla fo DV
-  #- hideSpawnMenu
+  categories:  #Delta V - No Tesla fo DV
+  - hideSpawnMenu
   components:
   - type: Flatpack
     entity: TeslaGenerator

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -3,8 +3,8 @@
   id: BaseFlatpack
   name: base flatpack
   description: A flatpack used for constructing something.
-  categories:
-  - hideSpawnMenu
+  #categories:  #Delta V - Allow these to be mapped
+  #- hideSpawnMenu
   components:
   - type: Item
     size: Large
@@ -129,6 +129,8 @@
   id: TeslaGeneratorFlatpack
   name: tesla generator flatpack
   description: A flatpack used for constructing a tesla generator.
+  #categories:  #Delta V - No Tesla fo DV
+  #- hideSpawnMenu
   components:
   - type: Flatpack
     entity: TeslaGenerator


### PR DESCRIPTION
## About the PR
Removes hideSpawnMenu from flatpacks so they can be mapped

## Why / Balance
Mainly for engine setups when we don't want to map an entire crate but simply add a piece or two. Could also be used in salvage wrecks down the line.  
