### PR TITLE
Add evac shuttle: NTES Fishbowl

### DIFF
--- a/Resources/Maps/Shuttles/DeltaV/NTES_Fishbowl.yml
+++ b/Resources/Maps/Shuttles/DeltaV/NTES_Fishbowl.yml
@@ -1,0 +1,11456 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  15: FloorBar
+  18: FloorBlue
+  34: FloorDarkDiagonal
+  35: FloorDarkDiagonalMini
+  38: FloorDarkMono
+  49: FloorGlass
+  58: FloorGreenCircuit
+  65: FloorKitchen
+  69: FloorMetalDiamond
+  73: FloorMiningLight
+  82: FloorRGlass
+  83: FloorReinforced
+  87: FloorShuttleBlack
+  93: FloorShuttleWhite
+  112: FloorTechMaint
+  129: Lattice
+  130: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 2
+    components:
+    - type: MetaData
+      name: grid
+    - type: Transform
+      pos: -0.52500004,-0.5562897
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: OgAAAAAAUgAAAAACJgAAAAAAJgAAAAAAUwAAAAAAUwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUgAAAAAAUgAAAAACUwAAAAAAUwAAAAAAUwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAAAABJgAAAAABUwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: MQAAAAACMQAAAAABMQAAAAADMQAAAAAAMQAAAAACMQAAAAAAMQAAAAAAMQAAAAADMQAAAAAAMQAAAAABMQAAAAADMQAAAAAAQQAAAAAAQQAAAAAAUwAAAAAAAAAAAAAAMQAAAAACMQAAAAAAMQAAAAACMQAAAAAAMQAAAAACMQAAAAACggAAAAAAggAAAAAAggAAAAAAUwAAAAAAJgAAAAADUwAAAAAAggAAAAAAUwAAAAAAggAAAAAAAAAAAAAAMQAAAAADMQAAAAADMQAAAAADIwAAAAABIwAAAAACIwAAAAADggAAAAAAIgAAAAABIgAAAAABJgAAAAACJgAAAAAAIgAAAAACggAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAMQAAAAABMQAAAAACMQAAAAADIwAAAAADIwAAAAABIwAAAAADggAAAAAAIgAAAAACIgAAAAACJgAAAAADJgAAAAAAIgAAAAADUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAACMQAAAAAAMQAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIgAAAAADIgAAAAACJgAAAAABJgAAAAAAIgAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAACDwAAAAAADwAAAAAAggAAAAAADwAAAAABDwAAAAACggAAAAAAIgAAAAADIgAAAAAAJgAAAAAAJgAAAAAAIgAAAAABUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAAADwAAAAADDwAAAAADDwAAAAADDwAAAAABDwAAAAACggAAAAAAIgAAAAAAIgAAAAABJgAAAAAAJgAAAAADIgAAAAACUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAABDwAAAAAADwAAAAAADwAAAAABDwAAAAACDwAAAAABggAAAAAAIgAAAAACIgAAAAAAJgAAAAACJgAAAAAAIgAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADwAAAAABDwAAAAAADwAAAAABggAAAAAAggAAAAAAggAAAAAAggAAAAAAIgAAAAACIgAAAAACJgAAAAACJgAAAAAAIgAAAAACggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAJgAAAAACggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAAAACUgAAAAAAJgAAAAADUgAAAAABJgAAAAACUwAAAAAAUwAAAAAAIgAAAAACIgAAAAADIgAAAAABJgAAAAAAIgAAAAADUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUgAAAAACJgAAAAABUgAAAAABJgAAAAACUgAAAAAAJgAAAAADJgAAAAABJgAAAAACJgAAAAADJgAAAAABJgAAAAACIgAAAAADUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAAAADUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAJgAAAAABJgAAAAADJgAAAAACJgAAAAACIgAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAAAAAUwAAAAAAUwAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIgAAAAABIgAAAAACIgAAAAAAIgAAAAACggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJgAAAAAAJgAAAAACJgAAAAADUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAggAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUgAAAAADUgAAAAAAJgAAAAAAJgAAAAABJgAAAAADUwAAAAAAUwAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAUwAAAAAAQQAAAAAAQQAAAAAAMQAAAAADMQAAAAABMQAAAAADMQAAAAAAMQAAAAABMQAAAAABMQAAAAADMQAAAAACMQAAAAABMQAAAAACMQAAAAADAAAAAAAAAAAAAAAAggAAAAAAUwAAAAAAggAAAAAAggAAAAAAUwAAAAAAEgAAAAAAUwAAAAAAggAAAAAAggAAAAAAggAAAAAAUwAAAAAAUwAAAAAAggAAAAAAMQAAAAABAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAggAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAggAAAAAAIwAAAAACIwAAAAAAIwAAAAACIwAAAAAAMQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAEgAAAAAAggAAAAAAIwAAAAABMQAAAAAAMQAAAAABIwAAAAAAMQAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAXQAAAAABXQAAAAAAXQAAAAABXQAAAAABXQAAAAADggAAAAAAIwAAAAACMQAAAAAAMQAAAAAAIwAAAAACMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAXQAAAAADXQAAAAABXQAAAAADXQAAAAADXQAAAAACggAAAAAAIwAAAAAAMQAAAAAAMQAAAAADIwAAAAADDwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAXQAAAAADXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAIwAAAAABMQAAAAABMQAAAAADIwAAAAACDwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXQAAAAAAXQAAAAADXQAAAAABXQAAAAABXQAAAAACggAAAAAAIwAAAAABIwAAAAAAIwAAAAABIwAAAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXQAAAAADXQAAAAAAXQAAAAABXQAAAAAAXQAAAAABggAAAAAAggAAAAAAggAAAAAAJgAAAAADggAAAAAADwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAXQAAAAAAggAAAAAAggAAAAAAggAAAAAAUwAAAAAAUwAAAAAAJgAAAAACUwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAXQAAAAADXQAAAAACXQAAAAABXQAAAAADXQAAAAAAUwAAAAAAUwAAAAAAJgAAAAADUgAAAAABJgAAAAABUgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAXQAAAAADXQAAAAAAXQAAAAAAXQAAAAACXQAAAAABJgAAAAADJgAAAAADUgAAAAABJgAAAAADUgAAAAADJgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAXQAAAAADXQAAAAAAXQAAAAABXQAAAAADXQAAAAACUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAXQAAAAACXQAAAAACXQAAAAADXQAAAAACggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAUwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAggAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAJgAAAAABJgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAUwAAAAAAUwAAAAAAJgAAAAACJgAAAAABJgAAAAAAUgAAAAAB
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAUwAAAAAAUwAAAAAAJgAAAAADJgAAAAABUgAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAUgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAUwAAAAAAJgAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAUwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAUwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        0,-2:
+          ind: 0,-2
+          tiles: ggAAAAAAggAAAAAAggAAAAAAVwAAAAABVwAAAAAAVwAAAAABVwAAAAADVwAAAAACVwAAAAADVwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAVwAAAAABVwAAAAACVwAAAAAAMQAAAAADVwAAAAAAVwAAAAAAVwAAAAADgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAAAVwAAAAAAVwAAAAACVwAAAAACVwAAAAACVwAAAAABggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAgQAAAAAAVwAAAAADVwAAAAABVwAAAAACMQAAAAADVwAAAAADVwAAAAABggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAgQAAAAAAVwAAAAADVwAAAAABVwAAAAADVwAAAAAAVwAAAAACUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAcAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAADVwAAAAAAVwAAAAADVwAAAAADUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAcAAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAABVwAAAAADVwAAAAADUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAcAAAAAAAcAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAADVwAAAAACggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAABUwAAAAAAUwAAAAAAggAAAAAAggAAAAAAUwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAVwAAAAAAVwAAAAABggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAABVwAAAAAAVwAAAAAAVwAAAAABVwAAAAAAVwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAABUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAACVwAAAAADVwAAAAABVwAAAAADVwAAAAAAVwAAAAADUwAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAADUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAADVwAAAAADVwAAAAACVwAAAAABVwAAAAACVwAAAAABUwAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAABVwAAAAADVwAAAAACVwAAAAABVwAAAAAAVwAAAAABUwAAAAAAgQAAAAAAgQAAAAAAUwAAAAAAVwAAAAABVwAAAAAAUwAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAMQAAAAACggAAAAAAUwAAAAAAVwAAAAAAVwAAAAABggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAAAVwAAAAABggAAAAAAUwAAAAAAggAAAAAAAAAAAAAAMQAAAAACMQAAAAABMQAAAAADMQAAAAAAMQAAAAACMQAAAAAAMQAAAAAAMQAAAAABMQAAAAACMQAAAAABMQAAAAAAMQAAAAADQQAAAAAAQQAAAAAAUwAAAAAAAAAAAAAAMQAAAAAAMQAAAAADMQAAAAACMQAAAAACMQAAAAABMQAAAAADMQAAAAACMQAAAAACMQAAAAADMQAAAAACMQAAAAACMQAAAAAAQQAAAAAAQQAAAAAAUwAAAAAAAAAAAAAA
+          version: 6
+        -1,-2:
+          ind: -1,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAACVwAAAAADVwAAAAADVwAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAVwAAAAACVwAAAAAAVwAAAAADMQAAAAACVwAAAAABVwAAAAADVwAAAAADgQAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAVwAAAAACVwAAAAABVwAAAAACVwAAAAADVwAAAAABVwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAACVwAAAAACMQAAAAADVwAAAAABVwAAAAAAVwAAAAADgQAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAADVwAAAAABVwAAAAAAVwAAAAABgQAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAADVwAAAAAAVwAAAAACVwAAAAACgQAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAcAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAAAVwAAAAACgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAcAAAAAAAcAAAAAAAcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAADVwAAAAADggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAVwAAAAADggAAAAAAgQAAAAAAgQAAAAAAggAAAAAAUwAAAAAAggAAAAAAggAAAAAAUwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAADVwAAAAAAVwAAAAACVwAAAAADVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAABVwAAAAACVwAAAAADVwAAAAACVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAACVwAAAAADUwAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAVwAAAAAAVwAAAAACVwAAAAAAVwAAAAADVwAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAUwAAAAAAVwAAAAACVwAAAAABUwAAAAAAgQAAAAAAgQAAAAAAUwAAAAAAVwAAAAAAVwAAAAACVwAAAAAAVwAAAAACVwAAAAABAAAAAAAAAAAAAAAAggAAAAAAUwAAAAAAggAAAAAAVwAAAAABVwAAAAADggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVwAAAAABVwAAAAAAUwAAAAAAggAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAQQAAAAAAQQAAAAAAMQAAAAADMQAAAAAAMQAAAAABMQAAAAAAMQAAAAABMQAAAAABMQAAAAACMQAAAAACMQAAAAAAMQAAAAAAMQAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAQQAAAAAAQQAAAAAAMQAAAAAAMQAAAAADMQAAAAABMQAAAAACMQAAAAACMQAAAAACMQAAAAADMQAAAAADMQAAAAACMQAAAAABMQAAAAAD
+          version: 6
+        0,-3:
+          ind: 0,-3
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAASQAAAAAAUwAAAAAASQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAARQAAAAAAcAAAAAAASQAAAAAAcAAAAAAASQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAARQAAAAAAcAAAAAAASQAAAAAAcAAAAAAASQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAASQAAAAAAUwAAAAAASQAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAADVwAAAAAAVwAAAAADVwAAAAADVwAAAAAAVwAAAAACVwAAAAAAVwAAAAACgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAACVwAAAAADVwAAAAACVwAAAAADVwAAAAADMQAAAAAAVwAAAAAAVwAAAAADVwAAAAABgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-3:
+          ind: -1,-3
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAASQAAAAAAUwAAAAAASQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAASQAAAAAAcAAAAAAASQAAAAAAcAAAAAAARQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAASQAAAAAAcAAAAAAASQAAAAAAcAAAAAAARQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAASQAAAAAAUwAAAAAASQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAABVwAAAAADVwAAAAACVwAAAAADVwAAAAADVwAAAAABVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAACVwAAAAADVwAAAAADMQAAAAABVwAAAAADVwAAAAABVwAAAAAAVwAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DeviceNetwork
+      configurators: []
+      deviceLists: []
+      transmitFrequencyId: ShuttleTimer
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            33: -5,-34
+            34: -3,-34
+            35: 3,-34
+            36: 5,-34
+        - node:
+            color: '#3C44AAFF'
+            id: BrickTileWhiteBox
+          decals:
+            41: 1,-25
+        - node:
+            color: '#B02E26FF'
+            id: BrickTileWhiteBox
+          decals:
+            42: -2,-26
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteInnerNe
+          decals:
+            224: -10,-9
+            225: -10,-10
+            230: -9,-10
+            231: -9,-9
+            238: -9,-11
+            239: -10,-11
+            272: -10,-12
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteInnerNw
+          decals:
+            226: -9,-9
+            227: -9,-10
+            228: -8,-10
+            229: -8,-9
+            240: -9,-11
+            241: -8,-11
+            271: -8,-12
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteInnerSe
+          decals:
+            234: -10,-9
+            235: -9,-9
+            236: -9,-10
+            242: -9,-11
+            243: -10,-11
+            244: -10,-10
+            270: -10,-8
+        - node:
+            color: '#52B4E996'
+            id: BrickTileWhiteInnerSw
+          decals:
+            232: -8,-9
+            233: -9,-9
+            245: -9,-11
+            246: -9,-10
+            247: -8,-10
+            248: -8,-11
+            269: -8,-8
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            0: -3,-26
+        - node:
+            color: '#DE3A3A96'
+            id: DiagonalCheckerAOverlay
+          decals:
+            133: 10,-3
+            134: 9,-3
+            135: 8,-3
+            136: 7,-6
+            137: 8,-6
+            138: 9,-6
+            139: 7,-8
+            140: 8,-8
+            141: 7,-10
+            142: 8,-10
+            143: 7,-12
+            144: 8,-12
+            145: 7,-14
+            146: 8,-14
+        - node:
+            color: '#DE3A3A96'
+            id: DiagonalCheckerBOverlay
+          decals:
+            130: 11,-4
+            131: 11,-5
+            132: 11,-6
+            147: 11,-14
+            148: 11,-13
+            149: 11,-12
+            150: 11,-11
+            151: 11,-10
+            152: 11,-9
+            153: 11,-8
+        - node:
+            color: '#DE3A3A96'
+            id: DiagonalOverlay
+          decals:
+            129: 11,-3
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerNe
+          decals:
+            81: -2,0
+            82: 3,0
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNe
+          decals:
+            201: -7,-4
+            202: -8,-3
+            252: -8,-8
+            258: -7,-8
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerNe
+          decals:
+            155: -2,-9
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerNw
+          decals:
+            79: -3,0
+            80: 2,0
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNw
+          decals:
+            203: -11,-3
+            249: -10,-8
+            262: -11,-8
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerNw
+          decals:
+            154: -5,-9
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerSe
+          decals:
+            83: 2,-2
+            128: 4,-6
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerSe
+          decals:
+            200: -7,-6
+            207: -10,-4
+            251: -8,-12
+            259: -7,-12
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerSe
+          decals:
+            156: -2,-14
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteCornerSw
+          decals:
+            84: -2,-2
+            127: -4,-6
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerSw
+          decals:
+            199: -11,-6
+            208: -8,-4
+            250: -10,-12
+            261: -11,-12
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteCornerSw
+          decals:
+            157: -5,-14
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteEndE
+          decals:
+            76: 1,2
+            85: 4,-1
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteEndE
+          decals:
+            198: -10,-6
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteEndW
+          decals:
+            75: -1,2
+            86: -4,-1
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteEndW
+          decals:
+            197: -8,-6
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteInnerNe
+          decals:
+            96: -2,-2
+            97: 3,-1
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteInnerNe
+          decals:
+            211: -11,-6
+            220: -7,-5
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteInnerNe
+          decals:
+            170: -5,-14
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerNe
+          decals:
+            179: -9,-6
+            180: -9,-5
+            181: -9,-4
+            182: -8,-5
+            183: -10,-5
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteInnerNw
+          decals:
+            98: -3,-1
+            99: 2,-2
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteInnerNw
+          decals:
+            212: -7,-6
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteInnerNw
+          decals:
+            171: -2,-14
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerNw
+          decals:
+            184: -10,-5
+            185: -9,-5
+            186: -9,-4
+            187: -9,-6
+            196: -8,-5
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteInnerSe
+          decals:
+            100: 0,-2
+            101: 2,-1
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteInnerSe
+          decals:
+            214: -11,-4
+            215: -10,-3
+            219: -7,-5
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteInnerSe
+          decals:
+            173: -5,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerSe
+          decals:
+            188: -9,-5
+            189: -9,-4
+            190: -8,-5
+            191: -10,-5
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteInnerSw
+          decals:
+            102: -2,-1
+            103: 0,-2
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteInnerSw
+          decals:
+            213: -7,-4
+            216: -8,-3
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteInnerSw
+          decals:
+            172: -2,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: MiniTileWhiteInnerSw
+          decals:
+            192: -10,-5
+            193: -9,-5
+            194: -9,-4
+            195: -8,-5
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteLineE
+          decals:
+            92: -2,-1
+            105: 0,-3
+            106: 0,-4
+            123: -3,-8
+            124: -3,-7
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineE
+          decals:
+            206: -11,-5
+            221: -9,-7
+            253: -8,-9
+            254: -7,-10
+            255: -8,-10
+            256: -8,-11
+            257: -7,-9
+            260: -7,-11
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteLineE
+          decals:
+            166: -5,-10
+            167: -5,-11
+            168: -5,-12
+            169: -5,-13
+            273: 5,-13
+            274: 5,-14
+            275: 4,-13
+            276: 4,-14
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteLineN
+          decals:
+            77: 0,2
+            93: -1,-2
+            94: 0,-2
+            95: 1,-2
+            108: -6,-5
+            109: -5,-5
+            110: -3,-5
+            111: -1,-5
+            112: 1,-5
+            113: 3,-5
+            114: 5,-5
+            115: 6,-5
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineN
+          decals:
+            217: -10,-3
+            218: -9,-3
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteLineN
+          decals:
+            158: -4,-14
+            159: -3,-14
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteLineS
+          decals:
+            78: 0,2
+            87: -3,-1
+            88: -1,-2
+            89: 1,-2
+            90: 3,-1
+            116: 6,-5
+            117: 5,-5
+            118: 2,-6
+            119: 0,-6
+            120: -2,-6
+            121: -5,-5
+            122: -6,-5
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineS
+          decals:
+            210: -9,-3
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteLineS
+          decals:
+            164: -3,-9
+            165: -4,-9
+        - node:
+            color: '#334E6DC8'
+            id: MiniTileWhiteLineW
+          decals:
+            91: 2,-1
+            104: 0,-3
+            107: 0,-4
+            125: -3,-8
+            126: -3,-7
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineW
+          decals:
+            204: -11,-4
+            205: -11,-5
+            209: -7,-5
+            222: -9,-7
+            263: -11,-9
+            264: -11,-10
+            265: -11,-11
+            266: -10,-11
+            267: -10,-10
+            268: -10,-9
+        - node:
+            color: '#79150096'
+            id: MiniTileWhiteLineW
+          decals:
+            160: -2,-13
+            161: -2,-12
+            162: -2,-11
+            163: -2,-10
+            277: 3,-13
+            278: 3,-14
+            279: 4,-14
+            280: 4,-13
+        - node:
+            color: '#52B4E996'
+            id: OffsetCheckerBOverlay
+          decals:
+            174: -9,-6
+            175: -9,-5
+            176: -9,-4
+            177: -10,-5
+            178: -8,-5
+            223: -9,-8
+            237: -9,-12
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            37: -5,-34
+            38: -3,-34
+            39: 3,-34
+            40: 5,-34
+        - node:
+            angle: 0.7853981633974483 rad
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            58: -4.0667815,-31.643078
+            59: -4.75949,-30.928764
+            60: -5.4678235,-30.219938
+            61: -6.176542,-29.517948
+            62: -6.8848753,-28.809122
+            63: -7.5772066,-28.113482
+            64: -8.280333,-27.404655
+            65: -8.97063,-26.696915
+            66: -9.50188,-26.165295
+        - node:
+            angle: 2.356194490192345 rad
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            43: 5.3808866,-30.317707
+            44: 6.0792017,-29.612453
+            45: 6.790943,-28.90884
+            46: 7.4948378,-28.210438
+            47: 8.198123,-27.504696
+            48: 8.901248,-26.799282
+            49: 9.592015,-26.116516
+            56: 4.673559,-31.025454
+            57: 3.9860592,-31.718643
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineGreyscaleE
+          decals:
+            17: -5,-35
+            18: -5,-36
+            19: -5,-37
+            20: -5,-38
+            21: -3,-38
+            22: -3,-37
+            23: -3,-36
+            24: -3,-35
+            25: 3,-35
+            26: 3,-36
+            27: 3,-37
+            28: 3,-38
+            29: 5,-38
+            30: 5,-37
+            31: 5,-36
+            32: 5,-35
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineGreyscaleW
+          decals:
+            1: -5,-38
+            2: -5,-37
+            3: -5,-36
+            4: -5,-35
+            5: -3,-35
+            6: -3,-36
+            7: -3,-37
+            8: -3,-38
+            9: 3,-38
+            10: 3,-37
+            11: 3,-36
+            12: 3,-35
+            13: 5,-35
+            14: 5,-36
+            15: 5,-37
+            16: 5,-38
+        - node:
+            angle: 0.7853981633974483 rad
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            67: -6.348762,-33.971275
+            68: -6.85397,-33.463444
+            69: -7.565277,-32.770252
+            70: -7.9164414,-32.42333
+            71: -8.614359,-31.719713
+            72: -8.973072,-31.375448
+            73: -9.66578,-30.666622
+            74: -9.993905,-30.333057
+        - node:
+            angle: 2.356194490192345 rad
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            50: 7.8102427,-32.55548
+            51: 8.502951,-31.84629
+            52: 9.195659,-31.137465
+            53: 9.903993,-30.449486
+            54: 7.1058507,-33.267727
+            55: 6.407934,-33.97134
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 30719
+          0,-1:
+            0: 65311
+          -1,0:
+            0: 52479
+            1: 256
+          0,1:
+            1: 8
+          1,0:
+            0: 19
+            1: 292
+          1,-1:
+            0: 30475
+            1: 32768
+          0,-4:
+            0: 65535
+          0,-5:
+            0: 65439
+          -1,-4:
+            0: 65423
+          0,-3:
+            0: 65399
+          -1,-3:
+            0: 65535
+          0,-2:
+            0: 65527
+          -1,-2:
+            0: 65530
+          -1,-1:
+            0: 65295
+          1,-4:
+            0: 47935
+          1,-3:
+            0: 48056
+          1,-2:
+            0: 64312
+          1,-5:
+            0: 65299
+            1: 8
+          2,-4:
+            0: 65359
+          2,-3:
+            0: 65535
+          2,-2:
+            0: 65359
+          2,-1:
+            0: 255
+            1: 61440
+          2,-5:
+            0: 65484
+            1: 1
+          3,-4:
+            0: 3
+            1: 1536
+          3,-1:
+            1: 4096
+          3,-5:
+            0: 13056
+            1: 6
+          -4,-4:
+            0: 8
+            1: 3072
+          -4,-5:
+            0: 34816
+            1: 12
+          -3,-4:
+            0: 61071
+          -3,-5:
+            0: 65382
+          -3,-3:
+            0: 61166
+          -3,-2:
+            0: 61070
+          -3,-1:
+            0: 238
+            1: 61440
+          -2,-4:
+            0: 47887
+          -2,-3:
+            0: 48059
+          -2,-2:
+            0: 64387
+          -2,-1:
+            0: 52251
+            1: 12288
+          -2,-5:
+            0: 65288
+            1: 3
+          -2,0:
+            1: 132
+            0: 8
+          -1,-5:
+            0: 65343
+          -1,1:
+            1: 2
+          0,-8:
+            1: 33712
+            0: 8
+          0,-9:
+            0: 65422
+          -1,-8:
+            1: 14752
+            0: 19
+          0,-7:
+            0: 65523
+            1: 8
+          -1,-7:
+            0: 61160
+            1: 19
+          0,-6:
+            0: 65521
+          -1,-6:
+            0: 65520
+          1,-8:
+            0: 52991
+            1: 12544
+          1,-7:
+            1: 149
+            0: 8
+          1,-6:
+            0: 13104
+            1: 8
+          1,-9:
+            0: 65315
+            1: 136
+          2,-8:
+            0: 63347
+            1: 132
+          2,-7:
+            0: 52991
+            1: 256
+          2,-6:
+            1: 1
+            0: 52428
+          2,-9:
+            0: 4096
+            1: 8448
+          3,-8:
+            1: 16
+          -3,-8:
+            1: 52
+            0: 60616
+          -3,-7:
+            0: 28398
+          -3,-6:
+            0: 26214
+          -3,-9:
+            1: 32768
+          -2,-8:
+            0: 32767
+            1: 32768
+          -2,-7:
+            0: 19
+            1: 292
+          -2,-6:
+            1: 3
+            0: 34944
+          -2,-9:
+            0: 65160
+            1: 290
+          -1,-9:
+            0: 65327
+          0,-10:
+            0: 59392
+          -1,-10:
+            0: 61952
+          1,-10:
+            0: 12800
+            1: 34816
+          -2,-10:
+            1: 8704
+            0: 34816
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirAlarm
+  entities:
+  - uid: 1607
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-23.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1692
+      - 1000
+      - 999
+      - 1679
+      - 1700
+      - 1699
+      - 1421
+      - 1402
+      - 1373
+      - 1371
+  - uid: 1684
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1681
+      - 1710
+      - 1682
+      - 1711
+      - 1679
+      - 1712
+      - 1713
+      - 1714
+      - 1715
+      - 1716
+      - 1661
+      - 1662
+      - 1656
+      - 1657
+  - uid: 1687
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1679
+      - 1709
+      - 1683
+      - 1710
+      - 1610
+      - 1611
+      - 1587
+      - 1582
+      - 1584
+      - 1585
+      - 1583
+      - 1586
+  - uid: 1688
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-12.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1679
+      - 1701
+      - 1683
+      - 1711
+      - 1630
+      - 1633
+      - 1631
+      - 1632
+      - 1650
+      - 1651
+  - uid: 1691
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1693
+      - 1699
+      - 1700
+      - 1680
+      - 1704
+      - 1705
+      - 1708
+      - 1706
+      - 1707
+      - 1692
+      - 1698
+      - 1697
+      - 1681
+      - 1709
+      - 1683
+      - 1716
+      - 1715
+      - 1714
+      - 1713
+      - 1712
+      - 1682
+      - 1701
+      - 1518
+      - 1514
+      - 1515
+      - 1516
+      - 1517
+      - 1513
+  - uid: 1694
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-23.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1693
+      - 1000
+      - 999
+      - 1679
+      - 1697
+      - 1698
+      - 1383
+      - 1436
+      - 1374
+      - 1372
+  - uid: 1702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-23.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1679
+      - 1704
+      - 1705
+      - 1708
+      - 1706
+      - 1707
+      - 1485
+      - 1484
+      - 1494
+      - 1495
+      - 1364
+      - 1367
+- proto: AirlockChiefMedicalOfficerGlassLocked
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+- proto: AirlockCommandGlassLocked
+  entities:
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+- proto: AirlockCommandLocked
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+- proto: AirlockEngineeringGlassLocked
+  entities:
+  - uid: 943
+    components:
+    - type: Transform
+      pos: 0.5,-23.5
+      parent: 2
+- proto: AirlockExternalGlass
+  entities:
+  - uid: 839
+    components:
+    - type: Transform
+      pos: 3.5,-34.5
+      parent: 2
+  - uid: 862
+    components:
+    - type: Transform
+      pos: -4.5,-34.5
+      parent: 2
+  - uid: 863
+    components:
+    - type: Transform
+      pos: -2.5,-34.5
+      parent: 2
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 5.5,-34.5
+      parent: 2
+- proto: AirlockExternalGlassShuttleEmergencyLocked
+  entities:
+  - uid: 953
+    components:
+    - type: Transform
+      pos: -4.5,-37.5
+      parent: 2
+  - uid: 954
+    components:
+    - type: Transform
+      pos: -2.5,-37.5
+      parent: 2
+  - uid: 955
+    components:
+    - type: Transform
+      pos: 3.5,-37.5
+      parent: 2
+  - uid: 956
+    components:
+    - type: Transform
+      pos: 5.5,-37.5
+      parent: 2
+- proto: AirlockGlass
+  entities:
+  - uid: 497
+    components:
+    - type: Transform
+      pos: 11.5,-18.5
+      parent: 2
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 10.5,-18.5
+      parent: 2
+  - uid: 499
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 2
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 3.5,-18.5
+      parent: 2
+  - uid: 501
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 2
+  - uid: 502
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 2
+  - uid: 503
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 504
+    components:
+    - type: Transform
+      pos: -10.5,-18.5
+      parent: 2
+- proto: AirlockHeadOfSecurityGlassLocked
+  entities:
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+- proto: AirlockMedicalGlass
+  entities:
+  - uid: 380
+    components:
+    - type: Transform
+      pos: -8.5,-14.5
+      parent: 2
+- proto: AirlockMedicalLocked
+  entities:
+  - uid: 298
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+- proto: AirlockSecurityGlassLocked
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 10.5,-14.5
+      parent: 2
+- proto: AirlockSecurityLocked
+  entities:
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 2
+- proto: AirSensor
+  entities:
+  - uid: 1679
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1695
+      - 1694
+      - 1696
+      - 1607
+      - 1689
+      - 1688
+      - 1703
+      - 1702
+      - 1686
+      - 1687
+      - 1685
+      - 1684
+  - uid: 1680
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+  - uid: 1681
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1685
+      - 1684
+  - uid: 1682
+    components:
+    - type: Transform
+      pos: -8.5,-9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1685
+      - 1684
+  - uid: 1683
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1689
+      - 1688
+      - 1686
+      - 1687
+  - uid: 1692
+    components:
+    - type: Transform
+      pos: 11.5,-25.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1696
+      - 1607
+      - 1690
+      - 1691
+  - uid: 1693
+    components:
+    - type: Transform
+      pos: -10.5,-25.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1695
+      - 1694
+      - 1690
+      - 1691
+- proto: APCBasic
+  entities:
+  - uid: 1010
+    components:
+    - type: MetaData
+      name: APC (Bridge)
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 1011
+    components:
+    - type: MetaData
+      name: APC (Medical)
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 1012
+    components:
+    - type: MetaData
+      name: APC (Security)
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
+- proto: APCHighCapacity
+  entities:
+  - uid: 923
+    components:
+    - type: MetaData
+      name: APC (General)
+    - type: Transform
+      pos: -2.5,-23.5
+      parent: 2
+- proto: Ashtray
+  entities:
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.774364,-10.50453
+      parent: 2
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.313136,-9.491326
+      parent: 2
+  - uid: 422
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.361864,-6.185007
+      parent: 2
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 957
+    components:
+    - type: Transform
+      pos: -4.5,-37.5
+      parent: 2
+  - uid: 958
+    components:
+    - type: Transform
+      pos: -2.5,-37.5
+      parent: 2
+  - uid: 959
+    components:
+    - type: Transform
+      pos: 3.5,-37.5
+      parent: 2
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 5.5,-37.5
+      parent: 2
+- proto: BedsheetMedical
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 2
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 2
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+- proto: BenchSofaCorpLeft
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 430
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-12.5
+      parent: 2
+  - uid: 431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-13.5
+      parent: 2
+- proto: BenchSofaCorpMiddle
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+- proto: BenchSofaCorpRight
+  entities:
+  - uid: 212
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 2
+  - uid: 432
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-12.5
+      parent: 2
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-13.5
+      parent: 2
+- proto: BookRandomStory
+  entities:
+  - uid: 655
+    components:
+    - type: Transform
+      pos: -4.4662004,-3.4040718
+      parent: 2
+- proto: BoozeDispenser
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 2
+- proto: BoxBottle
+  entities:
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -6.523621,-3.3158522
+      parent: 2
+- proto: BoxDarts
+  entities:
+  - uid: 428
+    components:
+    - type: Transform
+      pos: -2.4404633,-13.415643
+      parent: 2
+- proto: Brutepack
+  entities:
+  - uid: 404
+    components:
+    - type: Transform
+      pos: -10.627749,-13.423145
+      parent: 2
+  - uid: 405
+    components:
+    - type: Transform
+      pos: -10.440249,-13.448163
+      parent: 2
+  - uid: 406
+    components:
+    - type: Transform
+      pos: -10.277749,-13.460671
+      parent: 2
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -10.593628,-13.441943
+      parent: 2
+  - uid: 707
+    components:
+    - type: Transform
+      pos: -10.418629,-13.47947
+      parent: 2
+- proto: CableApcExtension
+  entities:
+  - uid: 1096
+    components:
+    - type: Transform
+      pos: -2.5,-23.5
+      parent: 2
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: -2.5,-24.5
+      parent: 2
+  - uid: 1098
+    components:
+    - type: Transform
+      pos: -1.5,-24.5
+      parent: 2
+  - uid: 1099
+    components:
+    - type: Transform
+      pos: -0.5,-24.5
+      parent: 2
+  - uid: 1100
+    components:
+    - type: Transform
+      pos: -0.5,-25.5
+      parent: 2
+  - uid: 1101
+    components:
+    - type: Transform
+      pos: 0.5,-24.5
+      parent: 2
+  - uid: 1102
+    components:
+    - type: Transform
+      pos: 1.5,-24.5
+      parent: 2
+  - uid: 1103
+    components:
+    - type: Transform
+      pos: 1.5,-25.5
+      parent: 2
+  - uid: 1104
+    components:
+    - type: Transform
+      pos: 0.5,-23.5
+      parent: 2
+  - uid: 1105
+    components:
+    - type: Transform
+      pos: 0.5,-22.5
+      parent: 2
+  - uid: 1106
+    components:
+    - type: Transform
+      pos: -4.5,-36.5
+      parent: 2
+  - uid: 1107
+    components:
+    - type: Transform
+      pos: -3.5,-36.5
+      parent: 2
+  - uid: 1108
+    components:
+    - type: Transform
+      pos: -2.5,-36.5
+      parent: 2
+  - uid: 1109
+    components:
+    - type: Transform
+      pos: -2.5,-35.5
+      parent: 2
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: -2.5,-34.5
+      parent: 2
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: -2.5,-33.5
+      parent: 2
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: -4.5,-35.5
+      parent: 2
+  - uid: 1113
+    components:
+    - type: Transform
+      pos: -4.5,-34.5
+      parent: 2
+  - uid: 1114
+    components:
+    - type: Transform
+      pos: -4.5,-33.5
+      parent: 2
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: -2.5,-32.5
+      parent: 2
+  - uid: 1116
+    components:
+    - type: Transform
+      pos: -3.5,-32.5
+      parent: 2
+  - uid: 1117
+    components:
+    - type: Transform
+      pos: -4.5,-32.5
+      parent: 2
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: -4.5,-31.5
+      parent: 2
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: -5.5,-31.5
+      parent: 2
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: -5.5,-30.5
+      parent: 2
+  - uid: 1121
+    components:
+    - type: Transform
+      pos: -6.5,-30.5
+      parent: 2
+  - uid: 1122
+    components:
+    - type: Transform
+      pos: -6.5,-29.5
+      parent: 2
+  - uid: 1123
+    components:
+    - type: Transform
+      pos: -7.5,-29.5
+      parent: 2
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: -7.5,-28.5
+      parent: 2
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: -8.5,-28.5
+      parent: 2
+  - uid: 1126
+    components:
+    - type: Transform
+      pos: 3.5,-36.5
+      parent: 2
+  - uid: 1127
+    components:
+    - type: Transform
+      pos: -9.5,-28.5
+      parent: 2
+  - uid: 1128
+    components:
+    - type: Transform
+      pos: -10.5,-28.5
+      parent: 2
+  - uid: 1129
+    components:
+    - type: Transform
+      pos: -9.5,-27.5
+      parent: 2
+  - uid: 1130
+    components:
+    - type: Transform
+      pos: -9.5,-26.5
+      parent: 2
+  - uid: 1131
+    components:
+    - type: Transform
+      pos: -9.5,-25.5
+      parent: 2
+  - uid: 1132
+    components:
+    - type: Transform
+      pos: 4.5,-36.5
+      parent: 2
+  - uid: 1133
+    components:
+    - type: Transform
+      pos: 5.5,-36.5
+      parent: 2
+  - uid: 1134
+    components:
+    - type: Transform
+      pos: 3.5,-35.5
+      parent: 2
+  - uid: 1135
+    components:
+    - type: Transform
+      pos: 3.5,-34.5
+      parent: 2
+  - uid: 1136
+    components:
+    - type: Transform
+      pos: 3.5,-33.5
+      parent: 2
+  - uid: 1137
+    components:
+    - type: Transform
+      pos: 5.5,-35.5
+      parent: 2
+  - uid: 1138
+    components:
+    - type: Transform
+      pos: 5.5,-34.5
+      parent: 2
+  - uid: 1139
+    components:
+    - type: Transform
+      pos: 5.5,-33.5
+      parent: 2
+  - uid: 1140
+    components:
+    - type: Transform
+      pos: 3.5,-32.5
+      parent: 2
+  - uid: 1141
+    components:
+    - type: Transform
+      pos: 4.5,-32.5
+      parent: 2
+  - uid: 1142
+    components:
+    - type: Transform
+      pos: 5.5,-32.5
+      parent: 2
+  - uid: 1143
+    components:
+    - type: Transform
+      pos: 5.5,-31.5
+      parent: 2
+  - uid: 1144
+    components:
+    - type: Transform
+      pos: 6.5,-31.5
+      parent: 2
+  - uid: 1145
+    components:
+    - type: Transform
+      pos: 6.5,-30.5
+      parent: 2
+  - uid: 1146
+    components:
+    - type: Transform
+      pos: 7.5,-30.5
+      parent: 2
+  - uid: 1147
+    components:
+    - type: Transform
+      pos: 7.5,-29.5
+      parent: 2
+  - uid: 1148
+    components:
+    - type: Transform
+      pos: 8.5,-28.5
+      parent: 2
+  - uid: 1149
+    components:
+    - type: Transform
+      pos: 8.5,-29.5
+      parent: 2
+  - uid: 1150
+    components:
+    - type: Transform
+      pos: 9.5,-28.5
+      parent: 2
+  - uid: 1151
+    components:
+    - type: Transform
+      pos: 10.5,-28.5
+      parent: 2
+  - uid: 1152
+    components:
+    - type: Transform
+      pos: 11.5,-28.5
+      parent: 2
+  - uid: 1153
+    components:
+    - type: Transform
+      pos: 10.5,-27.5
+      parent: 2
+  - uid: 1154
+    components:
+    - type: Transform
+      pos: 10.5,-26.5
+      parent: 2
+  - uid: 1155
+    components:
+    - type: Transform
+      pos: 10.5,-25.5
+      parent: 2
+  - uid: 1182
+    components:
+    - type: Transform
+      pos: -9.5,-24.5
+      parent: 2
+  - uid: 1183
+    components:
+    - type: Transform
+      pos: -9.5,-23.5
+      parent: 2
+  - uid: 1184
+    components:
+    - type: Transform
+      pos: -9.5,-22.5
+      parent: 2
+  - uid: 1185
+    components:
+    - type: Transform
+      pos: -9.5,-21.5
+      parent: 2
+  - uid: 1186
+    components:
+    - type: Transform
+      pos: -9.5,-20.5
+      parent: 2
+  - uid: 1187
+    components:
+    - type: Transform
+      pos: -9.5,-19.5
+      parent: 2
+  - uid: 1188
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 1189
+    components:
+    - type: Transform
+      pos: -9.5,-17.5
+      parent: 2
+  - uid: 1190
+    components:
+    - type: Transform
+      pos: 10.5,-24.5
+      parent: 2
+  - uid: 1191
+    components:
+    - type: Transform
+      pos: 10.5,-23.5
+      parent: 2
+  - uid: 1192
+    components:
+    - type: Transform
+      pos: 10.5,-22.5
+      parent: 2
+  - uid: 1193
+    components:
+    - type: Transform
+      pos: 10.5,-21.5
+      parent: 2
+  - uid: 1194
+    components:
+    - type: Transform
+      pos: 10.5,-20.5
+      parent: 2
+  - uid: 1195
+    components:
+    - type: Transform
+      pos: 10.5,-19.5
+      parent: 2
+  - uid: 1196
+    components:
+    - type: Transform
+      pos: 10.5,-18.5
+      parent: 2
+  - uid: 1197
+    components:
+    - type: Transform
+      pos: 10.5,-17.5
+      parent: 2
+  - uid: 1198
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 2
+  - uid: 1199
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 2
+  - uid: 1200
+    components:
+    - type: Transform
+      pos: -1.5,-21.5
+      parent: 2
+  - uid: 1201
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
+      parent: 2
+  - uid: 1202
+    components:
+    - type: Transform
+      pos: -3.5,-21.5
+      parent: 2
+  - uid: 1203
+    components:
+    - type: Transform
+      pos: -3.5,-20.5
+      parent: 2
+  - uid: 1204
+    components:
+    - type: Transform
+      pos: -3.5,-19.5
+      parent: 2
+  - uid: 1205
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 2
+  - uid: 1206
+    components:
+    - type: Transform
+      pos: -3.5,-17.5
+      parent: 2
+  - uid: 1207
+    components:
+    - type: Transform
+      pos: 1.5,-21.5
+      parent: 2
+  - uid: 1208
+    components:
+    - type: Transform
+      pos: 2.5,-21.5
+      parent: 2
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 3.5,-21.5
+      parent: 2
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: 4.5,-21.5
+      parent: 2
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 2
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: 4.5,-19.5
+      parent: 2
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 2
+  - uid: 1214
+    components:
+    - type: Transform
+      pos: 4.5,-17.5
+      parent: 2
+  - uid: 1215
+    components:
+    - type: Transform
+      pos: 5.5,-17.5
+      parent: 2
+  - uid: 1216
+    components:
+    - type: Transform
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 1217
+    components:
+    - type: Transform
+      pos: 7.5,-17.5
+      parent: 2
+  - uid: 1218
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 1219
+    components:
+    - type: Transform
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 1220
+    components:
+    - type: Transform
+      pos: 11.5,-17.5
+      parent: 2
+  - uid: 1221
+    components:
+    - type: Transform
+      pos: 12.5,-17.5
+      parent: 2
+  - uid: 1222
+    components:
+    - type: Transform
+      pos: 13.5,-17.5
+      parent: 2
+  - uid: 1223
+    components:
+    - type: Transform
+      pos: 13.5,-16.5
+      parent: 2
+  - uid: 1224
+    components:
+    - type: Transform
+      pos: 13.5,-15.5
+      parent: 2
+  - uid: 1225
+    components:
+    - type: Transform
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 1226
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 2
+  - uid: 1227
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 1228
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 1229
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 1230
+    components:
+    - type: Transform
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 1231
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 1232
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 1233
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 2
+  - uid: 1234
+    components:
+    - type: Transform
+      pos: -4.5,-17.5
+      parent: 2
+  - uid: 1235
+    components:
+    - type: Transform
+      pos: -5.5,-17.5
+      parent: 2
+  - uid: 1236
+    components:
+    - type: Transform
+      pos: -6.5,-17.5
+      parent: 2
+  - uid: 1237
+    components:
+    - type: Transform
+      pos: -7.5,-17.5
+      parent: 2
+  - uid: 1238
+    components:
+    - type: Transform
+      pos: -8.5,-17.5
+      parent: 2
+  - uid: 1239
+    components:
+    - type: Transform
+      pos: -10.5,-17.5
+      parent: 2
+  - uid: 1240
+    components:
+    - type: Transform
+      pos: -11.5,-17.5
+      parent: 2
+  - uid: 1241
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 2
+  - uid: 1242
+    components:
+    - type: Transform
+      pos: -12.5,-16.5
+      parent: 2
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: -12.5,-15.5
+      parent: 2
+  - uid: 1244
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 1245
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 1246
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 2
+  - uid: 1247
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 2
+  - uid: 1248
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 1249
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 1250
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 1251
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 2
+  - uid: 1252
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 2
+  - uid: 1253
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 2
+  - uid: 1254
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+  - uid: 1255
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 2
+  - uid: 1256
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 1257
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 2
+  - uid: 1258
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 2
+  - uid: 1259
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 2
+  - uid: 1260
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 2
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 2
+  - uid: 1262
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 1263
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 1269
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+  - uid: 1270
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 2
+  - uid: 1271
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
+  - uid: 1272
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 2
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 2
+  - uid: 1274
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 2
+  - uid: 1275
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 1276
+    components:
+    - type: Transform
+      pos: -9.5,-10.5
+      parent: 2
+  - uid: 1277
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 2
+  - uid: 1278
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+  - uid: 1279
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 1280
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 1316
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+  - uid: 1317
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+  - uid: 1318
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+  - uid: 1319
+    components:
+    - type: Transform
+      pos: -8.5,-3.5
+      parent: 2
+  - uid: 1320
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 1321
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 2
+  - uid: 1322
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 1323
+    components:
+    - type: Transform
+      pos: 10.5,-4.5
+      parent: 2
+  - uid: 1324
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+  - uid: 1325
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 2
+  - uid: 1326
+    components:
+    - type: Transform
+      pos: 11.5,-2.5
+      parent: 2
+  - uid: 1327
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 1328
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 1329
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 1330
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 2
+  - uid: 1331
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 2
+  - uid: 1332
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 2
+  - uid: 1333
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 2
+  - uid: 1334
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 2
+  - uid: 1335
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 1336
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 2
+  - uid: 1337
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 2
+  - uid: 1338
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 2
+  - uid: 1339
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 1340
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
+  - uid: 1341
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 1342
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 2
+  - uid: 1343
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 2
+  - uid: 1344
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 2
+  - uid: 1345
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 2
+  - uid: 1346
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 1347
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 1348
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 1349
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 1350
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+  - uid: 1351
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 1352
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 1353
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 2
+  - uid: 1354
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 2
+  - uid: 1355
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 1356
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+  - uid: 1357
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 1358
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 2
+- proto: CableHV
+  entities:
+  - uid: 909
+    components:
+    - type: Transform
+      pos: 0.5,-26.5
+      parent: 2
+  - uid: 910
+    components:
+    - type: Transform
+      pos: -0.5,-26.5
+      parent: 2
+  - uid: 911
+    components:
+    - type: Transform
+      pos: -1.5,-26.5
+      parent: 2
+  - uid: 912
+    components:
+    - type: Transform
+      pos: -0.5,-27.5
+      parent: 2
+  - uid: 913
+    components:
+    - type: Transform
+      pos: 1.5,-26.5
+      parent: 2
+  - uid: 914
+    components:
+    - type: Transform
+      pos: 2.5,-26.5
+      parent: 2
+  - uid: 915
+    components:
+    - type: Transform
+      pos: 1.5,-27.5
+      parent: 2
+  - uid: 916
+    components:
+    - type: Transform
+      pos: 0.5,-25.5
+      parent: 2
+  - uid: 917
+    components:
+    - type: Transform
+      pos: 0.5,-24.5
+      parent: 2
+  - uid: 918
+    components:
+    - type: Transform
+      pos: -0.5,-24.5
+      parent: 2
+  - uid: 919
+    components:
+    - type: Transform
+      pos: -1.5,-24.5
+      parent: 2
+  - uid: 920
+    components:
+    - type: Transform
+      pos: -2.5,-24.5
+      parent: 2
+  - uid: 921
+    components:
+    - type: Transform
+      pos: -3.5,-24.5
+      parent: 2
+  - uid: 1281
+    components:
+    - type: Transform
+      pos: 0.5,-23.5
+      parent: 2
+  - uid: 1282
+    components:
+    - type: Transform
+      pos: 0.5,-22.5
+      parent: 2
+  - uid: 1283
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 2
+  - uid: 1284
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
+      parent: 2
+  - uid: 1285
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 2
+  - uid: 1286
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 2
+  - uid: 1287
+    components:
+    - type: Transform
+      pos: 0.5,-17.5
+      parent: 2
+  - uid: 1288
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 1289
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 1290
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 1291
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 2
+  - uid: 1292
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
+  - uid: 1293
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 1294
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 1295
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 2
+  - uid: 1296
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 2
+  - uid: 1297
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 2
+  - uid: 1298
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 2
+  - uid: 1299
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 2
+  - uid: 1300
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 1301
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 1302
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 1303
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 1304
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 1305
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 1306
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 1307
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 1308
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 1309
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 1310
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 2
+  - uid: 1311
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 1312
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 1313
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 2
+  - uid: 1314
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 1315
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 2
+- proto: CableMV
+  entities:
+  - uid: 1013
+    components:
+    - type: Transform
+      pos: -3.5,-24.5
+      parent: 2
+  - uid: 1014
+    components:
+    - type: Transform
+      pos: -2.5,-24.5
+      parent: 2
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: -2.5,-23.5
+      parent: 2
+  - uid: 1016
+    components:
+    - type: Transform
+      pos: -1.5,-24.5
+      parent: 2
+  - uid: 1017
+    components:
+    - type: Transform
+      pos: -0.5,-24.5
+      parent: 2
+  - uid: 1018
+    components:
+    - type: Transform
+      pos: 0.5,-24.5
+      parent: 2
+  - uid: 1019
+    components:
+    - type: Transform
+      pos: 0.5,-23.5
+      parent: 2
+  - uid: 1020
+    components:
+    - type: Transform
+      pos: 0.5,-22.5
+      parent: 2
+  - uid: 1021
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 2
+  - uid: 1022
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
+      parent: 2
+  - uid: 1023
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 2
+  - uid: 1024
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 2
+  - uid: 1025
+    components:
+    - type: Transform
+      pos: 0.5,-17.5
+      parent: 2
+  - uid: 1026
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+  - uid: 1027
+    components:
+    - type: Transform
+      pos: 10.5,-15.5
+      parent: 2
+  - uid: 1028
+    components:
+    - type: Transform
+      pos: 0.5,-15.5
+      parent: 2
+  - uid: 1029
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 2
+  - uid: 1030
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 2
+  - uid: 1031
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
+  - uid: 1032
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 1033
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 2
+  - uid: 1034
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 2
+  - uid: 1035
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 2
+  - uid: 1036
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 2
+  - uid: 1037
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 2
+  - uid: 1038
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 2
+  - uid: 1039
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+  - uid: 1040
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 2
+  - uid: 1041
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 2
+  - uid: 1042
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 2
+  - uid: 1043
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 2
+  - uid: 1045
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 1046
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 1047
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+  - uid: 1048
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+  - uid: 1049
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 2
+  - uid: 1050
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 2
+  - uid: 1051
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 1052
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 1053
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 2
+  - uid: 1054
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 1055
+    components:
+    - type: Transform
+      pos: -0.5,-16.5
+      parent: 2
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: -1.5,-16.5
+      parent: 2
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: -2.5,-16.5
+      parent: 2
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: -3.5,-16.5
+      parent: 2
+  - uid: 1059
+    components:
+    - type: Transform
+      pos: -4.5,-16.5
+      parent: 2
+  - uid: 1060
+    components:
+    - type: Transform
+      pos: -5.5,-16.5
+      parent: 2
+  - uid: 1061
+    components:
+    - type: Transform
+      pos: -6.5,-16.5
+      parent: 2
+  - uid: 1062
+    components:
+    - type: Transform
+      pos: -7.5,-16.5
+      parent: 2
+  - uid: 1063
+    components:
+    - type: Transform
+      pos: -8.5,-16.5
+      parent: 2
+  - uid: 1064
+    components:
+    - type: Transform
+      pos: -8.5,-15.5
+      parent: 2
+  - uid: 1065
+    components:
+    - type: Transform
+      pos: -8.5,-14.5
+      parent: 2
+  - uid: 1066
+    components:
+    - type: Transform
+      pos: -8.5,-13.5
+      parent: 2
+  - uid: 1067
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 2
+  - uid: 1068
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 2
+  - uid: 1069
+    components:
+    - type: Transform
+      pos: -8.5,-10.5
+      parent: 2
+  - uid: 1070
+    components:
+    - type: Transform
+      pos: -8.5,-9.5
+      parent: 2
+  - uid: 1071
+    components:
+    - type: Transform
+      pos: -8.5,-8.5
+      parent: 2
+  - uid: 1072
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+  - uid: 1073
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+  - uid: 1074
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: 1.5,-16.5
+      parent: 2
+  - uid: 1076
+    components:
+    - type: Transform
+      pos: 2.5,-16.5
+      parent: 2
+  - uid: 1077
+    components:
+    - type: Transform
+      pos: 3.5,-16.5
+      parent: 2
+  - uid: 1078
+    components:
+    - type: Transform
+      pos: 4.5,-16.5
+      parent: 2
+  - uid: 1079
+    components:
+    - type: Transform
+      pos: 5.5,-16.5
+      parent: 2
+  - uid: 1080
+    components:
+    - type: Transform
+      pos: 6.5,-16.5
+      parent: 2
+  - uid: 1081
+    components:
+    - type: Transform
+      pos: 7.5,-16.5
+      parent: 2
+  - uid: 1082
+    components:
+    - type: Transform
+      pos: 8.5,-16.5
+      parent: 2
+  - uid: 1083
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+  - uid: 1084
+    components:
+    - type: Transform
+      pos: 10.5,-16.5
+      parent: 2
+  - uid: 1085
+    components:
+    - type: Transform
+      pos: 10.5,-14.5
+      parent: 2
+  - uid: 1086
+    components:
+    - type: Transform
+      pos: 10.5,-13.5
+      parent: 2
+  - uid: 1087
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+  - uid: 1088
+    components:
+    - type: Transform
+      pos: 10.5,-11.5
+      parent: 2
+  - uid: 1089
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+  - uid: 1090
+    components:
+    - type: Transform
+      pos: 10.5,-9.5
+      parent: 2
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: 10.5,-8.5
+      parent: 2
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+  - uid: 1093
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 1094
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
+- proto: CableTerminal
+  entities:
+  - uid: 908
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-26.5
+      parent: 2
+- proto: CandlePurple
+  entities:
+  - uid: 437
+    components:
+    - type: Transform
+      pos: 4.472037,-12.96533
+      parent: 2
+- proto: CarpetBlack
+  entities:
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 2
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 2
+  - uid: 445
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 2
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 2
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 2
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 2
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 2
+  - uid: 612
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 2
+  - uid: 613
+    components:
+    - type: Transform
+      pos: -4.5,-19.5
+      parent: 2
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -4.5,-20.5
+      parent: 2
+  - uid: 615
+    components:
+    - type: Transform
+      pos: -4.5,-21.5
+      parent: 2
+  - uid: 616
+    components:
+    - type: Transform
+      pos: -4.5,-22.5
+      parent: 2
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -3.5,-19.5
+      parent: 2
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -3.5,-20.5
+      parent: 2
+  - uid: 619
+    components:
+    - type: Transform
+      pos: -3.5,-21.5
+      parent: 2
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -3.5,-22.5
+      parent: 2
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -2.5,-19.5
+      parent: 2
+  - uid: 622
+    components:
+    - type: Transform
+      pos: -2.5,-20.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
+      parent: 2
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -2.5,-22.5
+      parent: 2
+  - uid: 625
+    components:
+    - type: Transform
+      pos: -1.5,-19.5
+      parent: 2
+  - uid: 626
+    components:
+    - type: Transform
+      pos: -1.5,-20.5
+      parent: 2
+  - uid: 627
+    components:
+    - type: Transform
+      pos: -1.5,-21.5
+      parent: 2
+  - uid: 628
+    components:
+    - type: Transform
+      pos: -1.5,-22.5
+      parent: 2
+  - uid: 629
+    components:
+    - type: Transform
+      pos: -0.5,-19.5
+      parent: 2
+  - uid: 630
+    components:
+    - type: Transform
+      pos: -0.5,-20.5
+      parent: 2
+  - uid: 631
+    components:
+    - type: Transform
+      pos: -0.5,-21.5
+      parent: 2
+  - uid: 632
+    components:
+    - type: Transform
+      pos: -0.5,-22.5
+      parent: 2
+  - uid: 633
+    components:
+    - type: Transform
+      pos: 3.5,-18.5
+      parent: 2
+  - uid: 634
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 2
+  - uid: 635
+    components:
+    - type: Transform
+      pos: 1.5,-19.5
+      parent: 2
+  - uid: 636
+    components:
+    - type: Transform
+      pos: 1.5,-20.5
+      parent: 2
+  - uid: 637
+    components:
+    - type: Transform
+      pos: 1.5,-21.5
+      parent: 2
+  - uid: 638
+    components:
+    - type: Transform
+      pos: 1.5,-22.5
+      parent: 2
+  - uid: 639
+    components:
+    - type: Transform
+      pos: 2.5,-19.5
+      parent: 2
+  - uid: 640
+    components:
+    - type: Transform
+      pos: 2.5,-20.5
+      parent: 2
+  - uid: 641
+    components:
+    - type: Transform
+      pos: 2.5,-21.5
+      parent: 2
+  - uid: 642
+    components:
+    - type: Transform
+      pos: 2.5,-22.5
+      parent: 2
+  - uid: 643
+    components:
+    - type: Transform
+      pos: 3.5,-19.5
+      parent: 2
+  - uid: 644
+    components:
+    - type: Transform
+      pos: 3.5,-20.5
+      parent: 2
+  - uid: 645
+    components:
+    - type: Transform
+      pos: 3.5,-21.5
+      parent: 2
+  - uid: 646
+    components:
+    - type: Transform
+      pos: 3.5,-22.5
+      parent: 2
+  - uid: 647
+    components:
+    - type: Transform
+      pos: 4.5,-19.5
+      parent: 2
+  - uid: 648
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 2
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 4.5,-21.5
+      parent: 2
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 4.5,-22.5
+      parent: 2
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 5.5,-19.5
+      parent: 2
+  - uid: 652
+    components:
+    - type: Transform
+      pos: 5.5,-20.5
+      parent: 2
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 5.5,-21.5
+      parent: 2
+  - uid: 654
+    components:
+    - type: Transform
+      pos: 5.5,-22.5
+      parent: 2
+- proto: CarpetSBlue
+  entities:
+  - uid: 591
+    components:
+    - type: Transform
+      pos: -10.5,-18.5
+      parent: 2
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -10.5,-19.5
+      parent: 2
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -10.5,-20.5
+      parent: 2
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -10.5,-21.5
+      parent: 2
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -10.5,-22.5
+      parent: 2
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 2
+  - uid: 597
+    components:
+    - type: Transform
+      pos: -9.5,-19.5
+      parent: 2
+  - uid: 598
+    components:
+    - type: Transform
+      pos: -9.5,-20.5
+      parent: 2
+  - uid: 599
+    components:
+    - type: Transform
+      pos: -9.5,-21.5
+      parent: 2
+  - uid: 600
+    components:
+    - type: Transform
+      pos: -9.5,-22.5
+      parent: 2
+  - uid: 601
+    components:
+    - type: Transform
+      pos: 10.5,-18.5
+      parent: 2
+  - uid: 602
+    components:
+    - type: Transform
+      pos: 10.5,-19.5
+      parent: 2
+  - uid: 603
+    components:
+    - type: Transform
+      pos: 10.5,-20.5
+      parent: 2
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 10.5,-21.5
+      parent: 2
+  - uid: 605
+    components:
+    - type: Transform
+      pos: 10.5,-22.5
+      parent: 2
+  - uid: 606
+    components:
+    - type: Transform
+      pos: 11.5,-18.5
+      parent: 2
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 11.5,-19.5
+      parent: 2
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 11.5,-20.5
+      parent: 2
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 11.5,-21.5
+      parent: 2
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 11.5,-22.5
+      parent: 2
+  - uid: 869
+    components:
+    - type: Transform
+      pos: 10.5,-23.5
+      parent: 2
+  - uid: 989
+    components:
+    - type: Transform
+      pos: -1.5,-32.5
+      parent: 2
+  - uid: 990
+    components:
+    - type: Transform
+      pos: -1.5,-33.5
+      parent: 2
+  - uid: 991
+    components:
+    - type: Transform
+      pos: -0.5,-32.5
+      parent: 2
+  - uid: 992
+    components:
+    - type: Transform
+      pos: -0.5,-33.5
+      parent: 2
+  - uid: 993
+    components:
+    - type: Transform
+      pos: 0.5,-32.5
+      parent: 2
+  - uid: 994
+    components:
+    - type: Transform
+      pos: 0.5,-33.5
+      parent: 2
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 1.5,-32.5
+      parent: 2
+  - uid: 996
+    components:
+    - type: Transform
+      pos: 1.5,-33.5
+      parent: 2
+  - uid: 997
+    components:
+    - type: Transform
+      pos: 2.5,-32.5
+      parent: 2
+  - uid: 998
+    components:
+    - type: Transform
+      pos: 2.5,-33.5
+      parent: 2
+  - uid: 1003
+    components:
+    - type: Transform
+      pos: -10.5,-23.5
+      parent: 2
+  - uid: 1004
+    components:
+    - type: Transform
+      pos: -10.5,-24.5
+      parent: 2
+  - uid: 1005
+    components:
+    - type: Transform
+      pos: -9.5,-23.5
+      parent: 2
+  - uid: 1006
+    components:
+    - type: Transform
+      pos: -9.5,-24.5
+      parent: 2
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: 10.5,-24.5
+      parent: 2
+  - uid: 1008
+    components:
+    - type: Transform
+      pos: 11.5,-23.5
+      parent: 2
+  - uid: 1009
+    components:
+    - type: Transform
+      pos: 11.5,-24.5
+      parent: 2
+- proto: Catwalk
+  entities:
+  - uid: 931
+    components:
+    - type: Transform
+      pos: -2.5,-24.5
+      parent: 2
+  - uid: 932
+    components:
+    - type: Transform
+      pos: -1.5,-24.5
+      parent: 2
+  - uid: 933
+    components:
+    - type: Transform
+      pos: -0.5,-24.5
+      parent: 2
+  - uid: 934
+    components:
+    - type: Transform
+      pos: 0.5,-24.5
+      parent: 2
+  - uid: 935
+    components:
+    - type: Transform
+      pos: -0.5,-26.5
+      parent: 2
+  - uid: 936
+    components:
+    - type: Transform
+      pos: -1.5,-26.5
+      parent: 2
+  - uid: 937
+    components:
+    - type: Transform
+      pos: 1.5,-26.5
+      parent: 2
+  - uid: 938
+    components:
+    - type: Transform
+      pos: 2.5,-26.5
+      parent: 2
+  - uid: 939
+    components:
+    - type: Transform
+      pos: 1.5,-27.5
+      parent: 2
+  - uid: 940
+    components:
+    - type: Transform
+      pos: -0.5,-27.5
+      parent: 2
+- proto: Chair
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 454
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-17.5
+      parent: 2
+  - uid: 455
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-17.5
+      parent: 2
+  - uid: 456
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-17.5
+      parent: 2
+- proto: ChairOfficeLight
+  entities:
+  - uid: 260
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.661122,-7.8314886
+      parent: 2
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -6.523621,-8.757131
+      parent: 2
+- proto: ChairPilotSeat
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 2
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 2
+  - uid: 167
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 2
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 2
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 2
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 2
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 2
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 2
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-3.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-4.5
+      parent: 2
+  - uid: 176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -8.5,-2.5
+      parent: 2
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -9.5,-2.5
+      parent: 2
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -10.5,-2.5
+      parent: 2
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 181
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 2
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-9.5
+      parent: 2
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-9.5
+      parent: 2
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 2
+  - uid: 203
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-9.5
+      parent: 2
+  - uid: 204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-10.5
+      parent: 2
+  - uid: 205
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-11.5
+      parent: 2
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-6.5
+      parent: 2
+  - uid: 265
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-10.5
+      parent: 2
+  - uid: 267
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-10.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-13.5
+      parent: 2
+  - uid: 452
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-13.5
+      parent: 2
+  - uid: 457
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-17.5
+      parent: 2
+  - uid: 458
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-17.5
+      parent: 2
+  - uid: 507
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-19.5
+      parent: 2
+  - uid: 508
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-20.5
+      parent: 2
+  - uid: 509
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-21.5
+      parent: 2
+  - uid: 510
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-22.5
+      parent: 2
+  - uid: 511
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-20.5
+      parent: 2
+  - uid: 512
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-21.5
+      parent: 2
+  - uid: 513
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-22.5
+      parent: 2
+  - uid: 514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-20.5
+      parent: 2
+  - uid: 515
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-21.5
+      parent: 2
+  - uid: 516
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-22.5
+      parent: 2
+  - uid: 517
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-20.5
+      parent: 2
+  - uid: 518
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-21.5
+      parent: 2
+  - uid: 519
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-22.5
+      parent: 2
+  - uid: 520
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-22.5
+      parent: 2
+  - uid: 521
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-21.5
+      parent: 2
+  - uid: 522
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-20.5
+      parent: 2
+  - uid: 523
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-19.5
+      parent: 2
+  - uid: 524
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-20.5
+      parent: 2
+  - uid: 525
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-21.5
+      parent: 2
+  - uid: 526
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-22.5
+      parent: 2
+- proto: ChairWood
+  entities:
+  - uid: 319
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-9.5
+      parent: 2
+  - uid: 320
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-10.5
+      parent: 2
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.375636,-10.479512
+      parent: 2
+  - uid: 414
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.513136,-11.442681
+      parent: 2
+- proto: ChemDispenser
+  entities:
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -10.5,-7.5
+      parent: 2
+- proto: ChemMaster
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -10.5,-8.5
+      parent: 2
+- proto: CigarCase
+  entities:
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 4.688879,-6.307292
+      parent: 2
+- proto: CigPackMixed
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.563879,1.4249408
+      parent: 2
+- proto: ClosetEmergencyFilledRandom
+  entities:
+  - uid: 977
+    components:
+    - type: Transform
+      pos: -0.5,-36.5
+      parent: 2
+  - uid: 978
+    components:
+    - type: Transform
+      pos: 1.5,-36.5
+      parent: 2
+- proto: ClosetEmergencyN2FilledRandom
+  entities:
+  - uid: 879
+    components:
+    - type: Transform
+      pos: -0.5,-35.5
+      parent: 2
+  - uid: 880
+    components:
+    - type: Transform
+      pos: 1.5,-35.5
+      parent: 2
+- proto: ClosetWallFireFilledRandom
+  entities:
+  - uid: 881
+    components:
+    - type: Transform
+      pos: -1.5,-31.5
+      parent: 2
+  - uid: 882
+    components:
+    - type: Transform
+      pos: 2.5,-31.5
+      parent: 2
+- proto: ClothingHeadHatFlowerWreath
+  entities:
+  - uid: 441
+    components:
+    - type: Transform
+      pos: 4.6095366,-13.490695
+      parent: 2
+- proto: ClothingMaskSterile
+  entities:
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -10.502749,-12.985342
+      parent: 2
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -10.502749,-13.085411
+      parent: 2
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -10.502749,-13.185481
+      parent: 2
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -10.502749,-13.273041
+      parent: 2
+  - uid: 709
+    components:
+    - type: Transform
+      pos: -10.506128,-12.929088
+      parent: 2
+- proto: ClothingNeckStethoscope
+  entities:
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -6.5486207,-5.392294
+      parent: 2
+- proto: ComputerComms
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 2
+- proto: ComputerCrewMonitoring
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 2
+- proto: ComputerEmergencyShuttle
+  entities:
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 2
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 2
+- proto: ComputerRadar
+  entities:
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 2
+- proto: CrateEmptySpawner
+  entities:
+  - uid: 930
+    components:
+    - type: Transform
+      pos: -2.5,-25.5
+      parent: 2
+- proto: CrowbarRed
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.561121,-1.351988
+      parent: 2
+- proto: d6Dice
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.3904636,-10.088332
+      parent: 2
+  - uid: 424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.4654634,-10.788818
+      parent: 2
+- proto: DrinkCreamCartonXL
+  entities:
+  - uid: 671
+    components:
+    - type: Transform
+      parent: 668
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: DrinkMugHeart
+  entities:
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -10.636122,-4.3665814
+      parent: 2
+- proto: DrinkMugMetal
+  entities:
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 11.351378,-7.8708773
+      parent: 2
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 11.613878,-8.008472
+      parent: 2
+- proto: EmergencyLight
+  entities:
+  - uid: 1159
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-35.5
+      parent: 2
+  - uid: 1160
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-35.5
+      parent: 2
+  - uid: 1161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-33.5
+      parent: 2
+  - uid: 1162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-33.5
+      parent: 2
+  - uid: 1163
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-23.5
+      parent: 2
+  - uid: 1164
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-23.5
+      parent: 2
+  - uid: 1165
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-25.5
+      parent: 2
+  - uid: 1166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-22.5
+      parent: 2
+  - uid: 1167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-22.5
+      parent: 2
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-17.5
+      parent: 2
+  - uid: 1169
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-17.5
+      parent: 2
+  - uid: 1170
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 2
+  - uid: 1171
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-9.5
+      parent: 2
+  - uid: 1172
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-5.5
+      parent: 2
+  - uid: 1173
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-5.5
+      parent: 2
+  - uid: 1174
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 1175
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 1176
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 2
+  - uid: 1177
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 2
+  - uid: 1178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-9.5
+      parent: 2
+- proto: FancyTableSpawner
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 2
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 2
+- proto: FireAlarm
+  entities:
+  - uid: 1685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-7.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1681
+      - 1710
+      - 1682
+      - 1711
+      - 1679
+      - 1712
+      - 1713
+      - 1714
+      - 1715
+      - 1716
+  - uid: 1686
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1679
+      - 1709
+      - 1683
+      - 1710
+  - uid: 1689
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-13.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1679
+      - 1701
+      - 1683
+      - 1711
+  - uid: 1690
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1701
+      - 1682
+      - 1712
+      - 1713
+      - 1714
+      - 1715
+      - 1716
+      - 1683
+      - 1709
+      - 1681
+      - 1697
+      - 1698
+      - 1692
+      - 1707
+      - 1706
+      - 1708
+      - 1705
+      - 1704
+      - 1680
+      - 1700
+      - 1699
+      - 1693
+  - uid: 1695
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-24.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1693
+      - 1000
+      - 999
+      - 1679
+      - 1697
+      - 1698
+  - uid: 1696
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-24.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1692
+      - 1000
+      - 999
+      - 1679
+      - 1700
+      - 1699
+  - uid: 1703
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-23.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 1679
+      - 1704
+      - 1705
+      - 1708
+      - 1706
+      - 1707
+- proto: FirelockEdge
+  entities:
+  - uid: 1708
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1703
+      - 1702
+  - uid: 1713
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1685
+      - 1684
+  - uid: 1714
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1685
+      - 1684
+  - uid: 1715
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1685
+      - 1684
+  - uid: 1716
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1685
+      - 1684
+- proto: FirelockGlass
+  entities:
+  - uid: 999
+    components:
+    - type: Transform
+      pos: 0.5,-33.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1695
+      - 1694
+      - 1696
+      - 1607
+  - uid: 1000
+    components:
+    - type: Transform
+      pos: 0.5,-32.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1695
+      - 1694
+      - 1696
+      - 1607
+  - uid: 1697
+    components:
+    - type: Transform
+      pos: 11.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1695
+      - 1694
+      - 1690
+      - 1691
+  - uid: 1698
+    components:
+    - type: Transform
+      pos: 10.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1695
+      - 1694
+      - 1690
+      - 1691
+  - uid: 1699
+    components:
+    - type: Transform
+      pos: -10.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1696
+      - 1607
+      - 1690
+      - 1691
+  - uid: 1700
+    components:
+    - type: Transform
+      pos: -9.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1696
+      - 1607
+      - 1690
+      - 1691
+  - uid: 1701
+    components:
+    - type: Transform
+      pos: -8.5,-14.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1689
+      - 1688
+  - uid: 1704
+    components:
+    - type: Transform
+      pos: -3.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1703
+      - 1702
+  - uid: 1705
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1703
+      - 1702
+  - uid: 1706
+    components:
+    - type: Transform
+      pos: 3.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1703
+      - 1702
+  - uid: 1707
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1703
+      - 1702
+  - uid: 1709
+    components:
+    - type: Transform
+      pos: 10.5,-14.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1686
+      - 1687
+  - uid: 1710
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1686
+      - 1687
+      - 1685
+      - 1684
+  - uid: 1711
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1689
+      - 1688
+      - 1685
+      - 1684
+  - uid: 1712
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1690
+      - 1691
+      - 1685
+      - 1684
+- proto: FlippoLighter
+  entities:
+  - uid: 308
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.338879,-6.4198694
+      parent: 2
+- proto: FolderSpawner
+  entities:
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 1.5263789,3.1761568
+      parent: 2
+- proto: FoodBowlBig
+  entities:
+  - uid: 675
+    components:
+    - type: Transform
+      pos: 13.556036,-17.226864
+      parent: 2
+- proto: FoodCartCold
+  entities:
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 12.5,-15.5
+      parent: 2
+- proto: FoodCartHot
+  entities:
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -11.5,-15.5
+      parent: 2
+- proto: FoodCondimentBottleHotsauce
+  entities:
+  - uid: 438
+    components:
+    - type: Transform
+      pos: 4.6720366,-12.615087
+      parent: 2
+- proto: FoodDough
+  entities:
+  - uid: 703
+    components:
+    - type: Transform
+      pos: -12.563487,-16.714008
+      parent: 2
+- proto: FoodFrozenPopsicleJumbo
+  entities:
+  - uid: 669
+    components:
+    - type: Transform
+      parent: 668
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 670
+    components:
+    - type: Transform
+      parent: 668
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: FoodFrozenSandwich
+  entities:
+  - uid: 672
+    components:
+    - type: Transform
+      parent: 668
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: FoodShakerPepper
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      pos: 4.3845367,-13.052892
+      parent: 2
+- proto: FoodShakerSalt
+  entities:
+  - uid: 439
+    components:
+    - type: Transform
+      pos: 4.5720367,-13.102925
+      parent: 2
+- proto: GasAnalyzer
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.461121,-1.389514
+      parent: 2
+- proto: GasMixerFlipped
+  entities:
+  - uid: 926
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-24.5
+      parent: 2
+    - type: GasMixer
+      inletTwoConcentration: 0.71000004
+      inletOneConcentration: 0.29
+- proto: GasPassiveVent
+  entities:
+  - uid: 946
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 927
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-25.5
+      parent: 2
+  - uid: 1095
+    components:
+    - type: Transform
+      pos: -8.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1375
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-36.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-35.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1378
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1380
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1381
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1396
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-36.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1397
+    components:
+    - type: Transform
+      pos: -2.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1398
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1399
+    components:
+    - type: Transform
+      pos: -5.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1400
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-35.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1417
+    components:
+    - type: Transform
+      pos: -4.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1419
+    components:
+    - type: Transform
+      pos: -7.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1432
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1433
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1434
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1464
+    components:
+    - type: Transform
+      pos: 11.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1473
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1588
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1589
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1590
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1594
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1648
+    components:
+    - type: Transform
+      pos: -9.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1649
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1658
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1659
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1660
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 1483
+    components:
+    - type: Transform
+      pos: 0.5,-19.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1491
+    components:
+    - type: Transform
+      pos: 0.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1519
+    components:
+    - type: Transform
+      pos: -9.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1520
+    components:
+    - type: Transform
+      pos: 10.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 1360
+    components:
+    - type: Transform
+      pos: -2.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1361
+    components:
+    - type: Transform
+      pos: -2.5,-27.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1366
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1368
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1369
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-23.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1370
+    components:
+    - type: Transform
+      pos: 0.5,-23.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1385
+    components:
+    - type: Transform
+      pos: 9.5,-27.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1386
+    components:
+    - type: Transform
+      pos: 9.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1388
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1389
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-30.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1390
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1391
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1392
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1393
+    components:
+    - type: Transform
+      pos: 3.5,-33.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1394
+    components:
+    - type: Transform
+      pos: 3.5,-34.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1395
+    components:
+    - type: Transform
+      pos: 3.5,-35.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1403
+    components:
+    - type: Transform
+      pos: 10.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-35.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1405
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-34.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1406
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-33.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1407
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1409
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1410
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1411
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1412
+    components:
+    - type: Transform
+      pos: -8.5,-27.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1413
+    components:
+    - type: Transform
+      pos: -8.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1414
+    components:
+    - type: Transform
+      pos: -5.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1415
+    components:
+    - type: Transform
+      pos: -5.5,-30.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1422
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-27.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1423
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1424
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1425
+    components:
+    - type: Transform
+      pos: -7.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1426
+    components:
+    - type: Transform
+      pos: -7.5,-30.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1427
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1429
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1430
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-33.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1431
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-34.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1437
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-27.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1438
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1439
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1440
+    components:
+    - type: Transform
+      pos: 8.5,-29.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1441
+    components:
+    - type: Transform
+      pos: 8.5,-30.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1442
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1443
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-31.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1444
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-32.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1445
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-33.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1446
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-34.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1447
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1448
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1449
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-23.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1450
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1451
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-21.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1452
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1453
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-19.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1454
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1455
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1456
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1457
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1458
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-23.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1459
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1460
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-21.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1461
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1462
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-19.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1463
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1465
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1466
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1467
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-23.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1468
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1469
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-21.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1470
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1471
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-19.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1472
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1474
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1475
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1476
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-23.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1477
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1478
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-21.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1479
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1480
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-19.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1481
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1482
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1486
+    components:
+    - type: Transform
+      pos: 0.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1487
+    components:
+    - type: Transform
+      pos: 0.5,-21.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1488
+    components:
+    - type: Transform
+      pos: 0.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1489
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1490
+    components:
+    - type: Transform
+      pos: 0.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1496
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1497
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1498
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1499
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1500
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1502
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1503
+    components:
+    - type: Transform
+      pos: -2.5,-21.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1504
+    components:
+    - type: Transform
+      pos: -2.5,-20.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1505
+    components:
+    - type: Transform
+      pos: -2.5,-19.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1506
+    components:
+    - type: Transform
+      pos: -2.5,-18.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1521
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1522
+    components:
+    - type: Transform
+      pos: 9.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1523
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1524
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1525
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1526
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1527
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1528
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1529
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1530
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1531
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1532
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1533
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1534
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1535
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1536
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1537
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1538
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1539
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1540
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1541
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1542
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1543
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1544
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1545
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1546
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1547
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1548
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1549
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1550
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1551
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1552
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1553
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1554
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1555
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1556
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1557
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1558
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1559
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1560
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1561
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1562
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1563
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1564
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1565
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1566
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1567
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1568
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1570
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1571
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1572
+    components:
+    - type: Transform
+      pos: -8.5,-16.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1592
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1593
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1595
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1596
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1597
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1598
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1599
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1600
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1601
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1602
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1603
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1604
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1605
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1606
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1612
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1613
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1614
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1615
+    components:
+    - type: Transform
+      pos: 10.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1616
+    components:
+    - type: Transform
+      pos: 10.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1617
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1618
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1619
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1620
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1621
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1622
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1624
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1625
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1627
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1628
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-14.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1634
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1635
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1636
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1637
+    components:
+    - type: Transform
+      pos: -8.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1638
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1639
+    components:
+    - type: Transform
+      pos: -9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1640
+    components:
+    - type: Transform
+      pos: -9.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1641
+    components:
+    - type: Transform
+      pos: -9.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1642
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1643
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1644
+    components:
+    - type: Transform
+      pos: -8.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1645
+    components:
+    - type: Transform
+      pos: -8.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1646
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1647
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1652
+    components:
+    - type: Transform
+      pos: -9.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1653
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1654
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1655
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1665
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1666
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1667
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1668
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1669
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1670
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1671
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1672
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1673
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1674
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1675
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1676
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1677
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1678
+    components:
+    - type: Transform
+      pos: 11.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 1362
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1365
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1382
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1401
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-26.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1435
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-28.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1492
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1493
+    components:
+    - type: Transform
+      pos: -0.5,-22.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1507
+    components:
+    - type: Transform
+      pos: -2.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1508
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -8.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1509
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1510
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1511
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-17.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1512
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-15.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1573
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1574
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1575
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1576
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1577
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-13.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1578
+    components:
+    - type: Transform
+      pos: 9.5,-12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1579
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1580
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1581
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1591
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1608
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1609
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1663
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1664
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-4.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasPort
+  entities:
+  - uid: 924
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-24.5
+      parent: 2
+  - uid: 925
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-25.5
+      parent: 2
+- proto: GasPressurePump
+  entities:
+  - uid: 928
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-24.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 929
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-25.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasVentPump
+  entities:
+  - uid: 1364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-24.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1702
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1373
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-35.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1607
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1374
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-35.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1694
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-29.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1607
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1436
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-29.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1694
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1484
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-19.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1702
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1485
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-19.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1702
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1516
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1691
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1517
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-16.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1691
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1518
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-16.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1691
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1585
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-11.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1586
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1587
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1611
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1632
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-10.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1688
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1633
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1688
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1651
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1688
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1656
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1684
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 1662
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1684
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 1367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-25.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1702
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1371
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-36.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1607
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-36.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1694
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-27.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1694
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,-27.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1607
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1494
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-22.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1702
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-22.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1702
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1513
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-15.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1691
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1514
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-15.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1691
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1515
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1691
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1582
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1583
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-12.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1584
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-10.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1610
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1687
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1630
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-13.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1688
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1631
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-10.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1688
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1650
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1688
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1657
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1684
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 1661
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 1684
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GeneratorRTG
+  entities:
+  - uid: 902
+    components:
+    - type: Transform
+      pos: -1.5,-26.5
+      parent: 2
+  - uid: 903
+    components:
+    - type: Transform
+      pos: -0.5,-27.5
+      parent: 2
+  - uid: 904
+    components:
+    - type: Transform
+      pos: 1.5,-27.5
+      parent: 2
+  - uid: 905
+    components:
+    - type: Transform
+      pos: 2.5,-26.5
+      parent: 2
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 906
+    components:
+    - type: Transform
+      pos: 0.5,-27.5
+      parent: 2
+- proto: Grille
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -4.5,-23.5
+      parent: 2
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -11.5,-10.5
+      parent: 2
+  - uid: 87
+    components:
+    - type: Transform
+      pos: -11.5,-9.5
+      parent: 2
+  - uid: 88
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 89
+    components:
+    - type: Transform
+      pos: -11.5,-4.5
+      parent: 2
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 2
+  - uid: 92
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 98
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 2
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 12.5,-5.5
+      parent: 2
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 2
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 12.5,-10.5
+      parent: 2
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 12.5,-11.5
+      parent: 2
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -11.5,-11.5
+      parent: 2
+  - uid: 328
+    components:
+    - type: Transform
+      pos: -11.5,-12.5
+      parent: 2
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -7.5,-14.5
+      parent: 2
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 12.5,-12.5
+      parent: 2
+  - uid: 378
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 2
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 2.5,-18.5
+      parent: 2
+  - uid: 543
+    components:
+    - type: Transform
+      pos: -11.5,-19.5
+      parent: 2
+  - uid: 544
+    components:
+    - type: Transform
+      pos: -11.5,-20.5
+      parent: 2
+  - uid: 545
+    components:
+    - type: Transform
+      pos: -11.5,-21.5
+      parent: 2
+  - uid: 546
+    components:
+    - type: Transform
+      pos: -11.5,-22.5
+      parent: 2
+  - uid: 547
+    components:
+    - type: Transform
+      pos: -8.5,-22.5
+      parent: 2
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -8.5,-21.5
+      parent: 2
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -8.5,-20.5
+      parent: 2
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -8.5,-19.5
+      parent: 2
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -5.5,-19.5
+      parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      pos: -5.5,-20.5
+      parent: 2
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -5.5,-21.5
+      parent: 2
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -5.5,-22.5
+      parent: 2
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 6.5,-22.5
+      parent: 2
+  - uid: 556
+    components:
+    - type: Transform
+      pos: 6.5,-21.5
+      parent: 2
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 6.5,-20.5
+      parent: 2
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 6.5,-19.5
+      parent: 2
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 9.5,-19.5
+      parent: 2
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 9.5,-20.5
+      parent: 2
+  - uid: 561
+    components:
+    - type: Transform
+      pos: 9.5,-21.5
+      parent: 2
+  - uid: 562
+    components:
+    - type: Transform
+      pos: 9.5,-22.5
+      parent: 2
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 12.5,-22.5
+      parent: 2
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 12.5,-21.5
+      parent: 2
+  - uid: 565
+    components:
+    - type: Transform
+      pos: 12.5,-20.5
+      parent: 2
+  - uid: 566
+    components:
+    - type: Transform
+      pos: 12.5,-19.5
+      parent: 2
+  - uid: 663
+    components:
+    - type: Transform
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 664
+    components:
+    - type: Transform
+      pos: 13.5,-18.5
+      parent: 2
+  - uid: 665
+    components:
+    - type: Transform
+      pos: 14.5,-17.5
+      parent: 2
+  - uid: 666
+    components:
+    - type: Transform
+      pos: 14.5,-16.5
+      parent: 2
+  - uid: 667
+    components:
+    - type: Transform
+      pos: 14.5,-15.5
+      parent: 2
+  - uid: 681
+    components:
+    - type: Transform
+      pos: -12.5,-18.5
+      parent: 2
+  - uid: 682
+    components:
+    - type: Transform
+      pos: -13.5,-17.5
+      parent: 2
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -13.5,-16.5
+      parent: 2
+  - uid: 684
+    components:
+    - type: Transform
+      pos: -13.5,-15.5
+      parent: 2
+  - uid: 685
+    components:
+    - type: Transform
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 711
+    components:
+    - type: Transform
+      pos: -1.5,-23.5
+      parent: 2
+  - uid: 712
+    components:
+    - type: Transform
+      pos: -0.5,-23.5
+      parent: 2
+  - uid: 713
+    components:
+    - type: Transform
+      pos: 1.5,-23.5
+      parent: 2
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 2.5,-23.5
+      parent: 2
+  - uid: 715
+    components:
+    - type: Transform
+      pos: 5.5,-23.5
+      parent: 2
+  - uid: 716
+    components:
+    - type: Transform
+      pos: 12.5,-25.5
+      parent: 2
+  - uid: 717
+    components:
+    - type: Transform
+      pos: 12.5,-26.5
+      parent: 2
+  - uid: 718
+    components:
+    - type: Transform
+      pos: 12.5,-27.5
+      parent: 2
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -11.5,-27.5
+      parent: 2
+  - uid: 720
+    components:
+    - type: Transform
+      pos: -11.5,-26.5
+      parent: 2
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -11.5,-25.5
+      parent: 2
+  - uid: 973
+    components:
+    - type: Transform
+      pos: -3.5,-37.5
+      parent: 2
+  - uid: 974
+    components:
+    - type: Transform
+      pos: 4.5,-37.5
+      parent: 2
+  - uid: 975
+    components:
+    - type: Transform
+      pos: 4.5,-34.5
+      parent: 2
+  - uid: 976
+    components:
+    - type: Transform
+      pos: -3.5,-34.5
+      parent: 2
+- proto: GrilleDiagonal
+  entities:
+  - uid: 1
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 132
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 133
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 134
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 141
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-34.5
+      parent: 2
+  - uid: 142
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-32.5
+      parent: 2
+  - uid: 143
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-30.5
+      parent: 2
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-29.5
+      parent: 2
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-27.5
+      parent: 2
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-25.5
+      parent: 2
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-27.5
+      parent: 2
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 773
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-26.5
+      parent: 2
+  - uid: 774
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-30.5
+      parent: 2
+  - uid: 775
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-27.5
+      parent: 2
+  - uid: 782
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-32.5
+      parent: 2
+  - uid: 783
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-32.5
+      parent: 2
+  - uid: 784
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-26.5
+      parent: 2
+  - uid: 785
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-30.5
+      parent: 2
+  - uid: 786
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-34.5
+      parent: 2
+  - uid: 797
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-30.5
+      parent: 2
+  - uid: 802
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-28.5
+      parent: 2
+  - uid: 803
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-29.5
+      parent: 2
+  - uid: 804
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-25.5
+      parent: 2
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 816
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 817
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 818
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 819
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 2
+  - uid: 824
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-25.5
+      parent: 2
+  - uid: 825
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-29.5
+      parent: 2
+  - uid: 826
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-28.5
+      parent: 2
+  - uid: 829
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-31.5
+      parent: 2
+  - uid: 830
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-33.5
+      parent: 2
+  - uid: 831
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-27.5
+      parent: 2
+  - uid: 832
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-26.5
+      parent: 2
+  - uid: 833
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-30.5
+      parent: 2
+  - uid: 834
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-27.5
+      parent: 2
+  - uid: 840
+    components:
+    - type: Transform
+      pos: 3.5,-30.5
+      parent: 2
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 4.5,-29.5
+      parent: 2
+  - uid: 842
+    components:
+    - type: Transform
+      pos: 5.5,-28.5
+      parent: 2
+  - uid: 843
+    components:
+    - type: Transform
+      pos: 6.5,-27.5
+      parent: 2
+  - uid: 844
+    components:
+    - type: Transform
+      pos: 7.5,-26.5
+      parent: 2
+  - uid: 845
+    components:
+    - type: Transform
+      pos: 8.5,-25.5
+      parent: 2
+  - uid: 846
+    components:
+    - type: Transform
+      pos: 10.5,-30.5
+      parent: 2
+  - uid: 847
+    components:
+    - type: Transform
+      pos: 9.5,-31.5
+      parent: 2
+  - uid: 848
+    components:
+    - type: Transform
+      pos: 8.5,-32.5
+      parent: 2
+  - uid: 849
+    components:
+    - type: Transform
+      pos: 7.5,-33.5
+      parent: 2
+  - uid: 851
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-33.5
+      parent: 2
+  - uid: 852
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-31.5
+      parent: 2
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-26.5
+      parent: 2
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-28.5
+      parent: 2
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-30.5
+      parent: 2
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-31.5
+      parent: 2
+  - uid: 857
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-33.5
+      parent: 2
+  - uid: 858
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-26.5
+      parent: 2
+  - uid: 898
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-26.5
+      parent: 2
+  - uid: 900
+    components:
+    - type: Transform
+      pos: 3.5,-26.5
+      parent: 2
+- proto: Gyroscope
+  entities:
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+- proto: HandheldHealthAnalyzerUnpowered
+  entities:
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -10.577749,-10.358518
+      parent: 2
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -6.5277495,-10.508621
+      parent: 2
+- proto: HatSpawner
+  entities:
+  - uid: 865
+    components:
+    - type: Transform
+      pos: -10.5,-27.5
+      parent: 2
+- proto: KitchenMicrowave
+  entities:
+  - uid: 700
+    components:
+    - type: Transform
+      pos: -12.5,-15.5
+      parent: 2
+- proto: LockerChemistryFilled
+  entities:
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 2
+- proto: LockerEvidence
+  entities:
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 11.5,-13.5
+      parent: 2
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 11.5,-12.5
+      parent: 2
+- proto: LockerFreezerBase
+  entities:
+  - uid: 668
+    components:
+    - type: Transform
+      pos: 13.5,-15.5
+      parent: 2
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 669
+          - 670
+          - 671
+          - 672
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LunchboxCommandFilledRandom
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -0.486121,2.688318
+      parent: 2
+- proto: MedicalBed
+  entities:
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -10.5,-9.5
+      parent: 2
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 2
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 2
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 4.513879,-1.276936
+      parent: 2
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 4.501379,-1.4270399
+      parent: 2
+- proto: NitrogenCanister
+  entities:
+  - uid: 945
+    components:
+    - type: Transform
+      pos: 3.5,-25.5
+      parent: 2
+- proto: Ointment
+  entities:
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -10.35275,-12.472486
+      parent: 2
+  - uid: 398
+    components:
+    - type: Transform
+      pos: -10.41525,-12.572556
+      parent: 2
+  - uid: 399
+    components:
+    - type: Transform
+      pos: -10.502749,-12.672625
+      parent: 2
+  - uid: 705
+    components:
+    - type: Transform
+      pos: -10.4936285,-12.553826
+      parent: 2
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -10.456128,-12.516301
+      parent: 2
+- proto: OxygenCanister
+  entities:
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 944
+    components:
+    - type: Transform
+      pos: 3.5,-24.5
+      parent: 2
+- proto: PaintingMonkey
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 2
+- proto: PaperBin10
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+- proto: PersonalAI
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.423622,-5.217172
+      parent: 2
+- proto: PlushieGhost
+  entities:
+  - uid: 1001
+    components:
+    - type: Transform
+      pos: 0.6539454,-30.054028
+      parent: 2
+- proto: PosterLegitBarDrinks
+  entities:
+  - uid: 442
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 2
+- proto: PosterLegitDontPanic
+  entities:
+  - uid: 868
+    components:
+    - type: Transform
+      pos: 0.5,-31.5
+      parent: 2
+- proto: PosterLegitFruitBowl
+  entities:
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 12.5,-14.5
+      parent: 2
+- proto: PosterLegitPizzaHope
+  entities:
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -11.5,-14.5
+      parent: 2
+- proto: PottedPlant14
+  entities:
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -0.44321662,-19.622223
+      parent: 2
+- proto: PottedPlant16
+  entities:
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 1.4817834,-19.709784
+      parent: 2
+- proto: PottedPlantRandom
+  entities:
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 2
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 227
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 2
+- proto: PowerCellRecharger
+  entities:
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 2
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 2
+- proto: Poweredlight
+  entities:
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -10.5,-15.5
+      parent: 2
+  - uid: 482
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-17.5
+      parent: 2
+  - uid: 483
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-17.5
+      parent: 2
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 12.5,-15.5
+      parent: 2
+  - uid: 485
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-10.5
+      parent: 2
+  - uid: 486
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-9.5
+      parent: 2
+  - uid: 487
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-13.5
+      parent: 2
+  - uid: 488
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 489
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 2
+  - uid: 490
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 2
+  - uid: 491
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 2
+  - uid: 492
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 2
+  - uid: 493
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 2
+  - uid: 494
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 2
+  - uid: 495
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,-5.5
+      parent: 2
+  - uid: 496
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-6.5
+      parent: 2
+  - uid: 870
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-23.5
+      parent: 2
+  - uid: 871
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-23.5
+      parent: 2
+  - uid: 872
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-27.5
+      parent: 2
+  - uid: 873
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-22.5
+      parent: 2
+  - uid: 874
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-22.5
+      parent: 2
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-33.5
+      parent: 2
+  - uid: 876
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-33.5
+      parent: 2
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-29.5
+      parent: 2
+  - uid: 878
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-29.5
+      parent: 2
+  - uid: 981
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-36.5
+      parent: 2
+  - uid: 982
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-36.5
+      parent: 2
+- proto: Rack
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 2
+  - uid: 216
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 2
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 2
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 2
+  - uid: 219
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 2
+- proto: Railing
+  entities:
+  - uid: 464
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-15.5
+      parent: 2
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-17.5
+      parent: 2
+  - uid: 466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-15.5
+      parent: 2
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-17.5
+      parent: 2
+  - uid: 529
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-19.5
+      parent: 2
+  - uid: 530
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-20.5
+      parent: 2
+  - uid: 531
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-21.5
+      parent: 2
+  - uid: 532
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-22.5
+      parent: 2
+  - uid: 533
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-22.5
+      parent: 2
+  - uid: 534
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-21.5
+      parent: 2
+  - uid: 535
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-20.5
+      parent: 2
+  - uid: 536
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-19.5
+      parent: 2
+- proto: RandomDrinkGlass
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 2
+- proto: RandomDrinkSoda
+  entities:
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+- proto: RandomFoodBakedSingle
+  entities:
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 2
+- proto: RandomFoodSingle
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+- proto: RandomInstruments
+  entities:
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 5.5,-22.5
+      parent: 2
+- proto: RandomItem
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 7.5,-17.5
+      parent: 2
+- proto: RandomPainting
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+- proto: RandomPosterLegit
+  entities:
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 2
+  - uid: 472
+    components:
+    - type: Transform
+      pos: 6.5,-18.5
+      parent: 2
+  - uid: 473
+    components:
+    - type: Transform
+      pos: 9.5,-18.5
+      parent: 2
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
+      parent: 2
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 2
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -5.5,-18.5
+      parent: 2
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -8.5,-18.5
+      parent: 2
+  - uid: 947
+    components:
+    - type: Transform
+      pos: -10.5,-29.5
+      parent: 2
+  - uid: 948
+    components:
+    - type: Transform
+      pos: 11.5,-29.5
+      parent: 2
+  - uid: 949
+    components:
+    - type: Transform
+      pos: 0.5,-34.5
+      parent: 2
+- proto: RandomProduce
+  entities:
+  - uid: 701
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 2
+  - uid: 702
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 2
+  - uid: 704
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 2
+- proto: RandomSnacks
+  entities:
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 11.5,-2.5
+      parent: 2
+- proto: RandomSpawner
+  entities:
+  - uid: 1158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-36.5
+      parent: 2
+- proto: RandomVending
+  entities:
+  - uid: 866
+    components:
+    - type: Transform
+      pos: -10.5,-28.5
+      parent: 2
+  - uid: 867
+    components:
+    - type: Transform
+      pos: 11.5,-28.5
+      parent: 2
+- proto: ReinforcedPlasmaWindow
+  entities:
+  - uid: 748
+    components:
+    - type: Transform
+      pos: -1.5,-23.5
+      parent: 2
+  - uid: 749
+    components:
+    - type: Transform
+      pos: -0.5,-23.5
+      parent: 2
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 1.5,-23.5
+      parent: 2
+  - uid: 751
+    components:
+    - type: Transform
+      pos: 2.5,-23.5
+      parent: 2
+- proto: RollerBed
+  entities:
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -6.5277495,-13.448163
+      parent: 2
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -6.5402493,-12.81022
+      parent: 2
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -6.515249,-12.197294
+      parent: 2
+- proto: SchoolgirlUniformSpawner
+  entities:
+  - uid: 538
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-21.5
+      parent: 2
+- proto: SciFlash
+  entities:
+  - uid: 314
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.026379,-5.5942965
+      parent: 2
+- proto: Screen
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 279
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-6.5
+      parent: 2
+  - uid: 280
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 281
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -7.5,-18.5
+      parent: 2
+  - uid: 950
+    components:
+    - type: Transform
+      pos: 3.5,-23.5
+      parent: 2
+  - uid: 951
+    components:
+    - type: Transform
+      pos: -1.5,-34.5
+      parent: 2
+  - uid: 952
+    components:
+    - type: Transform
+      pos: 2.5,-34.5
+      parent: 2
+- proto: ShuttleWindow
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 2
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 2
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 2
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 2
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 2
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 2
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 2
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -8.5,-1.5
+      parent: 2
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -9.5,-1.5
+      parent: 2
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -10.5,-1.5
+      parent: 2
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -11.5,-3.5
+      parent: 2
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -11.5,-4.5
+      parent: 2
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -11.5,-5.5
+      parent: 2
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 2
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 2
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 2
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 11.5,-1.5
+      parent: 2
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 12.5,-3.5
+      parent: 2
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 12.5,-4.5
+      parent: 2
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 12.5,-5.5
+      parent: 2
+  - uid: 24
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 2
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 2
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 2
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 2
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 12.5,-9.5
+      parent: 2
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 12.5,-10.5
+      parent: 2
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 12.5,-11.5
+      parent: 2
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -11.5,-9.5
+      parent: 2
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -11.5,-10.5
+      parent: 2
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 2
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 2
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 2
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 2
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 2
+  - uid: 353
+    components:
+    - type: Transform
+      pos: -11.5,-11.5
+      parent: 2
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -11.5,-12.5
+      parent: 2
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -9.5,-14.5
+      parent: 2
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -7.5,-14.5
+      parent: 2
+  - uid: 357
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 2
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 2
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 9.5,-14.5
+      parent: 2
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 11.5,-14.5
+      parent: 2
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 12.5,-12.5
+      parent: 2
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 2
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 2.5,-18.5
+      parent: 2
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 12.5,-22.5
+      parent: 2
+  - uid: 568
+    components:
+    - type: Transform
+      pos: 12.5,-21.5
+      parent: 2
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 12.5,-20.5
+      parent: 2
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 12.5,-19.5
+      parent: 2
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 9.5,-19.5
+      parent: 2
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 9.5,-20.5
+      parent: 2
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 9.5,-21.5
+      parent: 2
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 9.5,-22.5
+      parent: 2
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 6.5,-22.5
+      parent: 2
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 6.5,-21.5
+      parent: 2
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 6.5,-20.5
+      parent: 2
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 6.5,-19.5
+      parent: 2
+  - uid: 579
+    components:
+    - type: Transform
+      pos: -5.5,-22.5
+      parent: 2
+  - uid: 580
+    components:
+    - type: Transform
+      pos: -5.5,-21.5
+      parent: 2
+  - uid: 581
+    components:
+    - type: Transform
+      pos: -5.5,-20.5
+      parent: 2
+  - uid: 582
+    components:
+    - type: Transform
+      pos: -5.5,-19.5
+      parent: 2
+  - uid: 583
+    components:
+    - type: Transform
+      pos: -8.5,-19.5
+      parent: 2
+  - uid: 584
+    components:
+    - type: Transform
+      pos: -8.5,-20.5
+      parent: 2
+  - uid: 585
+    components:
+    - type: Transform
+      pos: -8.5,-21.5
+      parent: 2
+  - uid: 586
+    components:
+    - type: Transform
+      pos: -8.5,-22.5
+      parent: 2
+  - uid: 587
+    components:
+    - type: Transform
+      pos: -11.5,-22.5
+      parent: 2
+  - uid: 588
+    components:
+    - type: Transform
+      pos: -11.5,-21.5
+      parent: 2
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -11.5,-20.5
+      parent: 2
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -11.5,-19.5
+      parent: 2
+  - uid: 656
+    components:
+    - type: Transform
+      pos: 13.5,-14.5
+      parent: 2
+  - uid: 657
+    components:
+    - type: Transform
+      pos: 13.5,-18.5
+      parent: 2
+  - uid: 658
+    components:
+    - type: Transform
+      pos: 14.5,-17.5
+      parent: 2
+  - uid: 659
+    components:
+    - type: Transform
+      pos: 14.5,-16.5
+      parent: 2
+  - uid: 660
+    components:
+    - type: Transform
+      pos: 14.5,-15.5
+      parent: 2
+  - uid: 692
+    components:
+    - type: Transform
+      pos: -12.5,-14.5
+      parent: 2
+  - uid: 693
+    components:
+    - type: Transform
+      pos: -12.5,-18.5
+      parent: 2
+  - uid: 694
+    components:
+    - type: Transform
+      pos: -13.5,-17.5
+      parent: 2
+  - uid: 695
+    components:
+    - type: Transform
+      pos: -13.5,-16.5
+      parent: 2
+  - uid: 696
+    components:
+    - type: Transform
+      pos: -13.5,-15.5
+      parent: 2
+  - uid: 740
+    components:
+    - type: Transform
+      pos: -11.5,-27.5
+      parent: 2
+  - uid: 741
+    components:
+    - type: Transform
+      pos: -11.5,-26.5
+      parent: 2
+  - uid: 742
+    components:
+    - type: Transform
+      pos: -11.5,-25.5
+      parent: 2
+  - uid: 743
+    components:
+    - type: Transform
+      pos: -4.5,-23.5
+      parent: 2
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 12.5,-27.5
+      parent: 2
+  - uid: 745
+    components:
+    - type: Transform
+      pos: 12.5,-26.5
+      parent: 2
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 12.5,-25.5
+      parent: 2
+  - uid: 747
+    components:
+    - type: Transform
+      pos: 5.5,-23.5
+      parent: 2
+  - uid: 860
+    components:
+    - type: Transform
+      pos: -3.5,-34.5
+      parent: 2
+  - uid: 861
+    components:
+    - type: Transform
+      pos: 4.5,-34.5
+      parent: 2
+  - uid: 971
+    components:
+    - type: Transform
+      pos: -3.5,-37.5
+      parent: 2
+  - uid: 972
+    components:
+    - type: Transform
+      pos: 4.5,-37.5
+      parent: 2
+- proto: ShuttleWindowDiagonal
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 2
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 2
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 2
+  - uid: 129
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 2
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 2
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 2
+  - uid: 136
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 2
+  - uid: 137
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-0.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 2
+  - uid: 139
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 2
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-26.5
+      parent: 2
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-33.5
+      parent: 2
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-31.5
+      parent: 2
+  - uid: 150
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-30.5
+      parent: 2
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-28.5
+      parent: 2
+  - uid: 770
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-26.5
+      parent: 2
+  - uid: 771
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-30.5
+      parent: 2
+  - uid: 772
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-27.5
+      parent: 2
+  - uid: 781
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-31.5
+      parent: 2
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 3.5,-30.5
+      parent: 2
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 4.5,-29.5
+      parent: 2
+  - uid: 789
+    components:
+    - type: Transform
+      pos: 5.5,-28.5
+      parent: 2
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 6.5,-27.5
+      parent: 2
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 7.5,-26.5
+      parent: 2
+  - uid: 792
+    components:
+    - type: Transform
+      pos: 8.5,-25.5
+      parent: 2
+  - uid: 793
+    components:
+    - type: Transform
+      pos: 10.5,-30.5
+      parent: 2
+  - uid: 794
+    components:
+    - type: Transform
+      pos: 9.5,-31.5
+      parent: 2
+  - uid: 795
+    components:
+    - type: Transform
+      pos: 8.5,-32.5
+      parent: 2
+  - uid: 796
+    components:
+    - type: Transform
+      pos: 7.5,-33.5
+      parent: 2
+  - uid: 798
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-33.5
+      parent: 2
+  - uid: 799
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-28.5
+      parent: 2
+  - uid: 800
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-29.5
+      parent: 2
+  - uid: 801
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-25.5
+      parent: 2
+  - uid: 805
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-26.5
+      parent: 2
+  - uid: 806
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-26.5
+      parent: 2
+  - uid: 807
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,-30.5
+      parent: 2
+  - uid: 808
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-34.5
+      parent: 2
+  - uid: 809
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-32.5
+      parent: 2
+  - uid: 810
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 2
+  - uid: 811
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-0.5
+      parent: 2
+  - uid: 812
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 2
+  - uid: 813
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 2
+  - uid: 814
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 2
+  - uid: 820
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-0.5
+      parent: 2
+  - uid: 821
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-25.5
+      parent: 2
+  - uid: 822
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-29.5
+      parent: 2
+  - uid: 823
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-28.5
+      parent: 2
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-27.5
+      parent: 2
+  - uid: 828
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -7.5,-32.5
+      parent: 2
+  - uid: 835
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-26.5
+      parent: 2
+  - uid: 836
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-30.5
+      parent: 2
+  - uid: 837
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-27.5
+      parent: 2
+  - uid: 838
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-26.5
+      parent: 2
+  - uid: 850
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-30.5
+      parent: 2
+  - uid: 859
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-34.5
+      parent: 2
+  - uid: 890
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-32.5
+      parent: 2
+  - uid: 891
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-30.5
+      parent: 2
+  - uid: 892
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-29.5
+      parent: 2
+  - uid: 893
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-27.5
+      parent: 2
+  - uid: 894
+    components:
+    - type: Transform
+      pos: 3.5,-26.5
+      parent: 2
+  - uid: 895
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-25.5
+      parent: 2
+  - uid: 896
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-27.5
+      parent: 2
+  - uid: 897
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-31.5
+      parent: 2
+  - uid: 899
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-33.5
+      parent: 2
+- proto: SignBridge
+  entities:
+  - uid: 283
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 284
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 2
+- proto: SignEngineering
+  entities:
+  - uid: 941
+    components:
+    - type: Transform
+      pos: -0.5,-23.5
+      parent: 2
+  - uid: 942
+    components:
+    - type: Transform
+      pos: 1.5,-23.5
+      parent: 2
+- proto: SignMedical
+  entities:
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,-6.5
+      parent: 2
+  - uid: 407
+    components:
+    - type: Transform
+      pos: -6.5,-14.5
+      parent: 2
+- proto: SignSec
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-6.5
+      parent: 2
+  - uid: 408
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 2
+- proto: SignSpace
+  entities:
+  - uid: 979
+    components:
+    - type: Transform
+      pos: -1.5,-37.5
+      parent: 2
+  - uid: 980
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-37.5
+      parent: 2
+- proto: SinkStemlessWater
+  entities:
+  - uid: 290
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-8.5
+      parent: 2
+  - uid: 710
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-12.5
+      parent: 2
+- proto: SMESBasic
+  entities:
+  - uid: 907
+    components:
+    - type: MetaData
+      name: SMES (Main)
+    - type: Transform
+      pos: 0.5,-25.5
+      parent: 2
+- proto: SodaDispenser
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 2
+- proto: SpaceCash
+  entities:
+  - uid: 425
+    components:
+    - type: Transform
+      pos: -3.3904636,-11.426763
+      parent: 2
+- proto: SpaceVillainArcadeFilled
+  entities:
+  - uid: 429
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-13.5
+      parent: 2
+- proto: SpoonPlastic
+  entities:
+  - uid: 676
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.618536,-16.638954
+      parent: 2
+- proto: Stool
+  entities:
+  - uid: 415
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.013136,-13.394036
+      parent: 2
+- proto: StoolBar
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 2
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 2
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 2
+  - uid: 211
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 2
+  - uid: 416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-11.5
+      parent: 2
+  - uid: 417
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 2
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-11.5
+      parent: 2
+  - uid: 419
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-11.5
+      parent: 2
+- proto: SubstationWallBasic
+  entities:
+  - uid: 922
+    components:
+    - type: MetaData
+      name: Substation (Main)
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-24.5
+      parent: 2
+- proto: TableCarpet
+  entities:
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 2
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 2
+  - uid: 412
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 2
+- proto: TableCounterMetal
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 2
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 2
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 2
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 2
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 2
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 2
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 11.5,-7.5
+      parent: 2
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 11.5,-8.5
+      parent: 2
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 2
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 2
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 13.5,-16.5
+      parent: 2
+  - uid: 674
+    components:
+    - type: Transform
+      pos: 13.5,-17.5
+      parent: 2
+  - uid: 697
+    components:
+    - type: Transform
+      pos: -12.5,-17.5
+      parent: 2
+  - uid: 698
+    components:
+    - type: Transform
+      pos: -12.5,-16.5
+      parent: 2
+  - uid: 699
+    components:
+    - type: Transform
+      pos: -12.5,-15.5
+      parent: 2
+- proto: TableFancyBlack
+  entities:
+  - uid: 434
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 2
+  - uid: 435
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 2
+- proto: TableGlass
+  entities:
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 7.5,-17.5
+      parent: 2
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -6.5,-17.5
+      parent: 2
+- proto: TableReinforced
+  entities:
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 11.5,-2.5
+      parent: 2
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -10.5,-5.5
+      parent: 2
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -10.5,-4.5
+      parent: 2
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 2
+  - uid: 262
+    components:
+    - type: Transform
+      pos: -10.5,-10.5
+      parent: 2
+  - uid: 263
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 2
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -10.5,-13.5
+      parent: 2
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -10.5,-12.5
+      parent: 2
+- proto: TableWood
+  entities:
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 2
+- proto: TableWoodReinforced
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 2
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 2
+  - uid: 301
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 2
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 2
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 2
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 2
+- proto: TargetDarts
+  entities:
+  - uid: 426
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 2
+- proto: Thruster
+  entities:
+  - uid: 321
+    components:
+    - type: Transform
+      pos: -11.5,-0.5
+      parent: 2
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -9.5,-0.5
+      parent: 2
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 2
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 8.5,-0.5
+      parent: 2
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 2
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 12.5,-0.5
+      parent: 2
+  - uid: 539
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-19.5
+      parent: 2
+  - uid: 540
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-19.5
+      parent: 2
+  - uid: 541
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-19.5
+      parent: 2
+  - uid: 542
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-19.5
+      parent: 2
+  - uid: 677
+    components:
+    - type: Transform
+      pos: 13.5,-13.5
+      parent: 2
+  - uid: 678
+    components:
+    - type: Transform
+      pos: 14.5,-13.5
+      parent: 2
+  - uid: 679
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-19.5
+      parent: 2
+  - uid: 680
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-19.5
+      parent: 2
+  - uid: 686
+    components:
+    - type: Transform
+      pos: -12.5,-13.5
+      parent: 2
+  - uid: 687
+    components:
+    - type: Transform
+      pos: -13.5,-13.5
+      parent: 2
+  - uid: 688
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,-19.5
+      parent: 2
+  - uid: 689
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,-19.5
+      parent: 2
+  - uid: 983
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-35.5
+      parent: 2
+  - uid: 984
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-36.5
+      parent: 2
+  - uid: 985
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-37.5
+      parent: 2
+  - uid: 986
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-35.5
+      parent: 2
+  - uid: 987
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-36.5
+      parent: 2
+  - uid: 988
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-37.5
+      parent: 2
+  - uid: 1156
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,-30.5
+      parent: 2
+  - uid: 1157
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-30.5
+      parent: 2
+- proto: ToolboxEmergencyFilled
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 3.488879,-1.3394796
+      parent: 2
+- proto: VendingMachineBoozeUnlocked
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 2
+- proto: VendingMachineMedical
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 2
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 2
+- proto: WallShuttle
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 2
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 2
+  - uid: 35
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 2
+  - uid: 36
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 2
+  - uid: 37
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 2
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 2
+  - uid: 39
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 2
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 2
+  - uid: 41
+    components:
+    - type: Transform
+      pos: -11.5,-2.5
+      parent: 2
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -11.5,-1.5
+      parent: 2
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 2
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 2
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 2
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 2
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 2
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 2
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 12.5,-1.5
+      parent: 2
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 12.5,-2.5
+      parent: 2
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 12.5,-8.5
+      parent: 2
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 12.5,-7.5
+      parent: 2
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 12.5,-6.5
+      parent: 2
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 11.5,-6.5
+      parent: 2
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 2
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 2
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 2
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 2
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 2
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 2
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 2
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 2
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 2
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 2
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 2
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 2
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 2
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 2
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 2
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 2
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 2
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 2
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 2
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 2
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 2
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 2
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -9.5,-6.5
+      parent: 2
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -10.5,-6.5
+      parent: 2
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 2
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -11.5,-7.5
+      parent: 2
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -11.5,-8.5
+      parent: 2
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 12.5,-13.5
+      parent: 2
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 12.5,-14.5
+      parent: 2
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 8.5,-14.5
+      parent: 2
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 7.5,-14.5
+      parent: 2
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 2
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 6.5,-13.5
+      parent: 2
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 2
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 2
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 2
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 2
+  - uid: 346
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 2
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -6.5,-14.5
+      parent: 2
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -10.5,-14.5
+      parent: 2
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -11.5,-14.5
+      parent: 2
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -11.5,-13.5
+      parent: 2
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -11.5,-18.5
+      parent: 2
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -8.5,-18.5
+      parent: 2
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -7.5,-18.5
+      parent: 2
+  - uid: 365
+    components:
+    - type: Transform
+      pos: -6.5,-18.5
+      parent: 2
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -5.5,-18.5
+      parent: 2
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 6.5,-18.5
+      parent: 2
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 7.5,-18.5
+      parent: 2
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 8.5,-18.5
+      parent: 2
+  - uid: 370
+    components:
+    - type: Transform
+      pos: 9.5,-18.5
+      parent: 2
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 12.5,-18.5
+      parent: 2
+  - uid: 661
+    components:
+    - type: Transform
+      pos: 14.5,-14.5
+      parent: 2
+  - uid: 662
+    components:
+    - type: Transform
+      pos: 14.5,-18.5
+      parent: 2
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -13.5,-14.5
+      parent: 2
+  - uid: 691
+    components:
+    - type: Transform
+      pos: -13.5,-18.5
+      parent: 2
+  - uid: 722
+    components:
+    - type: Transform
+      pos: 6.5,-23.5
+      parent: 2
+  - uid: 723
+    components:
+    - type: Transform
+      pos: 3.5,-23.5
+      parent: 2
+  - uid: 724
+    components:
+    - type: Transform
+      pos: 4.5,-23.5
+      parent: 2
+  - uid: 725
+    components:
+    - type: Transform
+      pos: 4.5,-24.5
+      parent: 2
+  - uid: 726
+    components:
+    - type: Transform
+      pos: 4.5,-25.5
+      parent: 2
+  - uid: 727
+    components:
+    - type: Transform
+      pos: -5.5,-23.5
+      parent: 2
+  - uid: 728
+    components:
+    - type: Transform
+      pos: -3.5,-23.5
+      parent: 2
+  - uid: 729
+    components:
+    - type: Transform
+      pos: -3.5,-24.5
+      parent: 2
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -3.5,-25.5
+      parent: 2
+  - uid: 731
+    components:
+    - type: Transform
+      pos: -2.5,-23.5
+      parent: 2
+  - uid: 732
+    components:
+    - type: Transform
+      pos: -8.5,-24.5
+      parent: 2
+  - uid: 733
+    components:
+    - type: Transform
+      pos: -8.5,-23.5
+      parent: 2
+  - uid: 734
+    components:
+    - type: Transform
+      pos: 9.5,-24.5
+      parent: 2
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 9.5,-23.5
+      parent: 2
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 12.5,-24.5
+      parent: 2
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 12.5,-23.5
+      parent: 2
+  - uid: 738
+    components:
+    - type: Transform
+      pos: -11.5,-24.5
+      parent: 2
+  - uid: 739
+    components:
+    - type: Transform
+      pos: -11.5,-23.5
+      parent: 2
+  - uid: 752
+    components:
+    - type: Transform
+      pos: 11.5,-29.5
+      parent: 2
+  - uid: 753
+    components:
+    - type: Transform
+      pos: -5.5,-35.5
+      parent: 2
+  - uid: 754
+    components:
+    - type: Transform
+      pos: -5.5,-34.5
+      parent: 2
+  - uid: 755
+    components:
+    - type: Transform
+      pos: -1.5,-31.5
+      parent: 2
+  - uid: 756
+    components:
+    - type: Transform
+      pos: -0.5,-31.5
+      parent: 2
+  - uid: 757
+    components:
+    - type: Transform
+      pos: 0.5,-31.5
+      parent: 2
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 1.5,-31.5
+      parent: 2
+  - uid: 759
+    components:
+    - type: Transform
+      pos: 2.5,-31.5
+      parent: 2
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 6.5,-35.5
+      parent: 2
+  - uid: 761
+    components:
+    - type: Transform
+      pos: 6.5,-34.5
+      parent: 2
+  - uid: 776
+    components:
+    - type: Transform
+      pos: -11.5,-28.5
+      parent: 2
+  - uid: 777
+    components:
+    - type: Transform
+      pos: -11.5,-29.5
+      parent: 2
+  - uid: 778
+    components:
+    - type: Transform
+      pos: -10.5,-29.5
+      parent: 2
+  - uid: 779
+    components:
+    - type: Transform
+      pos: 12.5,-29.5
+      parent: 2
+  - uid: 780
+    components:
+    - type: Transform
+      pos: 12.5,-28.5
+      parent: 2
+  - uid: 883
+    components:
+    - type: Transform
+      pos: -1.5,-27.5
+      parent: 2
+  - uid: 884
+    components:
+    - type: Transform
+      pos: -1.5,-28.5
+      parent: 2
+  - uid: 885
+    components:
+    - type: Transform
+      pos: -0.5,-28.5
+      parent: 2
+  - uid: 886
+    components:
+    - type: Transform
+      pos: 0.5,-28.5
+      parent: 2
+  - uid: 887
+    components:
+    - type: Transform
+      pos: 1.5,-28.5
+      parent: 2
+  - uid: 888
+    components:
+    - type: Transform
+      pos: 2.5,-28.5
+      parent: 2
+  - uid: 889
+    components:
+    - type: Transform
+      pos: 2.5,-27.5
+      parent: 2
+  - uid: 961
+    components:
+    - type: Transform
+      pos: -5.5,-36.5
+      parent: 2
+  - uid: 962
+    components:
+    - type: Transform
+      pos: -5.5,-37.5
+      parent: 2
+  - uid: 963
+    components:
+    - type: Transform
+      pos: 6.5,-36.5
+      parent: 2
+  - uid: 964
+    components:
+    - type: Transform
+      pos: 6.5,-37.5
+      parent: 2
+  - uid: 965
+    components:
+    - type: Transform
+      pos: 0.5,-37.5
+      parent: 2
+  - uid: 966
+    components:
+    - type: Transform
+      pos: -0.5,-37.5
+      parent: 2
+  - uid: 967
+    components:
+    - type: Transform
+      pos: -1.5,-37.5
+      parent: 2
+  - uid: 968
+    components:
+    - type: Transform
+      pos: 1.5,-37.5
+      parent: 2
+  - uid: 969
+    components:
+    - type: Transform
+      pos: 2.5,-37.5
+      parent: 2
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 768
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-31.5
+      parent: 2
+  - uid: 769
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-31.5
+      parent: 2
+- proto: WallShuttleInterior
+  entities:
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 2
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 2
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 2
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 2
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 2
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 2
+  - uid: 372
+    components:
+    - type: Transform
+      pos: -4.5,-18.5
+      parent: 2
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -0.5,-18.5
+      parent: 2
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 1.5,-18.5
+      parent: 2
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 5.5,-18.5
+      parent: 2
+  - uid: 762
+    components:
+    - type: Transform
+      pos: -1.5,-34.5
+      parent: 2
+  - uid: 763
+    components:
+    - type: Transform
+      pos: -0.5,-34.5
+      parent: 2
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 0.5,-34.5
+      parent: 2
+  - uid: 765
+    components:
+    - type: Transform
+      pos: 1.5,-34.5
+      parent: 2
+  - uid: 766
+    components:
+    - type: Transform
+      pos: 2.5,-34.5
+      parent: 2
+  - uid: 767
+    components:
+    - type: Transform
+      pos: 0.5,-35.5
+      parent: 2
+  - uid: 970
+    components:
+    - type: Transform
+      pos: 0.5,-36.5
+      parent: 2
+- proto: WarpPointEvacShuttle
+  entities:
+  - uid: 1002
+    components:
+    - type: Transform
+      pos: 1.5,-15.5
+      parent: 2
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 2
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 2
+- proto: WelderMini
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 3.613879,1.687623
+      parent: 2
+- proto: WindoorKitchenLocked
+  entities:
+  - uid: 468
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,-16.5
+      parent: 2
+  - uid: 469
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-16.5
+      parent: 2
+- proto: WindoorSecureBarLocked
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-8.5
+      parent: 2
+- proto: WindoorSecureCommandLocked
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 274
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-7.5
+      parent: 2
+  - uid: 275
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-7.5
+      parent: 2
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 2
+  - uid: 277
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 2
+- proto: WindoorSecureEngineeringLocked
+  entities:
+  - uid: 505
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-18.5
+      parent: 2
+- proto: WindoorSecureMedicalLocked
+  entities:
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 2
+- proto: WindoorSecureSecurityLocked
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 2
+  - uid: 1179
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-12.5
+      parent: 2
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 2
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 2
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 2
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-7.5
+      parent: 2
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-9.5
+      parent: 2
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-10.5
+      parent: 2
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-10.5
+      parent: 2
+  - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-10.5
+      parent: 2
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 2
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 2
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
+      parent: 2
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 2
+  - uid: 1180
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-11.5
+      parent: 2
+  - uid: 1181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-13.5
+      parent: 2
+...

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -14,7 +14,7 @@
             !type:NanotrasenNameGenerator
             prefixCreator: 'NY'
         - type: StationEmergencyShuttle
-          emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Seal.yml
+          emergencyShuttlePath: /Maps/Shuttles/DeltaV/NTES_Fishbowl.yml
         - type: StationJobs
           availableJobs:
           #civilian


### PR DESCRIPTION
## About the PR
Adds The Fishbowl, a unique evac shuttle for The Hive

## Why / Balance
Is neat

## Media
![awdaada](https://github.com/DeltaV-Station/Delta-v/assets/107660393/7060cbfa-4f86-4137-afa4-fc95c6b793eb)

**Changelog**
:cl: Velcroboy
- add: Added the NTES-Fishbowl, a stylish new ride to Centcomm from The Hive Station
