### PR TITLE
Match syndie balloon price to current allotted TC for traitor

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1482,7 +1482,7 @@
   description: uplink-balloon-desc
   productEntity: BalloonSyn
   cost:
-    Telecrystal: 20
+    Telecrystal: 18
   categories:
   - UplinkPointless
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Syndie Balloon price goes to 18tc from 20tc

## Why / Balance
Currently Syndicate agents start with 18TC,  and can no longer do balloon ops (balloon is 20TC)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Syndicate balloon now costs 18TC
