### PR TITLE
Remove the space clown shuttle event

### DIFF
--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -7,7 +7,7 @@
     - id: UnknownShuttleCargoLost
     - id: UnknownShuttleTravelingCuisine
     - id: UnknownShuttleDisasterEvacPod
-    - id: UnknownShuttleHonki
+  #  - id: UnknownShuttleHonki #DeltaV - Removes the Clown Shuttle
 
 - type: entityTable
   id: UnknownShuttlesFreelanceTable
@@ -61,14 +61,14 @@
   - type: LoadMapRule
     preloadedGrid: DisasterEvacPod
 
-- type: entity
-  parent: BaseUnknownShuttleRule
-  id: UnknownShuttleHonki
-  components:
-  - type: StationEvent
-    weight: 2
-  - type: LoadMapRule
-    preloadedGrid: Honki
+# - type: entity #DeltaV - Remove Clown Shuttle
+#  parent: BaseUnknownShuttleRule
+#  id: UnknownShuttleHonki
+#  components:
+#  - type: StationEvent
+#    weight: 2
+#  - type: LoadMapRule
+#    preloadedGrid: Honki
 
 - type: entity
   parent: BaseUnknownShuttleRule


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Stops the space traffic control scheduler calling for the clown shuttle

## Why / Balance
Space Clowns. Uh. Bad.
People see them as le free antag coin and ESPECIALLY if they pull something "funny" from the lottery
Also clown spiders have been an issue for administration on at least a dozen occasions
The event as a whole doesnt lean to much RP besides "HEHE WE'RE GONNA RUIN THE DAY OF EVERYONE INVOLVED AND CRY SPACE LAW WHEN BRIGGED" despite docking without permission. Kid named tresspass:

TL;DR: Space clowns are not suited for MRP, and people constantly toe-the-rules with them. No bueno,
Something something 1984

## Technical details
If you can find a better/easier way to stop them, be my guest



## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Fox
- remove: Removed the clown shuttle from the unknown shuttle events pool.

