### PR TITLE
blacklist nukedisk from slime storage

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Misc/mouth_storage.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Misc/mouth_storage.yml
@@ -9,10 +9,11 @@
     grid:
     - 0,0,1,1
     maxItemSize: Small
-    blacklist: 
+    blacklist:
       components:
       - Sharp
       - MindContainer
+      - NukeDisk
   - type: ContainerContainer
     containers:
       storagebase: !type:Container

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -21,6 +21,9 @@
     maxItemSize: Large
     storageInsertSound:
       path: /Audio/Voice/Slime/slime_squish.ogg
+    blacklist: # DeltaV - add blacklist
+      components:
+      - NukeDisk
   - type: ContainerContainer
     containers:
       storagebase: !type:Container


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
what it says on the tin

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bug fix, you can't access storage when the target cryos so if the captain has the nuke disk there it will get sent to nullspace

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl because i can't come up with a good one
