### PR TITLE
Syndie Raid Suit Cold Protection

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -114,6 +114,9 @@
       shader: unshaded
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi
+  - type: TemperatureProtection
+    heatingCoefficient: 1.0
+    coolingCoefficient: 0.1
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gave the Syndie Raid suit insulation against the cold. 

## Why / Balance
So we can actually use the atmospheric suit on the one station with an atmosphere (glacier)

## Technical details
Modified armor.yml to give the suit the same cold insulation as a winter coat (still not as a good as a hardsuit). Didn't give it any heat insulation.

## Media
![image](https://github.com/user-attachments/assets/270c0787-742c-480e-9142-2a4509ea8f53)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The Syndicate raid suit now protects users from the cold. Have fun raiding Glacier!

