### PR TITLE
Revert "Firelocks are no longer pryable by hand if they are powered

### DIFF
--- a/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedFirelockSystem.cs
@@ -21,7 +21,8 @@ public abstract class SharedFirelockSystem : EntitySystem
 
         // Access/Prying
         SubscribeLocalEvent<FirelockComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
-        SubscribeLocalEvent<FirelockComponent, BeforePryEvent>(OnBeforePry);
+        // DeltaV: commented out to let people pry powered firelocks by hand
+        //SubscribeLocalEvent<FirelockComponent, BeforePryEvent>(OnBeforePry);
         SubscribeLocalEvent<FirelockComponent, GetPryTimeModifierEvent>(OnDoorGetPryTimeModifier);
         SubscribeLocalEvent<FirelockComponent, PriedEvent>(OnAfterPried);
 


### PR DESCRIPTION
## About the PR
you can now pry firelocks without a crowbar

## Why / Balance
- this did nothing in the event of spacing and power loss, which is extremely common
- this led to everything taking crowbars immediately because (brave statement) they dont want to get murdered by a powered firelock
- since everyone takes a crowbar, this had no effect on the powergamers but punished people that dont take them, in the case of fires by round removing them
- **nobody** enjoys getting killed by firelocks. not a single person

**Changelog**
:cl:
- tweak: You no longer need a crowbar to pry powered firelocks open.