### PR TITLE
blacklist winter coats from mail capsule

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Misc/mail_capsule.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Misc/mail_capsule.yml
@@ -43,6 +43,10 @@
         whitelist:
           components:
           - Food
+        blacklist:
+          components:
+          - Storage
+          - ItemSlots
         insertOnInteract: true
         priority: 2
       cash_slot:


### PR DESCRIPTION
## About the PR
prevents a tardis by chaining winter coats and mail capsules:
- winter coat is food
- mail capsule can contain food
- winter coat can contain mail capsule
- repeat infinitely
