### PR TITLE
Add Chief Justice Cloak to Uniform Printer

### DIFF
--- a/Resources/Prototypes/DeltaV/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Lathes/clothing.yml
@@ -80,3 +80,60 @@
   completetime: 4
   materials:
     Cloth: 500
+
+# Chief Justice Wardrobe
+
+- type: latheRecipe
+  id: ClothingHeadHatCJToque
+  result: ClothingHeadHatCJToque
+  completetime: 2
+  materials:
+    Cloth: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitChiefJustice
+  result: ClothingUniformJumpsuitChiefJustice
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+ 
+- type: latheRecipe
+  id: ClothingUniformJumpskirtChiefJustice
+  result: ClothingUniformJumpskirtChiefJustice
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitChiefJusticeFormal
+  result: ClothingUniformJumpsuitChiefJusticeFormal
+  completetime: 4
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingUniformJumpsuitChiefJusticeWhite
+  result: ClothingUniformJumpsuitChiefJusticeWhite
+  completetime: 5
+  materials:
+    Cloth: 300
+    Durathread: 100
+
+- type: latheRecipe
+  id: ClothingNeckCloakCJ
+  result: ClothingNeckCloakCJ
+  completetime: 2.8
+  materials:
+    Cloth: 200
+    Durathread: 150
+
+- type: latheRecipe
+  id: ClothingOuterChiefJustice
+  result: ClothingOuterChiefJustice
+  completetime: 3.2
+  materials:
+    Cloth: 300
+    Durathread: 200

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1122,6 +1122,7 @@
       - ClothingNeckMantleHOS
       - ClothingNeckMantleRD
       - ClothingNeckMantleQM
+      - ClothingNeckCloakCJ
       - ClothingOuterStasecSweater # DeltaV - added stasec sweater to uniform printer.
       - ClothingOuterWinterMusician
       - ClothingOuterWinterClown

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1122,7 +1122,7 @@
       - ClothingNeckMantleHOS
       - ClothingNeckMantleRD
       - ClothingNeckMantleQM
-      - ClothingNeckCloakCJ
+      - ClothingNeckCloakCJ # DeltaV - Chief Justice
       - ClothingOuterStasecSweater # DeltaV - added stasec sweater to uniform printer.
       - ClothingOuterWinterMusician
       - ClothingOuterWinterClown

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1075,6 +1075,11 @@
       - ClothingUniformJumpskirtQMTurtleneck
       - ClothingUniformJumpsuitQMFormal
       - ClothingHeadHatBeretRND
+      - ClothingHeadHatCJToque # DeltaV - Chief Justice
+      - ClothingUniformJumpsuitChiefJustice # DeltaV - Chief Justice
+      - ClothingUniformJumpskirtChiefJustice # DeltaV - Chief Justice
+      - ClothingUniformJumpsuitChiefJusticeFormal # DeltaV - Chief Justice
+      - ClothingUniformJumpsuitChiefJusticeWhite # DeltaV - Chief Justice
       - ClothingUniformJumpsuitResearchDirector
       - ClothingUniformJumpskirtResearchDirector
       - ClothingUniformJumpsuitScientist
@@ -1109,6 +1114,7 @@
       - ClothingOuterWinterWardenUnarmored
       - ClothingOuterWinterQM
       - ClothingOuterWinterRD
+      - ClothingOuterChiefJustice # DeltaV - Chief Justice
       - ClothingNeckMantleCap
       - ClothingNeckMantleCE
       - ClothingNeckMantleCMO


### PR DESCRIPTION
## About the PR
Adds the Chief Justice's outfit to the uniform printer. 

## Why / Balance
drip is everything

## Media
![image](https://github.com/DeltaV-Station/Delta-v/assets/157836624/73c35a56-907f-424a-b6a3-cf6713d1075c)
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Bellwether
- tweak: The Chief Justice's apparel is now available in the uniform printer 
