### PR TITLE
Pebble fix - June 11th

### DIFF
--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -7129,8 +7129,6 @@ entities:
       pos: 4.5,-26.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 47
   - uid: 259
@@ -48247,8 +48245,6 @@ entities:
       pos: 5.5,-28.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 47
   - uid: 11104
@@ -48289,8 +48285,6 @@ entities:
       pos: 4.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 11233
       - 47
@@ -48939,8 +48933,6 @@ entities:
       pos: 5.5,-26.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 47
     - type: AtmosPipeColor

--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -6373,7 +6373,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -28.5,34.5
       parent: 2
-  - uid: 7465
+  - uid: 4660
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -7129,6 +7129,8 @@ entities:
       pos: 4.5,-26.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 47
   - uid: 259
@@ -11781,6 +11783,11 @@ entities:
     components:
     - type: Transform
       pos: 32.5,-0.5
+      parent: 2
+  - uid: 5149
+    components:
+    - type: Transform
+      pos: -33.5,14.5
       parent: 2
 - proto: AtmosFixBlockerMarker
   entities:
@@ -20895,6 +20902,21 @@ entities:
     components:
     - type: Transform
       pos: -23.5,4.5
+      parent: 2
+  - uid: 11409
+    components:
+    - type: Transform
+      pos: 11.5,26.5
+      parent: 2
+  - uid: 11412
+    components:
+    - type: Transform
+      pos: 10.5,25.5
+      parent: 2
+  - uid: 11413
+    components:
+    - type: Transform
+      pos: 10.5,26.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -30923,6 +30945,11 @@ entities:
     - type: Transform
       pos: 27.5,-6.5
       parent: 2
+  - uid: 7914
+    components:
+    - type: Transform
+      pos: 19.5,36.5
+      parent: 2
 - proto: CrateFoodCooking
   entities:
   - uid: 420
@@ -31070,13 +31097,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -15.5,-17.5
-      parent: 2
-- proto: CyberPen
-  entities:
-  - uid: 4660
-    components:
-    - type: Transform
-      pos: -31.483238,-25.444899
       parent: 2
 - proto: d6Dice
   entities:
@@ -31265,6 +31285,11 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconEscapePod
   entities:
+  - uid: 7465
+    components:
+    - type: Transform
+      pos: -32.5,14.5
+      parent: 2
   - uid: 10895
     components:
     - type: Transform
@@ -34247,15 +34272,6 @@ entities:
     - type: PointLight
       enabled: True
     - type: ActiveEmergencyLight
-  - uid: 5139
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,24.5
-      parent: 2
-    - type: PointLight
-      enabled: True
-    - type: ActiveEmergencyLight
   - uid: 5140
     components:
     - type: Transform
@@ -34281,24 +34297,11 @@ entities:
     - type: PointLight
       enabled: True
     - type: ActiveEmergencyLight
-  - uid: 5144
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,12.5
-      parent: 2
-    - type: PointLight
-      enabled: True
-    - type: ActiveEmergencyLight
   - uid: 5145
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,7.5
+      pos: -5.5,10.5
       parent: 2
-    - type: PointLight
-      enabled: True
-    - type: ActiveEmergencyLight
   - uid: 5146
     components:
     - type: Transform
@@ -34322,15 +34325,6 @@ entities:
     - type: PointLight
       enabled: True
     - type: ActiveEmergencyLight
-  - uid: 5149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-25.5
-      parent: 2
-    - type: PointLight
-      enabled: True
-    - type: ActiveEmergencyLight
   - uid: 5150
     components:
     - type: Transform
@@ -34345,15 +34339,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,-12.5
-      parent: 2
-    - type: PointLight
-      enabled: True
-    - type: ActiveEmergencyLight
-  - uid: 5152
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -32.5,-3.5
       parent: 2
     - type: PointLight
       enabled: True
@@ -34423,6 +34408,29 @@ entities:
     - type: Transform
       pos: -18.5,9.5
       parent: 2
+  - uid: 7876
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-5.5
+      parent: 2
+  - uid: 7923
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -30.5,-1.5
+      parent: 2
+  - uid: 7932
+    components:
+    - type: Transform
+      pos: 11.5,26.5
+      parent: 2
+  - uid: 7979
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,24.5
+      parent: 2
   - uid: 11396
     components:
     - type: Transform
@@ -34457,6 +34465,18 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -20.5,-14.5
+      parent: 2
+  - uid: 11407
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,12.5
+      parent: 2
+  - uid: 11411
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-25.5
       parent: 2
 - proto: EmergencyRollerBed
   entities:
@@ -48245,6 +48265,8 @@ entities:
       pos: 5.5,-28.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 47
   - uid: 11104
@@ -48285,6 +48307,8 @@ entities:
       pos: 4.5,-32.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 11233
       - 47
@@ -48933,6 +48957,8 @@ entities:
       pos: 5.5,-26.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 47
     - type: AtmosPipeColor
@@ -50872,6 +50898,12 @@ entities:
     - type: Transform
       pos: -25.5,2.5
       parent: 2
+  - uid: 8355
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 2
   - uid: 8409
     components:
     - type: Transform
@@ -52754,6 +52786,11 @@ entities:
     - type: Transform
       pos: 28.5,-34.5
       parent: 2
+  - uid: 7973
+    components:
+    - type: Transform
+      pos: -29.5,1.5
+      parent: 2
   - uid: 9126
     components:
     - type: Transform
@@ -52766,6 +52803,31 @@ entities:
       parent: 2
 - proto: MaintenancePlantSpawner
   entities:
+  - uid: 5144
+    components:
+    - type: Transform
+      pos: 25.5,4.5
+      parent: 2
+  - uid: 7880
+    components:
+    - type: Transform
+      pos: -35.5,-29.5
+      parent: 2
+  - uid: 7961
+    components:
+    - type: Transform
+      pos: 17.5,4.5
+      parent: 2
+  - uid: 7972
+    components:
+    - type: Transform
+      pos: 13.5,-9.5
+      parent: 2
+  - uid: 7981
+    components:
+    - type: Transform
+      pos: -37.5,-28.5
+      parent: 2
   - uid: 9790
     components:
     - type: Transform
@@ -52776,8 +52838,18 @@ entities:
     - type: Transform
       pos: 27.5,19.5
       parent: 2
+  - uid: 11410
+    components:
+    - type: Transform
+      pos: 22.5,8.5
+      parent: 2
 - proto: MaintenanceToolSpawner
   entities:
+  - uid: 5139
+    components:
+    - type: Transform
+      pos: -31.5,-25.5
+      parent: 2
   - uid: 7673
     components:
     - type: Transform
@@ -52817,6 +52889,16 @@ entities:
       parent: 2
     - type: RandomSpawner
       chance: 1
+  - uid: 8748
+    components:
+    - type: Transform
+      pos: -43.5,31.5
+      parent: 2
+  - uid: 10519
+    components:
+    - type: Transform
+      pos: -42.5,-3.5
+      parent: 2
   - uid: 11271
     components:
     - type: Transform
@@ -54432,6 +54514,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 19.5,5.5
       parent: 2
+  - uid: 10681
+    components:
+    - type: Transform
+      pos: -18.5,3.5
+      parent: 2
 - proto: Poweredlight
   entities:
   - uid: 2283
@@ -54450,6 +54537,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -23.5,5.5
+      parent: 2
+  - uid: 5152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-23.5
       parent: 2
   - uid: 6933
     components:
@@ -54510,12 +54603,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.5,38.5
       parent: 2
-  - uid: 7876
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-2.5
-      parent: 2
   - uid: 7877
     components:
     - type: Transform
@@ -54533,11 +54620,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 27.5,-6.5
-      parent: 2
-  - uid: 7880
-    components:
-    - type: Transform
-      pos: 20.5,2.5
       parent: 2
   - uid: 7881
     components:
@@ -54666,10 +54748,8 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,7.5
+      pos: 8.5,12.5
       parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7902
     components:
     - type: Transform
@@ -54754,13 +54834,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 7914
-    components:
-    - type: Transform
-      pos: 4.5,13.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7915
     components:
     - type: Transform
@@ -54822,13 +54895,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 7923
-    components:
-    - type: Transform
-      pos: 6.5,17.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7924
     components:
     - type: Transform
@@ -54881,14 +54947,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 7932
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-19.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7933
     components:
     - type: Transform
@@ -54908,10 +54966,9 @@ entities:
   - uid: 7935
     components:
     - type: Transform
-      pos: -17.5,36.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,16.5
       parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7936
     components:
     - type: Transform
@@ -55040,11 +55097,9 @@ entities:
   - uid: 7955
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,12.5
+      rot: 1.5707963267948966 rad
+      pos: -15.5,-20.5
       parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7956
     components:
     - type: Transform
@@ -55080,14 +55135,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-0.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 7961
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,-22.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -55177,22 +55224,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 7972
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-22.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 7973
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.5,-25.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7975
     components:
     - type: Transform
@@ -55224,27 +55255,11 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 7979
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,-16.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 7980
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 10.5,-22.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 7981
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 26.5,24.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -55621,14 +55636,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 8032
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,32.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 8034
     components:
     - type: Transform
@@ -55851,6 +55858,12 @@ entities:
     - type: Transform
       pos: 21.5,-27.5
       parent: 2
+  - uid: 11408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,34.5
+      parent: 2
 - proto: PoweredLightBlueInterior
   entities:
   - uid: 8060
@@ -56014,6 +56027,12 @@ entities:
       parent: 2
 - proto: PoweredSmallLight
   entities:
+  - uid: 8032
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -31.5,25.5
+      parent: 2
   - uid: 8081
     components:
     - type: Transform
@@ -56299,21 +56318,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -32.5,29.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 8120
-    components:
-    - type: Transform
-      pos: -32.5,27.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 8121
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -32.5,24.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -57184,6 +57188,11 @@ entities:
     - type: Transform
       pos: 34.5,21.5
       parent: 2
+  - uid: 8354
+    components:
+    - type: Transform
+      pos: -31.5,40.5
+      parent: 2
 - proto: RandomPainting
   entities:
   - uid: 8266
@@ -57566,11 +57575,6 @@ entities:
     - type: Transform
       pos: 28.5,36.5
       parent: 2
-  - uid: 8339
-    components:
-    - type: Transform
-      pos: 24.5,27.5
-      parent: 2
   - uid: 8340
     components:
     - type: Transform
@@ -57640,16 +57644,6 @@ entities:
     components:
     - type: Transform
       pos: 24.5,34.5
-      parent: 2
-  - uid: 8354
-    components:
-    - type: Transform
-      pos: 25.5,27.5
-      parent: 2
-  - uid: 8355
-    components:
-    - type: Transform
-      pos: 22.5,27.5
       parent: 2
   - uid: 8356
     components:
@@ -57844,6 +57838,16 @@ entities:
     - type: Transform
       pos: -30.5,4.5
       parent: 2
+  - uid: 8120
+    components:
+    - type: Transform
+      pos: 24.5,27.5
+      parent: 2
+  - uid: 8121
+    components:
+    - type: Transform
+      pos: 22.5,27.5
+      parent: 2
   - uid: 8327
     components:
     - type: Transform
@@ -57853,6 +57857,11 @@ entities:
     components:
     - type: Transform
       pos: -13.5,13.5
+      parent: 2
+  - uid: 8339
+    components:
+    - type: Transform
+      pos: 25.5,27.5
       parent: 2
   - uid: 8373
     components:
@@ -58876,13 +58885,6 @@ entities:
     components:
     - type: Transform
       pos: -0.9342804,-11.419859
-      parent: 2
-- proto: Rickenbacker4003Instrument
-  entities:
-  - uid: 8616
-    components:
-    - type: Transform
-      pos: -31.52537,40.564377
       parent: 2
 - proto: RipleyChassis
   entities:
@@ -59954,6 +59956,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 20.5,-29.5
       parent: 2
+  - uid: 8616
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,9.5
+      parent: 2
   - uid: 8745
     components:
     - type: Transform
@@ -59971,12 +59979,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 24.5,-23.5
-      parent: 2
-  - uid: 8748
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 4.5,9.5
       parent: 2
   - uid: 8749
     components:
@@ -70665,11 +70667,6 @@ entities:
     - type: Transform
       pos: 0.5,18.5
       parent: 2
-  - uid: 10519
-    components:
-    - type: Transform
-      pos: 3.5,9.5
-      parent: 2
   - uid: 10520
     components:
     - type: Transform
@@ -71403,13 +71400,6 @@ entities:
     - type: Transform
       pos: 23.476604,-15.550745
       parent: 2
-- proto: WeaponPistolFlintlock
-  entities:
-  - uid: 10681
-    components:
-    - type: Transform
-      pos: -42.516632,28.328865
-      parent: 2
 - proto: WeaponPistolMk58
   entities:
   - uid: 10682
@@ -71907,6 +71897,12 @@ entities:
     components:
     - type: Transform
       pos: -23.5,0.5
+      parent: 2
+  - uid: 11406
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
       parent: 2
 - proto: WindowDirectional
   entities:

--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -7129,8 +7129,6 @@ entities:
       pos: 4.5,-26.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 47
   - uid: 259
@@ -48265,8 +48263,6 @@ entities:
       pos: 5.5,-28.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 47
   - uid: 11104
@@ -48307,8 +48303,6 @@ entities:
       pos: 4.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 11233
       - 47
@@ -48957,8 +48951,6 @@ entities:
       pos: 5.5,-26.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 47
     - type: AtmosPipeColor

--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -7129,6 +7129,8 @@ entities:
       pos: 4.5,-26.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 47
   - uid: 259
@@ -7456,7 +7458,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 5211
-      - 5663
       - 5233
       - 5246
       - 26
@@ -14492,6 +14493,11 @@ entities:
       parent: 2
 - proto: CableApcExtension
   entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -20.5,4.5
+      parent: 2
   - uid: 137
     components:
     - type: Transform
@@ -14501,6 +14507,11 @@ entities:
     components:
     - type: Transform
       pos: -19.5,14.5
+      parent: 2
+  - uid: 410
+    components:
+    - type: Transform
+      pos: -22.5,6.5
       parent: 2
   - uid: 1522
     components:
@@ -14520,7 +14531,7 @@ entities:
   - uid: 1619
     components:
     - type: Transform
-      pos: -21.5,5.5
+      pos: -22.5,5.5
       parent: 2
   - uid: 1620
     components:
@@ -17722,16 +17733,6 @@ entities:
     - type: Transform
       pos: -22.5,8.5
       parent: 2
-  - uid: 2268
-    components:
-    - type: Transform
-      pos: -21.5,7.5
-      parent: 2
-  - uid: 2269
-    components:
-    - type: Transform
-      pos: -21.5,6.5
-      parent: 2
   - uid: 2270
     components:
     - type: Transform
@@ -20876,6 +20877,26 @@ entities:
     components:
     - type: Transform
       pos: 20.5,-27.5
+      parent: 2
+  - uid: 11402
+    components:
+    - type: Transform
+      pos: -22.5,7.5
+      parent: 2
+  - uid: 11403
+    components:
+    - type: Transform
+      pos: -22.5,8.5
+      parent: 2
+  - uid: 11404
+    components:
+    - type: Transform
+      pos: -19.5,4.5
+      parent: 2
+  - uid: 11405
+    components:
+    - type: Transform
+      pos: -23.5,4.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -35256,16 +35277,6 @@ entities:
       - 5428
       - 5363
       - 5317
-  - uid: 5663
-    components:
-    - type: Transform
-      pos: -17.5,6.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 291
-      - 6340
-      - 8413
   - uid: 7031
     components:
     - type: Transform
@@ -35406,7 +35417,6 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5663
       - 5246
       - 7031
       - 88
@@ -36261,7 +36271,6 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 5663
       - 5246
       - 7031
       - 88
@@ -48238,6 +48247,8 @@ entities:
       pos: 5.5,-28.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 47
   - uid: 11104
@@ -48278,6 +48289,8 @@ entities:
       pos: 4.5,-32.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 11233
       - 47
@@ -48926,6 +48939,8 @@ entities:
       pos: 5.5,-26.5
       parent: 2
     - type: DeviceNetwork
+      configurators:
+      - invalid
       deviceLists:
       - 47
     - type: AtmosPipeColor
@@ -54327,10 +54342,20 @@ entities:
       parent: 2
 - proto: PottedPlantRandom
   entities:
+  - uid: 6012
+    components:
+    - type: Transform
+      pos: -19.5,7.5
+      parent: 2
   - uid: 6968
     components:
     - type: Transform
       pos: -25.5,-11.5
+      parent: 2
+  - uid: 7616
+    components:
+    - type: Transform
+      pos: -20.5,7.5
       parent: 2
   - uid: 7856
     components:
@@ -57736,11 +57761,6 @@ entities:
     - type: Transform
       pos: 40.5,16.5
       parent: 2
-  - uid: 410
-    components:
-    - type: Transform
-      pos: -23.5,6.5
-      parent: 2
   - uid: 2629
     components:
     - type: Transform
@@ -57770,11 +57790,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,3.5
-      parent: 2
-  - uid: 5309
-    components:
-    - type: Transform
-      pos: -21.5,9.5
       parent: 2
   - uid: 5649
     components:
@@ -57822,15 +57837,10 @@ entities:
     - type: Transform
       pos: -13.5,12.5
       parent: 2
-  - uid: 7616
-    components:
-    - type: Transform
-      pos: -14.5,10.5
-      parent: 2
   - uid: 7947
     components:
     - type: Transform
-      pos: -14.5,7.5
+      pos: -16.5,10.5
       parent: 2
   - uid: 8045
     components:
@@ -58782,6 +58792,11 @@ entities:
     components:
     - type: Transform
       pos: -31.5,6.5
+      parent: 2
+  - uid: 10660
+    components:
+    - type: Transform
+      pos: -18.5,12.5
       parent: 2
   - uid: 11024
     components:
@@ -62635,7 +62650,7 @@ entities:
   - uid: 1878
     components:
     - type: Transform
-      pos: -17.57217,5.5860868
+      pos: -14.497406,3.7313738
       parent: 2
 - proto: Table
   entities:
@@ -63655,12 +63670,6 @@ entities:
       parent: 2
 - proto: TableReinforcedGlass
   entities:
-  - uid: 39
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,5.5
-      parent: 2
   - uid: 1530
     components:
     - type: Transform
@@ -64607,7 +64616,7 @@ entities:
   - uid: 6343
     components:
     - type: Transform
-      pos: -20.5,7.5
+      pos: -17.5,5.5
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:
@@ -71667,10 +71676,25 @@ entities:
       parent: 2
 - proto: Window
   entities:
-  - uid: 6012
+  - uid: 2268
     components:
     - type: Transform
-      pos: -18.5,12.5
+      pos: -14.5,10.5
+      parent: 2
+  - uid: 2269
+    components:
+    - type: Transform
+      pos: -14.5,7.5
+      parent: 2
+  - uid: 5309
+    components:
+    - type: Transform
+      pos: -23.5,6.5
+      parent: 2
+  - uid: 5663
+    components:
+    - type: Transform
+      pos: -21.5,9.5
       parent: 2
   - uid: 8293
     components:
@@ -71726,11 +71750,6 @@ entities:
     components:
     - type: Transform
       pos: -11.5,32.5
-      parent: 2
-  - uid: 10660
-    components:
-    - type: Transform
-      pos: -16.5,10.5
       parent: 2
   - uid: 10726
     components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- Culled alot of lights around the station
- Moved alot of emergency lights around the station
- Moved medicals sus wire
- Moved nanomed into exam room
- Added recharger into medical
- Gives Janitorial a new window
- Removed EVEN MORE powergamer loot, replaced with random maints spawners (seriously? free generators?)

## Why / Balance
Because uhhhhhh I forgor to do these yesterday

## Technical details
Changes map file and YML

**Changelog**

:cl: DLondon
- fix: Fixes issues with Pebble's medical and lighting
