### PR TITLE
use old meteor entity

### DIFF
--- a/Content.Server/DeltaV/StationEvents/Events/MeteorSwarmRule.cs
+++ b/Content.Server/DeltaV/StationEvents/Events/MeteorSwarmRule.cs
@@ -67,7 +67,7 @@ namespace Content.Server.StationEvents.Events
                 var angle = new Angle(RobustRandom.NextFloat() * MathF.Tau);
                 var offset = angle.RotateVec(new Vector2((maximumDistance - minimumDistance) * RobustRandom.NextFloat() + minimumDistance, 0));
                 var spawnPosition = new MapCoordinates(center + offset, mapId);
-                var meteor = Spawn("MeteorLarge", spawnPosition);
+                var meteor = Spawn("MeteorLargeDeltaV", spawnPosition);
                 var physics = EntityManager.GetComponent<PhysicsComponent>(meteor);
                 _physics.SetBodyStatus(meteor, physics, BodyStatus.InAir);
                 _physics.SetLinearDamping(meteor, physics, 0f);

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -1,0 +1,40 @@
+- type: entity
+  id: MeteorLargeDeltaV
+  name: meteor
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    noRot: false
+    sprite: Objects/Weapons/Guns/Projectiles/meteor.rsi
+    scale: 4,4
+    layers:
+    - state: large
+      shader: unshaded
+  - type: ExplodeOnTrigger
+  - type: DeleteOnTrigger
+  - type: TriggerOnCollide
+    fixtureID: projectile
+  - type: Projectile
+    damage: {}
+    deleteOnCollide: false
+  - type: Explosive
+    explosionType: Default
+    totalIntensity: 600.0
+    intensitySlope: 30
+    maxIntensity: 45
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.8
+        density: 100
+        hard: true
+        # Didn't use MapGridComponent for now as the bounds are stuffed.
+        layer:
+        - LargeMobLayer
+        mask:
+        - Impassable
+        - BulletImpassable


### PR DESCRIPTION
## About the PR
title

## Why / Balance
missed when reverting to the old rule, it still spawned nu meteor

**Changelog**
:cl:
- tweak: Made meteor swarm event spawn the old meteors again
