### PR TITLE
add survival loadouts to deltav antags

### DIFF
--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -104,6 +104,8 @@
       max: 2
       pickPlayer: false
       startingGear: SyndicateListenerGear
+      roleLoadout:
+      - RoleSurvivalStandard
       components:
       - type: RandomMetadata
         nameSegments:
@@ -184,6 +186,8 @@
       max: 1
       pickPlayer: false
       startingGear: FugitiveGear
+      roleLoadout:
+      - RoleSurvivalStandard
       components:
       - type: RandomMetadata
         nameSegments:

--- a/Resources/Prototypes/DeltaV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/unknown_shuttles.yml
@@ -32,6 +32,8 @@
       max: 1
       pickPlayer: false
       startingGear: SyndicateRecruiterGear
+      roleLoadout:
+      - RoleSurvivalStandard
       components:
       - type: RandomMetadata
         nameSegments:
@@ -74,6 +76,8 @@
       max: 2
       pickPlayer: false
       startingGear: SyndicateSynthesisGear
+      roleLoadout:
+      - RoleSurvivalStandard
       components:
       - type: RandomMetadata
         nameSegments:


### PR DESCRIPTION
## About the PR
- fugitive (fixes #1663)
- listening post
- recruiter
- synthesis specialist
all get survival boxes and vox have mask tank harness and nitrogen tank

(paradox inherits the targets profile so if theyre a vox everything is fine)

## Media
(listening post doesnt get bag so no survival box)
![05:55:19](https://github.com/user-attachments/assets/b1ea28dd-b076-4fc9-9767-8dc1d53a7b48)

![05:52:49](https://github.com/user-attachments/assets/c0907bff-87ec-4334-8564-2118073017f1)

![05:53:58](https://github.com/user-attachments/assets/2318dd4d-7dda-4f88-b779-98c4c6caa12e)

![05:54:39](https://github.com/user-attachments/assets/6d3ceb9a-082f-4ec4-84f1-1b9e4ec9bc95)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- fix: Fixed Vox Fugitives and other antags not getting nitrogen.