### PR TITLE
disable station destruction artifact effect

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -676,4 +676,4 @@
   - type: SpawnArtifact
     maxSpawns: 1
     spawns:
-    - id: TeslaEnergyBallToy # DeltaV - no teslaloose
+    - id: TeslaToy # DeltaV - no teslaloose

--- a/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/normal_effects.yml
@@ -666,7 +666,7 @@
   - type: SpawnArtifact
     maxSpawns: 1
     spawns:
-    - id: Singularity
+    - id: SingularityToy # DeltaV - no singuloose
 
 - type: artifactEffect
   id: EffectTesla
@@ -676,4 +676,4 @@
   - type: SpawnArtifact
     maxSpawns: 1
     spawns:
-    - id: TeslaEnergyBall
+    - id: TeslaEnergyBallToy # DeltaV - no teslaloose


### PR DESCRIPTION
## About the PR
it happens like at least once a week either by a noob (bad) or automatically (very bad)

instead of ending the round it spawns a cool toy

## Changelog
:cl:
- remove: Artifacts can no longer create singularities or tesla balls.