### PR TITLE
add 1h requirement to cargo tech

### DIFF
--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Cargo/courier.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Cargo/courier.yml
@@ -4,6 +4,9 @@
   description: job-description-courier
   startingGear: CourierGear
   playTimeTracker: JobCourier
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 3600 # 1 hr
   icon: "JobIconCourier"
   supervisors: job-supervisors-qm
   access:

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -4,6 +4,9 @@
   description: job-description-cargotech
   playTimeTracker: JobCargoTechnician
   startingGear: CargoTechGear
+  requirements:
+  - !type:OverallPlaytimeRequirement # DeltaV
+    time: 3600 # 1 hr
   icon: "JobIconCargoTechnician"
   supervisors: job-supervisors-qm
   access:


### PR DESCRIPTION
## About the PR
pro raiders keep using cargo as a means to get free salv shit and bomb med etc
also they should know controls and stuff before demanding epi fill out a 8 page request form