### PR TITLE
fix agent id senior job icons

### DIFF
--- a/Resources/Locale/en-US/deltav/job/job-names.ftl
+++ b/Resources/Locale/en-US/deltav/job/job-names.ftl
@@ -5,6 +5,11 @@ job-name-prosecutor = Prosecutor
 job-name-lawyer = Attorney
 job-name-courier = Courier
 job-name-security-borg = Security Cyborg
+# Used by the Agent ID
+job-name-senior-physician = Senior Physician
+job-name-scientist-senior = Senior Researcher
+job-name-senior-engineer = Senior Engineer
+job-name-senior-officer = Senior Officer
 
 # Role timers
 JobMedicalBorg = Medical Cyborg

--- a/Resources/Locale/en-US/deltav/job/job-names.ftl
+++ b/Resources/Locale/en-US/deltav/job/job-names.ftl
@@ -7,7 +7,7 @@ job-name-courier = Courier
 job-name-security-borg = Security Cyborg
 # Used by the Agent ID
 job-name-senior-physician = Senior Physician
-job-name-scientist-senior = Senior Researcher
+job-name-senior-researcher = Senior Researcher
 job-name-senior-engineer = Senior Engineer
 job-name-senior-officer = Senior Officer
 

--- a/Resources/Locale/en-US/job/job-names.ftl
+++ b/Resources/Locale/en-US/job/job-names.ftl
@@ -1,29 +1,21 @@
 job-name-warden = Warden
 job-name-security = Security Officer
-# DeltaV - Used by the Agent ID
-job-name-senior-officer = Senior Officer
 job-name-cadet = Security Cadet
 job-name-hos = Head of Security
 job-name-detective = Detective
 job-name-brigmedic = Corpsman
 job-name-borg = Cyborg
 job-name-scientist = Scientist
-# DeltaV - Used by the Agent ID
-job-name-scientist-senior = Senior Researcher
 job-name-research-assistant = Research Assistant
 job-name-rd = Mystagogue
 job-name-psychologist = Psychologist
 job-name-intern = Medical Intern
-# DeltaV - Used by the Agent ID
-job-name-senior-physician = Senior Physician
 job-name-doctor = Medical Doctor
 job-name-paramedic = Paramedic
 job-name-cmo = Chief Medical Officer
 job-name-chemist = Chemist
 job-name-technical-assistant = Technical Assistant
 job-name-engineer = Station Engineer
-# DeltaV - Used by the Agent ID
-job-name-senior-engineer = Senior Engineer
 job-name-atmostech = Atmospheric Technician
 job-name-hop = Head of Personnel
 job-name-captain = Captain

--- a/Resources/Locale/en-US/job/job-names.ftl
+++ b/Resources/Locale/en-US/job/job-names.ftl
@@ -1,21 +1,29 @@
 job-name-warden = Warden
 job-name-security = Security Officer
+# DeltaV - Used by the Agent ID
+job-name-senior-officer = Senior Officer
 job-name-cadet = Security Cadet
 job-name-hos = Head of Security
 job-name-detective = Detective
 job-name-brigmedic = Corpsman
 job-name-borg = Cyborg
 job-name-scientist = Scientist
+# DeltaV - Used by the Agent ID
+job-name-scientist-senior = Senior Researcher
 job-name-research-assistant = Research Assistant
 job-name-rd = Mystagogue
 job-name-psychologist = Psychologist
 job-name-intern = Medical Intern
+# DeltaV - Used by the Agent ID
+job-name-senior-physician = Senior Physician
 job-name-doctor = Medical Doctor
 job-name-paramedic = Paramedic
 job-name-cmo = Chief Medical Officer
 job-name-chemist = Chemist
 job-name-technical-assistant = Technical Assistant
 job-name-engineer = Station Engineer
+# DeltaV - Used by the Agent ID
+job-name-senior-engineer = Senior Engineer
 job-name-atmostech = Atmospheric Technician
 job-name-hop = Head of Personnel
 job-name-captain = Captain

--- a/Resources/Prototypes/StatusIcon/job.yml
+++ b/Resources/Prototypes/StatusIcon/job.yml
@@ -403,7 +403,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorPhysician
-  # allowSelection: false # DeltaV - Make selectable
+  jobName: job-name-senior-physician # DeltaV - Agent ID localization
+  # allowSelection: false # DeltaV - Selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -411,7 +412,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorOfficer
-  # allowSelection: false # DeltaV - Make selectable
+  jobName: job-name-senior-officer # DeltaV - Agent ID localization
+  # allowSelection: false # DeltaV - Selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -419,7 +421,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorEngineer
-  # allowSelection: false # DeltaV - Make selectable
+  jobName: job-name-senior-engineer # DeltaV - Agent ID localization
+  # allowSelection: false # DeltaV - Selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -427,7 +430,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorResearcher
-  # allowSelection: false # DeltaV - Make selectable
+  jobName: job-name-scientist-senior # DeltaV - Agent ID localization
+  # allowSelection: false # DeltaV - Selectable
 
 - type: jobIcon
   parent: JobIcon

--- a/Resources/Prototypes/StatusIcon/job.yml
+++ b/Resources/Prototypes/StatusIcon/job.yml
@@ -403,8 +403,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorPhysician
+  allowSelection: true # DeltaV - Selectable, was false
   jobName: job-name-senior-physician # DeltaV - Agent ID localization
-  # allowSelection: false # DeltaV - Selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -412,8 +412,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorOfficer
+  allowSelection: true # DeltaV - Selectable, was false
   jobName: job-name-senior-officer # DeltaV - Agent ID localization
-  # allowSelection: false # DeltaV - Selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -421,8 +421,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorEngineer
+  allowSelection: true # DeltaV - Selectable, was false
   jobName: job-name-senior-engineer # DeltaV - Agent ID localization
-  # allowSelection: false # DeltaV - Selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -430,8 +430,8 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorResearcher
-  jobName: job-name-scientist-senior # DeltaV - Agent ID localization
-  # allowSelection: false # DeltaV - Selectable
+  allowSelection: true # DeltaV - Selectable, was false
+  jobName: job-name-senior-researcher # DeltaV - Agent ID localization
 
 - type: jobIcon
   parent: JobIcon

--- a/Resources/Prototypes/StatusIcon/job.yml
+++ b/Resources/Prototypes/StatusIcon/job.yml
@@ -403,7 +403,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorPhysician
-  allowSelection: false
+  # allowSelection: false # DeltaV - Make selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -411,7 +411,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorOfficer
-  allowSelection: false
+  # allowSelection: false # DeltaV - Make selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -419,7 +419,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorEngineer
-  allowSelection: false
+  # allowSelection: false # DeltaV - Make selectable
 
 - type: jobIcon
   parent: JobIcon
@@ -427,7 +427,7 @@
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: SeniorResearcher
-  allowSelection: false
+  # allowSelection: false # DeltaV - Make selectable
 
 - type: jobIcon
   parent: JobIcon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Fixes https://github.com/DeltaV-Station/Delta-v/issues/1586 senior job icons not being accessible in the agent ID. Wizden doesn't have or want them so they don't need it, so probably no point in upstreaming.

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
<!--
List any breaking changes, including namespace, public class/method/field changes, prototype renames; and provide instructions for fixing them. This will be pasted in #codebase-changes.
-->

**Changelog**

:cl:
- fix: Senior job icons are now selectable in agent IDs.
