### PR TITLE
Decrease minimum number of players to 20 for NukeOps

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -94,7 +94,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 35 # DeltaV - Was 20
+    minPlayers: 20
   - type: LoadMapRule
     gameMap: NukieOutpost
   - type: AntagSelection


### PR DESCRIPTION
## About the PR
Adjusted 35 roundstart players down to 20 for nukeops. 

## Why / Balance
^^ Bring us in line with upstream. Rarely do we have 35 people ready up in a 80 player lobby, making this round more scarce than was intended. 

## Technical details
YAML warrior 

## Media
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
Nah

**Changelog**
:cl:
- tweak: Reduced minimum number of players to 20 for nukies to spawn
