### PR TITLE
Fix the Mail Carrier PDA missing the MailMetrics program.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Devices/pda.yml
@@ -42,7 +42,7 @@
       - SecWatchCartridge
 
 - type: entity
-  parent: BasePDA
+  parent: CourierPDA # DeltaV - Gives them the MailMetrics cartbridge
   id: MailCarrierPDA
   name: mail carrier PDA
   description: Smells like unopened letters.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixes the Mail Carrier PDA missing the MailMetrics program.

## Why / Balance
It's a fix.

## Technical details
Made the `MailCarrierPDA` inherit from the `CourierPDA` to align with the alternate job titles.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/9a02b596-f608-431a-9977-ac5c99e68523)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- fix: Fixed the Mail Carrier PDA not coming with the MailMetrics program!
