### PR TITLE
add engine essentials crate

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Crates/engine.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Crates/engine.yml
@@ -1,0 +1,45 @@
+- type: entity
+  parent: CrateEngineering
+  id: CrateEngineEssentials
+  name: engine essentials crate
+  description: Everything you need to power the station, in a superposition of containing both a singularity and a tesla.
+  suffix: 1 per map MAX
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:GroupSelector
+        children:
+        - !type:NestedSelector
+          tableId: TeslaEssentials
+        - !type:NestedSelector
+          tableId: SingularityEssentials
+
+- type: entityTable
+  id: TeslaEssentials
+  table: !type:AllSelector
+    children:
+    - id: TeslaGeneratorFlatpack
+    - id: TeslaGeneratorFlatpack
+      prob: 0.3 # Small chance of a free backup
+    - id: TeslaCoilFlatpack
+      amount: !type:RangeNumberSelector
+        range: 4, 6
+    - id: TeslaGroundingRodFlatpack
+      amount: !type:ConstantNumberSelector
+        value: 4
+
+- type: entityTable
+  id: SingularityEssentials
+  table: !type:AllSelector
+    children:
+    - id: SingularityGeneratorFlatpack
+    - id: SingularityGeneratorFlatpack
+      prob: 0.3 # Small chance of a free backup
+    # intentionally separate rolls so they are probably mismatched
+    # you might get spare tanks you might have to get more from the tank dispenser
+    - id: RadiationCollectorFlatpack
+      amount: !type:RangeNumberSelector
+        range: 8, 12
+    - id: PlasmaTankFilled
+      amount: !type:RangeNumberSelector
+        range: 8, 12


### PR DESCRIPTION
## About the PR
adds a crate for mapping that has everything for either the tesla or singularity, with a bit of variation
doesnt contain any emitters or CFGs so they still need to be mapped separately

## Why / Balance
its a good idea, make lord tesloth more common while also providing more round variety

## Technical details
both crates contain a generator and have a 30% chance of containing a spare one

tesla crate has 4 grounding rods and 4-6 coils
singulo crate has 8-12 collectors and 8-12 tanks (they are rolled separately so you will probably have spares or need to get more from the tank dispenser)


## Media
![03:23:14](https://github.com/user-attachments/assets/b7ddf03d-1aef-4c56-a92f-a10e55ec29e5)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
mapping