### PR TITLE
Make powersinks more expensive

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -978,23 +978,23 @@
   categories:
   - UplinkDisruption
 
-- type: listing
-  id: UplinkPowerSink
-  name: uplink-power-sink-name
-  description: uplink-power-sink-desc
-  productEntity: PowerSink
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 3 # DeltaV - was 4
-  cost:
-    Telecrystal: 6 # DeltaV - was 8
-  categories:
-  - UplinkDisruption
-  conditions:
-  - !type:BuyerWhitelistCondition
-      blacklist:
-        components:
-          - SurplusBundle
+#- type: listing
+ # id: UplinkPowerSink
+#  name: uplink-power-sink-name
+#  description: uplink-power-sink-desc
+#  productEntity: PowerSink
+# discountCategory: usualDiscounts
+#  discountDownTo:
+#    Telecrystal: 3 # DeltaV - was 4
+#  cost:
+#    Telecrystal: 6 # DeltaV - was 8
+#  categories:
+#  - UplinkDisruption
+#  conditions:
+ # - !type:BuyerWhitelistCondition
+#      blacklist:
+ #       components:
+ #         - SurplusBundle
 
 - type: listing
   id: UplinkAntimovCircuitBoard

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -978,23 +978,23 @@
   categories:
   - UplinkDisruption
 
-#- type: listing
- # id: UplinkPowerSink
-#  name: uplink-power-sink-name
-#  description: uplink-power-sink-desc
-#  productEntity: PowerSink
-# discountCategory: usualDiscounts
-#  discountDownTo:
-#    Telecrystal: 3 # DeltaV - was 4
-#  cost:
-#    Telecrystal: 6 # DeltaV - was 8
-#  categories:
-#  - UplinkDisruption
-#  conditions:
- # - !type:BuyerWhitelistCondition
-#      blacklist:
- #       components:
- #         - SurplusBundle
+- type: listing
+ id: UplinkPowerSink
+  name: uplink-power-sink-name
+  description: uplink-power-sink-desc
+ productEntity: PowerSink
+ discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 5 # DeltaV - was 4
+  cost:
+   Telecrystal: 10 # DeltaV - was 8
+  categories:
+ - UplinkDisruption
+  conditions:
+  - !type:BuyerWhitelistCondition
+      blacklist:
+        components:
+         - SurplusBundle
 
 - type: listing
   id: UplinkAntimovCircuitBoard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Raised powersink price from 6 to 10

## Why / Balance
your essentially buying a blackout event, it should cost more than 6 tc. not to mention the fact that it ends the round 90% of the time cause the crew cant find it. for a round ending and incredibly useful tool such as this it should cost a little more
## Technical details
N/A
## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->



**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:


- tweak: Powersinks cost more in the uplink, engineers rejoice

-->
