### PR TITLE
fix railing directional construction

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
@@ -7,6 +7,7 @@
         - to: railing
           completed:
             - !type:SnapToGrid
+            # DeltaV: railings no longer forced to face south
           steps:
             - material: MetalRod
               amount: 1
@@ -14,6 +15,7 @@
         - to: railingCorner
           completed:
             - !type:SnapToGrid
+            # DeltaV: railings no longer forced to face south
           steps:
             - material: MetalRod
               amount: 2
@@ -21,6 +23,7 @@
         - to: railingCornerSmall
           completed:
             - !type:SnapToGrid
+            # DeltaV: railings no longer forced to face south
           steps:
             - material: MetalRod
               amount: 1
@@ -28,6 +31,7 @@
         - to: railingRound
           completed:
             - !type:SnapToGrid
+            # DeltaV: railings no longer forced to face south
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
@@ -7,7 +7,7 @@
         - to: railing
           completed:
             - !type:SnapToGrid
-            # DeltaV: railings no longer forced to face south
+            # southRotation: true # Delta-V : Removes forced South Rotation for building railings
           steps:
             - material: MetalRod
               amount: 1
@@ -15,7 +15,7 @@
         - to: railingCorner
           completed:
             - !type:SnapToGrid
-            # DeltaV: railings no longer forced to face south
+            # southRotation: true # Delta-V : Removes forced South Rotation for building railings
           steps:
             - material: MetalRod
               amount: 2
@@ -23,7 +23,7 @@
         - to: railingCornerSmall
           completed:
             - !type:SnapToGrid
-            # DeltaV: railings no longer forced to face south
+            # southRotation: true # Delta-V : Removes forced South Rotation for building railings
           steps:
             - material: MetalRod
               amount: 1
@@ -31,7 +31,7 @@
         - to: railingRound
           completed:
             - !type:SnapToGrid
-            # DeltaV: railings no longer forced to face south
+            # southRotation: true # Delta-V : Removes forced South Rotation for building railings
           steps:
             - material: MetalRod
               amount: 2

--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/railing.yml
@@ -7,7 +7,6 @@
         - to: railing
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 1
@@ -15,7 +14,6 @@
         - to: railingCorner
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 2
@@ -23,7 +21,6 @@
         - to: railingCornerSmall
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 1
@@ -31,7 +28,6 @@
         - to: railingRound
           completed:
             - !type:SnapToGrid
-              southRotation: true
           steps:
             - material: MetalRod
               amount: 2


### PR DESCRIPTION
## About the PR
railings are forced to face "south" for some ungodly reason when you build them so i fixed it 

## Why / Balance
stupid bug

## Technical details
i just removed "southRotation"

## Media

https://github.com/user-attachments/assets/08d8edbe-b544-4f74-93ee-d1ae6b64ffeb

- [X ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
none

**Changelog**

:cl: portfiend
- fix: railings can now be built directionally
