### PR TITLE
make people start rotting in 2 minutes

### DIFF
--- a/Content.Shared/Atmos/Rotting/PerishableComponent.cs
+++ b/Content.Shared/Atmos/Rotting/PerishableComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class PerishableComponent : Component
     /// How long it takes after death to start rotting.
     /// </summary>
     [DataField]
-    public TimeSpan RotAfter = TimeSpan.FromMinutes(10);
+    public TimeSpan RotAfter = TimeSpan.FromMinutes(2);
 
     /// <summary>
     /// How much rotting has occured


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
people now start to rot in 2 minutes. same reason as https://github.com/DeltaV-Station/Delta-v/pull/2091

pls dont repoban i have good intent
## Why / Balance
rotting is more fixable 

## Technical details
webedit 

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.



**Changelog**


:cl:
- tweak: Rotting starts two minutes after death
