### PR TITLE
Fixes the Helix shuttle wiring.

### DIFF
--- a/Resources/Maps/Shuttles/DeltaV/helix.yml
+++ b/Resources/Maps/Shuttles/DeltaV/helix.yml
@@ -17,7 +17,6 @@ entities:
     components:
     - type: MetaData
     - type: Transform
-      parent: invalid
     - type: MapGrid
       chunks:
         -1,-1:
@@ -510,8 +509,6 @@ entities:
     - type: Transform
       pos: 10.5,8.5
       parent: 1
-    - type: Apc
-      hasAccess: True
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 23

--- a/Resources/Maps/Shuttles/DeltaV/helix.yml
+++ b/Resources/Maps/Shuttles/DeltaV/helix.yml
@@ -17,6 +17,7 @@ entities:
     components:
     - type: MetaData
     - type: Transform
+      parent: invalid
     - type: MapGrid
       chunks:
         -1,-1:
@@ -366,7 +367,6 @@ entities:
     - type: RadiationGridResistance
     - type: SpreaderGrid
     - type: GravityShake
-      nextShake: 0
       shakeTimes: 10
 - proto: AirCanister
   entities:
@@ -499,17 +499,19 @@ entities:
   - uid: 205
     components:
     - type: MetaData
-      name: Treatment APC
+      name: Treatment / West docks APC
     - type: Transform
       pos: -3.5,7.5
       parent: 1
   - uid: 448
     components:
     - type: MetaData
-      name: Cryo APC
+      name: Cryo / East docks APC
     - type: Transform
       pos: 10.5,8.5
       parent: 1
+    - type: Apc
+      hasAccess: True
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 23
@@ -559,7 +561,7 @@ entities:
   - uid: 28
     components:
     - type: Transform
-      pos: 10.5,7.5
+      pos: -3.5,5.5
       parent: 1
   - uid: 29
     components:
@@ -951,6 +953,31 @@ entities:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 10.5,5.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      pos: 10.5,6.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 10.5,7.5
+      parent: 1
 - proto: CableHV
   entities:
   - uid: 107
@@ -1223,13 +1250,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,11.5
       parent: 1
-- proto: chem_master
-  entities:
-  - uid: 140
-    components:
-    - type: Transform
-      pos: 4.5,3.5
-      parent: 1
 - proto: ChemDispenser
   entities:
   - uid: 141
@@ -1243,6 +1263,13 @@ entities:
     components:
     - type: Transform
       pos: 3.5,1.5
+      parent: 1
+- proto: ChemMaster
+  entities:
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 4.5,3.5
       parent: 1
 - proto: ClosetWallEmergencyFilledRandom
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Pretty much what the title says, added a few LV wires and renamed the APCs to reflect the wiring changes.

## Why / Balance
Treatment area and the docks were unpowered, some thrusters didn't work neither.

## Technical details
Mapping changes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before:
![image](https://github.com/user-attachments/assets/6ceb6026-4c6d-4712-a6a2-e8c576e46e96)

After:
![image](https://github.com/user-attachments/assets/beb0a39a-915c-45e8-a1d0-56ed3fa426e2)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Hopefully none.

**Changelog**

No CL.
