### PR TITLE
the return of player character spawners (feat. mindshield bullshit)

### DIFF
--- a/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
+++ b/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
@@ -1,4 +1,7 @@
-﻿namespace Content.Server.Ghost.Roles.Components
+﻿using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Ghost.Roles.Components
 {
     /// <summary>
     ///     Allows a ghost to take this role, spawning their selected character.
@@ -17,18 +20,12 @@
         public int CurrentTakeovers = 0;
 
         [DataField]
-        public string OutfitPrototype = "PassengerGear";
+        public ProtoId<StartingGearPrototype> OutfitPrototype = "PassengerGear";
 
         /// <summary>
-        ///  Whether to give the MindShield and AntagImmune components on spawn.
+        ///  Components to give on spawn.
         /// </summary>
         [DataField]
-        public bool MindShield;
-
-        /// <summary>
-        /// Whether to give the TargetObjectiveImmune component on spawn.
-        /// </summary>
-        [DataField]
-        public bool TargetObjectiveImmune;
+        public ComponentRegistry Components = new();
     }
 }

--- a/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
+++ b/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
@@ -26,6 +26,6 @@ namespace Content.Server.Ghost.Roles.Components
         ///  Components to give on spawn.
         /// </summary>
         [DataField]
-        public ComponentRegistry Components = new();
+        public ComponentRegistry AddedComponents = new();
     }
 }

--- a/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
+++ b/Content.Server/DeltaV/Ghost/Roles/Components/GhostRoleCharacterSpawnerComponent.cs
@@ -7,16 +7,28 @@
     [Access(typeof(GhostRoleSystem))]
     public sealed partial class GhostRoleCharacterSpawnerComponent : Component
     {
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("deleteOnSpawn")]
+        [DataField]
         public bool DeleteOnSpawn = true;
 
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("availableTakeovers")]
+        [DataField]
         public int AvailableTakeovers = 1;
 
         [ViewVariables]
         public int CurrentTakeovers = 0;
 
-        [ViewVariables(VVAccess.ReadWrite)] [DataField("outfitPrototype")]
+        [DataField]
         public string OutfitPrototype = "PassengerGear";
+
+        /// <summary>
+        ///  Whether to give the MindShield and AntagImmune components on spawn.
+        /// </summary>
+        [DataField]
+        public bool MindShield;
+
+        /// <summary>
+        /// Whether to give the TargetObjectiveImmune component on spawn.
+        /// </summary>
+        [DataField]
+        public bool TargetObjectiveImmune;
     }
 }

--- a/Content.Server/DeltaV/Ghost/Roles/GhostRoleSystem.Character.cs
+++ b/Content.Server/DeltaV/Ghost/Roles/GhostRoleSystem.Character.cs
@@ -41,7 +41,7 @@ namespace Content.Server.Ghost.Roles
 
             SetOutfitCommand.SetOutfit(mob, component.OutfitPrototype, _entityManager);
 
-            EntityManager.AddComponents(mob, component.Components);
+            EntityManager.AddComponents(mob, component.AddedComponents);
 
             if (++component.CurrentTakeovers < component.AvailableTakeovers)
             {

--- a/Content.Server/DeltaV/Ghost/Roles/GhostRoleSystem.Character.cs
+++ b/Content.Server/DeltaV/Ghost/Roles/GhostRoleSystem.Character.cs
@@ -1,12 +1,14 @@
 ﻿using Content.Server.Administration.Commands;
+using Content.Server.Antag.Components;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Ghost.Roles.Events;
+using Content.Server.Objectives.Components;
 using Content.Server.Preferences.Managers;
 using Content.Server.Station.Systems;
 using Content.Shared.Mind.Components;
+using Content.Shared.Mindshield.Components;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Ghost.Roles
 {
@@ -44,6 +46,15 @@ namespace Content.Server.Ghost.Roles
 
             if (outfit != null)
                 SetOutfitCommand.SetOutfit(mob, outfit, _entityManager);
+
+            if (component.MindShield)
+            {
+                EnsureComp<MindShieldComponent>(mob);
+                EnsureComp<AntagImmuneComponent>(mob);
+            }
+
+            if (component.TargetObjectiveImmune)
+                EnsureComp<TargetObjectiveImmuneComponent>(mob);
 
             if (++component.CurrentTakeovers < component.AvailableTakeovers)
             {

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
@@ -25,7 +25,7 @@
   components:
   - type: GhostRoleCharacterSpawner
     addedComponents:
-    - MindShield
+    - type: MindShield
 
 - type: entity
   parent: SpawnPointPlayerCharacter
@@ -35,9 +35,9 @@
   components:
   - type: GhostRoleCharacterSpawner
     addedComponents:
-    - MindShield
-    - AntagImmune
-    - TargetObjectiveImmune
+    - type: MindShield
+    - type: AntagImmune
+    - type: TargetObjectiveImmune
 
 - type: entity # Part of ListeningPost
   categories: [ HideSpawnMenu, Spawner ]

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
@@ -1,14 +1,14 @@
 - type: entity
-  categories: [ HideSpawnMenu, Spawner ]
+  categories: [ Spawner ]
   parent: MarkerBase
   id: SpawnPointPlayerCharacter
   name: ghost role spawn point
-  suffix: player character, DO NOT MAP
+  suffix: player character
   components:
     - type: GhostRole
       name: Roleplay Ghost Role
-      description: Placeholder
-      rules: Placeholder
+      description: This is a custom event ghost role.
+      rules: ghost-role-component-default-rules
     - type: GhostRoleCharacterSpawner
     - type: Sprite
       sprite: Markers/jobs.rsi
@@ -16,6 +16,25 @@
         - state: green
         - sprite: Mobs/Species/Human/parts.rsi
           state: full
+
+- type: entity
+  parent: SpawnPointPlayerCharacter
+  id: SpawnPointPlayerCharacterMindShield
+  name: ghost role spawn point
+  suffix: mindshielded, player character
+  components:
+  - type: GhostRoleCharacterSpawner
+    mindShield: true
+
+- type: entity
+  parent: SpawnPointPlayerCharacter
+  id: SpawnPointPlayerCharacterTargetImmune
+  name: ghost role spawn point
+  suffix: mindshielded, KillObjectiveImmune, player character
+  components:
+  - type: GhostRoleCharacterSpawner
+    mindShield: true
+    targetObjectiveImmune: true
 
 - type: entity # Part of ListeningPost
   categories: [ HideSpawnMenu, Spawner ]

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
@@ -24,7 +24,8 @@
   suffix: mindshielded, player character
   components:
   - type: GhostRoleCharacterSpawner
-    mindShield: true
+    components:
+    - MindShield
 
 - type: entity
   parent: SpawnPointPlayerCharacter
@@ -33,8 +34,10 @@
   suffix: mindshielded, KillObjectiveImmune, player character
   components:
   - type: GhostRoleCharacterSpawner
-    mindShield: true
-    targetObjectiveImmune: true
+    components:
+    - MindShield
+    - AntagImmune
+    - TargetObjectiveImmune
 
 - type: entity # Part of ListeningPost
   categories: [ HideSpawnMenu, Spawner ]

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/ghost_roles.yml
@@ -24,7 +24,7 @@
   suffix: mindshielded, player character
   components:
   - type: GhostRoleCharacterSpawner
-    components:
+    addedComponents:
     - MindShield
 
 - type: entity
@@ -34,7 +34,7 @@
   suffix: mindshielded, KillObjectiveImmune, player character
   components:
   - type: GhostRoleCharacterSpawner
-    components:
+    addedComponents:
     - MindShield
     - AntagImmune
     - TargetObjectiveImmune


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
ghost role player character spawners are back from the dead (get it???)
idfk how it ended up with HideSpawnMenu, but we use these
removed the do not map suffix to fit with other spawners

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl i'll just ping everyone in admin general :blunt: