### PR TITLE
fix codeowners yml troll

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,8 @@
 /Content.*/ @DeltaV-Station/maintainers
 
 # YML files
-/Resources/**.yml @DeltaV-Station/yaml-maintainers
+/Resources/*.yml @DeltaV-Station/yaml-maintainers
+/Resources/**/*.yml @DeltaV-Station/yaml-maintainers
 
 # Sprites
 /Resources/Textures/ @IamVelcroboy


### PR DESCRIPTION
pros cant do recursive globbing right

Resources/egg.yml would be owned but Resources/Prototypes/egg.yml would not because funny

now thats fixed:

![04:32:59](https://github.com/user-attachments/assets/c3aa19da-6c3f-4a65-bb94-c9608b135af7)
