### PR TITLE
Fix Nukie Mouse reinforcements

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  parent: ReinforcementRadioSyndicate
+  parent: ReinforcementRadio
   id: ReinforcementRadioSyndicateNukieMouse
   name: suspicious moldy cheese
   description: Moldy cheese with a little worm sticking out of it and a... blinking antenna? Might attract an odd mouse.

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -1,22 +1,20 @@
 ﻿- type: entity
-  parent: ReinforcementRadio
+  parent: ReinforcementRadioSyndicate
   id: ReinforcementRadioSyndicateNukieMouse
   name: suspicious moldy cheese
   description: Moldy cheese with a little worm sticking out of it and a... blinking antenna? Might attract an odd mouse.
   components:
-    - type: Sprite
-      sprite: DeltaV/Objects/Devices/communication.rsi
-      layers:
-        - state: cheese-radio
-    - type: GhostRole
-      name: ghost-role-information-nukie-mouse-name
-      description: ghost-role-information-nukie-mouse-description
-      rules: ghost-role-information-nukie-mouse-rules
-      raffle:
-        settings: default
-    - type: GhostRoleMobSpawner
-      prototype: MobNukieMouse
-    - type: EmitSoundOnUse
-      sound: /Audio/Animals/mouse_squeak.ogg
-    - type: UseDelay
-      delay: 300
+  - type: Sprite
+    sprite: DeltaV/Objects/Devices/communication.rsi
+    layers:
+    - state: cheese-radio
+  - type: GhostRole
+    name: ghost-role-information-nukie-mouse-name
+    description: ghost-role-information-nukie-mouse-description
+    rules: ghost-role-information-nukie-mouse-rules
+  - type: GhostRoleMobSpawner
+    prototype: MobNukieMouse
+  - type: EmitSoundOnUse
+    sound: /Audio/Animals/mouse_squeak.ogg
+  - type: UseDelay
+    delay: 300

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/Syndicate_Gadgets/reinforcement_teleporter.yml
@@ -1,20 +1,22 @@
 ﻿- type: entity
-  parent: ReinforcementRadioSyndicate
+  parent: ReinforcementRadio
   id: ReinforcementRadioSyndicateNukieMouse
   name: suspicious moldy cheese
   description: Moldy cheese with a little worm sticking out of it and a... blinking antenna? Might attract an odd mouse.
   components:
-  - type: Sprite
-    sprite: DeltaV/Objects/Devices/communication.rsi
-    layers:
-    - state: cheese-radio
-  - type: GhostRole
-    name: ghost-role-information-nukie-mouse-name
-    description: ghost-role-information-nukie-mouse-description
-    rules: ghost-role-information-nukie-mouse-rules
-  - type: GhostRoleMobSpawner
-    prototype: MobNukieMouse
-  - type: EmitSoundOnUse
-    sound: /Audio/Animals/mouse_squeak.ogg
-  - type: UseDelay
-    delay: 300
+    - type: Sprite
+      sprite: DeltaV/Objects/Devices/communication.rsi
+      layers:
+        - state: cheese-radio
+    - type: GhostRole
+      name: ghost-role-information-nukie-mouse-name
+      description: ghost-role-information-nukie-mouse-description
+      rules: ghost-role-information-nukie-mouse-rules
+      raffle:
+        settings: default
+    - type: GhostRoleMobSpawner
+      prototype: MobNukieMouse
+    - type: EmitSoundOnUse
+      sound: /Audio/Animals/mouse_squeak.ogg
+    - type: UseDelay
+      delay: 300


### PR DESCRIPTION

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Makes it so you can no longer call in different syndicate reinforcments using the nukie mouse reinforcement radio.
## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Bug.
## Technical details
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
Changes the parent from ReinforcementRadioSyndicate to ReinforcementRadio.
## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase


**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->


:cl:
- fix: Nukie mouse reinforcement radios can no longer call in humans.

