### PR TITLE
Remove Security Borg's inventory slots until rework

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -59,4 +59,4 @@
       state: peace
     name: Security Cyborg
   - type: Inventory
-    templateId: borgNull
+    templateId: borgZero

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -58,3 +58,5 @@
       sprite: Mobs/Silicon/chassis.rsi
       state: peace
     name: Security Cyborg
+  - type: Inventory
+    templateId: null

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -59,4 +59,4 @@
       state: peace
     name: Security Cyborg
   - type: Inventory
-    templateId: null
+    templateId: borgNull

--- a/Resources/Prototypes/DeltaV/InventoryTemplates/borgnull.yml
+++ b/Resources/Prototypes/DeltaV/InventoryTemplates/borgnull.yml
@@ -1,0 +1,3 @@
+- type: inventoryTemplate
+  id: borgNull
+  slots: null

--- a/Resources/Prototypes/DeltaV/InventoryTemplates/borgnull.yml
+++ b/Resources/Prototypes/DeltaV/InventoryTemplates/borgnull.yml
@@ -1,3 +1,3 @@
 - type: inventoryTemplate
-  id: borgNull
+  id: borgZero
   slots: null


### PR DESCRIPTION
## About the PR
<!-- What did you change in this PR? -->
Title
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
I am reworking it soon, and putting hats over hats is insanely ugly and people should not do that.

**Changelog**
:cl: DangerRevolution
- remove: Removed Security Borgs' inventory slots until an upcoming clothing rework for them.
