### PR TITLE
add fulton beacon to fulton blueprint

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
@@ -27,6 +27,7 @@
   - type: Blueprint
     providedRecipes:
     - Fulton
+    - FultonBeacon # DeltaV
 
 - type: entity
   parent: BaseBlueprint


### PR DESCRIPTION
## About the PR
title

## Why / Balance
i have no idea why upstream even did this, you cant make beacons so why would you make fultons

**Changelog**
:cl:
- tweak: The fulton blueprint now unlocks fulton beacons too.