### PR TITLE
fix: Make CourierDrobe restockable using generic clothes restock

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -122,6 +122,7 @@
     - CargoDrobeInventory
     - ChefDrobeInventory
     - ChemDrobeInventory
+    - CourierDrobeInventory # DeltaV - Make CourierDrobe refillable
     - DetDrobeInventory
     - EngiDrobeInventory
     - GeneDrobeInventory


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This allows the CourierDrobe to be restocked using the generic clothing restock

## Why / Balance
It seemed like an oversight since other clothing vendors are restockable; this way, Couriers can acquire new RPDS capsules and bags, if necessary.

## Technical details
A simple YAML change adding the Courier Drobe inventory to the canRestock array on the generic clothing restock

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.
-->
Not needed (I assume)

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
No breaking changes

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: DisposableCrewmember42
- fix: The wardrobe restock box can now be used to restock the CourierDrobe. Lock and Load!
