### PR TITLE
Adjusts AME rate of diminishing returns

### DIFF
--- a/Content.Server/Ame/AmeNodeGroup.cs
+++ b/Content.Server/Ame/AmeNodeGroup.cs
@@ -173,7 +173,7 @@ public sealed class AmeNodeGroup : BaseNodeGroup
 
         // The adjustment for cores make it so that a 1 core AME at 2 injections is better than a 2 core AME at 2 injections.
         // However, for the relative amounts for each (1 core at 2 and 2 core at 4), more cores has more output.
-        return 200000f * MathF.Log10(fuel * fuel) * MathF.Pow(0.75f, cores - 1);
+        return 200000f * MathF.Log10(fuel * fuel) * 0.75f; //DeltaV - Adjust to create a smoother rate of diminishing returns 
     }
 
     public int GetTotalStability()


### PR DESCRIPTION
## About the PR
Changes the AME fuel input to power output to follow a proper rate of diminishing returns. 

## Why / Balance
Previously we had a constant input to output increase:
Assuming a safe injection:core ratio we had,
`80000/160000/240000/320000/400000/480000/560000/640000`

The recent upstream merge created a bell curve drop off in returns:
`120.4/180.6/175.1/152.4/126.9/103.2/82.5/65.3`
The more cores you add, the less power you get.

This change would make it a proper diminishing return:
You still gain power with increased cores but less with each additional core
`90,300/180,600/233,445/270,915/300,000/323,745/343,830/361,230`

## Technical details
n/a

## Media
n/a

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- tweak: Tweaked the AME to produce power with diminishing returns
