### PR TITLE
Chem vend changes

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -24,7 +24,7 @@
     JugSulfur: 1
   emaggedInventory:
     ToxinChemistryBottle: 1
-    LeadChemistryBottle: 2
+    LeadChemistryBottle: 2 #delta-v added lead to standard vend
 
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate
@@ -50,7 +50,7 @@
     JugSodium: 2
     JugSugar: 3
     JugSulfur: 1
-    JugWeldingFuel: 2
+    JugWeldingFuel: 2 #delta-v raised to 2 from 1
   emaggedInventory:
     PaxChemistryBottle: 3
     MuteToxinChemistryBottle: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -24,7 +24,7 @@
     JugSulfur: 1
   emaggedInventory:
     ToxinChemistryBottle: 1
-    LeadChemistryBottle: 2 #delta-v added lead to standard vend
+    LeadChemistryBottle: 2 # DeltaV: Added lead to standard chemvend
 
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate
@@ -50,7 +50,7 @@
     JugSodium: 2
     JugSugar: 3
     JugSulfur: 1
-    JugWeldingFuel: 2 #delta-v raised to 2 from 1
+    JugWeldingFuel: 2 # DeltaV: raised to 2 from 1
   emaggedInventory:
     PaxChemistryBottle: 3
     MuteToxinChemistryBottle: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -24,6 +24,7 @@
     JugSulfur: 1
   emaggedInventory:
     ToxinChemistryBottle: 1
+    LeadChemistryBottle: 2
 
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate
@@ -49,7 +50,7 @@
     JugSodium: 2
     JugSugar: 3
     JugSulfur: 1
-    JugWeldingFuel: 1
+    JugWeldingFuel: 2
   emaggedInventory:
     PaxChemistryBottle: 3
     MuteToxinChemistryBottle: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Lead bottles will now be available in emagged chemvends. syndie juice will receive an additional jug of welding fuel

## Why / Balance
Lead has been a fairly taboo chem, seeing as its only uses are for licoxide and as a VERY slow but effective poison. giving syndie chemists access to it will hopefully see more use for the zappy chems ;). additional welding fuel was added to the syndie-juice to promote the nukie flamethrower.
## Technical details
nothing to see here

## Media
nope

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none of these either ;)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:


- tweak: Emagging a chemvend will now give you access to lead! 
-->
