### PR TITLE
Limit "Die a glorious death" objective to one traitor per round.

### DIFF
--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -66,6 +66,10 @@
       - EscapeShuttleCondition
       - StealCondition
   - type: DieCondition
+  # The game turns into a massive suicide pact if enough of the traitors have it. Not fun for traitors or security!
+  # Giving it a limit keeps the objective unique and interesting without being overdone.
+  - type: ObjectiveLimit # Delta-V
+    limit: 1 # Delta-V
 
 #- type: entity
 #  parent: [BaseTraitorObjective, BaseLivingObjective]


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

See the title!

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

A lot of shifts (Especially with a lot of traitors) can end up having three or four people with the objective which ends up very chaotic and not fun. Limiting it to one per round still allows the objective to come up, just not dominate the round!

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

:cl: Beck Thompson
- tweak: The "Die a glorious death" objective is now limited to one traitor per round maximum!