### PR TITLE
Fixed Vulpkanin maskes not properly hiding the face on screen loadout.

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Species/vulpkanin.yml
@@ -109,3 +109,9 @@
   components:
   - type: HumanoidAppearance
     species: Vulpkanin
+    hideLayersOnEquip:
+    - Snout
+    - HeadTop
+    - HeadSide
+  - type: Inventory
+    speciesId: vulpkanin


### PR DESCRIPTION
## About the PR
Made vulpkanin clothing hide the snout during character customization.

## Why / Balance
Requested at https://github.com/DeltaV-Station/Delta-v/issues/1831

## Technical details
added hiding of Snout ,HeadTop, and HeadSide as done by portfiend here https://github.com/space-wizards/space-station-14/pull/30095

## Media
<img width="190" alt="VulpMaskFix" src="https://github.com/user-attachments/assets/558fa4e5-ae81-4f9a-a041-d3e691991ee2">

## Requirements
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: FryOfDestiny

- fix: Vulpkanin display correct mask sprites in character customization screen
