### PR TITLE
tweak: Remove 'nuke' replacement from Italian accent

### DIFF
--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -46,7 +46,7 @@
     accent-italian-words-18: accent-italian-words-replace-18
     accent-italian-words-19: accent-italian-words-replace-19
     accent-italian-words-20: accent-italian-words-replace-20
-    accent-italian-words-21: accent-italian-words-replace-21
+    # accent-italian-words-21: accent-italian-words-replace-21  # DeltaV - Remove nuke->spiciest meatball
     accent-italian-words-22: accent-italian-words-replace-22
     accent-italian-words-23: accent-italian-words-replace-23
     accent-italian-words-24: accent-italian-words-replace-24


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I removed the replacement of "nuke" with "spiciest-a meatball" from the Italian accent.

## Why / Balance
Some of the replacements can be funny, but this one is actually very annoying and stops you from communicating clearly during an emergency, especially as Security or Command. Given the discussion regarding accents in #1776, I believe this removal is appropriate, at least until a better system is implemented.

## Technical details
Commented out the relevant attribute in word_replacements.yml.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
nope