### PR TITLE
untroll glimmermobspawnrule

### DIFF
--- a/Content.Server/DeltaV/StationEvents/Events/GlimmerMobSpawnRule.cs
+++ b/Content.Server/DeltaV/StationEvents/Events/GlimmerMobSpawnRule.cs
@@ -7,6 +7,7 @@ using Content.Shared.Abilities.Psionics;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.NPC.Components;
 using Content.Shared.Psionics.Glimmer;
+using Content.Shared.Station.Components;
 using Robust.Shared.Random;
 using Robust.Shared.Map;
 
@@ -46,12 +47,17 @@ public sealed class GlimmerMobRule : StationEventSystem<GlimmerMobRuleComponent>
     private List<EntityCoordinates> GetCoords<T>() where T : IComponent
     {
         var coords = new List<EntityCoordinates>();
-        var query = EntityQueryEnumerator<TransformComponent, T>();
-        while (query.MoveNext(out var xform, out _))
+        if (TryGetRandomStation(out var station))
         {
-            coords.Add(xform.Coordinates);
+            var query = EntityQueryEnumerator<TransformComponent, T>();
+            while (query.MoveNext(out var xform, out _))
+            {
+                if (CompOrNull<StationMemberComponent>(xform.GridUid)?.Station == station)
+                {
+                    coords.Add(xform.Coordinates);
+                }
+            }
         }
-
         return coords;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
changes it so that GlimmerMobSpawn will no longer try spawning glimmer creatures outside the station

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
annoying AS FUCK

## Technical details
<!-- Summary of code changes for easier review. -->
blah code is clear enough but it does the same thing as the RandomSpawnRule basically

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Glimmer mobs will no longer spawn on CentCom or the evac shuttle.

