### PR TITLE
Fix deep fryer not being repairable once broken.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/deep_fryer.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/deep_fryer.yml
@@ -145,11 +145,8 @@
           collection: MetalBreak
       - !type:SpillBehavior
         solution: vat_oil
-      - !type:SpawnEntitiesBehavior
-        spawn:
-          MachineFrameDestroyed:
-            min: 1
-            max: 1
+      - !type:ChangeConstructionNodeBehavior
+        node: machineFrame
   - type: ApcPowerReceiver
     powerLoad: 300
   - type: Machine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the deep fryer repairable after being destroyed. I modified this watching from how other machines broke after getting damaged enough.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It didn't make sense on why it couldn't be repaired when the rest of the machines can be fixed, plus sometimes the broken machine spawned in weird places.
## Technical details
<!-- Summary of code changes for easier review. -->
Switched `!type:SpawnEntitiesBehavior` for `!type:ChangeConstructionNodeBehavior`, also removing the parameters of the first one.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:

https://github.com/user-attachments/assets/b63843be-ca21-4652-8458-383dcd105295

After:

https://github.com/user-attachments/assets/aff6a66f-7046-4382-b1fe-70f9f55a798b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Hopefully none.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed deep fryer not being repairable after being broken.
