### PR TITLE
update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,19 @@
 # Last match in file takes precedence.
 
-/Content.*/SimpleStation14/ @DEATHB4DEFEAT
+# C# code
+/Content.*/ @DeltaV-Station/maintainers
 
-/Resources/*.yml @Colin-Tel
-/Resources/*/SimpleStation14/ @DEATHB4DEFEAT
-/Resources/Maps/ @IamVelcroboy
-/Resources/Prototypes/Maps/ @IamVelcroboy
+# YML files
+/Resources/**.yml @DeltaV-Station/yaml-maintainers
+
+# Sprites
+/Resources/Textures/ @IamVelcroboy
+
+# Lobby art and music - automatically direction issues since its immediately visible to players
+/Resources/Audio/Lobby/ @DeltaV-Station/game-directors
+/Resources/Textures/LobbyScreens/ @DeltaV-Station/game-directors
+
+# Maps
+/Resources/Maps/ @DeltaV-Station/maptainers
+/Resources/Prototypes/Maps/ @DeltaV-Station/maptainers
+/Content.IntegrationTests/Tests/PostMapInitTest.cs @DeltaV-Station/maptainers


### PR DESCRIPTION
## About the PR
changed everything to use teams (except sprites theres no sprite team :trollface:)
- sprites reviewed by velcroboy
- map files and the map test get reviewed by maptainers team
- yml files get reviewed by yml maintainers team
- code in any assembly gets reviewed by maintainers team
- lobby art and music get reviewed by direction team

notably this makes the colin review on Resources/*.yml actually work as intended since thats not recursive, it wouldve only triggered for keybinds prs :trollface: