### PR TITLE
remove salt from salvage

### DIFF
--- a/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
+++ b/Resources/Prototypes/Procedural/Magnet/asteroid_ore_gens.yml
@@ -3,8 +3,8 @@
   weights:
     OreIron: 1.0
     OreQuartz: 1.0
-    OreCoal: 0.33
-    OreSalt: 0.25
+    OreCoal: 0.58 # DeltaV: was 0.33, added 0.25 from salt
+    #OreSalt: 0.25 # DeltaV: removed salt, added weight to coal
     OreGold: 0.25
     OreSilver: 0.25
     OrePlasma: 0.20

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -139,7 +139,7 @@
   guaranteed: true
   loots:
     - !type:BiomeMarkerLoot
-      proto: OreSalt
+      proto: OreCoal # DeltaV: replace salt with coal
 
 # - Medium value
 - type: salvageLoot

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -90,7 +90,7 @@
   id: RandomOreDistributionStandard
   weights:
     OreSteel: 10
-    OreCoal: 10
+    OreCoal: 12 # DeltaV: increased slightly from 10 so there is a surplus to give to chem
     OreSpaceQuartz: 8
     OreGold: 2
     OrePlasma: 4
@@ -98,7 +98,6 @@
     OreUranium: 1
     OreBananium: 0.5
     OreArtifactFragment: 0.5
-    OreSalt: 5 #Delta V - Adds so our rocks can spawn salt
 
 - type: weightedRandomOre
   id: OreCrab


### PR DESCRIPTION
## About the PR
replaced it with more coal spawners
coal in the random ore spawner is a bit more common so theres a stronger surplus to share with chem

## Why / Balance
- salv hates salt because its annoying
- chem hates salt because its fucking *salt* you never run out of sodium or chlorine so grinding it just a waste of your time that you would only do to make salv not feel like they completely wasted their time running to chem
- chem loves coal because carbon = life, and carbon is usually the only reason you buy a chemvend restock at all

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- remove: Removed salt ore in favour of coal. Give the chemists carbon!