### PR TITLE
remove noobtraps from hive

### DIFF
--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -319,7 +319,7 @@ entities:
           version: 6
         -4,1:
           ind: -4,1
-          tiles: fAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAABXAAAAAACXAAAAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAADXAAAAAABXAAAAAAAXAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAABXAAAAAADXAAAAAACXAAAAAABMwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAACXAAAAAADXAAAAAACXAAAAAADMwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAADXAAAAAADXAAAAAAAMwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAA
+          tiles: fAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAABXAAAAAACXAAAAAABfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAADXAAAAAABXAAAAAAAXAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAABXAAAAAADXAAAAAACXAAAAAABMwAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAACXAAAAAADXAAAAAACXAAAAAADMwAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAADXAAAAAADXAAAAAAAMwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAA
           version: 6
         -3,1:
           ind: -3,1
@@ -463,7 +463,7 @@ entities:
           version: 6
         -6,0:
           ind: -6,0
-          tiles: fAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: fAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAewAAAAAAfAAAAAAAewAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         -6,-1:
           ind: -6,-1
@@ -581,12 +581,6 @@ entities:
             4450: 12,-42
             4451: 12,-44
             4452: 12,-46
-        - node:
-            color: '#0000FBFF'
-            id: ArrowsGreyscale
-          decals:
-            4296: -52.228264,22.926834
-            4297: -51.759514,22.91641
         - node:
             angle: -7.853981633974483 rad
             color: '#52B4E996'
@@ -4184,14 +4178,10 @@ entities:
             4893: -92,11
             4894: -95,8
             4895: -92,8
-            4896: -88,8
             4897: -84,8
             4898: -81,8
-            4899: -84,4
-            4900: -92,4
             4901: -95,0
             4902: -92,0
-            4903: -88,0
             4904: -84,0
             4905: -81,0
             4906: -84,-3
@@ -14453,66 +14443,58 @@ entities:
         - DoorStatus: DoorBolt
 - proto: AirlockExternalGlassCargoLocked
   entities:
-  - uid: 2866
-    components:
-    - type: Transform
-      pos: -39.5,-35.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 324
-      - 248
-    - type: DeviceLinkSource
-      linkedPorts:
-        248:
-        - DoorStatus: DoorBolt
-        324:
-        - DoorStatus: DoorBolt
-  - uid: 5071
-    components:
-    - type: Transform
-      pos: -43.5,-40.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 25592
-      - 25586
-    - type: DeviceLinkSource
-      linkedPorts:
-        25586:
-        - DoorStatus: DoorBolt
-        25592:
-        - DoorStatus: DoorBolt
-  - uid: 5073
+  - uid: 273
     components:
     - type: Transform
       pos: -42.5,-40.5
       parent: 1
     - type: DeviceLinkSink
+      invokeCounter: 1
       links:
-      - 25592
-      - 25586
+      - 28398
     - type: DeviceLinkSource
       linkedPorts:
-        25592:
-        - DoorStatus: DoorBolt
-        25586:
-        - DoorStatus: DoorBolt
-  - uid: 8487
+        28397:
+        - DoorStatus: InputB
+  - uid: 274
     components:
     - type: Transform
-      pos: -38.5,-35.5
+      pos: -43.5,-40.5
       parent: 1
     - type: DeviceLinkSink
+      invokeCounter: 1
       links:
-      - 324
-      - 248
+      - 28398
     - type: DeviceLinkSource
       linkedPorts:
-        248:
-        - DoorStatus: DoorBolt
-        324:
-        - DoorStatus: DoorBolt
+        28397:
+        - DoorStatus: InputA
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -42.5,-43.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 28397
+    - type: DeviceLinkSource
+      linkedPorts:
+        28398:
+        - DoorStatus: InputB
+  - uid: 300
+    components:
+    - type: Transform
+      pos: -43.5,-43.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 28397
+    - type: DeviceLinkSource
+      linkedPorts:
+        28398:
+        - DoorStatus: InputA
   - uid: 16211
     components:
     - type: Transform
@@ -14533,36 +14515,6 @@ entities:
     - type: Transform
       pos: 64.5,-31.5
       parent: 1
-  - uid: 25586
-    components:
-    - type: Transform
-      pos: -43.5,-43.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 5071
-      - 5073
-    - type: DeviceLinkSource
-      linkedPorts:
-        5073:
-        - DoorStatus: DoorBolt
-        5071:
-        - DoorStatus: DoorBolt
-  - uid: 25592
-    components:
-    - type: Transform
-      pos: -42.5,-43.5
-      parent: 1
-    - type: DeviceLinkSink
-      links:
-      - 5071
-      - 5073
-    - type: DeviceLinkSource
-      linkedPorts:
-        5073:
-        - DoorStatus: DoorBolt
-        5071:
-        - DoorStatus: DoorBolt
 - proto: AirlockExternalGlassEngineeringLocked
   entities:
   - uid: 11935
@@ -15045,6 +14997,34 @@ entities:
       linkedPorts:
         4140:
         - DoorStatus: DoorBolt
+- proto: AirlockExternalGlassSalvageLocked
+  entities:
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -39.5,-35.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 28400
+    - type: DeviceLinkSource
+      linkedPorts:
+        28399:
+        - DoorStatus: InputA
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -38.5,-35.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+      links:
+      - 28400
+    - type: DeviceLinkSource
+      linkedPorts:
+        28399:
+        - DoorStatus: InputB
 - proto: AirlockExternalGlassShuttleArrivals
   entities:
   - uid: 9169
@@ -16454,36 +16434,32 @@ entities:
       parent: 1
 - proto: AirlockSalvageGlassLocked
   entities:
-  - uid: 248
+  - uid: 303
     components:
     - type: Transform
       pos: -38.5,-31.5
       parent: 1
     - type: DeviceLinkSink
+      invokeCounter: 1
       links:
-      - 8487
-      - 2866
+      - 28399
     - type: DeviceLinkSource
       linkedPorts:
-        2866:
-        - DoorStatus: DoorBolt
-        8487:
-        - DoorStatus: DoorBolt
-  - uid: 324
+        28400:
+        - DoorStatus: InputB
+  - uid: 305
     components:
     - type: Transform
       pos: -39.5,-31.5
       parent: 1
     - type: DeviceLinkSink
+      invokeCounter: 1
       links:
-      - 8487
-      - 2866
+      - 28399
     - type: DeviceLinkSource
       linkedPorts:
-        2866:
-        - DoorStatus: DoorBolt
-        8487:
-        - DoorStatus: DoorBolt
+        28400:
+        - DoorStatus: InputA
 - proto: AirlockSalvageLocked
   entities:
   - uid: 5058
@@ -42961,31 +42937,6 @@ entities:
     - type: Transform
       pos: -70.5,1.5
       parent: 1
-  - uid: 14940
-    components:
-    - type: Transform
-      pos: -75.5,4.5
-      parent: 1
-  - uid: 14965
-    components:
-    - type: Transform
-      pos: -74.5,4.5
-      parent: 1
-  - uid: 15069
-    components:
-    - type: Transform
-      pos: -73.5,4.5
-      parent: 1
-  - uid: 15758
-    components:
-    - type: Transform
-      pos: -72.5,4.5
-      parent: 1
-  - uid: 15926
-    components:
-    - type: Transform
-      pos: -71.5,4.5
-      parent: 1
   - uid: 15953
     components:
     - type: Transform
@@ -44445,6 +44396,11 @@ entities:
     components:
     - type: Transform
       pos: -17.5,-19.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: -75.5,4.5
       parent: 1
   - uid: 615
     components:
@@ -51141,6 +51097,16 @@ entities:
     - type: Transform
       pos: 105.5,29.5
       parent: 1
+  - uid: 28393
+    components:
+    - type: Transform
+      pos: -74.5,4.5
+      parent: 1
+  - uid: 28394
+    components:
+    - type: Transform
+      pos: -73.5,4.5
+      parent: 1
 - proto: CableMVStack
   entities:
   - uid: 16313
@@ -51282,6 +51248,11 @@ entities:
       parent: 1
 - proto: CarbonDioxideCanister
   entities:
+  - uid: 2499
+    components:
+    - type: Transform
+      pos: -42.5,28.5
+      parent: 1
   - uid: 2503
     components:
     - type: Transform
@@ -51291,11 +51262,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,42.5
-      parent: 1
-  - uid: 23418
-    components:
-    - type: Transform
-      pos: -43.5,31.5
       parent: 1
 - proto: CargoPallet
   entities:
@@ -62491,12 +62457,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -83.5,8.5
-      parent: 1
-  - uid: 24534
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -83.5,4.5
       parent: 1
   - uid: 24535
     components:
@@ -82912,7 +82872,7 @@ entities:
       pos: -45.5,24.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#B266FFFF'
+      color: '#FF1212FF'
   - uid: 392
     components:
     - type: Transform
@@ -82983,14 +82943,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 273
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -47.5,24.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#B266FFFF'
   - uid: 5577
     components:
     - type: Transform
@@ -83061,17 +83013,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#B266FFFF'
-  - uid: 305
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -53.5,24.5
-      parent: 1
-    - type: GasMixer
-      inletTwoConcentration: 0.20999998
-      inletOneConcentration: 0.79
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 314
     components:
     - type: Transform
@@ -83080,16 +83021,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF6666FF'
-- proto: GasMixerFlipped
-  entities:
-  - uid: 303
+  - uid: 323
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -48.5,27.5
+      pos: -51.5,24.5
       parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.20999998
+      inletOneConcentration: 0.79
+      targetPressure: 4500
     - type: AtmosPipeColor
-      color: '#B266FFFF'
+      color: '#03FCD3FF'
+- proto: GasMixerFlipped
+  entities:
   - uid: 315
     components:
     - type: Transform
@@ -83098,17 +83042,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#B266FFFF'
-  - uid: 326
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -50.5,22.5
-      parent: 1
-    - type: GasMixer
-      inletTwoConcentration: 0
-      inletOneConcentration: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 6481
     components:
     - type: Transform
@@ -83262,7 +83195,7 @@ entities:
   - uid: 333
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: 3.141592653589793 rad
       pos: -53.5,22.5
       parent: 1
     - type: AtmosPipeColor
@@ -83353,22 +83286,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#33FF33FF'
-  - uid: 274
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -47.5,23.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 276
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -48.5,24.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#B266FFFF'
   - uid: 299
     components:
     - type: Transform
@@ -83384,14 +83301,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#B266FFFF'
-  - uid: 306
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -51.5,24.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF6666FF'
   - uid: 320
     components:
     - type: Transform
@@ -83400,22 +83309,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF6666FF'
-  - uid: 327
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -50.5,23.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 330
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -54.5,24.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 407
     components:
     - type: Transform
@@ -83881,6 +83774,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 8487
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -40.5,23.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 9860
     components:
     - type: Transform
@@ -83926,6 +83827,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 10826
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -51.5,22.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 10865
     components:
     - type: Transform
@@ -86979,6 +86888,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 25592
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -53.5,24.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#3399FFFF'
   - uid: 25973
     components:
     - type: Transform
@@ -87454,6 +87371,22 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 28395
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -46.5,23.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 28396
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -46.5,24.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
 - proto: GasPipeFourway
   entities:
   - uid: 10396
@@ -87766,14 +87699,22 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#B266FFFF'
+  - uid: 306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -45.5,23.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 308
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -52.5,24.5
+      rot: -1.5707963267948966 rad
+      pos: -44.5,23.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#FF6666FF'
+      color: '#FF1212FF'
   - uid: 309
     components:
     - type: Transform
@@ -87788,6 +87729,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#3399FFFF'
+  - uid: 312
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -43.5,23.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 313
     components:
     - type: Transform
@@ -87831,22 +87780,31 @@ entities:
   - uid: 321
     components:
     - type: Transform
-      pos: -48.5,25.5
+      rot: -1.5707963267948966 rad
+      pos: -42.5,23.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#B266FFFF'
+      color: '#FF1212FF'
   - uid: 322
     components:
     - type: Transform
-      pos: -48.5,26.5
+      rot: -1.5707963267948966 rad
+      pos: -41.5,23.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#B266FFFF'
-  - uid: 323
+      color: '#FF1212FF'
+  - uid: 326
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -46.5,24.5
+      pos: -40.5,27.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 330
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -48.5,27.5
       parent: 1
     - type: AtmosPipeColor
       color: '#B266FFFF'
@@ -88357,11 +88315,10 @@ entities:
   - uid: 1044
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -48.5,23.5
+      pos: -51.5,23.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#0335FCFF'
+      color: '#03FCD3FF'
   - uid: 1188
     components:
     - type: Transform
@@ -88774,6 +88731,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 2498
+    components:
+    - type: Transform
+      pos: -40.5,28.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 2502
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -53.5,25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#3399FFFF'
   - uid: 2712
     components:
     - type: Transform
@@ -88953,6 +88925,13 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -2.5,46.5
       parent: 1
+  - uid: 5073
+    components:
+    - type: Transform
+      pos: -40.5,29.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 5347
     components:
     - type: Transform
@@ -89070,6 +89049,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 6377
+    components:
+    - type: Transform
+      pos: -40.5,30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 6461
     components:
     - type: Transform
@@ -89446,14 +89432,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 10826
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -40.5,31.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 10827
     components:
     - type: Transform
@@ -101587,6 +101565,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 14965
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -51.5,25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF6666FF'
   - uid: 14971
     components:
     - type: Transform
@@ -108334,6 +108320,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 23418
+    components:
+    - type: Transform
+      pos: -40.5,26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 23582
     components:
     - type: Transform
@@ -109165,6 +109158,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 24534
+    components:
+    - type: Transform
+      pos: -40.5,25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 24797
     components:
     - type: Transform
@@ -110047,6 +110047,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 25586
+    components:
+    - type: Transform
+      pos: -40.5,24.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 25618
     components:
     - type: Transform
@@ -110223,6 +110230,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 25758
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -52.5,24.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#3399FFFF'
   - uid: 25807
     components:
     - type: Transform
@@ -113753,14 +113768,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#33FF33FF'
-  - uid: 277
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -49.5,23.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 297
     components:
     - type: Transform
@@ -115667,6 +115674,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 14940
+    components:
+    - type: Transform
+      pos: -40.5,31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 14942
     components:
     - type: Transform
@@ -117104,6 +117118,8 @@ entities:
     - type: Transform
       pos: -51.5,28.5
       parent: 1
+    - type: GasPressurePump
+      targetPressure: 4500
     - type: AtmosPipeColor
       color: '#FF6666FF'
   - uid: 296
@@ -117111,6 +117127,8 @@ entities:
     - type: Transform
       pos: -53.5,28.5
       parent: 1
+    - type: GasPressurePump
+      targetPressure: 4500
     - type: AtmosPipeColor
       color: '#3399FFFF'
   - uid: 335
@@ -117132,6 +117150,16 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -61.5,31.5
       parent: 1
+  - uid: 935
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -50.5,22.5
+      parent: 1
+    - type: GasPressurePump
+      targetPressure: 300
+    - type: AtmosPipeColor
+      color: '#03FCD3FF'
   - uid: 5064
     components:
     - type: Transform
@@ -117140,14 +117168,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 6377
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -51.5,22.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 8657
     components:
     - type: Transform
@@ -117232,14 +117252,6 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#B266FFFF'
-  - uid: 300
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -53.5,25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#3399FFFF'
   - uid: 307
     components:
     - type: Transform
@@ -117260,14 +117272,6 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#3399FFFF'
-  - uid: 312
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -51.5,25.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF6666FF'
   - uid: 384
     components:
     - type: Transform
@@ -131039,6 +131043,92 @@ entities:
     - type: Transform
       pos: -38.376858,-14.443105
       parent: 1
+- proto: LogicGate
+  entities:
+  - uid: 28397
+    components:
+    - type: Transform
+      anchored: True
+      rot: -1.5707963267948966 rad
+      pos: -42.5,-41.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 2
+      links:
+      - 274
+      - 273
+    - type: DeviceLinkSource
+      linkedPorts:
+        300:
+        - Output: DoorBolt
+        277:
+        - Output: DoorBolt
+    - type: Physics
+      canCollide: False
+      bodyType: Static
+  - uid: 28398
+    components:
+    - type: Transform
+      anchored: True
+      rot: 1.5707963267948966 rad
+      pos: -42.5,-42.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 2
+      links:
+      - 300
+      - 277
+    - type: DeviceLinkSource
+      linkedPorts:
+        274:
+        - Output: DoorBolt
+        273:
+        - Output: DoorBolt
+    - type: Physics
+      canCollide: False
+      bodyType: Static
+  - uid: 28399
+    components:
+    - type: Transform
+      anchored: True
+      rot: 1.5707963267948966 rad
+      pos: -38.5,-34.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 2
+      links:
+      - 248
+      - 276
+    - type: DeviceLinkSource
+      linkedPorts:
+        305:
+        - Output: DoorBolt
+        303:
+        - Output: DoorBolt
+    - type: Physics
+      canCollide: False
+      bodyType: Static
+  - uid: 28400
+    components:
+    - type: Transform
+      anchored: True
+      rot: -1.5707963267948966 rad
+      pos: -38.5,-32.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 2
+      links:
+      - 305
+      - 303
+    - type: DeviceLinkSource
+      linkedPorts:
+        248:
+        - Output: DoorBolt
+        276:
+        - Output: DoorBolt
+    - type: Physics
+      canCollide: False
+      bodyType: Static
 - proto: LootSpawnerCableCoil
   entities:
   - uid: 26875
@@ -132632,10 +132722,10 @@ entities:
       parent: 1
 - proto: NitrogenCanister
   entities:
-  - uid: 2499
+  - uid: 327
     components:
     - type: Transform
-      pos: -51.5,31.5
+      pos: -50.5,28.5
       parent: 1
   - uid: 4333
     components:
@@ -132878,10 +132968,10 @@ entities:
     - type: InsideEntityStorage
 - proto: OxygenCanister
   entities:
-  - uid: 2498
+  - uid: 2866
     components:
     - type: Transform
-      pos: -53.5,31.5
+      pos: -52.5,28.5
       parent: 1
   - uid: 4332
     components:
@@ -133667,29 +133757,6 @@ entities:
 
 
         -CentComm Logistics Administration
-  - uid: 25758
-    components:
-    - type: Transform
-      pos: -54.64198,24.30191
-      parent: 1
-    - type: Paper
-      content: >-
-        Engineering Work Order: #34671
-
-
-        Details: Fix faulty vacuum seals
-
-
-        Observations: Seals were cracked and missing in some corners. Atmos technicians were circumventing the air chamber as a quick fix negating the potential for hull breach mitigation.
-
-
-        Work Completed: Replaced faulty or missing seals and repressurized. Vacuum tested and works as intended now.
-
-
-        Assigned Technician: Araston DePlois
-
-
-        Additional Notes: Bypassing the air chamber should no longer be necessary and should only be done under certain circumstances as extra pressure in the chamber is intended to help mitigate instances of significant spacings.
 - proto: PaperBin
   entities:
   - uid: 5810
@@ -134539,6 +134606,13 @@ entities:
     components:
     - type: Transform
       pos: -54.5,29.5
+      parent: 1
+- proto: PlasmaCanister
+  entities:
+  - uid: 15758
+    components:
+    - type: Transform
+      pos: -46.5,28.5
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
@@ -155167,20 +155241,10 @@ entities:
       parent: 1
 - proto: StorageCanister
   entities:
-  - uid: 935
-    components:
-    - type: Transform
-      pos: -49.5,31.5
-      parent: 1
   - uid: 1012
     components:
     - type: Transform
       pos: -4.5,26.5
-      parent: 1
-  - uid: 2502
-    components:
-    - type: Transform
-      pos: -45.5,31.5
       parent: 1
   - uid: 3683
     components:
@@ -155201,6 +155265,11 @@ entities:
     components:
     - type: Transform
       pos: -30.5,-29.5
+      parent: 1
+  - uid: 5071
+    components:
+    - type: Transform
+      pos: -48.5,28.5
       parent: 1
   - uid: 6087
     components:
@@ -155241,6 +155310,11 @@ entities:
     components:
     - type: Transform
       pos: -13.5,26.5
+      parent: 1
+  - uid: 15926
+    components:
+    - type: Transform
+      pos: -44.5,28.5
       parent: 1
   - uid: 15992
     components:
@@ -181070,6 +181144,13 @@ entities:
     components:
     - type: Transform
       pos: 4.5,-11.5
+      parent: 1
+- proto: WarningAir
+  entities:
+  - uid: 15069
+    components:
+    - type: Transform
+      pos: -54.5,23.5
       parent: 1
 - proto: WarningCO2
   entities:


### PR DESCRIPTION
## About the PR
- removed the decals suggesting to have midpoints in singulo containment, this led to singuloose every round and there was no reason to have it anyway, cfgs span 7 tiles anyway
- bypass the shitty air chamber by default since noobs dont know its bad if you want to use it for something you still can
- remove completely useless mixer input from the recycler, what would you be trying to mix into the burn chamber from it exactly? instead it goes into waste so you can, in theory, replenish distro with it. of course its still impractical because its a bad setup but whatever
- add logic gates to salv airlocks so they dont space salv every round
