### PR TITLE
add fulton recipes to a t1 tech

### DIFF
--- a/Resources/Locale/en-US/deltav/research/technologies.ftl
+++ b/Resources/Locale/en-US/deltav/research/technologies.ftl
@@ -1,7 +1,6 @@
+research-technology-aerial-extraction = Aerial Extraction
+
 research-technology-exotic-ammunition = Exotic Ammunition
-
 research-technology-energy-gun = Energy Guns
-
 research-technology-energy-gun-advance = Advanced Energy Manipulation
-
 research-technology-advance-laser = Advanced Laser Manipulation

--- a/Resources/Prototypes/DeltaV/Research/industrial.yml
+++ b/Resources/Prototypes/DeltaV/Research/industrial.yml
@@ -1,0 +1,12 @@
+- type: technology
+  id: AerialExtraction
+  name: research-technology-aerial-extraction
+  icon:
+    sprite: Objects/Tools/fulton.rsi
+    state: extraction_pack
+  discipline: Industrial
+  tier: 1
+  cost: 5000
+  recipeUnlocks:
+  - Fulton
+  - FultonBeacon

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -302,7 +302,6 @@
       - AnomalyScanner
       - AnomalyLocator
       - AnomalyLocatorWide
-      - HandheldCrewMonitor # DeltaV
       - Scalpel
       - Retractor
       - Cautery
@@ -353,16 +352,21 @@
       - ClothingBackpackDuffelHolding
       - WelderExperimental
       - JawsOfLife
-      - CoreSilver # Nyanotrasen - Silver Golem core
       - FauxTileAstroGrass
       - FauxTileMowedAstroGrass
       - FauxTileJungleAstroGrass
       - FauxTileAstroIce
       - FauxTileAstroSnow
       - OreBagOfHolding
-      - PlantBagOfHolding #DeltaV
       - DeviceQuantumSpinInverter
-      - RCDAmmo # DeltaV
+      # Begin DeltaV additions
+      - CoreSilver # Nyanotrasen - Silver Golem core
+      - HandheldCrewMonitor
+      - PlantBagOfHolding
+      - RCDAmmo
+      - Fulton
+      - FultonBeacon
+      # End DeltaV additions
   - type: EmagLatheRecipes
     emagDynamicRecipes:
       - BoxBeanbag


### PR DESCRIPTION
## About the PR
incase salv doesnt get them from gacha, epi can get unlock and make them at the protolathe

if its still bad the blueprint stuff can be undone entirely later

## Why / Balance
in a new t1 industrial tech so its not 500 items in salv equipment, so hopefully less stress on epi and salvage on average getting equipment earlier
being made in protolathe also means the researched recipes can be made with hyperlathe to save cloth

## Technical details
no

## Media
![01:10:03](https://github.com/user-attachments/assets/3e17e489-8b64-4b64-bfb4-d6033595174e)

![01:10:15](https://github.com/user-attachments/assets/5836f02a-a61f-4bca-a179-ce4d4c03016f)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
:cl:
- add: Fulton recipes can now be unlocked with the Aerial Extractions tech.
