### PR TITLE
the big RE culling/rebalance

### DIFF
--- a/Resources/Prototypes/DeltaV/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Lathes/powercells.yml
@@ -1,0 +1,10 @@
+- type: latheRecipe
+  id: PowerCellHyper
+  result: PowerCellHyperPrinted
+  category: Parts
+  completetime: 8
+  materials:
+    Steel: 600
+    Glass: 500
+    Silver: 200
+    Gold: 100

--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -170,6 +170,12 @@
   - type: Storage
     grid:
     - 0,0,8,4
+  - type: ReverseEngineering # DeltaV: can RE any valid bag for BoH
+    difficulty: 4
+    recipes:
+    - ClothingBackpackHolding
+    - ClothingBackpackDuffelHolding
+    - ClothingBackpackSatchelHolding
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicate

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -35,10 +35,6 @@
   - type: Tag
     tags:
     - WhitelistChameleon
-  - type: ReverseEngineering # DeltaV
-    difficulty: 2
-    recipes:
-    - ClothingShoesBootsMagSci
 
 - type: entity
   parent: [ClothingShoesBootsMagBase]

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -123,10 +123,10 @@
         name: power-cell-slot-component-slot-name-default
   - type: Tag
     tags: []
-  - type: ReverseEngineering # delta
+  - type: ReverseEngineering # DeltaV
     difficulty: 4
     recipes:
-      - ClothingShoesBootsSpeed
+    - ClothingShoesBootsSpeed
 
 - type: entity
   id: ActionToggleSpeedBoots
@@ -154,3 +154,7 @@
     price: 75
   - type: Tag
     tags: [ ]
+  - type: ReverseEngineering # DeltaV: upgrade moonboots T1 to speedboots T3
+    difficulty: 5
+    recipes:
+    - ClothingShoesBootsSpeed

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -365,7 +365,7 @@
     - type: ReverseEngineering # DeltaV
       difficulty: 2
       recipes:
-      - WeaponPistolChimp
+      - WeaponPistolCHIMP
 
 - type: entity
   id: ThermomachineFreezerMachineCircuitBoard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -10,6 +10,10 @@
         MatterBin: 3
         Manipulator: 1
         Glass: 1
+    - type: ReverseEngineering # DeltaV
+      difficulty: 2
+      recipes:
+      - AutolatheHyperConvectionMachineCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -26,10 +30,6 @@
       Igniter:
         amount: 1
         defaultPrototype: Igniter
-  - type: ReverseEngineering # delta
-    difficulty: 2
-    recipes:
-      - AutolatheHyperConvectionMachineCircuitboard
 
 - type: entity
   id: ProtolatheMachineCircuitboard
@@ -46,6 +46,10 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: ReverseEngineering # DeltaV
+      difficulty: 2
+      recipes:
+      - ProtolatheHyperConvectionMachineCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -64,10 +68,6 @@
       Igniter:
         amount: 1
         defaultPrototype: Igniter
-  - type: ReverseEngineering # delta
-    difficulty: 2
-    recipes:
-      - ProtolatheHyperConvectionMachineCircuitboard
 
 - type: entity
   id: BiofabricatorMachineCircuitboard
@@ -80,10 +80,6 @@
       stackRequirements:
         MatterBin: 4
         Glass: 1
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-       - BiofabricatorMachineCircuitboard
 
 - type: entity
   id: SecurityTechFabCircuitboard
@@ -187,10 +183,6 @@
       MatterBin: 1
       Manipulator: 3
       Glass: 5
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-      - ExosuitFabricatorMachineCircuitboard
   - type: GuideHelp
     guides:
     - Robotics
@@ -254,10 +246,6 @@
         GlassBeaker:
           amount: 1
           defaultPrototype: Beaker
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-      - VaccinatorMachineCircuitboard
 
 - type: entity
   id: DiagnoserMachineCircuitboard
@@ -278,10 +266,6 @@
       BotanySwab:
         amount: 1
         defaultPrototype: DiseaseSwab
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-    - DiagnoserMachineCircuitboard
 
 - type: entity
   id: ArtifactAnalyzerMachineCircuitboard
@@ -297,10 +281,6 @@
         Manipulator: 3
         Capacitor: 1
         Glass: 5
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - ArtifactAnalyzerMachineCircuitboard
 
 - type: entity
   id: ArtifactCrusherMachineCircuitboard
@@ -316,10 +296,6 @@
       Manipulator: 2
       Glass: 1
       Steel: 5
-  - type: ReverseEngineering # delta
-    difficulty: 3
-    recipes:
-      - ArtifactCrusherMachineCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -338,7 +314,7 @@
     - type: ReverseEngineering # Nyano
       difficulty: 2
       recipes:
-        - AnomalyVesselCircuitboard
+      - AnomalyVesselExperimentalCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -355,10 +331,6 @@
       Cable: 5
       PlasmaGlass: 15
       MetalRod: 4
-  - type: ReverseEngineering # delta
-    difficulty: 3
-    recipes:
-      - AnomalyVesselExperimentalCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -375,10 +347,6 @@
         Capacitor: 5
         PlasmaGlass: 5
         Cable: 5
-    - type: ReverseEngineering # delta
-      difficulty: 3
-      recipes:
-       - AnomalySynchronizerCircuitboard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -394,10 +362,10 @@
         Capacitor: 2
         Cable: 1
         Glass: 1
-    - type: ReverseEngineering # Nyano
+    - type: ReverseEngineering # DeltaV
       difficulty: 2
       recipes:
-        - APECircuitboard
+      - WeaponPistolChimp
 
 - type: entity
   id: ThermomachineFreezerMachineCircuitBoard
@@ -417,14 +385,14 @@
     deconstructionTarget: null
     graph: ThermomachineBoard
     node: freezer
-  - type: ReverseEngineering # Nyano
+  - type: ReverseEngineering # DeltaV
     difficulty: 2
     recipes:
-      - ThermomachineFreezerMachineCircuitBoard
+    - HellfireFreezerMachineCircuitBoard
 
 - type: entity
   id: ThermomachineHeaterMachineCircuitBoard
-  parent: BaseMachineCircuitboard
+  parent: ThermomachineFreezerMachineCircuitBoard # DeltaV: inherit RE from freezer board
   name: heater thermomachine machine board
   description: Looks like you could use a screwdriver to change the board type.
   components:
@@ -459,10 +427,6 @@
     deconstructionTarget: null
     graph: ThermomachineBoard
     node: hellfirefreezer
-  - type: ReverseEngineering # delta
-    difficulty: 3
-    recipes:
-      - HellfireFreezerMachineCircuitBoard
 
 - type: entity
   parent: BaseMachineCircuitboard
@@ -550,11 +514,11 @@
     - type: ReverseEngineering # Nyano
       difficulty: 4
       recipes:
-        - CloningPodMachineCircuitboard
+      - CloningPodMachineCircuitboard
 
 - type: entity
   id: MedicalScannerMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseCloningBoard ] # DeltaV
   name: medical scanner machine board
   description: A machine printed circuit board for a medical scanner.
   components:
@@ -566,10 +530,6 @@
         Capacitor: 1
         Glass: 5
         Cable: 1
-    - type: ReverseEngineering # Nyano
-      difficulty: 3
-      recipes:
-        - MedicalScannerMachineCircuitboard
 
 - type: entity
   id: CrewMonitoringServerMachineCircuitboard
@@ -596,10 +556,6 @@
       stackRequirements:
         Glass: 5
         Cable: 1
-    - type: ReverseEngineering # Nyano
-      difficulty: 3
-      recipes:
-        - CryoPodMachineCircuitboard
 
 - type: entity
   id: ChemMasterMachineCircuitboard
@@ -656,10 +612,6 @@
           amount: 2
           defaultPrototype: KitchenKnife
           examineName: construction-insert-info-examine-name-knife
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-      - BiomassReclaimerMachineCircuitboard
 
 - type: entity
   id: HydroponicsTrayMachineCircuitboard
@@ -679,10 +631,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - HydroponicsTrayMachineCircuitboard
 
 - type: entity
   id: SeedExtractorMachineCircuitboard
@@ -700,10 +648,6 @@
         # replacing the console screen
         Glass: 1
         Cable: 2
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - SeedExtractorMachineCircuitboard
 
 - type: entity
   id: SMESMachineCircuitboard
@@ -766,10 +710,6 @@
         Plastic: 30
     - type: StaticPrice
       price: 30
-    - type: ReverseEngineering # delta
-      difficulty: 3
-      recipes:
-        - PowerCageRechargerCircuitboard
 
 - type: entity
   id: BorgChargerCircuitboard
@@ -831,10 +771,6 @@
     materialComposition:
       Steel: 30
       Plastic: 30
-  - type: ReverseEngineering # delta
-    difficulty: 2
-    recipes:
-      - TurboItemRechargerCircuitboard
 
 - type: entity
   id: SubstationMachineCircuitboard
@@ -892,10 +828,6 @@
           amount: 1
           defaultPrototype: SaxophoneInstrument
           examineName: construction-insert-info-examine-name-instrument-woodwind
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-      - DawInstrumentMachineCircuitboard
 
 - type: entity
   id: PortableGeneratorPacmanMachineCircuitboard
@@ -909,10 +841,6 @@
       stackRequirements:
         Capacitor: 1
         CableHV: 5
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - PortableGeneratorPacmanMachineCircuitboard
     - type: PhysicalComposition
       materialComposition:
         Glass: 200
@@ -931,10 +859,6 @@
     stackRequirements:
       Capacitor: 4
       Steel: 5
-  - type: ReverseEngineering # delta
-    difficulty: 3
-    recipes:
-      - ThrusterMachineCircuitboard
 
 - type: entity
   id: GyroscopeMachineCircuitboard
@@ -947,10 +871,6 @@
       Manipulator: 2
       Capacitor: 1
       Glass: 2
-  - type: ReverseEngineering # delta
-    difficulty: 3
-    recipes:
-      - GyroscopeMachineCircuitboard
 
 - type: entity
   id: PortableGeneratorSuperPacmanMachineCircuitboard
@@ -969,10 +889,6 @@
         Glass: 200
       chemicalComposition:
         Silicon: 20
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - PortableGeneratorSuperPacmanMachineCircuitboard
     - type: StaticPrice
       price: 40
 
@@ -995,10 +911,6 @@
         Silicon: 20
     - type: StaticPrice
       price: 40
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - PortableGeneratorJrPacmanMachineCircuitboard
 
 - type: entity
   id: ReagentGrinderMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -37,9 +37,6 @@
       state: cpu_engineering
     - type: ComputerBoard
       prototype: ComputerPowerMonitoring
-    - type: ReverseEngineering # Nyano
-      recipes:
-        - PowerComputerCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -133,10 +130,6 @@
       prototype: ComputerSalvageExpedition
     - type: StealTarget
       stealGroup: SalvageExpeditionsComputerCircuitboard
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - SalvageExpeditionsComputerCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -160,10 +153,6 @@
     - type: Tag
       tags:
         - SurveillanceCameraMonitorCircuitboard
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - SurveillanceCameraMonitorCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -173,10 +162,6 @@
   components:
     - type: ComputerBoard
       prototype: ComputerSurveillanceWirelessCameraMonitor
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - SurveillanceWirelessCameraMonitorCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -189,10 +174,6 @@
     - type: Tag
       tags:
        - ComputerTelevisionCircuitboard
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - ComputerTelevisionCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -215,10 +196,6 @@
       state: cpu_science
     - type: ComputerBoard
       prototype: ComputerAnalysisConsole
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - AnalysisComputerCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -230,10 +207,6 @@
     state: cpu_science
   - type: ComputerBoard
     prototype: ComputerTechnologyDiskTerminal
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-      - TechDiskComputerCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -302,10 +275,9 @@
   components:
   - type: ComputerBoard
     prototype: ComputerRadar
-  - type: ReverseEngineering # delta
-    difficulty: 2
+  - type: ReverseEngineering
     recipes:
-      - RadarConsoleCircuitboard
+    - HandHeldMassScanner
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -317,10 +289,6 @@
       state: cpu_engineering
     - type: ComputerBoard
       prototype: ComputerSolarControl
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - SolarControlComputerCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -359,10 +327,6 @@
   components:
     - type: ComputerBoard
       prototype: ComputerShuttle
-    - type: ReverseEngineering # delta
-      difficulty: 3
-      recipes:
-        - ShuttleConsoleCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -374,7 +338,7 @@
       prototype: ComputerShuttleSyndie
 
 - type: entity
-  parent: BaseComputerCircuitboard
+  parent: [ BaseComputerCircuitboard, BaseCloningBoard ] # DeltaV
   id: CloningConsoleComputerCircuitboard
   name: cloning console computer board
   description: A computer printed circuit board for a cloning console.
@@ -383,10 +347,6 @@
       state: cpu_medical
     - type: ComputerBoard
       prototype: ComputerCloningConsole
-    - type: ReverseEngineering # Nyano
-      difficulty: 3
-      recipes:
-        - CloningConsoleComputerCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -420,10 +380,6 @@
       price: 150
     - type: ComputerBoard
       prototype: ComputerMassMedia
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - ComputerMassMediaCircuitboard
 
 - type: entity
   parent: BaseComputerCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -67,10 +67,6 @@
       - HolofanProjector
   - type: StaticPrice
     price: 80
-  - type: ReverseEngineering # Nayno
-    difficulty: 3
-    recipes:
-      - HolofanProjector
 
 - type: entity
   parent: HolofanProjector
@@ -99,10 +95,6 @@
         - HolofanProjector
     - type: StaticPrice
       price: 130
-    - type: ReverseEngineering # delta
-      difficulty: 3
-      recipes:
-        - HoloprojectorField
 
 - type: entity
   parent: HoloprojectorField
@@ -131,10 +123,6 @@
         - HolofanProjector
     - type: StaticPrice
       price: 50
-    - type: ReverseEngineering # delta
-      difficulty: 2
-      recipes:
-        - HoloprojectorSecurity
 
 - type: entity
   parent: HoloprojectorSecurity

--- a/Resources/Prototypes/Entities/Objects/Devices/swapper.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/swapper.yml
@@ -25,7 +25,7 @@
   - type: Tag
     tags:
     - QuantumSpinInverter
-  - type: ReverseEngineering # delta
+  - type: ReverseEngineering # DeltaV
     difficulty: 4
     recipes:
-      - DeviceQuantumSpinInverter
+    - DeviceQuantumSpinInverter

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -146,6 +146,10 @@
   - type: Battery
     maxCharge: 1080
     startingCharge: 1080
+  - type: ReverseEngineering # DeltaV: Upgrade line of high -> hyper -> microreactor
+    difficulty: 3
+    recipes:
+    - PowerCellHyper
 
 - type: entity
   id: PowerCellHighPrinted
@@ -181,6 +185,10 @@
   - type: Battery
     maxCharge: 1800
     startingCharge: 1800
+  - type: ReverseEngineering # DeltaV
+    difficulty: 4
+    recipes:
+    - PowerCellMicroreactor
 
 - type: entity
   id: PowerCellHyperPrinted
@@ -255,6 +263,10 @@
     - type: BatterySelfRecharger
       autoRecharge: true
       autoRechargeRate: 40
+    - type: ReverseEngineering # DeltaV
+      difficulty: 4
+      recipes:
+      - PowerCellMicroreactor
 
 # Power cage (big heavy power cell for big devices)
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Hydroponics/tools.yml
@@ -139,3 +139,7 @@
         - Produce
         - Seed
   - type: Dumpable
+  - type: ReverseEngineering # DeltaV
+    difficulty: 2
+    recipes:
+    - PlantBagOfHolding

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -21,10 +21,6 @@
     - ScannersAndVessels
   - type: Item
     storedRotation: -90
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-      - AnomalyScanner
 
 - type: entity
   id: AnomalyLocatorUnpowered

--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -26,3 +26,7 @@
         - ArtifactFragment
         - Ore
   - type: Dumpable
+  - type: ReverseEngineering # DeltaV
+    difficulty: 2
+    recipes:
+    - OreBagOfHolding

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/node_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/node_scanner.yml
@@ -12,10 +12,6 @@
     - type: NodeScanner
     - type: UseDelay
       delay: 3
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - NodeScanner
     - type: GuideHelp
       guides:
       - ArtifactReports

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -243,10 +243,6 @@
       beaker:
         maxVol: 60
         canReact: false
-  - type: ReverseEngineering # delta
-    difficulty: 2
-    recipes:
-    - CryostasisBeaker
 
 - type: entity
   name: bluespace beaker
@@ -267,7 +263,7 @@
       beaker:
         maxVol: 1000
         canReact: true
-  - type: ReverseEngineering # delta
+  - type: ReverseEngineering # DeltaV
     difficulty: 4
     recipes:
       - BluespaceBeaker
@@ -432,7 +428,7 @@
     tags:
     - Syringe
     - Trash
-  - type: ReverseEngineering # delta
+  - type: ReverseEngineering # DeltaV
     difficulty: 4
     recipes:
       - SyringeBluespace
@@ -467,10 +463,6 @@
     tags:
     - Syringe
     - Trash
-  - type: ReverseEngineering # delta
-    difficulty: 2
-    recipes:
-      - SyringeCryostasis
 
 
 - type: entity
@@ -536,9 +528,9 @@
     tags:
       - PillCanister
   - type: Storage
-    whitelist: # DV - Remove the ability to store anything other than pills in pill canisters
-      tags: 
-        - Pill
+    whitelist: # DeltaV - Remove the ability to store anything other than pills in pill canisters
+      tags:
+      - Pill
     grid:
     - 0,0,4,1
     quickInsert: true

--- a/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/handheld_mass_scanner.yml
@@ -37,10 +37,6 @@
         type: RadarConsoleBoundUserInterface
   - type: StaticPrice
     price: 150
-  - type: ReverseEngineering # delta
-    difficulty: 2
-    recipes:
-       - HandHeldMassScanner
 
 - type: entity
   id: HandHeldMassScannerEmpty

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -59,10 +59,10 @@
       price: 100
 #    - type: DynamicPrice
 #      price: 100
-    - type: ReverseEngineering # Nyano
+    - type: ReverseEngineering # DeltaV: all jetpacks can RE to void jetpacks, the best kind which can't be bought
       difficulty: 3
       recipes:
-        - JetpackBlue
+      - JetpackVoid
 
 - type: entity
   id: ActionToggleJetpack
@@ -205,10 +205,6 @@
       outputPressure: 42.6
       air:
         volume: 1.5
-    - type: ReverseEngineering # Nyano
-      difficulty: 2
-      recipes:
-        - JetpackMini
 
 # Filled mini
 - type: entity
@@ -277,10 +273,6 @@
       - Back
       - suitStorage
       - Belt
-  - type: ReverseEngineering # DeltaV - make void jetpack RE'able
-    difficulty: 4
-    recipes:
-    - JetpackVoid
 
 # Filled void
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -273,10 +273,6 @@
       Plastic: 100
 #  - type: DynamicPrice
 #    price: 100
-  - type: ReverseEngineering # Nyano
-    difficulty: 2
-    recipes:
-      - PowerDrill
   - type: StaticPrice
     price: 100
   - type: MeleeWeapon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -65,7 +65,7 @@
   - type: ReverseEngineering # DeltaV
     difficulty: 2
     recipes:
-    - MiningDrill
+    - MiningDrillDiamond
 
 - type: entity
   name: diamond tipped mining drill
@@ -88,10 +88,6 @@
         Brute: 6
       types:
         Structural: 30
-  - type: ReverseEngineering # DeltaV
-    difficulty: 3
-    recipes:
-    - MiningDrillDiamond
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -370,6 +370,7 @@
       - RCDAmmo
       - Fulton
       - FultonBeacon
+      - PowerCellHyper
       # End DeltaV additions
   - type: EmagLatheRecipes
     emagDynamicRecipes:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/CircuitBoards/production.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/CircuitBoards/production.yml
@@ -1,22 +1,30 @@
+# you can RE any cloning board you find to unlock all 3
+- type: entity
+  abstract: true
+  id: BaseCloningBoard
+  components:
+  - type: ReverseEngineering
+    difficulty: 3
+    recipes:
+    - CloningConsoleComputerCircuitboard
+    - MetempsychoticMachineCircuitboard
+    - MedicalScannerMachineCircuitboard
+
 - type: entity
   id: MetempsychoticMachineCircuitboard
-  parent: BaseMachineCircuitboard
+  parent: [ BaseMachineCircuitboard, BaseCloningBoard ]
   name: metempsychotic machine machine board
   description: A machine printed circuit board for a cloning pod
   components:
-    - type: Sprite
-      state: medical
-    - type: MachineBoard
-      prototype: MetempsychoticMachine
-      stackRequirements:
-        Glass: 1
-        Cable: 1
-        Capacitor: 2
-        Manipulator: 2
-    - type: ReverseEngineering
-      difficulty: 3
-      recipes:
-        - MetempsychoticMachineCircuitboard
+  - type: Sprite
+    state: medical
+  - type: MachineBoard
+    prototype: MetempsychoticMachine
+    stackRequirements:
+      Glass: 1
+      Cable: 1
+      Capacitor: 2
+      Manipulator: 2
 
 - type: entity
   id: ReverseEngineeringMachineCircuitboard
@@ -24,51 +32,48 @@
   name: reverse engineering machine machine board
   description: A machine printed circuit board for a reverse engineering machine
   components:
-    - type: Sprite
-      state: engineering
-    - type: MachineBoard
-      prototype: ReverseEngineeringMachine
-      stackRequirements:
-        Cable: 1
-        PlasmaGlass: 5
-        MatterBin: 1
-        Manipulator: 1
-      tagRequirements:
-        BorgArm:
-          amount: 3
-          defaultPrototype: LeftArmBorg
-    - type: ReverseEngineering
-      difficulty: 2
-      recipes:
-        - ReverseEngineeringMachineCircuitboard
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: ReverseEngineeringMachine
+    stackRequirements:
+      Cable: 1
+      PlasmaGlass: 5
+      MatterBin: 1
+      Manipulator: 1
+    tagRequirements:
+      BorgArm:
+        amount: 3
+        defaultPrototype: LeftArmBorg
+  # TODO: make this reverse engineerable to the upgraded one
 
 - type: entity
   id: DeepFryerMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: deep fryer machine board
   components:
-    - type: Sprite
-      state: service
-    - type: MachineBoard
-      prototype: KitchenDeepFryer
-      stackRequirements:
-        Steel: 4
-        Glass: 2
-        Cable: 4
-        Capacitor: 1
-        MatterBin: 1
+  - type: Sprite
+    state: service
+  - type: MachineBoard
+    prototype: KitchenDeepFryer
+    stackRequirements:
+      Steel: 4
+      Glass: 2
+      Cable: 4
+      Capacitor: 1
+      MatterBin: 1
 
 - type: entity
   id: MailTeleporterMachineCircuitboard
   parent: BaseMachineCircuitboard
   name: mail teleporter machine board
   components:
-    - type: Sprite
-      state: supply
-    - type: MachineBoard
-      prototype: MailTeleporter
-      stackRequirements:
-        Steel: 4
-        Cable: 4
-        Capacitor: 1
-        MatterBin: 1
+  - type: Sprite
+    state: supply
+  - type: MachineBoard
+    prototype: MailTeleporter
+    stackRequirements:
+      Steel: 4
+      Cable: 4
+      Capacitor: 1
+      MatterBin: 1

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -56,8 +56,8 @@
   cost: 5000
   recipeUnlocks:
   - TechDiskComputerCircuitboard
-  - ReverseEngineeringMachineCircuitboard #delta change
-  
+  - ReverseEngineeringMachineCircuitboard # DeltaV
+
 - type: technology
   id: MagnetsTech
   name: research-technology-magnets-tech


### PR DESCRIPTION
## About the PR
- anything that wasnt worth REing was removed
- any cloning board unlocks recipe for all cloning boards, you can get "roundstart" cloning by REing one of meds boards they might have already
- made REing upgrade items where it was obvious (drill, jetpacks, freezer, ore and plant bags, hyper/antique cell)
- moonboots can upgrade to speedboots
- high-capacity cell from sec can upgrade to hyper (new recipe) which can in turn upgrade to microreactor
- valid bags can be REd for bags of holding

## Why / Balance
makes RE more useful as per #1882

T3 industrial can now be completely replaced with reverse engineering so now maybe you will see people research something else

## Media
![07:11:47](https://github.com/user-attachments/assets/9ba0d92f-a087-46b9-a180-b2f9611b51e9)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Syndicate duffelbags can be reverse engineered for bags of holding.
- add: Hyper-capacity powercells can be made by reverse engineering high-capacity powercells, which can also be reverse engineered to make microreactor cells.
- add: Moonboots can now be reverse engineered for speedboots.
- tweak: Any cloning board that gets reverse engineered unlocks every cloning board instead of itself (which was useless since you already have it).
- remove: Removed reverse engineering from items that made no sense to reverse engineer like roundstart equipment or tier 1 techs.
