### PR TITLE
Stop Burning Bodies Turning into Ash

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -60,21 +60,21 @@
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior { }
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+#    - trigger:                       #DeltaV- We don't like round removing people for being in the same room as a plasma trapped crate. 
+#        !type:DamageTypeTrigger
+#        damageType: Heat
+#        damage: 1500
+#      behaviors:
+#      - !type:SpawnEntitiesBehavior
+#        spawnInContainer: true
+#        spawn:
+#          Ash:
+#            min: 1
+#            max: 1
+#      - !type:BurnBodyBehavior { }
+#      - !type:PlaySoundBehavior
+#        sound:
+#          collection: MeatLaserImpact
   - type: RadiationReceiver
   - type: Stamina
   - type: MobState


### PR DESCRIPTION
## About the PR
I stopped bodies that are burning being turned into ash.

## Why / Balance
Being round removed for being in the same room as a plasma trapped crate is funny once. 

## Technical details
Commented out some yaml. 

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Yaml warrior reporting in clear

**Changelog**

:cl:
- tweak: Burning bodies no longer ash

