### PR TITLE
Made pie cannon usable by pacifists

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/pneumatic_cannon.yml
@@ -103,7 +103,8 @@
     containers:
       storagebase: !type:Container
         ents: []
-        
+  - type: PacifismAllowedGun # DeltaV - Allow pacifist to use the pie cannon.
+
 - type: entity
   name: syringe gun
   parent: BaseStorageItem


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made the pie cannon usable by pacifists.

## Why / Balance
People can already throw pies, and the cannon has a whitelist for the pies so why not?.

## Technical details
Added `PacifismAllowedGun` to the pie cannon.

## Media
Before:

https://github.com/user-attachments/assets/b53c7145-f3e7-41c2-a1db-4cf0dd0364c8

After:

https://github.com/user-attachments/assets/12ad22c9-aa6f-4155-9b4d-1a6fab343c01


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
:cl:

- tweak: Pie cannons can now be fired by pacifists!
