### PR TITLE
Remove clown medal theft objective

### DIFF
--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -308,7 +308,7 @@
 
 #- type: entity
 #  parent: BaseThiefStealObjective
-# id: ClothingNeckClownmedalStealObjective #Delta-V, We dont have the clown medal
+# id: ClothingNeckClownmedalStealObjective
 #  components:
 #  - type: NotJobRequirement
 #    job: Captain

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -306,16 +306,16 @@
   - type: Objective
     difficulty: 1
 
-- type: entity
-  parent: BaseThiefStealObjective
-  id: ClothingNeckClownmedalStealObjective
-  components:
-  - type: NotJobRequirement
-    job: Captain
-  - type: StealCondition
-    stealGroup: ClothingNeckClownmedal
-  - type: Objective
-    difficulty: 1
+#- type: entity
+#  parent: BaseThiefStealObjective
+# id: ClothingNeckClownmedalStealObjective #Delta-V, We dont have the clown medal
+#  components:
+#  - type: NotJobRequirement
+#    job: Captain
+#  - type: StealCondition
+#    stealGroup: ClothingNeckClownmedal
+#  - type: Objective
+#    difficulty: 1
 
 # Structures
 

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -306,7 +306,7 @@
   - type: Objective
     difficulty: 1
 
-#- type: entity
+#- type: entity - Delta-V : Removes clown medal steal objective for Thieves; as we don't have the Clown Medal
 #  parent: BaseThiefStealObjective
 # id: ClothingNeckClownmedalStealObjective
 #  components:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removes "Steal the clown medal" as a thief objective

## Why / Balance
We uh, dont have the clown medal on Delta

**Changelog**

:cl: DLondon
- remove: Removed "Steal The Clown Medal" thief objective


