### PR TITLE
remove sentient artifact effect

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -188,24 +188,25 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/revolver.ogg
 
-- type: artifactEffect
-  id: EffectSentience
-  targetDepth: 3
-  effectHint: artifact-effect-hint-sentience
-  permanentComponents:
-  - type: GhostRole
-    allowMovement: true
-    allowSpeech: true
-    makeSentient: true
-    name: ghost-role-information-artifact-name
-    description: ghost-role-information-artifact-description
-    rules: ghost-role-information-freeagent-rules
-    raffle:
-      settings: default
-  - type: GhostTakeoverAvailable
-  - type: MovementSpeedModifier
-    baseWalkSpeed: 0.25
-    baseSprintSpeed: 0.5
+# DeltaV: disabled sentience due to very rarely being good RP, and usually ending the round early
+#- type: artifactEffect
+#  id: EffectSentience
+#  targetDepth: 3
+#  effectHint: artifact-effect-hint-sentience
+#  permanentComponents:
+#  - type: GhostRole
+#    allowMovement: true
+#    allowSpeech: true
+#    makeSentient: true
+#    name: ghost-role-information-artifact-name
+#    description: ghost-role-information-artifact-description
+#    rules: ghost-role-information-freeagent-rules
+#    raffle:
+#      settings: default
+#  - type: GhostTakeoverAvailable
+#  - type: MovementSpeedModifier
+#    baseWalkSpeed: 0.25
+#    baseSprintSpeed: 0.5
 
 - type: artifactEffect
   id: EffectMultitool


### PR DESCRIPTION
## About the PR
title

## Why / Balance
ive seen good rp from artifact players like 4 times total, the rest of the time they just spam activate and murderbone with trit/explosions/radiation/etc
it also does nothing on lowpop 
if the artifact also has structural phasing its literally impossible to do anything about a shitter using it to destroy everything

**Changelog**
:cl:
- remove: Artifacts can no longer become sentient.