### PR TITLE
Expands Borg Construction Steps

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/armor.yml
@@ -22,6 +22,9 @@
   - type: ExplosionResistance # More protective against explosives than you think. Helps in preventing all those vital organs from jiggling around o.o
     damageCoefficient: 0.70
   - type: AllowSuitStorage
+  - type: Tag
+    tags:
+      - BorgSecurityArmour
 
 #Alternate / slim basic armor vest replacement
 - type: entity
@@ -44,6 +47,9 @@
   - type: ExplosionResistance # Better than nothing against a blast or shockwave.
     damageCoefficient: 0.90
   - type: AllowSuitStorage
+  - type: Tag
+    tags:
+      - BorgSecurityArmour
 
 - type: entity
   parent: ClothingOuterBaseLarge
@@ -69,3 +75,7 @@
     damageCoefficient: 0.80
   - type: GroupExamine
   - type: AllowSuitStorage
+  - type: Tag
+    tags:
+      - BorgSecurityArmour
+      - WhitelistChameleon # Inherited from Parent

--- a/Resources/Prototypes/DeltaV/tags.yml
+++ b/Resources/Prototypes/DeltaV/tags.yml
@@ -11,7 +11,7 @@
 
 - type: Tag
   id: CartridgeSpecial # For the .38 special ammo and revolver
-  
+
 - type: Tag
   id: CartridgeMusket #For the Craftable Musket
 
@@ -38,10 +38,10 @@
 
 - type: Tag
   id: MagazinePistolSpecial # For the .38 special ammo and pistol
-  
+
 - type: Tag
   id: ModularBreech #Craftable Musket
-  
+
 - type: Tag
   id: ModularTrigger #Craftable Musket
 
@@ -68,18 +68,21 @@
 
 - type: Tag
   id: BorgSecurityTorso
-  
+
 - type: Tag
   id: BorgSecurityRLeg
-  
+
 - type: Tag
   id: BorgSecurityLLeg
-  
+
 - type: Tag
   id: BorgSecurityRArm
 
 - type: Tag
   id: BorgSecurityLArm
-  
+
 - type: Tag
   id: Skirt
+
+- type: Tag
+  id: BorgSecurityArmour

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -209,7 +209,7 @@
 
       - material: Plasteel
         amount: 2
-        doafter: 1
+        doAfter: 1
         store: part-container
 
       - tool: Welding
@@ -219,11 +219,11 @@
         name: one of security's armour vests
         store: part-container
         icon:
-          sprite: DeltaV/Clothing/OuterClothing/Armor/platercarrier.rsi
+          sprite: DeltaV/Clothing/OuterClothing/Armor/platecarrier.rsi
           state: icon
 
       - tool: Cutting
-        doafter: 1
+        doAfter: 1
 
       - tool: Welding
         doAfter: 2 # Delta-V : End

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/cyborg.yml
@@ -205,7 +205,28 @@
           state: flash
 
       - tool: Screwing
-        doAfter: 2 # Delta-V Security Borg End
+        doAfter: 2
+
+      - material: Plasteel
+        amount: 2
+        doafter: 1
+        store: part-container
+
+      - tool: Welding
+        doAfter: 2
+
+      - tag: BorgSecurityArmour
+        name: one of security's armour vests
+        store: part-container
+        icon:
+          sprite: DeltaV/Clothing/OuterClothing/Armor/platercarrier.rsi
+          state: icon
+
+      - tool: Cutting
+        doafter: 1
+
+      - tool: Welding
+        doAfter: 2 # Delta-V : End
 
   - node: cyborg
     entity: BorgChassisGeneric


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Adds extra steps; adding a use for Plasteel and requiring a Security Vest to be used in the construction.

This stops Epi getting free emag food (and hence Security Access).
It was something intended to be originally shipped with the Borg but I had to look into the range of what I could do with Construction Graphs to see the options before I wanted to commit to a certain way of doing it

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

This stops Epi getting free emag food (and hence Security Access).

**Changelog**
:cl: DangerRevolution
- tweak: Construction of Security Cyborgs now requires extra steps.