### PR TITLE
Wake up Sleepy Agents

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -111,7 +111,7 @@
 
 - type: entity
   parent: BaseGameRule
-    id: NinjaSpawn
+  id: NinjaSpawn
   noSpawn: true
   components:
   - type: StationEvent

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -111,7 +111,7 @@
 
 - type: entity
   parent: BaseGameRule
-  id: NinjaSpawn
+    id: NinjaSpawn
   noSpawn: true
   components:
   - type: StationEvent
@@ -483,29 +483,29 @@
       - type: NukeopsRole
         prototype: Nukeops
 
-#- type: entity # DeltaV - Currently many issues with this event
-#  noSpawn: true
-#  parent: BaseTraitorRule
-#  id: SleeperAgentsRule
-#  components:
-#  - type: StationEvent
-#    earliestStart: 30
-#    weight: 8
-#    minimumPlayers: 15
-#    maxOccurrences: 1 # can only happen once per round
-#    startAnnouncement: station-event-communication-interception
-#    startAudio:
-#      path: /Audio/Announcements/intercept.ogg
-#  - type: AlertLevelInterceptionRule
-#  - type: AntagSelection
-#    definitions:
-#    - prefRoles: [ Traitor ]
-#      min: 1
-#      max: 2
-#      playerRatio: 10
-#      mindComponents:
-#      - type: TraitorRole
-#        prototype: Traitor
+- type: entity
+  noSpawn: true
+  parent: BaseTraitorRule
+  id: SleeperAgentsRule
+  components:
+  - type: StationEvent
+    earliestStart: 30
+    weight: 5 # DeltaV - Was 8 now 5
+    minimumPlayers: 15
+    maxOccurrences: 1 # can only happen once per round
+    startAnnouncement: station-event-communication-interception
+    startAudio:
+      path: /Audio/Announcements/intercept.ogg
+  - type: AlertLevelInterceptionRule
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      min: 1
+      max: 4 # DeltaV - Was 2 now 4
+      playerRatio: 10
+      mindComponents:
+      - type: TraitorRole
+        prototype: Traitor
 
 - type: entity
   id: MassHallucinations


### PR DESCRIPTION
## About the PR
Enable Sleeper Agents. 

## Why / Balance
Traitors are a good mechanic. No longer a busted event. 
Decrease weight from 8 to 5. Increases max number of sleepy fellows to 4 instead of 2. 
Fox & I like it. 

## Technical details
YAML edit

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Sleeper Agents are waking up!
