### PR TITLE
disable eating brains

### DIFF
--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -50,6 +50,8 @@
   - type: Examiner
   - type: BlockMovement
   - type: BadFood
+  - type: Food
+    requiredStomachs: 20 # DeltaV: Prevent eating brains as borgs don't remember what happened to them
   - type: Tag
     tags:
       - Meat

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -50,8 +50,8 @@
   - type: Examiner
   - type: BlockMovement
   - type: BadFood
-  - type: Food
-    requiredStomachs: 20 # DeltaV: Prevent eating brains as borgs don't remember what happened to them
+  - type: Food # DeltaV: Prevent eating brains as borgs don't remember what happened to them
+    requiredStomachs: 20 
   - type: Tag
     tags:
       - Meat


### PR DESCRIPTION
## About the PR
title

## Why / Balance
borgs arent allowed to remember what led to their death, so this isnt an issue
as such eating brains is only done by shitters or people that are used to wizden and think they have to destroy the brain to avoid being snitched on

## Technical details
requires that you have 20 stomachs to stomach eating a brain :trollface::trollface::trollface:

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: You can no longer eat brains, they aren't allowed to remember who killed them anyway!
