### PR TITLE
The Return Of War

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -128,8 +128,7 @@
     pocket1: DoubleEmergencyOxygenTankFilled
     pocket2: BaseUplinkRadio40TC
     belt: ClothingBeltMilitaryWebbing
-  #inhand: # DeltaV - Prevent commander spawning with the declaration of war
-  #  - NukeOpsDeclarationOfWar
+  inhand: NukeOpsDeclarationOfWar
 
 #Nuclear Operative Medic Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -128,7 +128,8 @@
     pocket1: DoubleEmergencyOxygenTankFilled
     pocket2: BaseUplinkRadio40TC
     belt: ClothingBeltMilitaryWebbing
-  inhand: NukeOpsDeclarationOfWar
+  inhand:
+    - NukeOpsDeclarationOfWar
 
 #Nuclear Operative Medic Gear
 - type: startingGear


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adds back the ability for nuclear operative commanders to declare war

## Why / Balance
Brief admin discussion, and why not, might be fun, might be undone if the experiment doesnt go well

## Technical details
Removes some # comments
## Media
https://www.youtube.com/watch?v=TS3kiRYcDAo


## Breaking changes
No

**Changelog**

:cl: Fox
- add: Nuclear Operative teams have started sending brazen war declarations to Nanotrasen stations.


