### PR TITLE
make jobs that dont use whitelist greyed out on whitelist panel

### DIFF
--- a/Content.Client/DeltaV/Administration/UI/DepartmentWhitelistPanel.xaml.cs
+++ b/Content.Client/DeltaV/Administration/UI/DepartmentWhitelistPanel.xaml.cs
@@ -18,11 +18,14 @@ public sealed partial class DepartmentWhitelistPanel : PanelContainer
         RobustXamlLoader.Load(this);
 
         var allWhitelisted = true;
+        var grey = Color.FromHex("#ccc");
         foreach (var id in department.Roles)
         {
             var thisJob = id; // closure capturing funny
             var button = new CheckBox();
             button.Text = proto.Index(id).LocalizedName;
+            if (!proto.Index(id).Whitelisted)
+                button.Modulate = grey; // Let admins know whitelisting this job is only for futureproofing.
             button.Pressed = whitelists.Contains(id);
             button.OnPressed += _ => OnSetJob?.Invoke(thisJob, button.Pressed);
             JobsContainer.AddChild(button);


### PR DESCRIPTION
## About the PR
jobs that dont use whitelist (whitelisting them would do nothing) are a bit darker now so admins can tell its just for futureproofing someone incase they get whitelisted in the future

dark enough that you can tell it apart from captain etc, but not too dark that it gets hard to read

## Why / Balance
dont troll admins

## Media
![01:30:19](https://github.com/user-attachments/assets/3235d09d-fc64-4de6-bed0-f06ca4a26667)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
DELTAVADMIN:
- tweak: Job Whitelists panel now makes jobs that don't use whitelist darker.
