### PR TITLE
Return dragons

### DIFF
--- a/Content.Server/Devour/DevourSystem.cs
+++ b/Content.Server/Devour/DevourSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Devour;
@@ -15,6 +16,7 @@ public sealed class DevourSystem : SharedDevourSystem
         base.Initialize();
 
         SubscribeLocalEvent<DevourerComponent, DevourDoAfterEvent>(OnDoAfter);
+        SubscribeLocalEvent<DevourerComponent, BeingGibbedEvent>(OnGibContents); // Delta-V
     }
 
     private void OnDoAfter(EntityUid uid, DevourerComponent component, DevourDoAfterEvent args)
@@ -45,5 +47,17 @@ public sealed class DevourSystem : SharedDevourSystem
 
         _audioSystem.PlayPvs(component.SoundDevour, uid);
     }
+
+    // Delta-V begin
+    private void OnGibContents(EntityUid uid, DevourerComponent component, ref BeingGibbedEvent args)
+    {
+        if (!component.ShouldStoreDevoured)
+            return;
+
+        // For some reason we have two different systems that should handle gibbing,
+        // and for some another reason GibbingSystem, which should empty all containers, doesn't get involved in this process
+        ContainerSystem.EmptyContainer(component.Stomach);
+    }
+    // Delta-V end
 }
 

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -79,35 +79,35 @@
   - type: RandomEntityStorageSpawnRule
     prototype: MobSkeletonCloset
 
-#- type: entity # DeltaV: remove space dragon spawn event
-#  parent: BaseGameRule
-#  id: DragonSpawn
-#  noSpawn: true
-#  components:
-#  - type: StationEvent
-#    weight: 1 # DeltaV - was 6.5
-#    earliestStart: 60 # DeltaV - was 40
-#    reoccurrenceDelay: 20
-#    minimumPlayers: 45 # DeltaV - was 20
-#  - type: AntagRandomSpawn
-#  - type: AntagSpawner
-#    prototype: MobDragon
-#  - type: AntagObjectives
-#    objectives:
-#    - CarpRiftsObjective
-#    - DragonSurviveObjective
-#  - type: AntagSelection
-#    agentName: dragon-round-end-agent-name
-#    definitions:
-#    - spawnerPrototype: SpawnPointGhostDragon
-#      min: 1
-#      max: 1
-#      pickPlayer: false
-#      mindComponents:
-#      - type: DragonRole
-#        prototype: Dragon
-#      - type: RoleBriefing
-#        briefing: dragon-role-briefing
+- type: entity
+  parent: BaseGameRule
+  id: DragonSpawn
+  noSpawn: true
+  components:
+  - type: StationEvent
+    weight: 1 # DeltaV - was 6.5
+    earliestStart: 60 # DeltaV - was 40
+    reoccurrenceDelay: 20
+    minimumPlayers: 45 # DeltaV - was 20
+  - type: AntagRandomSpawn
+  - type: AntagSpawner
+    prototype: MobDragon
+  - type: AntagObjectives
+    objectives:
+    - CarpRiftsObjective
+    - DragonSurviveObjective
+  - type: AntagSelection
+    agentName: dragon-round-end-agent-name
+    definitions:
+    - spawnerPrototype: SpawnPointGhostDragon
+      min: 1
+      max: 1
+      pickPlayer: false
+      mindComponents:
+      - type: DragonRole
+        prototype: Dragon
+      - type: RoleBriefing
+        briefing: dragon-role-briefing
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -2,13 +2,13 @@
 - type: weightedRandom
   id: NinjaThreats
   weights:
-#    Dragon: 1 # DeltaV
+    Dragon: 1
     Revenant: 1
 
-#- type: ninjaHackingThreat # DeltaV
-#  id: Dragon
-#  announcement: terror-dragon
-#  rule: DragonSpawn
+- type: ninjaHackingThreat
+  id: Dragon
+  announcement: terror-dragon
+  rule: DragonSpawn
 
 - type: ninjaHackingThreat
   id: Revenant


### PR DESCRIPTION
## About the PR
Returns the space dragon event and fixes the devour system

## Why / Balance
Because more time was wasted discussing the removal of one of the few midround antags than it took me to fix what caused the removal in the first place.

As I was told, the reason was round-removal of eaten bodies.

## Technical details
Made DevourSystem empty the stomach container of the Devourer when it's being gibbed (butchering includes gibbing) and reverted the PR that removed the dragon spawn.

## Media

https://github.com/DeltaV-Station/Delta-v/assets/69920617/0eaeb2db-9418-49c0-a1cb-69bebaed6757



- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
:cl:
- fix: The space dragon event is back!
- fix: Butchering or gibbing a space dragon will now properly drop the bodies it has eaten.
