### PR TITLE
Rules: close MMI loophole in New Life Rules

### DIFF
--- a/Resources/ServerInfo/Guidebook/DeltaV/Rules/GameRules/3_NewLife.xml
+++ b/Resources/ServerInfo/Guidebook/DeltaV/Rules/GameRules/3_NewLife.xml
@@ -1,6 +1,6 @@
 <Document>
   # Rule 3: New Life Guidelines
-  - If a player dies and is brought back by way of cloning or borging, they forget the last five minutes leading up to their death and cannot describe who or what killed them.
+  - If a player dies and is brought back by way of cloning, borging or having their brain put into an MMI, they forget the last five minutes leading up to their death and cannot describe who or what killed them.
   - Players that are revived by using a defibrillator can only recall vague details about their death, such as "Someone shot me" or "I was set ablaze" but they cannot recall details beyond that. [color=#ff0000]Please report players who break this rule.[/color]
   - In either case, characters do not have any knowledge of what happened while they were dead (i.e. ghosted/observing).
 


### PR DESCRIPTION
## About the PR
If you are put into an MMI, you now explicitly have to forget the last five minutes leading up to your death and cannot describe who or what killed you.

A player can be brought back without being cloned or borged if they are just put in an MMI. 

## Why / Balance
Currently the rule is too ambiguous and may be misinterpreted.

Your brain being put into an MMI may not be understood by players as "borging", especially since, as an MMI, you can refuse to be put in a cyborg body, or might simply not be placed into one because no bodies can be made at the time. I also get the impression that some Sec players want to put victims' brains into an MMI specifically to find out who killed them, which seems like  wanting to make use of that loophole or simply not being aware enough of the New Life Rules.

Pinging @Lyndomen since it's a rule change. 

**Changelog**
no cl no fun
