### PR TITLE
Double the amount of Hardsuits for sec

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -139,11 +139,11 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
-        Amount: 2
+          amount: 2 #DeltaV - Double the tanks
         - id: ClothingOuterHardsuitCombatOfficer # DeltaV - ClothingOuterHardsuitSecurity replaced in favour of security combat hardsuit.
-        Amount: 2
+          amount: 2 #DeltaV - Double the suits
         - id: ClothingMaskBreath
-        Amount: 2
+          amount: 2 #Delta-V Double the masks
   - type: AccessReader
     access: [["Security"]]
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -139,8 +139,11 @@
   - type: StorageFill
     contents:
         - id: OxygenTankFilled
+        Amount: 2
         - id: ClothingOuterHardsuitCombatOfficer # DeltaV - ClothingOuterHardsuitSecurity replaced in favour of security combat hardsuit.
+        Amount: 2
         - id: ClothingMaskBreath
+        Amount: 2
   - type: AccessReader
     access: [["Security"]]
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Doubled the hardsuits, masks, and oxy tank

## Why / Balance
currently a majority of our maps have over double the amount of sec slots as there are hardsuits. for the combatants that space the whole station this essentially cripples half of sec.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: 
- remove: 
- tweak: Security will now receive double the amount of hardsuits
- fix: 
-->
