### PR TITLE
add tank harness to mantis loadout

### DIFF
--- a/Resources/Prototypes/DeltaV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/role_loadouts.yml
@@ -2,6 +2,7 @@
 - type: roleLoadout
   id: JobCourier
   groups:
+  - GroupTankHarness
   - CourierHead
   - CourierNeck
   - CourierJumpsuit
@@ -32,6 +33,7 @@
 - type: roleLoadout
   id: JobChiefJustice
   groups:
+  - GroupTankHarness
   - ChiefJusticeHead
   - ChiefJusticeJumpsuit
   - ChiefJusticeNeck
@@ -46,6 +48,7 @@
 - type: roleLoadout
   id: JobClerk
   groups:
+  - GroupTankHarness
   - ClerkJumpsuit
   - ClerkNeck
   - ClerkOuterClothing

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -2,6 +2,7 @@
 - type: roleLoadout
   id: JobMailCarrier
   groups:
+  - GroupTankHarness
   - MailCarrierHead
   - MailCarrierJumpsuit
   - CommonBackpack
@@ -68,6 +69,7 @@
 - type: roleLoadout
   id: JobGladiator
   groups:
+  - GroupTankHarness
   - GladiatorJumpsuit
   - CommonBackpack
   - GladiatorOuterClothing

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -2,7 +2,6 @@
 - type: roleLoadout
   id: JobMailCarrier
   groups:
-  - GroupTankHarness
   - MailCarrierHead
   - MailCarrierJumpsuit
   - CommonBackpack
@@ -15,6 +14,7 @@
 - type: roleLoadout
   id: JobForensicMantis
   groups:
+  - GroupTankHarness
   - MantisHead
   - MantisJumpsuit
   - MantisBackpack


### PR DESCRIPTION
## About the PR
turns out nitrogen tank cant fit in their coat so they get trolled

## Why / Balance
fixes #1646

**Changelog**
:cl:
- fix: Fixed Vox mantes not getting a tank harness.
