### PR TITLE
Revert "make the credits action commit directly"

### DIFF
--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -32,8 +32,21 @@ jobs:
       # Uncomment this and comment the other line if you do this.
       # https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches
 
-      - name: Commit new credit files
-        uses: stefanzweifel/git-auto-commit-action@v4
+      #- name: Commit new credit files
+      #  uses: stefanzweifel/git-auto-commit-action@v4
+      #  with:
+      #    commit_message: Update Credits
+      #    commit_author: PJBot <pieterjan.briers+bot@gmail.com>
+
+      # This will make a PR
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
         with:
-          commit_message: Update Credits
-          commit_author: DeltaV-Bot <github@delta-v.org>
+          commit-message: Update Credits
+          title: Update Credits
+          body: This is an automated Pull Request. This PR updates the github contributors in the credits section.
+          author: DeltaV-Bot <github@delta-v.org>
+          branch: automated/credits-${{env.NOW}}


### PR DESCRIPTION
Reverts DeltaV-Station/Delta-v#1735

it doesnt work, seemingly github is ignoring the branch protection exclusion.