### PR TITLE
fix: syndicate synthesis translation string improperly named

### DIFF
--- a/Resources/Locale/en-US/deltav/prototypes/roles/antags.ftl
+++ b/Resources/Locale/en-US/deltav/prototypes/roles/antags.ftl
@@ -7,8 +7,8 @@ roles-antag-listening-post-objective = Spy on the station to gather crucial inte
 roles-antag-fugitive-name = Fugitive
 roles-antag-fugitive-objective = Stay on the run for your crimes.
 
-roles-antag-synthesis-specialist-name = Synthesis Specialist
-roles-antag-synthesis-specialist-objective = Sell your finest chemicals.
+roles-antag-syndicate-synthesis-name = Synthesis Specialist
+roles-antag-syndicate-synthesis-objective = Sell your finest chemicals.
 
 roles-antag-syndicate-recruiter-name = Syndicate Recruiter
 roles-antag-syndicate-recruiter-objective = Find and recruit the best agents for the Syndicate.


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Adjusted the key of a translation to match the one specified in the prototype.

## Why / Balance
The translation key currently shows up in round end summaries, since there is no value assigned.

## Technical details
Changes the translation keys in antags.ftl to be consistent with synthesis_specialist.yml ([Here](https://github.com/DisposableCrewmember42/Delta-v/blob/715c0f056ded8193a86a0619d8dddf1f0365fce3/Resources/Prototypes/DeltaV/Roles/Antags/synthesis_specialist.yml#L3-L4))

## Media
None

## Requirements
<!-- 
Due to influx of PR's we require to ensure that PR's are following the correct guidelines.

Please take a moment to read these if its your first time.

Check the boxes below to confirm that you have in fact seen these (put an X in the brackets, like [X]):
-->
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: DisposableCrewmember42
- fix: The Synthesis Specialist now shows up properly in Round End Summaries
