### PR TITLE
add random gun safe spawners

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -33,7 +33,7 @@
       amount: 2
     - id: MagazineLightRifle
       amount: 4
-
+      
 - type: entity
   parent: GunSafe
   id: GunSafeAdjutantShotgun
@@ -45,7 +45,7 @@
       amount: 2
     - id: MagazineShotgun
       amount: 4
-
+      
 - type: entity
   parent: GunSafe
   id: GunSafeEnergyGun
@@ -55,7 +55,7 @@
     contents:
     - id: WeaponEnergyGun
       amount: 3
-
+      
 - type: entity
   parent: GunSafe
   id: GunSafeEnergyGunMini

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -33,7 +33,7 @@
       amount: 2
     - id: MagazineLightRifle
       amount: 4
-      
+
 - type: entity
   parent: GunSafe
   id: GunSafeAdjutantShotgun
@@ -45,7 +45,7 @@
       amount: 2
     - id: MagazineShotgun
       amount: 4
-      
+
 - type: entity
   parent: GunSafe
   id: GunSafeEnergyGun
@@ -55,7 +55,7 @@
     contents:
     - id: WeaponEnergyGun
       amount: 3
-      
+
 - type: entity
   parent: GunSafe
   id: GunSafeEnergyGunMini
@@ -65,3 +65,15 @@
     contents:
     - id: WeaponEnergyGunMini
       amount: 3
+
+- type: entity
+  parent: GunSafe
+  id: GunSafeM90Rifle
+  name: M-90 rifle safe
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponRifleM90
+      amount: 2
+    - id: MagazineRifle
+      amount: 4

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -1,0 +1,55 @@
+- type: entity
+  name: random shotgun safe spawner
+  id: ShotgunSafeSpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Structures/Storage/closet.rsi
+          state: shotguncase
+    - type: RandomSpawner
+      prototypes:
+        - GunSafeShotgunEnforcer
+        - GunSafeShotgunKammerer
+        - GunSafeAdjutantShotgun
+      offset: 0
+
+- type: entity
+  name: random rifle safe spawner
+  id: RifleSafeSpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Structures/Storage/closet.rsi
+          state: shotguncase
+    - type: RandomSpawner
+      prototypes:
+        - GunSafeVulcanRifle
+        - GunSafeSubMachineGunDrozd
+        - GunSafeRifleLecter
+        - GunSafeM90Rifle
+      offset: 0
+
+- type: entity
+  name: random handgun safe spawner
+  id: HandgunSafeSpawner
+  parent: MarkerBase
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Structures/Storage/closet.rsi
+          state: shotguncase
+    - type: RandomSpawner
+      prototypes:
+        - GunSafePistolMk58
+      chance: 0.85
+      rarePrototypes:
+        - GunSafeEnergyGunMini
+        - GunSafePistolUniversal
+        - GunSafeSubMachineGunWt550
+      rareChance: 0.15
+      offset: 0

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: BaseGunSafeSpawner
+  name: random safe spawner
   parent: MarkerBase
   abstract: true
   components:
@@ -12,7 +13,6 @@
       offset: 0
 
 - type: entity
-  name: random safe spawner
   suffix: Shotgun
   id: ShotgunSafeSpawner
   parent: BaseGunSafeSpawner
@@ -24,7 +24,6 @@
         - GunSafeAdjutantShotgun
 
 - type: entity
-  name: random safe spawner
   suffix: Rifle
   id: RifleSafeSpawner
   parent: BaseGunSafeSpawner
@@ -37,7 +36,6 @@
         - GunSafeM90Rifle
 
 - type: entity
-  name: random safe spawner
   suffix: Handgun
   id: HandgunSafeSpawner
   parent: BaseGunSafeSpawner

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -1,7 +1,7 @@
 - type: entity
-  name: random shotgun safe spawner
-  id: ShotgunSafeSpawner
+  id: BaseGunSafeSpawner
   parent: MarkerBase
+  abstract: true
   components:
     - type: Sprite
       layers:
@@ -9,47 +9,44 @@
         - sprite: Structures/Storage/closet.rsi
           state: shotguncase
     - type: RandomSpawner
+      offset: 0
+
+- type: entity
+  name: random safe spawner
+  suffix: Shotgun
+  id: ShotgunSafeSpawner
+  parent: BaseGunSafeSpawner
+  components:
+    - type: RandomSpawner
       prototypes:
         - GunSafeShotgunEnforcer
         - GunSafeShotgunKammerer
         - GunSafeAdjutantShotgun
-      offset: 0
 
 - type: entity
-  name: random rifle safe spawner
+  name: random safe spawner
+  suffix: Rifle
   id: RifleSafeSpawner
-  parent: MarkerBase
+  parent: BaseGunSafeSpawner
   components:
-    - type: Sprite
-      layers:
-        - state: red
-        - sprite: Structures/Storage/closet.rsi
-          state: shotguncase
     - type: RandomSpawner
       prototypes:
         - GunSafeVulcanRifle
         - GunSafeSubMachineGunDrozd
         - GunSafeRifleLecter
         - GunSafeM90Rifle
-      offset: 0
 
 - type: entity
-  name: random handgun safe spawner
+  name: random safe spawner
+  suffix: Handgun
   id: HandgunSafeSpawner
-  parent: MarkerBase
+  parent: BaseGunSafeSpawner
   components:
-    - type: Sprite
-      layers:
-        - state: red
-        - sprite: Structures/Storage/closet.rsi
-          state: shotguncase
     - type: RandomSpawner
       prototypes:
         - GunSafePistolMk58
-      chance: 0.85
       rarePrototypes:
         - GunSafeEnergyGunMini
         - GunSafePistolUniversal
         - GunSafeSubMachineGunWt550
       rareChance: 0.15
-      offset: 0


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Someone mentioned it in le server meeting, so I decided to add it in. Also adds a filled safe for the M-90 as that's already a thing on Shoko so it's probably fine. The handgun safe has a low chance of spawning with universals, WT550s or miniature energy guns. Miniature guns were also on sub so I assume that's fine too.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Gives security a more varied choice of weapons and adds a random element to the rounds. Kinda cool.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![obraz_2024-07-07_020656080](https://github.com/DeltaV-Station/Delta-v/assets/96891493/6edd1a81-9728-4fff-aae0-eb07ebb3d6f0)

- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added randomized handgun, rifle and shotgun safe spawners for mapping.

