### PR TITLE
make bookshelf storage more flexible

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/bookshelf.yml
@@ -48,15 +48,9 @@
   - type: Occluder
   - type: Storage
     grid:
-    - 0,0,15,3
-    maxItemSize: Normal
-    whitelist:
-      tags:
-        - Document
-        - Folder
-        - Write
-        - Book
-        - Spellbook
+    - 0,0,5,1 # DeltaV, make it 2 rows of 6 instead of a giant block
+    - 0,3,5,4
+    #maxItemSize: Normal # DeltaV: removed whitelist and max item size
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:


### PR DESCRIPTION
## About the PR
instead of being a massive block of storage thats whitelisted to books and paper, you can now hide anything that will fit one of its 2x6 shelves

## Why / Balance
as seen commented in shelf whitelist removal pr
now watch sec raid the library every round :trollface:

## Media
![10:49:42](https://github.com/user-attachments/assets/6857805a-3e39-4928-ab8e-d2e2c2315793)

## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Bookshelves can now fit any kind of item, not just books.