### PR TITLE
add playtime requirement to disaster victim ghost roles

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -785,9 +785,9 @@
       rules: ghost-role-information-disaster-victim-rules
       raffle:
         settings: default
-      requirements:
+      requirements: # DeltaV
       - !type:OverallPlaytimeRequirement
-        time: 72000 # DeltaV - 20 hours
+        time: 72000 # 20 hours
 
 - type: randomHumanoidSettings
   id: DisasterVictimResearchDirector

--- a/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/humanoid.yml
@@ -785,6 +785,9 @@
       rules: ghost-role-information-disaster-victim-rules
       raffle:
         settings: default
+      requirements:
+      - !type:OverallPlaytimeRequirement
+        time: 72000 # DeltaV - 20 hours
 
 - type: randomHumanoidSettings
   id: DisasterVictimResearchDirector


### PR DESCRIPTION
## About the PR
20 hours so shitters dont get free AA and a fucking gun to play with
no whitelist so there still some variety from cap mains and who picks these roles

**Changelog**
:cl:
- tweak: Disaster victim ghost roles now have a playtime requirement.