### PR TITLE
Remove nukies axe plating prying capabilities.

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: fireaxe
+  name: fire axe
   parent: [BaseItem, BaseEngineeringContraband]
-  id: FireAxe
-  description: Truly, the weapon of a madman. Who would think to fight fire with an axe?
+  id: FireAxeFlaming
+  description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
   - type: Tag
     tags:
@@ -11,10 +11,10 @@
   - type: Execution
     doAfterDuration: 4.0
   - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxe.rsi
+    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
     state: icon
   - type: MeleeWeapon
-    wideAnimationRotation: 135
+    wideAnimationRotation: 90
     swingLeft: true
     attackRate: 0.75
     damage:
@@ -34,14 +34,13 @@
   - type: Item
     size: Ginormous
   - type: Clothing
-    sprite: Objects/Weapons/Melee/fireaxe.rsi
+    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
     quickEquip: false
     slots:
     - back
   - type: Tool
     qualities:
       - Prying
-      - Axing # DeltaV - The return of fireaxe prying
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay
@@ -49,23 +48,26 @@
   - type: StealTarget
     stealGroup: FireAxe
   - type: IgniteOnMeleeHit
-    fireStacks: -4
+    fireStacks: 1
 
 - type: entity
-  id: FireAxeFlaming
-  name: fire axe
-  parent: [BaseSyndicateContraband, FireAxe]
-  description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
+  id: FireAxe
+  name: fireaxe
+  parent: FireAxeFlaming
+  description: Truly, the weapon of a madman. Who would think to fight fire with an axe?
   components:
   - type: MeleeWeapon
-    wideAnimationRotation: 90
+    wideAnimationRotation: 135
   - type: IgniteOnMeleeHit
-    fireStacks: 1
+    fireStacks: -4
   - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
+    sprite: Objects/Weapons/Melee/fireaxe.rsi
     state: icon
   - type: Clothing
-    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
+    sprite: Objects/Weapons/Melee/fireaxe.rsi
+  - type: Tool
+    qualities:
+      - Axing # DeltaV - The return of fireaxe prying
     quickEquip: false
     slots:
     - back

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -1,8 +1,9 @@
+#Inverted inheritance from atmos axe to nuclear operative axe as parent, to prevent plate prying. https://github.com/DeltaV-Station/Delta-v/pull/1844
 - type: entity
-  name: fire axe
+  name: fire axe #DeltaV - #1844, original: fireaxe
   parent: [BaseItem, BaseEngineeringContraband]
-  id: FireAxeFlaming
-  description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
+  id: FireAxeFlaming #DeltaV - #1844, original: FireAxe
+  description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle! #DeltaV - #1844, original: Truly, the weapon of a madman. Who would think to fight fire with an axe?
   components:
   - type: Tag
     tags:
@@ -11,10 +12,10 @@
   - type: Execution
     doAfterDuration: 4.0
   - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
+    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi #DeltaV - #1844, original: fireaxe.rsi
     state: icon
   - type: MeleeWeapon
-    wideAnimationRotation: 90
+    wideAnimationRotation: 90 #DeltaV - #1844, original: 135
     swingLeft: true
     attackRate: 0.75
     damage:
@@ -34,13 +35,15 @@
   - type: Item
     size: Ginormous
   - type: Clothing
-    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
+    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi #DeltaV - #1844, original: fireaxe.rsi
     quickEquip: false
     slots:
     - back
   - type: Tool
     qualities:
       - Prying
+      #- Axing
+      # Commented out due to Inverted inheritance.
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay
@@ -48,23 +51,24 @@
   - type: StealTarget
     stealGroup: FireAxe
   - type: IgniteOnMeleeHit
-    fireStacks: 1
+    fireStacks: 1 #DeltaV - #1844, original: -4
 
+#Inverted inheritance from atmos axe to nuclear operative axe as parent, to prevent plate prying. https://github.com/DeltaV-Station/Delta-v/pull/1844
 - type: entity
-  id: FireAxe
+  id: FireAxe #DeltaV - #1844, original: FireAxeFlaming
   name: fireaxe
-  parent: FireAxeFlaming
-  description: Truly, the weapon of a madman. Who would think to fight fire with an axe?
+  parent: FireAxeFlaming #DeltaV - #1844, original: FireAxe
+  description: Truly, the weapon of a madman. Who would think to fight fire with an axe? #DeltaV - #1844, original: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
   - type: MeleeWeapon
-    wideAnimationRotation: 135
+    wideAnimationRotation: 135 #DeltaV - #1844, original: 90
   - type: IgniteOnMeleeHit
-    fireStacks: -4
+    fireStacks: -4 #DeltaV - #1844, original: 1
   - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxe.rsi
+    sprite: Objects/Weapons/Melee/fireaxe.rsi #DeltaV - #1844, original: fireaxeflaming
     state: icon
   - type: Clothing
-    sprite: Objects/Weapons/Melee/fireaxe.rsi
+    sprite: Objects/Weapons/Melee/fireaxe.rsi #DeltaV - #1844, original: fireaxeflaming
   - type: Tool
     qualities:
       - Axing # DeltaV - The return of fireaxe prying

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -69,9 +69,9 @@
     state: icon
   - type: Clothing
     sprite: Objects/Weapons/Melee/fireaxe.rsi #DeltaV - #1844, original: fireaxeflaming
-  - type: Tool
-    qualities:
-      - Axing # DeltaV - The return of fireaxe prying
     quickEquip: false
     slots:
     - back
+  - type: Tool
+    qualities:
+      - Axing # DeltaV - The return of fireaxe prying

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -1,9 +1,8 @@
-#Inverted inheritance from atmos axe to nuclear operative axe as parent, to prevent plate prying. https://github.com/DeltaV-Station/Delta-v/pull/1844
 - type: entity
-  name: fire axe #DeltaV - #1844, original: fireaxe
+  name: fireaxe
   parent: [BaseItem, BaseEngineeringContraband]
-  id: FireAxeFlaming #DeltaV - #1844, original: FireAxe
-  description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle! #DeltaV - #1844, original: Truly, the weapon of a madman. Who would think to fight fire with an axe?
+  id: FireAxe
+  description: Truly, the weapon of a madman. Who would think to fight fire with an axe?
   components:
   - type: Tag
     tags:
@@ -12,10 +11,10 @@
   - type: Execution
     doAfterDuration: 4.0
   - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi #DeltaV - #1844, original: fireaxe.rsi
+    sprite: Objects/Weapons/Melee/fireaxe.rsi
     state: icon
   - type: MeleeWeapon
-    wideAnimationRotation: 90 #DeltaV - #1844, original: 135
+    wideAnimationRotation: 135
     swingLeft: true
     attackRate: 0.75
     damage:
@@ -35,15 +34,14 @@
   - type: Item
     size: Ginormous
   - type: Clothing
-    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi #DeltaV - #1844, original: fireaxe.rsi
+    sprite: Objects/Weapons/Melee/fireaxe.rsi
     quickEquip: false
     slots:
     - back
   - type: Tool
     qualities:
       - Prying
-      #- Axing
-      # Commented out due to Inverted inheritance.
+      - Axing # DeltaV - The return of fireaxe prying
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay
@@ -51,27 +49,26 @@
   - type: StealTarget
     stealGroup: FireAxe
   - type: IgniteOnMeleeHit
-    fireStacks: 1 #DeltaV - #1844, original: -4
+    fireStacks: -4
 
-#Inverted inheritance from atmos axe to nuclear operative axe as parent, to prevent plate prying. https://github.com/DeltaV-Station/Delta-v/pull/1844
 - type: entity
-  id: FireAxe #DeltaV - #1844, original: FireAxeFlaming
-  name: fireaxe
-  parent: FireAxeFlaming #DeltaV - #1844, original: FireAxe
-  description: Truly, the weapon of a madman. Who would think to fight fire with an axe? #DeltaV - #1844, original: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
+  id: FireAxeFlaming
+  name: fire axe
+  parent: [BaseSyndicateContraband, FireAxe]
+  description: Why fight fire with an axe when you can fight with fire and axe? Now featuring rugged rubberized handle!
   components:
   - type: MeleeWeapon
-    wideAnimationRotation: 135 #DeltaV - #1844, original: 90
+    wideAnimationRotation: 90
   - type: IgniteOnMeleeHit
-    fireStacks: -4 #DeltaV - #1844, original: 1
+    fireStacks: 1
   - type: Sprite
-    sprite: Objects/Weapons/Melee/fireaxe.rsi #DeltaV - #1844, original: fireaxeflaming
+    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
     state: icon
   - type: Clothing
-    sprite: Objects/Weapons/Melee/fireaxe.rsi #DeltaV - #1844, original: fireaxeflaming
+    sprite: Objects/Weapons/Melee/fireaxeflaming.rsi
     quickEquip: false
     slots:
     - back
   - type: Tool
     qualities:
-      - Axing # DeltaV - The return of fireaxe prying
+    - Prying #DeltaV - Makes so it can only pry tiles, not plates. #1844


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the ability to pry plating as I think the intent behind https://github.com/DeltaV-Station/Delta-v/pull/1700 was to make only the atmos (and bridge) axe being able to pry plating.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Nukies are going back to the old meta of carrying the axe spacing every room they are in with it.

## Technical details
<!-- Summary of code changes for easier review. -->
I inverted the inheritance so the nukie fire axe doesn't get the `Axing` tag.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before

https://github.com/user-attachments/assets/b15ca132-4011-44a8-8e95-bd00f0479857

After

https://github.com/user-attachments/assets/e9d152a9-07fc-4fb2-ad41-cbfb7a76b3db


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
I hope none.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Nuclear operatives fire axe is no longer able to pry plating.
