### PR TITLE
Add pockets to clerk's vest

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/vests.yml
@@ -39,7 +39,7 @@
     damageCoefficient: 0.9
 
 - type: entity
-  parent: ClothingOuterBase
+  parent: ClothingOuterStorageBase
   id: ClothingOuterClerkVest
   name: clerk's vest
   description: a silken magenta vest with a pocket to put your notary stamp.


### PR DESCRIPTION
## About the PR
The Clerk's Vest now has an accurate description by dint of now having storage. 

## Why / Balance
The description referencing a non-existent pocket offended me deeply on a personal level /s
(I play a lot of Clerk and it vaguely bugged me)

## Media
![clerkpocket](https://github.com/DeltaV-Station/Delta-v/assets/157836624/67ccab84-4d71-47ce-a249-68e2c4f89613)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl: Bellwether
- fix: The Clerk's Vest now has a pocket, matching its description. 