### PR TITLE
Make Nukie Agent require chem time 

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -28,9 +28,9 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 108000 # DeltaV - 30 hours
-  - !type:DepartmentTimeRequirement # DeltaV - Medical dept time requirement
-    department: Medical
-    time: 36000 # DeltaV - 10 hours
+  - !type:RoleTimeRequirement #Delta V - they should be able to make basic chems 
+    role: JobChemist
+    time: 14400 # DeltaV- 4 hours 
 
 - type: antag
   id: NukeopsCommander


### PR DESCRIPTION


## About the PR
Subbed out medical playtime of 10 hours for 4 hours of chem. We have always had a problem of agents not knowing how to make bicar, which sucks for the whole team

## Why / Balance
Agents should be able to operate chem master

## Technical details
Webedit

## Media

## Requirements

- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No 

**Changelog**
:cl:
- tweak: Nuclear Operative Agent now requires 4 hours of Chemist playtime.