### PR TITLE
ACTUALLY locks ifrit behind playtime

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
@@ -11,6 +11,10 @@
     name: Mystagogue's Ifrit
     description: Obey the mystagogue. Defend the oracle.
     rules: You are a servant of the mystagogue. Obey them directly.
+    requirements:
+    - !type:DepartmentTimeRequirement
+      department: Epistemics
+      time: 14400 #DeltaV - 4 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Ifrit should now be behind 4 hours of Epi playtime, as a file wasnt changed in #972 that should have been apparently

## Why / Balance
Stops shitters :trollface: 

## Technical details
Changes YML

## Media

## Breaking changes
no
**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Fox
- fix: Ifrit should now be behind 4 hours of Epistemics playtime

