### PR TITLE
Add the gold and silver ring to loadouts

### DIFF
--- a/Resources/Prototypes/DeltaV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/Miscellaneous/trinkets.yml
@@ -3,3 +3,15 @@
   storage:
     back:
     - AACTablet
+
+- type: loadout
+  id: GoldRing
+  storage:
+    back:
+    - GoldRing
+
+- type: loadout
+  id: SilverRing
+  storage:
+    back:
+    - SilverRing

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -26,6 +26,8 @@
   - ClothingNeckAutismPin
   - ClothingNeckGoldAutismPin
   - AACTablet # DeltaV
+  - GoldRing # DeltaV
+  - SilverRing # DeltaV
 
 - type: loadoutGroup
   id: Glasses


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Adds the gold and silver ring to loadouts!

Requires: [#31372](https://github.com/space-wizards/space-station-14/pull/31372)

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Peoples characters get married and allowing them to have rings round start makes sense.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->

![Screenshot 2024-08-23 113318](https://github.com/user-attachments/assets/5f67c6d8-6486-4a94-95f7-65f06f349d2b)

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Beck Thompson
- add: You can now equip rings in your loadout!
