### PR TITLE
Enable OOC on Horizon

### DIFF
--- a/Resources/ConfigPresets/DeltaV/horizon.toml
+++ b/Resources/ConfigPresets/DeltaV/horizon.toml
@@ -9,5 +9,8 @@ map_enabled = true
 [shuttle]
 emergency_early_launch_allowed = true
 
+[ooc]
+enable_during_round = true
+
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Enabled OOC during rounds on Horizon.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Horizon is usually either small population of periapsis overflow, often both at the same time. Since this is often a place people will go to learn a new role, having a way to ask OOC questions about mechanics is often very desirable. I don't see any real downside to having it enabled by default here, especially considering it's _usually_ fine on periapsis.

## Technical details
<!-- Summary of code changes for easier review. -->
Tested offline, loads fine when horizon is set the config preset.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Don't think a changelog is needed.
