### PR TITLE
More Locked Blast Doors

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -1,0 +1,111 @@
+- type: entity
+  id: BlastDoorUnlinkedBridge
+  parent: BlastDoor
+  suffix: Bridge
+  components:
+    - type: AccessReader
+      access: [["Command"]]
+
+- type: entity
+  id: BlastDoorUnlinkedBridgeOpen
+  parent: BlastDoorOpen
+  suffix: Open, Bridge
+  components:
+    - type: AccessReader
+      access: [["Command"]]
+
+- type: entity
+  id: BlastDoorUnlinkedEngineering
+  parent: BlastDoor
+  suffix: Engineering
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Engineering"]]
+
+- type: entity
+  id: BlastDoorUnlinkedEngineeringOpen
+  parent: BlastDoorOpen
+  suffix: Open, Engineering
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Engineering"]]
+
+- type: entity
+  id: BlastDoorUnlinkedEpistemics
+  parent: BlastDoor
+  suffix: Epistemics
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Research"]]
+
+- type: entity
+  id: BlastDoorUnlinkedEpistemicsOpen
+  parent: BlastDoorOpen
+  suffix: Open, Epistemics
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Research"]]
+
+- type: entity
+  id: BlastDoorUnlinkedSecurity
+  parent: BlastDoor
+  suffix: Security
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Security"]]
+
+- type: entity
+  id: BlastDoorUnlinkedSecurityOpen
+  parent: BlastDoorOpen
+  suffix: Open, Security
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Security"]]
+
+- type: entity
+  id: BlastDoorUnlinkedMedical
+  parent: BlastDoor
+  suffix: Medical
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Medical"]]
+
+- type: entity
+  id: BlastDoorUnlinkedMedicalOpen
+  parent: BlastDoorOpen
+  suffix: Open, Medical
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Medical"]]
+
+- type: entity
+  id: BlastDoorUnlinkedLogistics
+  parent: BlastDoor
+  suffix: Logistics
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Cargo"]]
+
+- type: entity
+  id: BlastDoorUnlinkedLogisticsOpen
+  parent: BlastDoorOpen
+  suffix: Open, Logistics
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Cargo"]]
+
+- type: entity
+  id: BlastDoorUnlinkedArmory
+  parent: BlastDoor
+  suffix: Armory
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Armory"]]
+
+- type: entity
+  id: BlastDoorUnlinkedArmoryOpen
+  parent: BlastDoorOpen
+  suffix: Open, Armory
+  components:
+  - type: AccessReader
+    access: [["Command"], ["Armory"]]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

 This PR just adds non-autolink access-locked blast doors for most of the departments that could reasonably need them.

Accesses added:

- Command
- Engineering
- Epistemics
- Security
- Medical
- Logistics
- Armory

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

It annoyed me that we got *a few* blast doors with access locks, but not, like, _security or the armory,_ and they were all autolink exclusive, meaning you couldn't use them for more than one thing.

## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

YML-exclusive changes.

NOTE: I hereby release all changes made in this PR under MIT license.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

<img width="555" alt="Content Client_MzBuIt9wt7" src="https://github.com/user-attachments/assets/256f2f87-3300-4c89-812a-5ae843f0bc34">


## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl:
- add: Added more access-locked blast doors for mappers.
