### PR TITLE
Ports #576 from Einstein Engines : "Restore HoP as a functional job"

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -3,8 +3,19 @@
   startingInventory:
     PassengerPDA: 5
     ClearPDA: 5
-# Begin Delta-V additions
-    ServiceWorkerPDA: 2
+  # Basic Department PDAs
+    SecurityPDA: 2
+    SecurityCadetPDA: 4
+    MedicalPDA: 2
+    MedicalInternPDA: 4
+    EngineerPDA: 2
+    TechnicalAssistantPDA: 4
+    SciencePDA: 2
+    ResearchAssistantPDA: 4
+    CargoPDA: 2
+    SalvagePDA: 2
+  # HOP's service department
+    ServiceWorkerPDA: 4
     ChefPDA: 2
     BotanistPDA: 2
     BartenderPDA: 2
@@ -17,18 +28,18 @@
     ClownPDA: 1
     MimePDA: 1
     MusicianPDA: 1
-# End Delta-V additions
-    PassengerIDCard: 5
     ClothingHeadsetGrey: 5
-    ClothingHeadsetService: 5 # Delta-V
+    ClothingHeadsetService: 4
+    ClothingHeadsetCargo: 2
+    ClothingHeadsetEngineering: 2
+    ClothingHeadsetMedical: 2
+    ClothingHeadsetScience: 2
     RubberStampApproved: 1
     RubberStampDenied: 1
     Paper: 10
-# Begin Delta-V subtractions
-  #  EncryptionKeyCargo: 2
-  #  EncryptionKeyEngineering: 2
-  #  EncryptionKeyMedical: 2
-  #  EncryptionKeyScience: 2
-  #  EncryptionKeySecurity: 1
-# End Delta-V subtractions
-    EncryptionKeyService: 3
+    EncryptionKeyCargo: 2
+    EncryptionKeyEngineering: 2
+    EncryptionKeyMedical: 2
+    EncryptionKeyScience: 2
+    EncryptionKeySecurity: 2
+    EncryptionKeyService: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -3,7 +3,7 @@
   startingInventory:
     PassengerPDA: 5
     ClearPDA: 5
-  # Basic Department PDAs
+  # Basic Department PDAs # Einstein Engines : Start
     SecurityPDA: 2
     SecurityCadetPDA: 4
     MedicalPDA: 2
@@ -15,7 +15,7 @@
     CargoPDA: 2
     SalvagePDA: 2
   # HOP's service department
-    ServiceWorkerPDA: 4
+    ServiceWorkerPDA: 4 # Einstein Engines : End
     ChefPDA: 2
     BotanistPDA: 2
     BartenderPDA: 2
@@ -29,17 +29,17 @@
     MimePDA: 1
     MusicianPDA: 1
     ClothingHeadsetGrey: 5
-    ClothingHeadsetService: 4
+    ClothingHeadsetService: 4 # Einstein Engines : Start
     ClothingHeadsetCargo: 2
     ClothingHeadsetEngineering: 2
     ClothingHeadsetMedical: 2
-    ClothingHeadsetScience: 2
+    ClothingHeadsetScience: 2 # Einstein Engines : End
     RubberStampApproved: 1
     RubberStampDenied: 1
     Paper: 10
-    EncryptionKeyCargo: 2
+    EncryptionKeyCargo: 2 # Einstein Engines : Start
     EncryptionKeyEngineering: 2
     EncryptionKeyMedical: 2
     EncryptionKeyScience: 2
     EncryptionKeySecurity: 2
-    EncryptionKeyService: 4
+    EncryptionKeyService: 4 # Einstein Engines : End

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -16,7 +16,7 @@
     SalvagePDA: 2
   # HOP's service department
     ServiceWorkerPDA: 4 # Einstein Engines : End
-    ChefPDA: 2
+    ChefPDA: 2 # Delta-V : Start
     BotanistPDA: 2
     BartenderPDA: 2
     JanitorPDA: 2
@@ -27,7 +27,7 @@
     BoxerPDA: 1
     ClownPDA: 1
     MimePDA: 1
-    MusicianPDA: 1
+    MusicianPDA: 1 # Delta-V : End
     ClothingHeadsetGrey: 5
     ClothingHeadsetService: 4 # Einstein Engines : Start
     ClothingHeadsetCargo: 2

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -52,6 +52,7 @@
 #  - Lawyer # Lawyer is now part of the justice dept
 
 #  - Cargo (( UP FOR DISCUSSION - ORIGINAL PR HAS THIS ))
+#  - Justice (( DELTA-RELATED CHANGE - UP FOR DISCUSSION ))
 
 #  - Atmospherics
 #  - Medical

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -50,7 +50,9 @@
 #  - Security # NoooOoOo!! My HoPcurity!1
 #  - Brig
 #  - Lawyer # Lawyer is now part of the justice dept
-#  - Cargo
+
+#  - Cargo (( UP FOR DISCUSSION - ORIGINAL PR HAS THIS ))
+
 #  - Atmospherics
 #  - Medical
   - Boxer # DeltaV - Add Boxer access


### PR DESCRIPTION
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Adds PDAs into HoPvend, while retaining their loss of access.

This lets HoP hire staff through the vend, without allowing them to roam freely (as the original concern in the revert).

While HoPs may be able to (with care) juggle IDs and give themselves access (although they risk wiping their ID if they misclick).  The fact that they do not innately have departmental accesses means they would be weirdly trespassing anywhere they walk in. They would be the same as a Scientist walking into Security with Security access on their ID, their only defence would be the meta-knowledge that Heads cannot be antags, which is outside the scope of this PR.

## Media

- [ X ] I have added screenshots/videos to this PR showcasing its changes ingame

![image](https://github.com/user-attachments/assets/601cee43-f23a-4119-9e5a-e7f987fbd6d8)

**Changelog**

:cl: DangerRevolution, OldDanceJacket, VMSolidus
- add: Restored HoP's ability to hire departmental staff.