### PR TITLE
Temporarily remove Clerk time from CJ Job Requirements

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Justice/chief_justice.yml
@@ -4,9 +4,9 @@
   description: job-description-chief-justice
   playTimeTracker: JobChiefJustice
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobClerk
-      time: 36000 # DeltaV - 10 hours
+#    - !type:RoleTimeRequirement # DeltaV - Comment out clerk time till more people have clerk time. Maybe a week or so. 
+#      role: JobClerk
+#      time: 36000 # DeltaV - 10 hours
     - !type:RoleTimeRequirement
       role: JobLawyer
       time: 36000 # 10 hours


### PR DESCRIPTION
## About the PR
Removing Clerk playtime requirement from CJ Job Requirements

## Why / Balance
10 hour prosecutor, 10 hour clerk, 10 hour lawyer, 25 hour playtime, whitelist :trollface: 
Kinda nutty when nobody has clerk time. Revert this in a week or so. 

## Technical details
Comments out YAML

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Nope

**Changelog**
Nah
