### PR TITLE
Added hiss emote to tarantulas

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2329,7 +2329,7 @@
   - type: Speech
     speechVerb: Arachnid
     speechSounds: Arachnid
-    allowedEmotes: ['Click', 'Chitter']
+    allowedEmotes: ['Click', 'Chitter', 'Hiss'] #DeltaV added Hiss
   - type: Vocal
     sounds:
       Male: UnisexArachnid

--- a/Resources/Prototypes/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Voice/speech_emote_sounds.yml
@@ -249,6 +249,8 @@
       path: /Audio/Voice/Arachnid/arachnid_chitter.ogg
     Click:
       path: /Audio/Voice/Arachnid/arachnid_click.ogg
+    Hiss:
+      path: /Audio/Animals/snake_hiss.ogg #DeltaV
     Weh:
       collection: Weh
     Gasp:


### PR DESCRIPTION
## About the PR
I made it so that spiders could hiss on command

## Why / Balance
Spiders could already hiss when being pet and I wanted to be able to do it in a threatening way so I added it.

## Technical details
Added hiss to UnisexArachnid which is shared by the arachnid but arachnid does not have hiss emote so it only affects tarantulas which now have the Hiss emote available. It uses the Snake_Hiss sound.

## Media
Not sure how to add video and the change is minor so i don't think it requires it.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Should not break anything unless the UnisexArachnid is used in a spot I am unaware of.

**Changelog**
:cl:
- tweak: Spiders can now hiss.
