### PR TITLE
refactor gun safe spawners to use entity tables

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -1,50 +1,55 @@
 - type: entity
+  abstract: true
+  parent: MarkerBase
   id: BaseGunSafeSpawner
   name: random safe spawner
-  parent: MarkerBase
-  abstract: true
   components:
-    - type: Sprite
-      layers:
-        - state: red
-        - sprite: Structures/Storage/closet.rsi
-          state: shotguncase
-    - type: RandomSpawner
-      offset: 0
+  - type: Sprite
+    layers:
+    - state: red
+    - sprite: Structures/Storage/closet.rsi
+      state: shotguncase
+  - type: EntityTableSpawner
+    offset: 0
 
 - type: entity
-  suffix: Shotgun
+  parent: BaseGunSafeSpawner
   id: ShotgunSafeSpawner
-  parent: BaseGunSafeSpawner
+  suffix: Shotgun
   components:
-    - type: RandomSpawner
-      prototypes:
-        - GunSafeShotgunEnforcer
-        - GunSafeShotgunKammerer
-        - GunSafeAdjutantShotgun
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: GunSafeShotgunEnforcer
+      - id: GunSafeShotgunKammerer
+      - id: GunSafeAdjutantShotgun
 
 - type: entity
-  suffix: Rifle
+  parent: BaseGunSafeSpawner
   id: RifleSafeSpawner
-  parent: BaseGunSafeSpawner
+  suffix: Rifle
   components:
-    - type: RandomSpawner
-      prototypes:
-        - GunSafeVulcanRifle
-        - GunSafeSubMachineGunDrozd
-        - GunSafeRifleLecter
-        - GunSafeM90Rifle
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: GunSafeVulcanRifle
+      - id: GunSafeSubMachineGunDrozd
+      - id: GunSafeRifleLecter
+      - id: GunSafeM90Rifle
 
 - type: entity
-  suffix: Handgun
-  id: HandgunSafeSpawner
   parent: BaseGunSafeSpawner
+  id: HandgunSafeSpawner
+  suffix: Handgun
   components:
-    - type: RandomSpawner
-      prototypes:
-        - GunSafePistolMk58
-      rarePrototypes:
-        - GunSafeEnergyGunMini
-        - GunSafePistolUniversal
-        - GunSafeSubMachineGunWt550
-      rareChance: 0.15
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: GunSafePistolMk58
+        weight: 0.85
+      - !type:GroupSelector
+        weight: 0.15
+        children:
+        - id: GunSafeEnergyGunMini
+        - id: GunSafePistolUniversal
+        - id: GunSafeSubMachineGunWt550


### PR DESCRIPTION
## About the PR
EntityTableSpawner + cleanup

no ingame changes

## Why / Balance
more flexible, can do things like weighting certain spawns individually or using nested table selectors to share tables between spawners

side note: why is there a 5% chance of pistol spawner spawning a wt550????? will probably be removed when adding new guns to spawners

## Media
![04:36:56](https://github.com/user-attachments/assets/8296f909-d143-44e0-8fd3-d524c2f0e613)


## Requirements
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

## Breaking changes
no

**Changelog**
no cl no fun