### PR TITLE
fix blanket whitelist not working in client

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -144,6 +144,10 @@ public sealed partial class JobRequirementsManager : ISharedPlaytimeManager
         if (!_cfg.GetCVar(CCVars.GameRoleWhitelist))
             return true;
 
+        // DeltaV - blanket whitelist check in client
+        if (_whitelisted)
+            return true;
+
         if (job.Whitelisted && !_jobWhitelists.Contains(job.ID))
         {
             reason = FormattedMessage.FromUnformatted(Loc.GetString("role-not-whitelisted"));


### PR DESCRIPTION
## About the PR
server allowed it but client has copy paste code so it wasnt changed :trollface:
now it has a similar check in the copy pasted function

## Media

**Changelog**
:cl:
- fix: Fixed whitelists not working for some people.