### PR TITLE
make it clearer what code is ours instead of from other codebases

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Any changes made to files belonging to our upstream should be properly marked in
 Content contributed to this repository after commit 87c70a89a67d0521a56388e6b1c3f2cb947943e4 is licensed under the GNU Affero General Public License version 3.0, unless otherwise stated. See `LICENSE-AGPLv3.txt`.
 Content contributed to this repository before commit 87c70a89a67d0521a56388e6b1c3f2cb947943e4 is licensed under the MIT license, unless otherwise stated. See `LICENSE-MIT.txt`.
 
+To be more specific, code in `Content.*/DeltaV`, `Content.*/Nyanotrasen`, `Resources/*/DeltaV` and `Resources/*/Nyanotrasen` and any Delta-V/Nyano specific scripts in `Tools` are licensed under AGPLv3. Other files are originally from other codebases and are not owned by Delta-V, though any code must be relicensable to AGPLv3. SS14 is MIT licensed so this forking is possible.
+
 [87c70a89a67d0521a56388e6b1c3f2cb947943e4](https://github.com/DeltaV-Station/Delta-v/commit/87c70a89a67d0521a56388e6b1c3f2cb947943e4) was pushed on February 17th 2024 at 21:48 UTC
 
 Most assets are licensed under [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) unless stated otherwise. Assets have their license and the copyright in the metadata file. [Example](https://github.com/DeltaV-Station/Delta-v/blob/master/Resources/Textures/Objects/Tools/crowbar.rsi/meta.json).


### PR DESCRIPTION
## About the PR
we did not create SS14 and do not own its code. this pr makes it more clear what is and isnt AGPL


## The thing
code after commit ... is AGPLv3
code before commit ... is MIT

To be more specific, code in `Content.*/DeltaV`, `Content.*/Nyanotrasen`, `Resources/*/DeltaV` and `Resources/*/Nyanotrasen`, or any Delta-V/Nyano specific scripts in `Tools` are licensed under AGPLv3.        
46 Other files are originally from other codebases and are not owned by Delta-V, though any code must be relicensable to AGPLv3. SS14 is MIT licensed so this forking is possible.