### PR TITLE
Can no longer use an emag to early launch the shuttle

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -25,7 +25,7 @@
           False: { visible: false }
         computerLayerKeys:
           True: { visible: true, shader: unshaded }
-          False: { visible: true, shader: shaded }   
+          False: { visible: true, shader: shaded }
       enum.AtmosAlertsComputerVisuals.ComputerLayerScreen:
         computerLayerScreen:
           0: { state: alert-0 }
@@ -62,6 +62,9 @@
     radius: 1.5
     energy: 1.6
     color: "#43ccb5"
+  - type: Tag
+    tags:
+    - EmagImmune #Delta-V Change
   - type: Rotatable
     rotateWhileAnchored: true
 


### PR DESCRIPTION
## About the PR
Made the early launch shuttle console immune to emag's so that it can not be early launched by anyone

## Why / Balance
I got left behind and i was sad

## Technical details
added emagImmune tag to the emergency shuttle console.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**

:cl:
- remove: Emag can no longer be used to early launch the evacuation shuttle.

