### PR TITLE
mining re-rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -37,7 +37,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawGold: 100
+      RawGold: 300 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: goldore
   - type: SolutionContainerManager
@@ -99,7 +99,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawIron: 100
+      RawIron: 200 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: ironore
   - type: SolutionContainerManager
@@ -130,7 +130,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawPlasma: 100
+      RawPlasma: 500 # DeltaV - was 100
   - type: PointLight
     radius: 1.2
     energy: 0.6
@@ -166,7 +166,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawSilver: 100
+      RawSilver: 300 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: silverore
   - type: SolutionContainerManager
@@ -197,7 +197,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawQuartz: 100
+      RawQuartz: 200 # DeltaV - was 100
   - type: Extractable
     grindableSolutionName: quartzore
   - type: SolutionContainerManager
@@ -228,7 +228,7 @@
   - type: Material
   - type: PhysicalComposition
     materialComposition:
-      RawUranium: 100
+      RawUranium: 300 # DeltaV
   - type: PointLight
     radius: 1.2
     energy: 0.8
@@ -323,7 +323,7 @@
           Quantity: 0.1
   - type: PhysicalComposition
     materialComposition:
-      Coal: 100
+      Coal: 200 # DeltaV
 
 - type: entity
   parent: Coal


### PR DESCRIPTION
## About the PR
- iron and quartz to 2, it's alright right now but you need to be mining full time + debris recycling makes a stupid amount of steel anyway
- gold uranium and silver to 3, its annoying how little you get. still not as stupid as 30 stacks of gold every shift but less unforgiving
- plasma is back to 5, even before rebalance it was fairly hard to get
- bananium still low cause 50 rad deathstack should take time

**Changelog**
:cl:
- tweak: Rebalanced mining again, it's a bit fairer.