### PR TITLE
Update maintenance closet inventory

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -185,30 +185,30 @@
         - id: ClothingBackpackDuffelSyndicate
           prob: 0.005
           orGroup: syndiemaintloot
-        #- id: CyberPen # DeltaV - Nuh uh
-        #  prob: 0.005
-        #  orGroup: syndiemaintloot
-        #- id: CigPackSyndicate
-        #  prob: 0.005
-        #  orGroup: syndiemaintloot
+        - id: CyberPen
+          prob: 0.005
+          orGroup: syndiemaintloot
+        - id: CigPackSyndicate
+          prob: 0.005
+          orGroup: syndiemaintloot
         - id: ClothingBackpackDuffelSyndicatePyjamaBundle
           prob: 0.005
           orGroup: syndiemaintloot
-        #- id: ClothingBeltMilitaryWebbing
-        #  prob: 0.005
-        #  orGroup: syndiemaintloot
-        #- id: ClothingShoesBootsCombatFilled
-        #  prob: 0.005
-        #  orGroup: syndiemaintloot
-        #- id: ToolboxSyndicateFilled
-        #  prob: 0.005
-        #  orGroup: syndiemaintloot
-        #- id: BalloonSyn
-        #  prob: 0.005
-        #  orGroup: syndiemaintloot
-        #- id: WeaponSniperMosin
-        #  prob: 0.0010
-        #  orGroup: syndiemaintloot
+        - id: ClothingBeltMilitaryWebbing
+          prob: 0.005
+          orGroup: syndiemaintloot
+        - id: ClothingShoesBootsCombatFilled
+          prob: 0.005
+          orGroup: syndiemaintloot
+        - id: ToolboxSyndicateFilled
+          prob: 0.005
+          orGroup: syndiemaintloot
+        - id: BalloonSyn
+          prob: 0.005
+          orGroup: syndiemaintloot
+        - id: WeaponSniperMosin
+          prob: 0.0010
+          orGroup: syndiemaintloot
 
 - type: entity
   id: ClosetWallMaintenanceFilledRandom


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Made the maintenance closet inventory consistent with the maintenance wall closet

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

You could obtain this loot from wall closets anyways, and there wasn't really any concern over "crazy" loot. It also gives some random contraband for security to look out for that isn't really concerning from an admin perspective.

This was discussed in admin vc with DLondon *et al*.

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
They'll figure it out.