### PR TITLE
add overcoat to prosecutor loadout

### DIFF
--- a/Resources/Locale/en-US/deltav/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/deltav/preferences/loadout-groups.ftl
@@ -107,6 +107,7 @@ loadout-group-clerk-shoes = Clerk shoes
 
 loadout-group-prosecutor-jumpsuit = Prosecutor jumpsuit
 loadout-group-prosecutor-neck = Prosecutor neck
+loadout-group-prosecutor-outer-clothing = Prosecutor outer clothing
 
 # Wildcards
 loadout-group-prisoner-jumpsuit = Prisoner jumpsuit

--- a/Resources/Prototypes/DeltaV/Loadouts/Jobs/Justice/prosecutor.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/Jobs/Justice/prosecutor.yml
@@ -14,3 +14,9 @@
   id: ProsecutorNeck
   equipment:
     neck: ClothingNeckProsecutorbadge
+
+# OuterClothing
+- type: loadout
+  id: ProsecutorOvercoat
+  equipment:
+    outerClothing: ClothingOuterCoatOvercoat

--- a/Resources/Prototypes/DeltaV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/loadout_groups.yml
@@ -220,13 +220,20 @@
   - LawyerJumpskirtRed
   - LawyerJumpsuitGood
   - LawyerJumpskirtGood
-  
+
 - type: loadoutGroup
   id: ProsecutorNeck
   name: loadout-group-prosecutor-neck
   minLimit: 0
   loadouts:
   - ProsecutorNeck
+
+- type: loadoutGroup
+  id: ProsecutorOuterClothing
+  name: loadout-group-prosecutor-outer-clothing
+  minLimit: 0
+  loadouts:
+  - ProsecutorOvercoat
 
 # PDAs
 - type: loadoutGroup

--- a/Resources/Prototypes/DeltaV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/role_loadouts.yml
@@ -65,6 +65,7 @@
   - GroupTankHarness
   - ProsecutorJumpsuit
   - ProsecutorNeck
+  - ProsecutorOuterClothing
   - CommonBackpack
   - Glasses
   - Survival


### PR DESCRIPTION
## About the PR
title

## Why / Balance
coat

## Media
![08:27:19](https://github.com/user-attachments/assets/01db5e2b-2f2d-420b-a624-899a2da19743)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: Prosecutors can now add their overcoat to loadouts.