### PR TITLE
fix ninja requirement not existing

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -169,6 +169,9 @@
     rules: ghost-role-information-space-ninja-rules
     raffle:
       settings: default
+    requirements:
+    - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+      time: 259200 # DeltaV - 72 hours
   - type: GhostRoleMobSpawner
     prototype: MobHumanSpaceNinja
   - type: Sprite


### PR DESCRIPTION
## About the PR
spawners have their own requirements and ignore the antag prototype so have to copy paste gaming

## Changelog
:cl:
- fix: Fixed ninja requirements not working.