### PR TITLE
Goliath HP Nerf

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -90,12 +90,12 @@
     - id: FoodMeatGoliath
       amount: 3
     - id: MaterialGoliathHide1
-- type: Prying # DeltaV: let sentient goliaths pry doors
-   - pryPowered: true
-   - force: true
-   - speedModifier: 1.5
-   - useSound:
-      path: /Audio/Items/crowbar.ogg
+   - type: Prying # DeltaV: let sentient goliaths pry doors
+    - pryPowered: true
+    - force: true
+    - speedModifier: 1.5
+    - useSound:
+       path: /Audio/Items/crowbar.ogg
 
 - type: entity
   id: ActionGoliathTentacle

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -55,7 +55,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      300: Dead
+      100: Dead
   - type: MeleeWeapon
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -90,11 +90,11 @@
     - id: FoodMeatGoliath
       amount: 3
     - id: MaterialGoliathHide1
-  - type: Prying # DeltaV: let sentient goliaths pry doors
-    pryPowered: true
-    force: true
-    speedModifier: 1.5
-    useSound:
+- type: Prying # DeltaV: let sentient goliaths pry doors
+   - pryPowered: true
+   - force: true
+   - speedModifier: 1.5
+   - useSound:
       path: /Audio/Items/crowbar.ogg
 
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -91,11 +91,11 @@
       amount: 3
     - id: MaterialGoliathHide1
    - type: Prying # DeltaV: let sentient goliaths pry doors
-    - pryPowered: true
-    - force: true
-    - speedModifier: 1.5
-    - useSound:
-       path: /Audio/Items/crowbar.ogg
+   - pryPowered: true
+   - force: true
+   - speedModifier: 1.5
+   - useSound:
+      path: /Audio/Items/crowbar.ogg
 
 - type: entity
   id: ActionGoliathTentacle

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -90,11 +90,11 @@
     - id: FoodMeatGoliath
       amount: 3
     - id: MaterialGoliathHide1
-   - type: Prying # DeltaV: let sentient goliaths pry doors
-   - pryPowered: true
-   - force: true
-   - speedModifier: 1.5
-   - useSound:
+  - type: Prying # DeltaV: let sentient goliaths pry doors
+    pryPowered: true
+    force: true
+    speedModifier: 1.5
+    useSound:
       path: /Audio/Items/crowbar.ogg
 
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Dropped Goliath HP from 300 -> 100

## Why / Balance
One goliath should not be able to take out a team of 3 people with decent weapons, but it can, due to immense HP, no blood loss, and generally being annoying as well to fight

## Technical details
Dropped a single number from 300 to 100, I am not sure why I had to re-add the prying though


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl: 
- tweak: Goliaths are far less hardy than they once were
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
