### PR TITLE
Allows green jumpsuits/hats for service workers

### DIFF
--- a/Resources/Locale/en-US/deltav/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/deltav/preferences/loadout-groups.ftl
@@ -21,6 +21,9 @@ loadout-group-mime-neck = Mime neck
 loadout-group-musician-jumpsuit = Musician jumpsuit
 loadout-group-musician-neck = Musician neck
 
+loadout-group-serviceworker-head = Service Worker head
+loadout-group-serviceworker-jumpsuit = Service Worker jumpsuit
+
 # Logistics
 
 loadout-group-cargo-technician-neck = Cargo Technician neck

--- a/Resources/Prototypes/DeltaV/Loadouts/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/Jobs/Civilian/service_worker.yml
@@ -1,0 +1,65 @@
+# Head
+- type: loadout
+  id: ServiceWorkerCap
+  equipment: ServiceWorkerCap
+
+- type: startingGear
+  id: ServiceWorkerCap
+  equipment:
+    head: ClothingHeadHatGreensoft
+
+- type: loadout
+  id: ServiceWorkerCapFlip
+  equipment: ServiceWorkerCapFlip
+
+- type: startingGear
+  id: ServiceWorkerCapFlip
+  equipment:
+    head: ClothingHeadHatGreensoftFlipped
+
+- type: loadout
+  id: ServiceWorkerBandana
+  equipment: ServiceWorkerBandana
+
+- type: startingGear
+  id: ServiceWorkerBandana
+  equipment:
+    head: ClothingHeadBandGreen
+
+# Jumpsuit
+
+- type: loadout
+  id: ServiceWorkerJumpsuit
+  equipment: ServiceWorkerJumpsuit
+
+- type: startingGear
+  id: ServiceWorkerJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorGreen
+
+- type: loadout
+  id: ServiceWorkerJumpskirt
+  equipment: ServiceWorkerJumpskirt
+
+- type: startingGear
+  id: ServiceWorkerJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorGreen
+
+- type: loadout
+  id: ServiceWorkerJumpsuitDark
+  equipment: ServiceWorkerJumpsuitDark
+
+- type: startingGear
+  id: ServiceWorkerJumpsuitDark
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitColorDarkGreen
+
+- type: loadout
+  id: ServiceWorkerJumpskirtDark
+  equipment: ServiceWorkerJumpskirtDark
+
+- type: startingGear
+  id: ServiceWorkerJumpskirtDark
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtColorDarkGreen

--- a/Resources/Prototypes/DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/loadout_groups.yml
@@ -1,3 +1,27 @@
+# Civilian (actually Service but hey, that's what they called it :shrug:)
+## Service Worker
+- type: loadoutGroup
+  id: ServiceWorkerHead
+  name: loadout-group-serviceworker-head
+  minLimit: 0
+  loadouts:
+  - ServiceWorkerCap
+  - ServiceWorkerCapFlip
+  - ServiceWorkerBandana
+
+- type: loadoutGroup
+  id: ServiceWorkerJumpsuit
+  name: loadout-group-serviceworker-jumpsuit
+  minLimit: 0
+  loadouts:
+  - ServiceWorkerJumpsuit
+  - ServiceWorkerJumpskirt
+  - ServiceWorkerJumpsuitDark
+  - ServiceWorkerJumpskirtDark
+  - BartenderJumpsuit
+  - BartenderJumpskirt
+  - BartenderJumpsuitPurple
+
 # Logistics
 ## Courier
 - type: loadoutGroup

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -55,8 +55,7 @@
   groups:
   - ServiceWorkerHead # DeltaV
   - Scarfs # DeltaV
-  #- BartenderJumpsuit
-  - ServiceWorkerJumpsuit # DeltaV, replaces above
+  - ServiceWorkerJumpsuit # DeltaV, was BartenderJumpsuit
   - CommonBackpack
   - Glasses
   - Trinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -53,8 +53,10 @@
 - type: roleLoadout
   id: JobServiceWorker
   groups:
+  - ServiceWorkerHead # DeltaV
   - Scarfs # DeltaV
-  - BartenderJumpsuit
+  #- BartenderJumpsuit
+  - ServiceWorkerJumpsuit # DeltaV, replaces above
   - CommonBackpack
   - Glasses
   - Trinkets


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Makes them more greem.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Service workers being stuck with bartender outfits suck.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

Adds a new loadout group in the DeltaV space including the previous bartender jumpsuits.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

![image](https://github.com/user-attachments/assets/232eedec-dec0-4c04-9834-4d5e2d8aa5c7)

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

If you don't check your loadout before spawning in as a Service worker you might be naked hee hee

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->
:cl:
- add: Service Workers can now choose green clothes in their loadouts!