### PR TITLE
Raised the price of tracking implants.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -24,7 +24,7 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateTrackingImplants
-  cost: 4000
+  cost: 4000 # DeltaV - was 1000
   category: cargoproduct-category-name-armory
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -24,7 +24,7 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateTrackingImplants
-  cost: 1000
+  cost: 4000
   category: cargoproduct-category-name-armory
   group: market
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Raises the tracking implants price 4 times.

## Why / Balance
I'm seeing consistently a lot of trackers bought for security but never used on prisoners even when they constantly escape or are violent, I usually see 3 crates of tracking implants per round at security for themselves.
This PR should help reduce that, no longer can cargo buy trackers shift start, but now they got more of a reason to deny them since 3 crates would be 12k.

## Technical details
One line change of YAML.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The tracking implants crate is now more expensive.
