### PR TITLE
prevent telegnomes from interacting with anything

### DIFF
--- a/Content.Client/Nyanotrasen/Abilities/Psionics/TelegnosisPowerSystem.cs
+++ b/Content.Client/Nyanotrasen/Abilities/Psionics/TelegnosisPowerSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Abilities.Psionics;
+
+namespace Content.Client.Abilities.Psionics;
+
+public sealed class TelegnosisPowerSystem : SharedTelegnosisPowerSystem;

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/TelegnosisPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/TelegnosisPowerSystem.cs
@@ -9,7 +9,7 @@ using Content.Shared.Actions.Events;
 
 namespace Content.Server.Abilities.Psionics
 {
-    public sealed class TelegnosisPowerSystem : EntitySystem
+    public sealed class TelegnosisPowerSystem : SharedTelegnosisPowerSystem
     {
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
         [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Telegnosis/SharedTelegnosisPowerSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Telegnosis/SharedTelegnosisPowerSystem.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Interaction.Events;
+
+namespace Content.Shared.Abilities.Psionics;
+
+public abstract class SharedTelegnosisPowerSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<TelegnosticProjectionComponent, InteractionAttemptEvent>(OnInteractionAttempt);
+    }
+
+    private void OnInteractionAttempt(Entity<TelegnosticProjectionComponent> ent, ref InteractionAttemptEvent args)
+    {
+        // no astrally stealing someones shoes
+        args.Cancelled = true;
+    }
+}

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Telegnosis/TelegnosisPowerComponent.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Telegnosis/TelegnosisPowerComponent.cs
@@ -5,7 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 
 namespace Content.Shared.Abilities.Psionics
 {
-    [RegisterComponent]
+    [RegisterComponent, Access(typeof(SharedTelegnosisPowerSystem))]
     public sealed partial class TelegnosisPowerComponent : Component
     {
         [DataField("prototype")]

--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Telegnosis/TelegnosticProjectionComponent.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/Telegnosis/TelegnosticProjectionComponent.cs
@@ -1,6 +1,4 @@
-namespace Content.Shared.Abilities.Psionics
-{
-    [RegisterComponent]
-    public sealed partial class TelegnosticProjectionComponent : Component
-    {}
-}
+namespace Content.Shared.Abilities.Psionics;
+
+[RegisterComponent, Access(typeof(SharedTelegnosisPowerSystem))]
+public sealed partial class TelegnosticProjectionComponent : Component;


### PR DESCRIPTION
## About the PR
title
they can still use telepathic chat and return to body, just no playing with ripleys / toggling welders and shit / spilling jugs maybe

## Why / Balance
fixes #2081

## Technical details
InteractionAttemptEvent gameplay

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Fixed telegnostic projections being able to interact with things.
