### PR TITLE
Adding clerk access to evidence lockers and brig timers.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -384,7 +384,7 @@
   description: To store bags of bullet casings and detainee belongings.
   components:
   - type: AccessReader
-    access: [["Security"], ["Prosecutor"]] # DeltaV - allow Pros access to Evidence
+    access: [["Security"], ["Prosecutor"], ["Clerk"]] # DeltaV - allow Pros and Clerk access to Evidence
 
 # Syndicate
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/timer.yml
@@ -89,7 +89,7 @@
   description: It's a timer for brig cells.
   components:
   - type: AccessReader
-    access: [["Security"], ["Prosecutor"]] # DeltaV - Added justice dept
+    access: [["Security"], ["Prosecutor"], ["Clerk"]] # DeltaV - Added justice dept
   - type: Construction
     graph: Timer
     node: brig


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the Clerk access to evidence lockers and brig timer items.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Current SOP has a lot of responsibilities for "Prosecutor, or Clerk in their absence". However, the Clerk never received the quality of life access updates #1422 and #1430 to accomplish the expectations of their job on their own: in the case where a Prosecutor is not present, or similar. Justice department does not normally have a full retinue, so this would help empower the Chief Justice + Clerk duo in the absence of a Prosecutor.

Why evidence lockers? Clerks can potentially gather evidence from the lockers for court. It is their duty to do this if there is no Prosecutor.
Why brig timers? "In the case that the accused requests an appeal for a felony sentence, the Court Clerk should be called to preside over a small, prompt adjudication, where the Prosecutor and accused will argue their sides. The Clerk will be responsible for deciding the sentence or acquittal of the accused." Now Clerks can update the brig timer with the corrected time on their own. 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Clerks now have brig timer and evidence locker access. Don't steal the Prosecutor's job from them!
