### PR TITLE
Removes suffix from toy box.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -456,7 +456,7 @@
   parent: CratePirate
   id: CrateToyBox
   name: toy box
-  suffix: Empty
+  #suffix: Empty # Delta V - Commented out simply for clarity at spawn menu on other uses besides the filled toy box.
   description: A box overflowing with fun.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It just removes the suffix from the toy box crate.

## Why / Balance
Toy box crate was used in only one place so the original author put the `[Empty]` suffix to it, removed for any other uses of the crate like my [foam toys crate](https://github.com/DeltaV-Station/Delta-v/pull/1985).

## Technical details
Commented out the suffix from the toy crate.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
![image](https://github.com/user-attachments/assets/f3c2d941-5d36-4535-9328-98abacb1366a)
![image](https://github.com/user-attachments/assets/d98f6d16-b368-4597-bd28-49d5a2b076c2)


After:
![image](https://github.com/user-attachments/assets/42beaff3-8637-4751-8b07-917424c48476)
![image](https://github.com/user-attachments/assets/092ba1a7-cc44-4d06-9842-5d2d1ee829e7)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
I hope not.
**Changelog**
no cl.
