### PR TITLE
Makes sneaky rodents able to avoid traps

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3360,6 +3360,7 @@
     rootTask:
       task: RuminantCompound
 
+
 - type: entity
   name: diona nymph
   parent: [SimpleMobBase, StripableInventoryBase]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3360,7 +3360,6 @@
     rootTask:
       task: RuminantCompound
 
-
 - type: entity
   name: diona nymph
   parent: [SimpleMobBase, StripableInventoryBase]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1648,7 +1648,7 @@
       10: Critical
       20: Dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 1.9
+    baseWalkSpeed : 1.9  #Delta V: Allows them to sneak over traps
     baseSprintSpeed : 5
   - type: DamageStateVisuals
     states:
@@ -3206,7 +3206,7 @@
       40: Critical
       60: Dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 1.9
+    baseWalkSpeed : 1.9  #Delta V: Allows them to sneak over traps
     baseSprintSpeed : 4
   - type: Inventory
     speciesId: hamster

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1903,7 +1903,7 @@
       state: slug
       sprite: Mobs/Animals/slug.rsi
   - type: Carriable #DeltaV
-    freeHandsRequired: 1
+    freeHandsRequired: 1 
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -3359,7 +3359,7 @@
   - type: HTN
     rootTask:
       task: RuminantCompound
-
+      
 - type: entity
   name: diona nymph
   parent: [SimpleMobBase, StripableInventoryBase]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1648,7 +1648,7 @@
       10: Critical
       20: Dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
+    baseWalkSpeed : 1.9
     baseSprintSpeed : 5
   - type: DamageStateVisuals
     states:
@@ -1903,7 +1903,7 @@
       state: slug
       sprite: Mobs/Animals/slug.rsi
   - type: Carriable #DeltaV
-    freeHandsRequired: 1 
+    freeHandsRequired: 1
   - type: Physics
   - type: Fixtures
     fixtures:
@@ -3206,7 +3206,7 @@
       40: Critical
       60: Dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.5
+    baseWalkSpeed : 1.9
     baseSprintSpeed : 4
   - type: Inventory
     speciesId: hamster
@@ -3359,7 +3359,7 @@
   - type: HTN
     rootTask:
       task: RuminantCompound
-      
+
 - type: entity
   name: diona nymph
   parent: [SimpleMobBase, StripableInventoryBase]

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1648,7 +1648,7 @@
       10: Critical
       20: Dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 1.9  #Delta V: Allows them to sneak over traps
+    baseWalkSpeed : 1.9  # DeltaV - Allows them to sneak over traps
     baseSprintSpeed : 5
   - type: DamageStateVisuals
     states:
@@ -3206,7 +3206,7 @@
       40: Critical
       60: Dead
   - type: MovementSpeedModifier
-    baseWalkSpeed : 1.9  #Delta V: Allows them to sneak over traps
+    baseWalkSpeed : 1.9  # DeltaV - Allows them to sneak over traps
     baseSprintSpeed : 4
   - type: Inventory
     speciesId: hamster


### PR DESCRIPTION
## About the PR
- Reduces walk speed of mice and hamsters so they are able to avoid traps by being sneaky.   

## Why / Balance
I feel this is balanced by being slow and allows for some more interesting gameplay for mice players

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: Velcroboy
- tweak: Sneaky mice and hamsters can avoid traps by walking very, very slow
