### PR TITLE
Prescription security HUD fix

### DIFF
--- a/Resources/Prototypes/DeltaV/Recipes/Construction/Graphs/clothing/prescription_huds.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Construction/Graphs/clothing/prescription_huds.yml
@@ -41,10 +41,10 @@
             - tag: HudSecurity
               name: security hud
               icon:
-                sprite: Clothing/Eyes/Hud/med.rsi
+                sprite: Clothing/Eyes/Hud/sec.rsi
                 state: icon
               doAfter: 5
-            - tag: GlassesNearsight
+            - component: VisionCorrection
               name: glasses
               icon:
                 sprite: Clothing/Eyes/Glasses/glasses.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes the prescription security HUD not being craftable and  changes the HUD sprite in crafting to the correct one.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug, was forgotten in the last prescription hud fix.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Makes it so crafting uses the VisionCorrection component instead of the outdated GlassesNearsight tag and uses sec.rsi to display the correct sprite in the crafting menu.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:

- fix: Prescriptions security HUDs are no longer uncraftable.

