### PR TITLE
Change hunger rate again

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class HungerComponent : Component
     /// The base amount at which <see cref="CurrentHunger"/> decays.
     /// </summary>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.05f; //DeltaV: changed from 0.01666666666f
+    public float BaseDecayRate = 0.035f; //DeltaV: changed from 0.01666666666f
 
     /// <summary>
     /// The actual amount at which <see cref="CurrentHunger"/> decays.

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -8,7 +8,7 @@
   - type: HumanoidAppearance
     species: Diona
   - type: Hunger
-    baseDecayRate: 0.02 #DeltaV
+    baseDecayRate: 0.015 #DeltaV
   - type: Thirst
     baseDecayRate: 0.15 # DeltaV
   - type: Carriable # Carrying system from nyanotrasen.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Lowered hunger decay rate. The fastest time to get to starving should be around 35 minutes now.

Diona also had their hunger rate lowered for consistency's sake.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Popular opinion on changing hunger for the benefit of the chef role is positive, however the rate itself was just too high. After a brief poll on Discord, lowering the rate from 0.05 to 0.035 seems like a safe enough bet.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

One line change.

## Media

![image](https://github.com/DeltaV-Station/Delta-v/assets/113523727/c301a08d-a40c-403c-935c-4d7a4e90eeeb)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- tweak: Adjusted hunger rate to be slightly less painful.
