### PR TITLE
fix chameleon projector bug

### DIFF
--- a/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
+++ b/Content.Shared/Polymorph/Systems/SharedChameleonProjectorSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Polymorph;
 using Content.Shared.Polymorph.Components;
 using Content.Shared.Popups;
+using Content.Shared.Storage.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Components;
@@ -43,6 +44,7 @@ public abstract class SharedChameleonProjectorSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ChameleonDisguiseComponent, GotEquippedHandEvent>(OnDisguiseEquippedHand);
+        SubscribeLocalEvent<ChameleonDisguiseComponent, InsertIntoEntityStorageAttemptEvent>(OnDisguiseInsertAttempt);
         SubscribeLocalEvent<ChameleonDisguiseComponent, ComponentShutdown>(OnDisguiseShutdown);
 
         SubscribeLocalEvent<ChameleonDisguisedComponent, DamageChangedEvent>(OnDamageChanged);
@@ -61,6 +63,12 @@ public abstract class SharedChameleonProjectorSystem : EntitySystem
     {
         TryReveal(ent.Comp.User);
         args.Handled = true;
+    }
+
+    private void OnDisguiseInsertAttempt(Entity<ChameleonDisguiseComponent> ent, ref InsertIntoEntityStorageAttemptEvent args)
+    {
+        // stay parented to the user, not the storage
+        args.Cancelled = true;
     }
 
     private void OnDisguiseShutdown(Entity<ChameleonDisguiseComponent> ent, ref ComponentShutdown args)


### PR DESCRIPTION
## About the PR
fixes #1585

## Why / Balance
code so robust i think the only actual issue with it is just a mispredict

## Technical details
prevent disguises being reparented
added to upstream pr too (hasnt been merged for 6 months :sob:) so no comments

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed chameleon projectors making you invisible when used with a crate.
