### PR TITLE
Add canes to loadouts :3

### DIFF
--- a/Resources/Prototypes/DeltaV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/Miscellaneous/trinkets.yml
@@ -21,3 +21,9 @@
   storage:
     back:
     - Cane
+
+- type: loadout
+  id: WhiteCane
+  storage:
+    back:
+    - WhiteCane

--- a/Resources/Prototypes/DeltaV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/DeltaV/Loadouts/Miscellaneous/trinkets.yml
@@ -15,3 +15,9 @@
   storage:
     back:
     - SilverRing
+
+- type: loadout
+  id: Cane
+  storage:
+    back:
+    - Cane

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -48,6 +48,7 @@
   - AACTablet # DeltaV
   - GoldRing # DeltaV
   - SilverRing # DeltaV
+  - Cane # DeltaV
 
 - type: loadoutGroup
   id: Glasses

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -49,6 +49,7 @@
   - GoldRing # DeltaV
   - SilverRing # DeltaV
   - Cane # DeltaV
+  - WhiteCane #DeltaV
 
 - type: loadoutGroup
   id: Glasses


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added both canes to the trinkets section of loadouts!
(I have no clue if I wrote this right, please don't hit me with hammers)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Brown cane gives people more options in RPing physical disabilities without finding a curadrobe. Folks were asking for the white cane too, so here it is.
I imagine folks could possibly use these as free weapons but like... _why_ would you do that? 

## Technical details
No

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![Screenshot 2024-11-02 154559](https://github.com/user-attachments/assets/ad6ca194-d2cc-4fe1-934a-5b847c7f6b5c)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**

:cl:
- add: Canes can now be selected in loadouts.

