### PR TITLE
remove 8 second role rule timer

### DIFF
--- a/Content.Shared/CCVar/CCVars.cs
+++ b/Content.Shared/CCVar/CCVars.cs
@@ -2120,7 +2120,7 @@ namespace Content.Shared.CCVar
         /// The time you must spend reading the rules, before the "Request" button is enabled
         /// </summary>
         public static readonly CVarDef<float> GhostRoleTime =
-            CVarDef.Create("ghost.role_time", 8f, CVar.REPLICATED | CVar.SERVER);
+            CVarDef.Create("ghost.role_time", 3f, CVar.REPLICATED | CVar.SERVER);
 
         /// <summary>
         /// If ghost role lotteries should be made near-instanteous.


### PR DESCRIPTION
## About the PR
its now 3 seconds, the default

## Why / Balance
shitters dont care about rules anyway so the extra 5 seconds didnt matter
what it actually did is lock you out of a raffle if it had 8 seconds or less remaining, so if you are late seeing it you get just trolled

**Changelog**
:cl:
- tweak: Ghost role waiting time is down to 3 seconds, from 8.