### PR TITLE
erase verb for all entities

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -230,7 +230,7 @@ namespace Content.Server.Administration.Systems
                     args.Verbs.Add(new Verb
                     {
                         Text = Loc.GetString("admin-verbs-erase"),
-                        Message = Loc.GetString("admin-verbs-erase-description"),
+                        Message = Loc.GetString("admin-verbs-erase-item-description"),
                         Category = VerbCategory.Admin,
                         Icon = new SpriteSpecifier.Texture(
                             new("/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png")),

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -225,6 +225,23 @@ namespace Content.Server.Administration.Systems
                         // No logimpact as the command does it internally.
                     });
                 }
+                else // DeltaV - Erase verb for entities without a mind
+                {
+                    args.Verbs.Add(new Verb
+                    {
+                        Text = Loc.GetString("admin-verbs-erase"),
+                        Message = Loc.GetString("admin-verbs-erase-description"),
+                        Category = VerbCategory.Admin,
+                        Icon = new SpriteSpecifier.Texture(
+                            new("/Textures/Interface/VerbIcons/delete_transparent.svg.192dpi.png")),
+                        Act = () =>
+                        {
+                            _adminSystem.Erase(args.Target);
+                        },
+                        Impact = LogImpact.Extreme,
+                        ConfirmationPopup = true
+                    });
+                }
 
                 // Freeze
                 var frozen = TryComp<AdminFrozenComponent>(args.Target, out var frozenComp);

--- a/Resources/Locale/en-US/deltav/administration/admin-verbs.ftl
+++ b/Resources/Locale/en-US/deltav/administration/admin-verbs.ftl
@@ -1,0 +1,2 @@
+admin-verbs-erase-item-description = Removes the entity from the round.
+    Players are shown a popup indicating them to play as if it never existed.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
adds the erase verb to all entities

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
funny

## Technical details
<!-- Summary of code changes for easier review. -->
the erase method is so fucking shit i need to refactor it upstream at some point but review hell
i commented it as best as I could but big code change so
split into two methods, one for NetUserId and another one for EntityUid
the NetUserId one calls the base EntityUid method and does some extra shit like nuking messages and spawning an observer
ideally this would all be in helper methods instead of whatever fever dream this is
AdminVerbSystem modified to add the erase verb for entities without a mind
**Contents of this entire PR are dual-licensed under MIT, forks that are not AGPL are free to use them.**

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/78c5051d-f2e1-4a4f-864a-82de8130e1fe)
![image](https://github.com/user-attachments/assets/0ed4b980-bf06-4385-9beb-55e311fcdd8d)
![image](https://github.com/user-attachments/assets/39f80f46-eee2-4d6f-8b1f-cfd9f71da197)


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
backwards compatible
trust 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
DELTAVADMIN:
- tweak: The Erase verb is now available on all entities.

