### PR TITLE
Removes DragonSpawn event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -79,35 +79,35 @@
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
 
-- type: entity
-  parent: BaseGameRule
-  id: DragonSpawn
-  noSpawn: true
-  components:
-  - type: StationEvent
-    weight: 1 # DeltaV - was 6.5
-    earliestStart: 60 # DeltaV - was 40
-    reoccurrenceDelay: 20
-    minimumPlayers: 45 # DeltaV - was 20
-  - type: AntagRandomSpawn
-  - type: AntagSpawner
-    prototype: MobDragon
-  - type: AntagObjectives
-    objectives:
-    - CarpRiftsObjective
-    - DragonSurviveObjective
-  - type: AntagSelection
-    agentName: dragon-round-end-agent-name
-    definitions:
-    - spawnerPrototype: SpawnPointGhostDragon
-      min: 1
-      max: 1
-      pickPlayer: false
-      mindComponents:
-      - type: DragonRole
-        prototype: Dragon
-      - type: RoleBriefing
-        briefing: dragon-role-briefing
+#- type: entity # DeltaV: remove space dragon spawn event
+#  parent: BaseGameRule
+#  id: DragonSpawn
+#  noSpawn: true
+#  components:
+#  - type: StationEvent
+#    weight: 1 # DeltaV - was 6.5
+#    earliestStart: 60 # DeltaV - was 40
+#    reoccurrenceDelay: 20
+#    minimumPlayers: 45 # DeltaV - was 20
+#  - type: AntagRandomSpawn
+#  - type: AntagSpawner
+#    prototype: MobDragon
+#  - type: AntagObjectives
+#    objectives:
+#    - CarpRiftsObjective
+#    - DragonSurviveObjective
+#  - type: AntagSelection
+#    agentName: dragon-round-end-agent-name
+#    definitions:
+#    - spawnerPrototype: SpawnPointGhostDragon
+#      min: 1
+#      max: 1
+#      pickPlayer: false
+#      mindComponents:
+#      - type: DragonRole
+#        prototype: Dragon
+#      - type: RoleBriefing
+#        briefing: dragon-role-briefing
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -2,13 +2,13 @@
 - type: weightedRandom
   id: NinjaThreats
   weights:
-    Dragon: 1
+#    Dragon: 1 # DeltaV
     Revenant: 1
 
-- type: ninjaHackingThreat
-  id: Dragon
-  announcement: terror-dragon
-  rule: DragonSpawn
+#- type: ninjaHackingThreat # DeltaV
+#  id: Dragon
+#  announcement: terror-dragon
+#  rule: DragonSpawn
 
 - type: ninjaHackingThreat
   id: Revenant


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Prevents the dragon spawn event from occurring in game.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

The round-removing practice of swallowing people is *no bueno*.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl: Lyndomen, DLondon, Colin_Tel
- remove: The Space Dragon is no longer a random event that occurs.