### PR TITLE
cherry pick Remove upgrading reinforced windows to shuttle windows (#33160)

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/window.yml
@@ -223,11 +223,6 @@
             - material: Uranium
               amount: 2
               doAfter: 1
-        - to: shuttleWindow
-          steps:
-            - material: Plasteel
-              amount: 2
-              doAfter: 3
 
     - node: reinforcedPlasmaWindow
       entity: ReinforcedPlasmaWindow


### PR DESCRIPTION
## About the PR
removes 3 second doafter to make brig windows almost indestructible

## Why / Balance
upstream will revert window upgrading entirely for a year or whatever and i will be skipping that, this is the only abusable part of it (though ive never seen it here, im sure people will start doing it once it has eyes on it)

**Changelog**
:cl: clinux
- remove: Removed the ability to upgrade reinforced windows to into shuttle windows
