### PR TITLE
TraitorReinforcementRemoval

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -189,14 +189,14 @@
       mindRoles:
       - MindRoleTraitor
 
-- type: entity
-  id: TraitorReinforcement
-  parent: Traitor
-  components:
-  - type: TraitorRule
-    giveUplink: false
-    giveCodewords: false # It would actually give them a different set of codewords than the regular traitors, anyway
-    giveBriefing: false
+#- type: entity #Delta-V change, this is sleepers but they dont get uplinks. We dont need this. - Solaris
+#  id: TraitorReinforcement
+#  parent: Traitor
+#  components:
+#  - type: TraitorRule
+#    giveUplink: false
+#    giveCodewords: false # It would actually give them a different set of codewords than the regular traitors, anyway
+#    giveBriefing: false
 
 - type: entity
   id: Revolutionary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Disables an event that is just a worse version of sleeper agents.

## Why / Balance
This event is just sleeper agents but they dont get uplinks, which makes zero sense.

## Technical details
Comments out a worse version of the sleeper agents.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- ✅  I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- ✅ I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**

:cl:
- remove: Removed an event that is what I can only describe as the sleeper agents but worse.
