### PR TITLE
Fix shuttle windows

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/shuttle.yml
@@ -8,6 +8,9 @@
     sprite: Structures/Windows/shuttle_window.rsi
   - type: Icon
     sprite: Structures/Windows/shuttle_window.rsi
+  - type: Repairable
+    fuelCost: 15
+    doAfterDelay: 3
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: RGlass
@@ -38,6 +41,9 @@
         acts: [ "Destruction" ]
   - type: IconSmooth
     base: swindow
+  - type: Construction
+    graph: Window
+    node: shuttleWindow
   - type: Appearance
   - type: DamageVisuals
     thresholds: [4, 8, 12]
@@ -46,7 +52,7 @@
     damageOverlay:
       sprite: Structures/Windows/cracks.rsi
   - type: StaticPrice
-    price: 75
+    price: 100
 
 - type: entity
   parent: ShuttleWindow


### PR DESCRIPTION
## About the PR
fixes [#1518](https://github.com/DeltaV-Station/Delta-v/issues/1518)

## Why / Balance
These were merged wrong from upstream a long time ago because we had some inherited stuff from Nyano. This brings them in-line with upstream and fixes the issue linked above.

**Changelog**
:cl: Velcroboy
- fix: Fixed shuttle windows being too easy to deconstruct