### PR TITLE
make meteors duds on glacier

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -38,3 +38,61 @@
         mask:
         - Impassable
         - BulletImpassable
+
+# this gets spawned by the meteor swarm rule if the target map has an atmosphere
+# since meteors dont make much sense
+- type: entity
+  categories: [ HideSpawnMenu ]
+  id: MeteorGlacierDeltaV
+  name: meteor
+  description: This meteor is burning up like a in the atmosphere, like a... meteor.
+  components:
+  - type: Sprite
+    noRot: false
+    sprite: Objects/Weapons/Guns/Projectiles/meteor.rsi
+    scale: 0.5,0.5
+    layers:
+    - state: large
+      shader: unshaded
+  - type: PointLight
+    radius: 3
+    energy: 5
+    color: "#ff6622"
+  - type: AmbientSound
+    enabled: true
+    volume: 2
+    range: 14
+    sound:
+      path: /Audio/Items/Flare/flare_burn.ogg
+      params:
+        loop: true
+  - type: IgnitionSource
+    ignited: true
+    temperature: 500
+  - type: DeleteOnTrigger
+  - type: TriggerOnCollide
+    fixtureID: projectile
+  - type: Projectile
+    damage: {}
+    deleteOnCollide: false
+  - type: Explosive
+    explosionType: Default
+    totalIntensity: 600.0
+    intensitySlope: 30
+    maxIntensity: 45
+  - type: Physics
+    bodyType: Dynamic
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.8
+        density: 100
+        hard: true
+        # Didn't use MapGridComponent for now as the bounds are stuffed.
+        layer:
+        - LargeMobLayer
+        mask:
+        - Impassable
+        - BulletImpassable

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -75,11 +75,6 @@
   - type: Projectile
     damage: {}
     deleteOnCollide: false
-  - type: Explosive
-    explosionType: Default
-    totalIntensity: 600.0
-    intensitySlope: 30
-    maxIntensity: 45
   - type: Physics
     bodyType: Dynamic
   - type: Fixtures


### PR DESCRIPTION
## About the PR
they dont explode, and if you somehow get hit by one itll just light you on fire instead of gibbing you

## Why / Balance
meteors burn up in the atmosphere, it just makes sense
balance wise this literally gives engi nothing to do on survival, could have something more ice themed with station-created event schedulers

## Technical details
basically its a flare

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Glacier's atmosphere now protects it from meteor storms.
