### PR TITLE
Adjusts steal group for Shiva/Laika discrepancy on maps

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
@@ -53,6 +53,8 @@
     - CannotSuicide
     - VimPilot
     - DoorBumpOpener
+  - type: StealTarget
+    stealGroup: AnimalSecurity #DeltaV - Adjusts because we have multiple possible sec animals
 
 - type: entity
   parent: MobCarp

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -652,7 +652,7 @@
     - DoorBumpOpener
     - FootstepSound
   - type: StealTarget
-    stealGroup: AnimalShiva
+    stealGroup: AnimalSecurity #DeltaV - Adjusts because we have multiple possible sec animals
 
 - type: entity
   name: Willow

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -389,7 +389,7 @@
     state: fox
 
 - type: stealTargetGroup
-  id: AnimalShiva
+  id: AnimalSecurity
   name: Shiva
   sprite:
     sprite: Mobs/Pets/shiva.rsi

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -389,8 +389,8 @@
     state: fox
 
 - type: stealTargetGroup
-  id: AnimalSecurity
-  name: Shiva
+  id: AnimalSecurity #DeltaV - Adjusts because we have multiple possible sec animals
+  name: Security Pet #DeltaV - Adjusts because we have multiple possible sec animals
   sprite:
     sprite: Mobs/Pets/shiva.rsi
     state: shiva

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -489,7 +489,7 @@
   - type: NotJobRequirement
     job: SecurityOfficer
   - type: StealCondition
-    stealGroup: AnimalShiva
+    stealGroup: AnimalSecurity #DeltaV - Adjusts because we have multiple possible sec animals
   - type: Objective
     difficulty: 2
 


### PR DESCRIPTION
## About the PR
Because we have 2 different sec animals and only 1 per map. This fixes the issue where one might not be available to secure the objective.

## Why / Balance
Fixes thief objective form being unobtainable. 

## Technical details
n/a

## Media
n/a

## Breaking changes
n/a

**Changelog**
n/a
