### PR TITLE
disable species vision filters by default

### DIFF
--- a/Content.Shared/DeltaV/CCVars/DCCVars.cs
+++ b/Content.Shared/DeltaV/CCVars/DCCVars.cs
@@ -20,7 +20,7 @@ public sealed class DCCVars
     /// Disables all vision filters for species like Vulpkanin or Harpies. There are good reasons someone might want to disable these.
     /// </summary>
     public static readonly CVarDef<bool> NoVisionFilters =
-        CVarDef.Create("accessibility.no_vision_filters", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("accessibility.no_vision_filters", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
     /// <summary>
     /// Whether the Shipyard is enabled.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
defaults accessibility.no_vision_filters to true

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
no one knows it exists anyways

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Species vision filters are now disabled by default. You can re-enable them in the settings!
