### PR TITLE
Reduce Topical Cook Time

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -2,7 +2,7 @@
   id: RecipeAloeCream
   name: aloe cream recipe
   result: AloeCream
-  time: 5
+  time: 5 # DeltaV - Changed from 10 to 5
   solids:
     FoodAloe: 1
 
@@ -10,7 +10,7 @@
   id: RecipeMedicatedSuture
   name: medicated suture recipe
   result: MedicatedSuture
-  time: 5
+  time: 5 # DeltaV - Changed from 10 to 5
   solids:
     FoodPoppy: 1
     Brutepack: 1
@@ -23,7 +23,7 @@
   id: RecipeRegenerativeMesh
   name: regenerative mesh recipe
   result: RegenerativeMesh
-  time: 5
+  time: 5 # DeltaV - Changed from 10 to 5
   solids:
     FoodAloe: 1
     Ointment: 1

--- a/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/medical_recipes.yml
@@ -2,7 +2,7 @@
   id: RecipeAloeCream
   name: aloe cream recipe
   result: AloeCream
-  time: 10
+  time: 5
   solids:
     FoodAloe: 1
 
@@ -10,7 +10,7 @@
   id: RecipeMedicatedSuture
   name: medicated suture recipe
   result: MedicatedSuture
-  time: 10
+  time: 5
   solids:
     FoodPoppy: 1
     Brutepack: 1
@@ -23,7 +23,7 @@
   id: RecipeRegenerativeMesh
   name: regenerative mesh recipe
   result: RegenerativeMesh
-  time: 10
+  time: 5
   solids:
     FoodAloe: 1
     Ointment: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changes topical cook times from 10 seconds to 5 seconds
## Why / Balance
Sitting in front of a microwave and waiting 10 seconds over and over isn't exactly ideal gameplay. This doesn't entirely fix it but it definitely idealizes making the topicals more often.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Reduce advanced topicals cook time

