### PR TITLE
CancerMouseFix

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Mail/mail.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Mail/mail.yml
@@ -1484,9 +1484,9 @@
       - id: MobMouse2
         orGroup: Critter
         prob: 0.33
-      - id: MobMouseCancer
-        orGroup: Critter
-        prob: 0.01 # Rare
+      #- id: MobMouseCancer #Delta-V change, This is supposed to be admin only, plus its just stupid. - Solaris
+      #  orGroup: Critter
+      #  prob: 0.01 # Rare
 
 - type: entity
   parent: BaseMail


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Disabled the ability to get Cancer Mice from the mail.

## Why / Balance
I removed this because this entity is _supposed_ to be only spawnable by admins and those running events.

## Technical details
Comments out an unnecessary mail item.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- ✅ I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- ✅ I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

:cl:
- remove: Cancer mice no longer infest the mail system. 
