### PR TITLE
Revert "Block emotes for sleeping" (#32779)

### DIFF
--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -2,7 +2,7 @@ using Content.Shared.Actions;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.ForceSay;
-using Content.Shared.Emoting;
+//using Content.Shared.Emoting; # DeltaV - Reverted "Block emotes for sleeping" (upstream PR #32779)
 using Content.Shared.Examine;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.IdentityManagement;
@@ -62,7 +62,7 @@ public sealed partial class SleepingSystem : EntitySystem
 
         SubscribeLocalEvent<ForcedSleepingComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<SleepingComponent, UnbuckleAttemptEvent>(OnUnbuckleAttempt);
-        SubscribeLocalEvent<SleepingComponent, EmoteAttemptEvent>(OnEmoteAttempt);
+        //SubscribeLocalEvent<SleepingComponent, EmoteAttemptEvent>(OnEmoteAttempt); # DeltaV - Reverted "Block emotes for sleeping" (upstream PR #32779)
     }
 
     private void OnUnbuckleAttempt(Entity<SleepingComponent> ent, ref UnbuckleAttemptEvent args)
@@ -312,7 +312,7 @@ public sealed partial class SleepingSystem : EntitySystem
         Wake((ent, ent.Comp));
         return true;
     }
-
+    /*   DeltaV - Reverted "Block emotes for sleeping" (upstream PR #32779)
     /// <summary>
     /// Prevents the use of emote actions while sleeping
     /// </summary>
@@ -320,6 +320,7 @@ public sealed partial class SleepingSystem : EntitySystem
     {
         args.Cancel();
     }
+    */
 }
 
 

--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -2,7 +2,7 @@ using Content.Shared.Actions;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Damage;
 using Content.Shared.Damage.ForceSay;
-//using Content.Shared.Emoting; # DeltaV - Reverted "Block emotes for sleeping" (upstream PR #32779)
+using Content.Shared.Emoting;
 using Content.Shared.Examine;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.IdentityManagement;
@@ -312,7 +312,7 @@ public sealed partial class SleepingSystem : EntitySystem
         Wake((ent, ent.Comp));
         return true;
     }
-    /*   DeltaV - Reverted "Block emotes for sleeping" (upstream PR #32779)
+
     /// <summary>
     /// Prevents the use of emote actions while sleeping
     /// </summary>
@@ -320,7 +320,6 @@ public sealed partial class SleepingSystem : EntitySystem
     {
         args.Cancel();
     }
-    */
 }
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reverted "Block emotes for sleeping" per asking of [WYCI Suggestion](https://discord.com/channels/968983104247185448/1301835443909955584/1301835443909955584).

## Why / Balance
The emote system apparently was being abused in LRP when you got slept, as a MRP server we should have less problems with it while it helps with RP of narcoleptic people.

## Technical details
Commented out the PRs added lines out of `SleepingSystem.cs`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/15e5cd77-8cfd-4bdf-9f08-bdd927a252fb


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: You can use emotes while sleeping to enhance narcoleptic RP.