### PR TITLE
fix: Return search to the Drinks guide

### DIFF
--- a/Resources/Prototypes/Guidebook/references.yml
+++ b/Resources/Prototypes/Guidebook/references.yml
@@ -12,6 +12,7 @@
   id: Drinks
   name: guide-entry-drinks
   text: "/ServerInfo/Guidebook/ReferenceTables/Drinks.xml"
+  filterEnabled: true
 
 - type: guideEntry
   id: FoodRecipes

--- a/Resources/Prototypes/Guidebook/service.yml
+++ b/Resources/Prototypes/Guidebook/service.yml
@@ -13,7 +13,6 @@
   id: Bartender
   name: guide-entry-bartender
   text: "/ServerInfo/Guidebook/Service/Bartender.xml"
-  filterEnabled: True
 
 - type: guideEntry
   id: Botany


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Returned the search bar to the Drinks page, where it belongs. I assume this was accidentally removed after being split from the Service->Bartender page?

## Why / Balance
It makes playing bartender enjoyable again, if you don't have enough recipes memorized. No endless scrolling necessary.

## Technical details
Removed the filterEnabled attribute override from the Bartender guidebook prototype and added it to the Drinks guidebook prototype

## Media
https://github.com/user-attachments/assets/9e89fa85-1519-49e8-9d1e-a02fa2016ec9


## Requirements
- [x] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [x] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
None

**Changelog**

:cl: DisposableCrewmember42
- fix: Returned search functionality to the Drinks page. Bartenders, rejoice!
