### PR TITLE
Syndicate Agents may purchase the Death Acidifer

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1141,11 +1141,11 @@
     Telecrystal: 4
   categories:
     - UplinkImplants
-  conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - NukeOpsUplink
+ # conditions:                               #DeltaV- Allows Death Acidifer for our Syndibros
+ #   - !type:StoreWhitelistCondition
+ #     whitelist:
+ #       tags:
+ #         - NukeOpsUplink
 
 - type: listing
   id: UplinkUplinkImplanter # uplink uplink real

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -166,7 +166,7 @@
   name: uplink-l6-saw-bundle-name
   description: uplink-l6-saw-bundle-desc
   icon: { sprite: /Textures/Objects/Weapons/Guns/LMGs/l6.rsi, state: icon }
-  productEntity: ClothingBackpackDuffelSyndicateFilledLMG
+  productEntity: ClothingBackpackDuffelicateFilledLMG
   cost:
     Telecrystal: 30
   categories:
@@ -1138,10 +1138,10 @@
   icon: { sprite: /Textures/Objects/Magic/magicactions.rsi, state: gib }
   productEntity: DeathAcidifierImplanter
   cost:
-    Telecrystal: 5                           #DeltaV- Was 4, now 5
+    Telecrystal: 5 #DeltaV- Was 4, now 5
   categories:
     - UplinkImplants
- # conditions:                               #DeltaV- Allows Death Acidifer for our Syndibros
+ # conditions: #DeltaV- Allows Death Acidifer for our Syndibros
  #   - !type:StoreWhitelistCondition
  #     whitelist:
  #       tags:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1138,7 +1138,7 @@
   icon: { sprite: /Textures/Objects/Magic/magicactions.rsi, state: gib }
   productEntity: DeathAcidifierImplanter
   cost:
-    Telecrystal: 4
+    Telecrystal: 5                           #DeltaV- Was 4, now 5
   categories:
     - UplinkImplants
  # conditions:                               #DeltaV- Allows Death Acidifer for our Syndibros


### PR DESCRIPTION
## About the PR
TC Changed from 4 to 5. Removed whitelist from Death Acidifier. 

## Why / Balance
Encourages hostage taking, and our damage proportional to objective rule makes agents less likely to abuse this compared to upstream. 

## Technical details
Comments out a whitelist statement, updates YAML. 

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Nope

**Changelog**
:cl:
- tweak: Death Acidifiers are now in Syndicate Uplinks once more

