### PR TITLE
Defib no longer revives dead people

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -169,7 +169,7 @@ public sealed class DefibrillatorSystem : EntitySystem
                 _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
                 dead = true;
             }
-         
+
             if (_mind.TryGetMind(target, out _, out var mind) &&
                 mind.Session is { } playerSession)
             {

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -146,14 +146,14 @@ public sealed class DefibrillatorSystem : EntitySystem
 
         ICommonSession? session = null;
 
-       var dead = true;
-       if (_rotting.IsRotten(target))
-       {
-           _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-rotten"),
-              InGameICChatType.Speak, true);
-       }
-       else if (HasComp<UnrevivableComponent>(target))
-       {
+        var dead = true;
+        if (_rotting.IsRotten(target))
+        {
+            _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-rotten"),
+                InGameICChatType.Speak, true);
+        }
+        else if (HasComp<UnrevivableComponent>(target))
+        {
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-unrevivable"),
                 InGameICChatType.Speak, true);
        }
@@ -169,6 +169,7 @@ public sealed class DefibrillatorSystem : EntitySystem
               _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
               dead = true;
           }
+         
           if (_mind.TryGetMind(target, out _, out var mind) &&
               mind.Session is { } playerSession)
           {
@@ -179,6 +180,7 @@ public sealed class DefibrillatorSystem : EntitySystem
               }
           }
           else
+          
           {
               _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-no-mind"),
                   InGameICChatType.Speak, true);

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -156,36 +156,36 @@ public sealed class DefibrillatorSystem : EntitySystem
         {
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-unrevivable"),
                 InGameICChatType.Speak, true);
-       }
-       else
-       {
-           if (_mobState.IsCritical(target, mob)) //DeltaV -  change to only work on critical
-              _damageable.TryChangeDamage(target, component.ZapHeal, true, origin: uid);
+        }
+        else
+        {
+            if (_mobState.IsCritical(target, mob)) //DeltaV -  change to only work on critical
+                _damageable.TryChangeDamage(target, component.ZapHeal, true, origin: uid);
 
-           if (_mobThreshold.TryGetThresholdForState(target, MobState.Critical, out var threshold) &&
-              TryComp<DamageableComponent>(target, out var damageableComponent) &&
-              damageableComponent.TotalDamage < threshold)
-          {
-              _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
-              dead = true;
-          }
+            if (_mobThreshold.TryGetThresholdForState(target, MobState.Critical, out var threshold) &&
+                TryComp<DamageableComponent>(target, out var damageableComponent) &&
+                damageableComponent.TotalDamage < threshold)
+            {
+                _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
+                dead = true;
+            }
          
-          if (_mind.TryGetMind(target, out _, out var mind) &&
-              mind.Session is { } playerSession)
-          {
-              session = playerSession;
-              if (mind.CurrentEntity != target)
-              {
-                  _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind), session);
-              }
-          }
-          else
-          
-          {
-              _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-no-mind"),
-                  InGameICChatType.Speak, true);
-          }
-       }
+            if (_mind.TryGetMind(target, out _, out var mind) &&
+                mind.Session is { } playerSession)
+            {
+                session = playerSession;
+                // notify them they're being revived.
+                if (mind.CurrentEntity != target)
+                {
+                    _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind), session);
+                }
+            }
+            else
+            {
+                _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-no-mind"),
+                    InGameICChatType.Speak, true);
+            }
+        }
 
         var sound = dead || session == null
             ? component.FailureSound

--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -146,46 +146,44 @@ public sealed class DefibrillatorSystem : EntitySystem
 
         ICommonSession? session = null;
 
-        var dead = true;
-        if (_rotting.IsRotten(target))
-        {
-            _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-rotten"),
-                InGameICChatType.Speak, true);
-        }
-        else if (HasComp<UnrevivableComponent>(target))
-        {
+       var dead = true;
+       if (_rotting.IsRotten(target))
+       {
+           _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-rotten"),
+              InGameICChatType.Speak, true);
+       }
+       else if (HasComp<UnrevivableComponent>(target))
+       {
             _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-unrevivable"),
                 InGameICChatType.Speak, true);
-        }
-        else
-        {
-            if (_mobState.IsDead(target, mob))
-                _damageable.TryChangeDamage(target, component.ZapHeal, true, origin: uid);
+       }
+       else
+       {
+           if (_mobState.IsCritical(target, mob)) //DeltaV -  change to only work on critical
+              _damageable.TryChangeDamage(target, component.ZapHeal, true, origin: uid);
 
-            if (_mobThreshold.TryGetThresholdForState(target, MobState.Dead, out var threshold) &&
-                TryComp<DamageableComponent>(target, out var damageableComponent) &&
-                damageableComponent.TotalDamage < threshold)
-            {
-                _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
-                dead = false;
-            }
-
-            if (_mind.TryGetMind(target, out _, out var mind) &&
-                mind.Session is { } playerSession)
-            {
-                session = playerSession;
-                // notify them they're being revived.
-                if (mind.CurrentEntity != target)
-                {
-                    _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind), session);
-                }
-            }
-            else
-            {
-                _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-no-mind"),
-                    InGameICChatType.Speak, true);
-            }
-        }
+           if (_mobThreshold.TryGetThresholdForState(target, MobState.Critical, out var threshold) &&
+              TryComp<DamageableComponent>(target, out var damageableComponent) &&
+              damageableComponent.TotalDamage < threshold)
+          {
+              _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
+              dead = true;
+          }
+          if (_mind.TryGetMind(target, out _, out var mind) &&
+              mind.Session is { } playerSession)
+          {
+              session = playerSession;
+              if (mind.CurrentEntity != target)
+              {
+                  _euiManager.OpenEui(new ReturnToBodyEui(mind, _mind), session);
+              }
+          }
+          else
+          {
+              _chatManager.TrySendInGameICMessage(uid, Loc.GetString("defibrillator-no-mind"),
+                  InGameICChatType.Speak, true);
+          }
+       }
 
         var sound = dead || session == null
             ? component.FailureSound

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -52,7 +52,7 @@
       state: "creampie_human"
       visible: false
   - type: DamageVisuals
-    thresholds: [ 10, 20, 30, 50, 70, 100 ]
+    thresholds: [ 10, 20, 30, 50, 70, 120 ] #DeltaV, crit went up in base.yml
     targetLayers:
     - "enum.HumanoidVisualLayers.Chest"
     - "enum.HumanoidVisualLayers.Head"

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -67,7 +67,7 @@
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-#    - trigger:                       #DeltaV- We don't like round removing people for being in the same room as a plasma trapped crate. 
+#    - trigger:                       #DeltaV- We don't like round removing people for being in the same room as a plasma trapped crate.
 #        !type:DamageTypeTrigger
 #        damageType: Heat
 #        damage: 1500
@@ -88,8 +88,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      100: Critical
-      200: Dead
+      120: Critical #DeltaV, make it harder to die because no defib
+      300: Dead #DeltaV, make it harder to die because no defib
   - type: MobStateActions
     actions:
       Critical:

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -67,7 +67,7 @@
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-#    - trigger:                       #DeltaV- We don't like round removing people for being in the same room as a plasma trapped crate.
+#    - trigger:                       #DeltaV- We don't like round removing people for being in the same room as a plasma trapped crate. 
 #        !type:DamageTypeTrigger
 #        damageType: Heat
 #        damage: 1500

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/defib.yml
@@ -39,7 +39,7 @@
     - type: Defibrillator
       zapHeal:
         types:
-          Asphyxiation: -40
+          Asphyxiation: -100 #DeltaV, doesnt revive dead anymore but reduces massive amounts of aspyx.
     - type: DoAfter
     - type: UseDelay
     - type: StaticPrice


### PR DESCRIPTION


## About the PR
Defib no longer revives dead people, but reduces a massive amount of asphyx damage when critical. 
Damage states for basemob (most things) changed to 120 critical, 300 dead. People will be in crit way longer. 

## Why / Balance
Cloning exists still here, and people treat death as nothing more than an inconvenience. Hostage situation? just kill the hostage and move on right? 

## Technical details
mostly YAML, i did butcher the defib C# tho 

## Media
Uhhh I think no?

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
I mean this breaks the original intent of the defib.

**Changelog**
:cl:
- tweak: Defibrillator no longer revives dead people
- tweak: Defibrillator heals 100 asphyxiation on critical people
- tweak: Mobs with default health go critical at 120 damage (including players)
- tweak: Mobs with default health die at 300 damage (including players)