### PR TITLE
make void jetpack REable

### DIFF
--- a/Resources/Prototypes/DeltaV/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Lathes/devices.yml
@@ -1,0 +1,10 @@
+- type: latheRecipe
+  id: JetpackVoid
+  result: JetpackVoid
+  completetime: 15
+  materials:
+    Steel: 3000
+    Glass: 1500
+    Plastic: 1000
+    Gold: 300
+    Silver: 800

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -276,6 +276,10 @@
       - Back
       - suitStorage
       - Belt
+  - type: ReverseEngineering # DeltaV - make void jetpack RE'able
+    difficulty: 4
+    recipes:
+    - JetpackVoid
 
 # Filled void
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -647,6 +647,9 @@
     - JetpackBlue
     - JetpackMini
   # End Nyano additions
+  # Begin DeltaV additions
+    - JetpackVoid
+  # End DeltaV additions
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION
## About the PR
you can reverse engineer void jetpack, difficulty 4 because its objectively better than normal ones
also much more expensive, costing silver and glass but a little less plastic

## Why / Balance
- salv can find them on wrecks+ruins to be REd to make more of them for everyone
  right now you have 2-3 people with em and the rest suffer :trollface:
- ce can RE it roundstart at the cost of having no jetpack for a while

## Technical details
no

## Media
![07:19:11](https://github.com/DeltaV-Station/Delta-v/assets/39013340/6298ae6f-2196-4536-bffe-e5e1a0727a1e)

![07:20:38](https://github.com/DeltaV-Station/Delta-v/assets/39013340/db4840b1-c9fb-4e16-a313-4bc1744f601b)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- tweak: Void Jetpacks can now be reverse engineered.
