### PR TITLE
more yaml nospawn cleanup

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/rodentia.yml
@@ -117,7 +117,7 @@
   name: Rodentia Dummy
   parent: MobHumanDummy
   id: MobRodentiaDummy
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   description: A dummy rodentia meant to be used in character setup.
   components:
   - type: HumanoidAppearance

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/mouth_storage.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/mouth_storage.yml
@@ -2,7 +2,7 @@
   id: CheekStorage
   name: cheek storage
   description: The cheeks of an animal, capable of storing small objects.
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   components:
   - type: Storage
     clickInsert: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -104,11 +104,12 @@
       types:
         Blunt: 1
 
+# DeltaV - We're keping rubbers so make sure to keep this updated
 - type: entity
   id: BaseBulletRubber
   name: base bullet rubber
   parent: BaseBullet
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/ghost_roles.yml
@@ -3,7 +3,7 @@
   name: ghost role spawn point
   suffix: Ifrit
   parent: MarkerBase
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   components:
   - type: GhostRoleMobSpawner
     prototype: MobIfritFamiliar

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Mail/base_mail_large.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Mail/base_mail_large.yml
@@ -73,7 +73,7 @@
     isLarge: true
 
 - type: entity
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   parent: BaseMailLarge
   id: MailLargeAdminFun
   suffix: adminfun

--- a/Resources/Prototypes/_NF/Mail/Items/misc.yml
+++ b/Resources/Prototypes/_NF/Mail/Items/misc.yml
@@ -3,7 +3,7 @@
 - type: entity
   id: DelayedSmoke
   parent: BaseItem
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   name: delayed smoke
   suffix: "(10s)"
   components:
@@ -16,7 +16,7 @@
 
 - type: entity
   id: AdminInstantEffectEMP7
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   suffix: EMP, 7 meters
   parent: AdminInstantEffectBase
   components:
@@ -27,7 +27,7 @@
 - type: entity
   id: DelayedEMP
   parent: BaseItem
-  noSpawn: true
+  categories: [ HideSpawnMenu ]
   name: delayed EMP (7 meters)
   components:
   - type: Sprite #DeltaV: Apparently these want sprites, probably because they're baseitems


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
yaml cleanup mostly frontier files (ADEI!!!) and rodentia 
no comments since no one cares, idk if we even ported the latest mail pr and upstream doesn't have rubbers anyways

could probably move rubbers down to deltav projectiles section since you can't put it in a different file anyways :blunt:

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
nospawn finally removed after a year
