### PR TITLE
make uncloneable popup more clear

### DIFF
--- a/Resources/Locale/en-US/medical/components/cloning-console-component.ftl
+++ b/Resources/Locale/en-US/medical/components/cloning-console-component.ftl
@@ -26,5 +26,6 @@ cloning-console-component-msg-no-cloner = Not Ready: No Cloner Detected
 cloning-console-component-msg-no-mind = Not Ready: No Soul Activity Detected
 
 cloning-console-chat-error = ERROR: INSUFFICIENT BIOMASS. CLONING THIS BODY REQUIRES {$units} UNITS OF BIOMASS.
-cloning-console-uncloneable-trait-error = ERROR: SOUL IS ABSENT, CLONING IS IMPOSSIBLE.
+# DeltaV: change from SOUL IS ABSENT to INCOMPATIBLE GENOME
+cloning-console-uncloneable-trait-error = ERROR: INCOMPATIBLE GENOME, CLONING IS IMPOSSIBLE.
 cloning-console-cellular-warning = WARNING: GENEFSCK CONFIDENCE SCORE IS {$percent}%. CLONING MAY HAVE UNEXPECTED RESULTS.


### PR DESCRIPTION
## About the PR
SOUL IS ABSENT -> INCOMPATIBLE GENOME

## Why / Balance
it sounds like someone left when no they did not its just a trait

**Changelog**
:cl:
- tweak: The Uncloneable trait's failure message is clearer now.
