### PR TITLE
Theobromine Tweaks (vulps + coffee)

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/ingredients.yml
@@ -234,6 +234,9 @@
           reagent: Nutriment
           min: 0.1
         factor: 1
+      - !type:AdjustReagent # DeltaV - Make cocoa powder actually toxic to animal organs
+        reagent: Theobromine
+        amount: 0.2
   plantMetabolism:
   - !type:PlantAdjustNutrition
     amount: 0.1

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -403,7 +403,7 @@
   boilingPoint: 554 # I'm not a chemist, but it boils at 295, lower than melting point, idk how it works so I gave it higher value
   metabolisms:
     Poison:
-      metabolismRate: 0.05
+      metabolismRate: 0.04 # DeltaV - Slowed to allow coffee/etc to build up theobromine
       effects:
       - !type:HealthChange
         conditions:
@@ -411,12 +411,15 @@
           type: Animal # Applying damage to the mobs with lower metabolism capabilities
         damage:
           types:
-            Poison: 0.4
+            Poison: 0.3 # DeltaV - slightly reduced to account for slowed metabolism rate
       - !type:ChemVomit
-        probability: 0.04 #Scaled for time, not metabolismrate.
+        probability: 0.1 #Scaled for time, not metabolismrate. # DeltaV - Increased from .04 Vomit more when there is a lot of it
         conditions:
           - !type:OrganType
             type: Animal
+          - !type:ReagentThreshold #DeltaV - Readded this. No longer causes vomitting at the lightest whiff of coffee
+            reagent: Theobromine
+            min: 0.5
 
 - type: reagent
   id: Amatoxin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Tweaked theombromine stats to make its effects more logical. Small amounts will no longer cause vomiting, but large amounts are more likely to. 

Also made cocoa powder metabolize into theobromine.

## Why / Balance
At some point upstream changed theobromine such that any amount has a chance to cause vomiting. This sucks for any animal race that wants to enjoy coffee/chocolate products without vomiting everywhere and ruining the scene.

Cocoa powder is one of the most concentrated sources of theobromine irl, makes no sense that it didn't metabolize into it.

## Technical details
Modified the ingredients and toxins yaml files to tweak cocoa powder and theobromine. 

Theobromine metabolizes slightly slower now, allowing drinks like coffee to cause a slow buildup in the body (previously the amount of it being created perfectly matched the speed at which it metabolized). The toxin damage per second was slightly reduced to offset the slower metabolism.

Most notably, vomiting will no longer happen unless there is at least .5u, requiring the entity to consume a larger amount before vomiting can set in. Increased vomiting chance per second from 4% to 10% since vomiting should only occur at higher doses now.

Cocoa powder metabolizes into .2u theobromine per second (a high amount relative to the other reagents like coffee).

## Media
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Small doses of theobromine no longer cause vomiting in animal species.

