### PR TITLE
Revert low pressure nerf

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -287,7 +287,8 @@ namespace Content.Shared.Atmos
         ///     so it just applies this flat value).
         /// </summary>
         // Original value is 4, buff back when we have proper ways for players to deal with breaches.
-        public const int LowPressureDamage = 1;
+        // Delta V - Keep original dmg value
+        public const int LowPressureDamage = 4;
 
         public const float WindowHeatTransferCoefficient = 0.1f;
 


### PR DESCRIPTION
## About the PR
Reverts the upstream nerf.

## Why / Balance
It's a terrible change with silly results and not very good justification. We've had players coming to our server to avoid it upstream. 

## Technical details
n/a