### PR TITLE
Re-add removed security gear + Fix boot knives

### DIFF
--- a/Resources/Locale/en-US/deltav/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/deltav/preferences/loadout-groups.ftl
@@ -62,6 +62,8 @@ loadout-group-station-engineer-neck = Station Engineer neck
 loadout-group-atmospheric-technician-neck = Atmospheric Technician neck
 
 # Security
+loadout-group-head-of-security-shoes = Head of Security shoes
+
 loadout-group-security-eyes = Security eyes
 loadout-group-security-neck = Security neck
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -352,6 +352,7 @@
       - id: BoxPDASecurity # Delta-V
       - id: WeaponEnergyGunMultiphase # DeltaV - HoS Energy Gun
       - id: HoSIDCard # Delta-V
+      - id: ClothingShoesBootsWinterHeadOfSecurity #Delta V: Add departmental winter boots
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
 
@@ -380,6 +381,7 @@
       - id: BoxPDASecurity # Delta-V
       - id: WeaponEnergyGunMultiphase # DeltaV - HoS Energy Gun
       - id: HoSIDCard # Delta-V
+      - id: ClothingShoesBootsWinterHeadOfSecurity #Delta V: Add departmental winter boots
       - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
         prob: 0.3
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -22,6 +22,7 @@
       - id: ClothingOuterHardsuitCombatWarden # DeltaV - ClothingOuterHardsuitWarden replaced in favour of warden's riot combat hardsuit.
       - id: HoloprojectorSecurity
       - id: BoxPDAPrisoner # Delta-V
+      - id: ClothingShoesBootsWinterWarden #Delta V: Add departmental winter boots
       - id: BoxEncryptionKeyPrisoner #Delta-V
       - id: LunchboxSecurityFilledRandom # Delta-v Lunchboxes!
         prob: 0.3
@@ -49,6 +50,7 @@
       - id: DoorRemoteArmory
       - id: HoloprojectorSecurity
       - id: BoxPDAPrisoner # Delta-V
+      - id: ClothingShoesBootsWinterWarden #Delta V: Add departmental winter boots
       - id: BoxEncryptionKeyPrisoner #Delta-V
       - id: LunchboxSecurityFilledRandom # Delta-v Lunchboxes!
         prob: 0.3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -1,19 +1,19 @@
 - type: vendingMachineInventory
   id: DetDrobeInventory
   startingInventory:
-##    ClothingUniformJumpsuitDetective: 2 # DeltaV - set detective uniform
-##    ClothingUniformJumpskirtDetective: 2 # DeltaV - set detective uniform
-    ClothingUniformJumpsuitForensicSpecialist: 2
-    ClothingUniformJumpskirtForensicSpecialist: 2
-##    ClothingShoesColorBrown: 2 # DeltaV -set detective uniform
-##    ClothingOuterCoatDetective: 2 # DeltaV - set detective uniform
-    ClothingOuterStasecCoatDet: 2
-##    ClothingHeadHatFedoraBrown: 2 # DeltaV - set detective uniform
-##    ClothingUniformJumpsuitDetectiveGrey: 2 # DeltaV - set detective uniform
-##    ClothingUniformJumpskirtDetectiveGrey: 2 # DeltaV - set detective uniform
-##    ClothingOuterVestDetective: 2 # DeltaV - set detective uniform
-    ClothingNeckTieDet: 2 # DeltaV - Fuck it, they can keep the tie if they want.
-##    ClothingHeadHatFedoraGrey: 2  # DeltaV - set detective uniform
+    ClothingUniformJumpsuitForensicSpecialist: 2 # DeltaV - station security uniform
+    ClothingUniformJumpskirtForensicSpecialist: 2 # DeltaV - station security uniform
+    ClothingOuterStasecCoatDet: 2 # DeltaV - station security uniform
+    ClothingUniformJumpsuitDetective: 2
+    ClothingUniformJumpskirtDetective: 2
+    ClothingShoesColorBrown: 2
+    ClothingOuterCoatDetective: 2
+    ClothingHeadHatFedoraBrown: 2
+    ClothingUniformJumpsuitDetectiveGrey: 2
+    ClothingUniformJumpskirtDetectiveGrey: 2
+    ClothingOuterVestDetective: 2
+    ClothingNeckTieDet: 2
+    ClothingHeadHatFedoraGrey: 2
     ClothingHandsGlovesColorBlack: 2
     ClothingHandsGlovesLatex: 2
     ClothingHeadsetSecurity: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -26,6 +26,6 @@
     ClothingMaskNeckGaiter: 3 # DeltaV - what could go wrong?
     ClothingShoesBootsJack: 3 # DeltaV - moved it down with the combat boots
     ClothingShoesBootsCombat: 1
-##    ClothingShoesBootsWinterSec: 2 # DeltaV - removed until they fit the uniform
-##    ClothingShoesBootsCowboyBlack: 1 # DeltaV - hearing these things give me a headache.
-##    ClothingHeadHatCowboyBlack: 1 # DeltaV - seeing these things don't give me a headache, but please wear actual uniform.
+    ClothingShoesBootsWinterSec: 2 # DeltaV
+    ClothingShoesBootsCowboyBlack: 1 # DeltaV
+    ClothingHeadHatCowboyBlack: 1 # DeltaV

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -19,10 +19,8 @@
   - Security
   #- Brig #Delta V: Removed brig access
   - Maintenance
-  - Service # The rest of security has this access.
   - External
   - Corpsman
-  - Cryogenics # The rest of security also gets this access.
   extendedAccess:
   - Chemistry
   special:

--- a/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/DeltaV/Roles/Jobs/Security/brigmedic.yml
@@ -30,7 +30,7 @@
 - type: startingGear
   id: CorpsmanGear # see Prototypes/Roles/Jobs/Fun/misc_startinggear.yml for "BrigmedicGear"
   equipment:
-#    eyes: ClothingEyesHudMedical
+#    eyes: ClothingEyesHudMedical # Moved MedHud to loadout
     outerClothing: ClothingOuterCoatLabCorpsman
     id: CorpsmanPDA
     ears: ClothingHeadsetBrigmedic

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1043,7 +1043,7 @@
       - ClothingUniformJumpskirtSecFormal # DeltaV - formal security uniforms
       - ClothingUniformJumpsuitHoSAlt
       - ClothingUniformJumpskirtHoSAlt
-#      - ClothingUniformJumpsuitHoSBlue # DeltaV - Remove erroneous second entry.
+      - ClothingUniformJumpsuitHoSBlue
       - ClothingUniformJumpsuitHoSGrey
       - ClothingUniformJumpsuitHoSParadeMale
       - ClothingUniformJumpskirtHoSParadeMale
@@ -1068,8 +1068,8 @@
       - ClothingUniformJumpsuitMusician
       - ClothingUniformJumpsuitParamedic
       - ClothingUniformJumpskirtParamedic
-#      - ClothingUniformJumpsuitSeniorOfficer # DeltaV - replaced with tactical jumpsuit
-#      - ClothingUniformJumpskirtSeniorOfficer # DeltaV - replaced with tactical jumpsuit
+      - ClothingUniformJumpsuitSeniorOfficer
+      - ClothingUniformJumpskirtSeniorOfficer
       - ClothingUniformJumpsuitPrisoner
       - ClothingUniformJumpskirtPrisoner
       - ClothingHeadHatQMsoft
@@ -1120,8 +1120,8 @@
       - ClothingOuterWinterCE
       - ClothingOuterWinterCMO
       - ClothingOuterWinterHoP
-#      - ClothingOuterWinterHoSUnarmored # DeltaV - replaced in favour of stasec coats
-#      - ClothingOuterWinterWardenUnarmored # DeltaV - replaced in favour of stasec coats
+      - ClothingOuterWinterHoSUnarmored
+      - ClothingOuterWinterWardenUnarmored
       - ClothingOuterWinterQM
       - ClothingOuterWinterRD
       - ClothingOuterChiefJustice # DeltaV - Chief Justice
@@ -1153,7 +1153,7 @@
       - ClothingOuterWinterViro
       - ClothingOuterWinterSci
       - ClothingOuterWinterRobo
-#      - ClothingOuterWinterSec # DeltaV - replaced in favour of stasec coats
+      - ClothingOuterWinterSec
       - ClothingOuterStasecCoat # DeltaV - security winter gear
       - ClothingOuterCoatLabCorpsman # DeltaV - security winter gear
       - ClothingOuterStasecCoatDet # DeltaV - security winter gear

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -3,7 +3,7 @@
   id: ForensicSpecialistBeret
   equipment: ForensicSpecialistBeret
 
-- type: startingGear # DeltaV
+- type: startingGear
   id: ForensicSpecialistBeret
   equipment:
     head: ClothingHeadHatBeretForensicSpecialist

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -1,30 +1,30 @@
 # Head
-#- type: loadout # DeltaV
-#  id: DetectiveFedora
-#  equipment: DetectiveFedora
-
-#- type: startingGear # DeltaV
-#  id: DetectiveFedora
-#  equipment:
-#    head: ClothingHeadHatFedoraBrown
-
-#- type: loadout # DeltaV
-#  id: DetectiveFedoraGrey
-#  equipment: DetectiveFedoraGrey
-
-#- type: startingGear # DeltaV
-#  id: DetectiveFedoraGrey
-#  equipment:
-#    head: ClothingHeadHatFedoraGrey
-
 - type: loadout # DeltaV
-  id: DetectiveBeret
-  equipment: DetectiveBeret
+  id: ForensicSpecialistBeret
+  equipment: ForensicSpecialistBeret
 
 - type: startingGear # DeltaV
-  id: DetectiveBeret
+  id: ForensicSpecialistBeret
   equipment:
     head: ClothingHeadHatBeretForensicSpecialist
+
+- type: loadout
+  id: DetectiveFedora
+  equipment: DetectiveFedora
+
+- type: startingGear
+  id: DetectiveFedora
+  equipment:
+    head: ClothingHeadHatFedoraBrown
+
+- type: loadout
+  id: DetectiveFedoraGrey
+  equipment: DetectiveFedoraGrey
+
+- type: startingGear
+  id: DetectiveFedoraGrey
+  equipment:
+    head: ClothingHeadHatFedoraGrey
 
 # Neck
 - type: loadout
@@ -37,6 +37,24 @@
     neck: ClothingNeckTieDet
 
 # Jumpsuit
+- type: loadout # DeltaV
+  id: ForensicSpecialistJumpsuit
+  equipment: ForensicSpecialistJumpsuit
+
+- type: startingGear
+  id: ForensicSpecialistJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitForensicSpecialist
+
+- type: loadout # DeltaV
+  id: ForensicSpecialistJumpskirt
+  equipment: ForensicSpecialistJumpskirt
+
+- type: startingGear
+  id: ForensicSpecialistJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtForensicSpecialist
+
 - type: loadout
   id: DetectiveJumpsuit
   equipment: DetectiveJumpsuit
@@ -44,7 +62,7 @@
 - type: startingGear
   id: DetectiveJumpsuit
   equipment:
-    jumpsuit: ClothingUniformJumpsuitForensicSpecialist # DeltaV - replace ClothingUniformJumpsuitDetective with an actual uniform
+    jumpsuit: ClothingUniformJumpsuitDetective
 
 - type: loadout
   id: DetectiveJumpskirt
@@ -53,25 +71,25 @@
 - type: startingGear
   id: DetectiveJumpskirt
   equipment:
-    jumpsuit: ClothingUniformJumpskirtForensicSpecialist # DeltaV - replace ClothingUniformJumpskirtDetective with an actual uniform
+    jumpsuit: ClothingUniformJumpskirtDetective
 
-#- type: loadout # DeltaV
-#  id: NoirJumpsuit
-#  equipment: NoirJumpsuit
+- type: loadout # DeltaV
+  id: NoirJumpsuit
+  equipment: NoirJumpsuit
 
-#- type: startingGear # DeltaV
-#  id: NoirJumpsuit
-#  equipment:
-#    jumpsuit: ClothingUniformJumpsuitDetectiveGrey
+- type: startingGear # DeltaV
+  id: NoirJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitDetectiveGrey
 
-#- type: loadout # DeltaV
-#  id: NoirJumpskirt
-#  equipment: NoirJumpskirt
+- type: loadout # DeltaV
+  id: NoirJumpskirt
+  equipment: NoirJumpskirt
 
-#- type: startingGear # DeltaV
-#  id: NoirJumpskirt
-#  equipment:
-#    jumpsuit: ClothingUniformJumpskirtDetectiveGrey
+- type: startingGear # DeltaV
+  id: NoirJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtDetectiveGrey
 
 # Back
 - type: loadout
@@ -102,23 +120,23 @@
     back: ClothingBackpackDuffelSecurityFilledDetective
 
 # OuterClothing
-#- type: loadout # DeltaV
-#  id: DetectiveArmorVest
-#  equipment: DetectiveArmorVest
+- type: loadout # DeltaV
+  id: DetectiveArmorVest
+  equipment: DetectiveArmorVest
 
-#- type: startingGear # DeltaV
-#  id: DetectiveArmorVest
-#  equipment:
-#    outerClothing: ClothingOuterVestDetective
+- type: startingGear # DeltaV
+  id: DetectiveArmorVest
+  equipment:
+    outerClothing: ClothingOuterVestDetective
 
-#- type: loadout # DeltaV
-#  id: DetectiveCoat
-#  equipment: DetectiveCoat
+- type: loadout # DeltaV
+  id: DetectiveCoat
+  equipment: DetectiveCoat
 
-#- type: startingGear # DeltaV
-#  id: DetectiveCoat
-#  equipment:
-#    outerClothing: ClothingOuterCoatDetective
+- type: startingGear # DeltaV
+  id: DetectiveCoat
+  equipment:
+    outerClothing: ClothingOuterCoatDetective
 
 - type: loadout # DeltaV
   id: DetectiveStasecCoat

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -128,24 +128,6 @@
     neck: ClothingNeckMantleHOS
 
 # OuterClothing
-#- type: loadout # DeltaV
-#  id: HeadofSecurityCoat
-#  equipment: HeadofSecurityCoat
-
-#- type: startingGear # DeltaV
-#  id: HeadofSecurityCoat
-#  equipment:
-#    outerClothing: ClothingOuterCoatHoSTrench
-
-#- type: loadout # DeltaV
-#  id: HeadofSecurityWinterCoat
-#  equipment: HeadofSecurityWinterCoat
-
-#- type: startingGear # DeltaV
-#  id: HeadofSecurityWinterCoat
-#  equipment:
-#    outerClothing: ClothingOuterWinterHoS
-
 - type: loadout # DeltaV
   id: HoSStasecCoat
   equipment: HoSStasecCoat
@@ -154,6 +136,24 @@
   id: HoSStasecCoat
   equipment:
     outerClothing: ClothingOuterStasecCoatHoS
+
+- type: loadout # DeltaV
+  id: HeadofSecurityCoat
+  equipment: HeadofSecurityCoat
+
+- type: startingGear # DeltaV
+  id: HeadofSecurityCoat
+  equipment:
+    outerClothing: ClothingOuterCoatHoSTrench
+
+- type: loadout # DeltaV
+  id: HeadofSecurityWinterCoat
+  equipment: HeadofSecurityWinterCoat
+
+- type: startingGear # DeltaV
+  id: HeadofSecurityWinterCoat
+  equipment:
+    outerClothing: ClothingOuterWinterHoS
 
 # Shoes - DeltaV
 - type: loadout # DeltaV

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -154,3 +154,13 @@
   id: HoSStasecCoat
   equipment:
     outerClothing: ClothingOuterStasecCoatHoS
+
+# Shoes - DeltaV
+- type: loadout # DeltaV
+  id: HeadOfSecurityWinterBoots
+  equipment: HeadOfSecurityWinterBoots
+
+- type: startingGear # DeltaV
+  id: HeadOfSecurityWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterHeadOfSecurity

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_cadet.yml
@@ -1,18 +1,18 @@
-# Jumpsuit - DeltaV deprecated
-#- type: loadout
-#  id: RedJumpsuit
-#  equipment: RedJumpsuit
+# Jumpsuit
+- type: loadout
+  id: RedJumpsuit
+  equipment: RedJumpsuit
 
-#- type: startingGear
-#  id: RedJumpsuit
-#  equipment:
-#    jumpsuit: ClothingUniformJumpsuitColorRed
+- type: startingGear
+  id: RedJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorRed
 
-#- type: loadout
-#  id: RedJumpskirt
-#  equipment: RedJumpskirt
+- type: loadout
+  id: RedJumpskirt
+  equipment: RedJumpskirt
 
-#- type: startingGear
-#  id: RedJumpskirt
-#  equipment:
-#    jumpsuit: ClothingUniformJumpskirtColorRed
+- type: startingGear
+  id: RedJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorRed

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -24,14 +24,14 @@
   equipment:
     head: ClothingHeadHelmetBasic
 
-#- type: loadout # DeltaV
-#  id: SecurityHat
-#  equipment: SecurityHat
+- type: loadout # DeltaV
+  id: SecurityHat
+  equipment: SecurityHat
 
-#- type: startingGear # DeltaV
-#  id: SecurityHat
-#  equipment:
-#    head: ClothingHeadHatSecsoft
+- type: startingGear # DeltaV
+  id: SecurityHat
+  equipment:
+    head: ClothingHeadHatSecsoft
 
 - type: loadout
   id: SecurityBeret
@@ -134,6 +134,15 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtSecBlue
 
+- type: loadout # DeltaV
+  id: SecurityJumpsuitTactical
+  equipment: SecurityJumpsuitTactical
+
+- type: startingGear # DeltaV
+  id: SecurityJumpsuitTactical
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSecurityTactical 
+
 - type: loadout
   id: SeniorOfficerJumpsuit
   equipment: SeniorOfficerJumpsuit
@@ -144,19 +153,19 @@
 - type: startingGear
   id: SeniorOfficerJumpsuit
   equipment:
-    jumpsuit: ClothingUniformJumpsuitSecurityTactical # DeltaV - replace ClothingUniformJumpsuitSeniorOfficer
+    jumpsuit: ClothingUniformJumpsuitSeniorOfficer
 
-#- type: loadout # DeltaV
-#  id: SeniorOfficerJumpskirt
-#  equipment: SeniorOfficerJumpskirt
-#  effects:
-#  - !type:GroupLoadoutEffect
-#    proto: SeniorOfficer
+- type: loadout # DeltaV
+  id: SeniorOfficerJumpskirt
+  equipment: SeniorOfficerJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: SeniorOfficer
 
-#- type: startingGear # DeltaV
-#  id: SeniorOfficerJumpskirt
-#  equipment:
-#    jumpsuit: ClothingUniformJumpskirtSeniorOfficer
+- type: startingGear # DeltaV
+  id: SeniorOfficerJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSeniorOfficer
 
 # Back
 - type: loadout
@@ -206,32 +215,32 @@
     belt: ClothingBeltSecurityWebbingFilled
 
 # Outerclothing
-#- type: loadout # DeltaV - deprecated
-#  id: ArmorVest
-#  equipment: ArmorVest
+- type: loadout
+  id: ArmorVest
+  equipment: ArmorVest
 
-#- type: startingGear # DeltaV
-#  id: ArmorVest
-#  equipment:
-#    outerClothing: ClothingOuterArmorBasic
+- type: startingGear
+  id: ArmorVest
+  equipment:
+    outerClothing: ClothingOuterArmorBasic
 
-#- type: loadout # DeltaV - deprecated
-#  id: ArmorVestSlim
-#  equipment: ArmorVestSlim
+- type: loadout
+  id: ArmorVestSlim
+  equipment: ArmorVestSlim
 
-#- type: startingGear # DeltaV
-#  id: ArmorVestSlim
-#  equipment:
-#    outerClothing: ClothingOuterArmorBasicSlim
+- type: startingGear
+  id: ArmorVestSlim
+  equipment:
+    outerClothing: ClothingOuterArmorBasicSlim
 
-#- type: loadout # DeltaV - deprecated
-#  id: SecurityOfficerWintercoat
-#  equipment: SecurityOfficerWintercoat
+- type: loadout # DeltaV - deprecated
+  id: SecurityOfficerWintercoat
+  equipment: SecurityOfficerWintercoat
 
-#- type: startingGear # DeltaV
-#  id: SecurityOfficerWintercoat
-#  equipment:
-#    outerClothing: ClothingOuterWinterSec
+- type: startingGear # DeltaV
+  id: SecurityOfficerWintercoat
+  equipment:
+    outerClothing: ClothingOuterWinterSec
 
 - type: loadout # DeltaV
   id: PlateCarrier
@@ -286,16 +295,16 @@
 - type: startingGear # DeltaV
   id: JackBoots
   equipment:
-    shoes: ClothingShoesBootsJackFilled
+    shoes: ClothingShoesBootsJack
 
-#- type: loadout # DeltaV
-#  id: SecurityWinterBoots
-#  equipment: SecurityWinterBoots
+- type: loadout # DeltaV
+  id: SecurityWinterBoots
+  equipment: SecurityWinterBoots
 
-#- type: startingGear # DeltaV
-#  id: SecurityWinterBoots
-#  equipment:
-#    shoes: ClothingShoesBootsWinterSec
+- type: startingGear # DeltaV
+  id: SecurityWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterSec
 
 # PDA
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -286,7 +286,7 @@
 - type: startingGear
   id: CombatBoots
   equipment:
-    shoes: ClothingShoesBootsCombat
+    shoes: ClothingShoesBootsCombatFilled
 
 - type: loadout # DeltaV
   id: JackBoots
@@ -295,7 +295,7 @@
 - type: startingGear # DeltaV
   id: JackBoots
   equipment:
-    shoes: ClothingShoesBootsJack
+    shoes: ClothingShoesBootsJackFilled
 
 - type: loadout # DeltaV
   id: SecurityWinterBoots

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -73,23 +73,23 @@
     jumpsuit: ClothingUniformJumpskirtWardenBlue
 
 # OuterClothing
-#- type: loadout # DeltaV
-#  id: WardenCoat
-#  equipment: WardenCoat
+- type: loadout # DeltaV
+  id: WardenCoat
+  equipment: WardenCoat
 
-#- type: startingGear # DeltaV
-#  id: WardenCoat
-#  equipment:
-#    outerClothing: ClothingOuterCoatWarden
+- type: startingGear # DeltaV
+  id: WardenCoat
+  equipment:
+    outerClothing: ClothingOuterCoatWarden
 
-#- type: loadout # DeltaV
-#  id: WardenArmoredWinterCoat
-#  equipment: WardenArmoredWinterCoat
+- type: loadout # DeltaV
+  id: WardenArmoredWinterCoat
+  equipment: WardenArmoredWinterCoat
 
-#- type: startingGear # DeltaV
-#  id: WardenArmoredWinterCoat
-#  equipment:
-#    outerClothing: ClothingOuterWinterWarden
+- type: startingGear # DeltaV
+  id: WardenArmoredWinterCoat
+  equipment:
+    outerClothing: ClothingOuterWinterWarden
 
 - type: loadout # DeltaV
   id: WardenStasecCoat

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1179,7 +1179,7 @@
   - DetectiveJumpskirt
   - NoirJumpsuit
   - NoirJumpskirt
- 
+
 - type: loadoutGroup
   id: DetectiveBackpack
   name: loadout-group-detective-backpack
@@ -1198,13 +1198,6 @@
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
   - DetectiveArmorVest
-
-- type: loadoutGroup # DeltaV
-  id: SecurityCadetHead
-  name: loadout-group-security-cadet-head
-  minLimit: 0
-  loadouts:
-  - MimeHead # DeltaV - Red Beret
 
 - type: loadoutGroup # DeltaV
   id: SecurityCadetJumpsuit

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1020,11 +1020,20 @@
   id: HeadofSecurityOuterClothing
   name: loadout-group-head-of-security-outerclothing
   loadouts:
+  - HoSStasecCoat # DeltaV
   - HeadofSecurityCoat
   - HeadofSecurityWinterCoat
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
-  - HoSStasecCoat # DeltaV
+
+- type: loadoutGroup # DeltaV
+  id: HeadOfSecurityShoes
+  name: loadout-group-head-of-security-shoes
+  loadouts:
+  - CombatBoots
+  - JackBoots # DeltaV
+  - SecurityWinterBoots
+  - HeadOfSecurityWinterBoots # DeltaV
 
 - type: loadoutGroup
   id: WardenHead
@@ -1049,11 +1058,11 @@
   id: WardenOuterClothing
   name: loadout-group-warden-outerclothing
   loadouts:
+  - WardenStasecCoat # DeltaV
   - WardenCoat
   - WardenArmoredWinterCoat
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
-  - WardenStasecCoat # DeltaV
 
 - type: loadoutGroup
   id: SecurityHead
@@ -1063,6 +1072,7 @@
   - SecurityHelmet
   - SecurityBeret
   - SecurityHat # DeltaV
+  - MimeHead # DeltaV - Red Beret
 
 # DeltaV - add more options to security officer eyewear.
 
@@ -1111,13 +1121,13 @@
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
   loadouts:
-  - ArmorVest
-  - ArmorVestSlim
-  - SecurityOfficerWintercoat
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
+  - ArmorVestSlim
+  - ArmorVest
   - SecurityOfficerStasecCoat # DeltaV
   - SecurityOfficerStasecSweater # DeltaV
+  - SecurityOfficerWintercoat
 
 - type: loadoutGroup
   id: SecurityShoes
@@ -1183,11 +1193,18 @@
   name: loadout-group-detective-outerclothing
   minLimit: 0
   loadouts:
-  - DetectiveArmorVest
-  - DetectiveCoat
   - DetectiveStasecCoat # DeltaV
+  - DetectiveCoat
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
+  - DetectiveArmorVest
+
+- type: loadoutGroup # DeltaV
+  id: SecurityCadetHead
+  name: loadout-group-security-cadet-head
+  minLimit: 0
+  loadouts:
+  - MimeHead # DeltaV - Red Beret
 
 - type: loadoutGroup # DeltaV
   id: SecurityCadetJumpsuit

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1090,7 +1090,7 @@
   - SecurityJumpskirtBlue # DeltaV
   - SecurityJumpsuitTactical # DeltaV
   - SeniorOfficerJumpsuit
-  - SeniorOfficerJumpskirt # DeltaV
+  - SeniorOfficerJumpskirt
 
 - type: loadoutGroup
   id: SecurityBackpack

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1033,7 +1033,6 @@
   - CombatBoots
   - JackBoots # DeltaV
   - SecurityWinterBoots
-  - HeadOfSecurityWinterBoots # DeltaV
 
 - type: loadoutGroup
   id: WardenHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1179,7 +1179,7 @@
   - DetectiveJumpskirt
   - NoirJumpsuit
   - NoirJumpskirt
-
+ 
 - type: loadoutGroup
   id: DetectiveBackpack
   name: loadout-group-detective-backpack

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1020,8 +1020,8 @@
   id: HeadofSecurityOuterClothing
   name: loadout-group-head-of-security-outerclothing
   loadouts:
-#  - HeadofSecurityCoat # DeltaV
-#  - HeadofSecurityWinterCoat # DeltaV
+  - HeadofSecurityCoat
+  - HeadofSecurityWinterCoat
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
   - HoSStasecCoat # DeltaV
@@ -1049,8 +1049,8 @@
   id: WardenOuterClothing
   name: loadout-group-warden-outerclothing
   loadouts:
-#  - WardenCoat # DeltaV
-#  - WardenArmoredWinterCoat # DeltaV
+  - WardenCoat
+  - WardenArmoredWinterCoat
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
   - WardenStasecCoat # DeltaV
@@ -1062,7 +1062,7 @@
   loadouts:
   - SecurityHelmet
   - SecurityBeret
-#  - SecurityHat # DeltaV
+  - SecurityHat # DeltaV
 
 # DeltaV - add more options to security officer eyewear.
 
@@ -1088,8 +1088,9 @@
   - SecurityJumpskirtGrey
   - SecurityJumpsuitBlue # DeltaV
   - SecurityJumpskirtBlue # DeltaV
+  - SecurityJumpsuitTactical # DeltaV
   - SeniorOfficerJumpsuit
-#  - SeniorOfficerJumpskirt # DeltaV
+  - SeniorOfficerJumpskirt # DeltaV
 
 - type: loadoutGroup
   id: SecurityBackpack
@@ -1110,9 +1111,9 @@
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
   loadouts:
-#  - ArmorVest # DeltaV
-#  - ArmorVestSlim # DeltaV
-#  - SecurityOfficerWintercoat # DeltaV
+  - ArmorVest
+  - ArmorVestSlim
+  - SecurityOfficerWintercoat
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
   - SecurityOfficerStasecCoat # DeltaV
@@ -1125,6 +1126,7 @@
   - CombatBoots
   - JackBoots # DeltaV
   - LaceupShoes # DeltaV
+  - SecurityWinterBoots
 
 - type: loadoutGroup
   id: SecurityPDA
@@ -1145,9 +1147,9 @@
   name: loadout-group-detective-head
   minLimit: 0
   loadouts:
-#  - DetectiveFedora # DeltaV
-#  - DetectiveFedoraGrey # DeltaV
   - DetectiveBeret # DeltaV
+  - DetectiveFedora
+  - DetectiveFedoraGrey
 
 - type: loadoutGroup
   id: DetectiveNeck
@@ -1161,10 +1163,12 @@
   id: DetectiveJumpsuit
   name: loadout-group-detective-jumpsuit
   loadouts:
+  - ForensicSpecialistJumpsuit # DeltaV
+  - ForensicSpecialistJumpskirt # DeltaV
   - DetectiveJumpsuit
   - DetectiveJumpskirt
-#  - NoirJumpsuit # DeltaV
-#  - NoirJumpskirt # DeltaV
+  - NoirJumpsuit
+  - NoirJumpskirt
 
 - type: loadoutGroup
   id: DetectiveBackpack
@@ -1179,18 +1183,18 @@
   name: loadout-group-detective-outerclothing
   minLimit: 0
   loadouts:
-#  - DetectiveArmorVest # DeltaV
-#  - DetectiveCoat # DeltaV
+  - DetectiveArmorVest
+  - DetectiveCoat
   - DetectiveStasecCoat # DeltaV
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV
 
-#- type: loadoutGroup # DeltaV
-#  id: SecurityCadetJumpsuit
-#  name: loadout-group-security-cadet-jumpsuit
-#  loadouts:
-#  - RedJumpsuit
-#  - RedJumpskirt
+- type: loadoutGroup # DeltaV
+  id: SecurityCadetJumpsuit
+  name: loadout-group-security-cadet-jumpsuit
+  loadouts:
+  - RedJumpsuit
+  - RedJumpskirt
 
 # Medical
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1033,6 +1033,7 @@
   - CombatBoots
   - JackBoots # DeltaV
   - SecurityWinterBoots
+  - HeadOfSecurityWinterBoots # DeltaV
 
 - type: loadoutGroup
   id: WardenHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1032,6 +1032,7 @@
   loadouts:
   - CombatBoots
   - JackBoots # DeltaV
+  - LaceupShoes # DeltaV
   - SecurityWinterBoots
   - HeadOfSecurityWinterBoots # DeltaV
 

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1158,7 +1158,7 @@
   name: loadout-group-detective-head
   minLimit: 0
   loadouts:
-  - DetectiveBeret # DeltaV
+  - ForensicSpecialistBeret # DeltaV
   - DetectiveFedora
   - DetectiveFedoraGrey
 

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -281,7 +281,6 @@
   - SecurityBackpack
   - SecurityBelt
   - HeadofSecurityOuterClothing
-  - SecurityShoes
   - HeadOfSecurityShoes # DeltaV
   - Trinkets
 

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -282,6 +282,7 @@
   - SecurityBelt
   - HeadofSecurityOuterClothing
   - SecurityShoes
+  - HeadOfSecurityShoes # DeltaV
   - Trinkets
 
 - type: roleLoadout


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
- Re-adds the removed legacy security gear to loadouts for more customisation.
- - In the interest of not entirely undoing intent, the Station Security line of customisation options have been moved to the top of security loadouts where applicable. Security lockers will also maintain StaSec coats.
- Fixes missing boot knives from combat boots.
- Re-adds winter boots to HoS and Warden lockers.
- Re-adds winter boots and cowboy boots to Secdrobe.
- Removed service / cryogenics access from brigmedic, as this is outdated design.

**IMPORTANT:**
This PR also reverts the removal of Wizden armors. This is a special conversation, but I don't think that a change like this should have been PR'd with a resprite. See below. 

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
A 'resprite' shouldn't involve a net reduction in content as it left quite a few people frustrated, and a few people were especially frustrated over the detective coat 1984 in particular. By removing the opposition's content, you lose the ability to gather metrics/feedback from comparing different sprites in use. Also, Loadouts serve to provide character customisation option to the player, and attempting to standardise security uniform is counter-intuitive to its implementation.

This PR only reverts changes in the last PR, otherwise I'd be hypocritical. However, the situation has raised some questions.

- While removing knives from combat boots was an accident, I do think it's wise to think about making combat knife independent of boot selection. Combat/jackboots are basically mandatory even if you want winter boots.
- We've had Wizden armours in loadouts for a while now, and I think security officers have gotten comfortable using them. They will either need to be resprited / rebalanced / removed in a future PR.
- - I'm all for more options, but the Wizden armours don't align with DeltaV's "specialised armour" design. I'd like to see new stats for either of them - personally I think a 'flak jacket' which reduces explosive damage by 20% would do nicely with breaching charge personalities (me).
- Warden didn't have an option to select winter boots in loadouts beforehand, and thus will not be getting the option in this PR either. I'm happy for TJ to add it if they eventually resprite winter boots like they say, or for anyone else to PR it earlier.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
All YAML

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->
![image](https://github.com/user-attachments/assets/b297a2e7-84ae-4d31-a555-3e2f136d1698)
![image](https://github.com/user-attachments/assets/2eb14147-3893-459a-b782-5626674f30f6)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->
No

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Readded some legacy clothing options to Security loadouts.
- fix: Security officers get their combat knives back.