### PR TITLE
Make permas start with tracking implant already implanted.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -13,6 +13,9 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 21600
+  special:
+  - !type:AddImplantSpecial
+    implants: [ TrackingImplant ]
 
 - type: startingGear
   id: PrisonerGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made perma prisoners spawn with a tracking implant already implanted in them.

## Why / Balance
They are supposed to be dangerous prisoners left in this station's care, security powergames the tracking implants and never uses them for their true purpose, tracking prisoners, even after multiple and continued escapes.

## Technical details
3 line change to a YML, added a `special` category for the them to spawn with the implant.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/05c9698b-a33c-42de-8ee5-88b4efd7c9cd


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Hopefully none.

**Changelog**

:cl:
- tweak: Now perma prisoners will spawn with tracking implants already implanted.
