### PR TITLE
add contributing guidelines and update github stuff

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
+<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->
 
 ## About the PR
 <!-- What did you change? -->
@@ -10,23 +10,22 @@
 <!-- Summary of code changes for easier review. -->
 
 ## Media
-<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
-Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
+<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
+Small fixes/refactors are exempt. -->
 
 ## Requirements
 <!-- Confirm the following by placing an X in the brackets [X]: -->
-- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
+- [ ] I have tested all added content and changes.
 - [ ] I have added media to this PR or it does not require an ingame showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
 
 ## Breaking changes
-<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
-This will be posted in #codebase-changes. -->
+<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
 
 **Changelog**
 <!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
 Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
-Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
+Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
 <!--
 :cl:
 - add: Added fun!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Delta-V Contributing Guidelines
+
+Generally we follow [upstream's PR guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) for code quality and such.
+
+Upstream is the [space-wizards/space-station-14](https://github.com/space-wizards/space-station-14) repository that wizden runs on.
+
+# Content specific to Delta-V
+
+In general anything you create from scratch (not modifying something that exists from upstream) should go in a DeltaV subfolder.
+
+Examples:
+- `Content.Server/DeltaV/Chapel/SacrificialAltarSystem.cs`
+- `Resources/Prototypes/DeltaV/ai_factions.yml`
+- `Resources/Audio/DeltaV/Items/gavel.ogg`
+- `Resources/Textures/DeltaV/Icons/cri.rsi`
+- `Resources/Locale/en-US/deltav/shipyard/shipyard-console.ftl`
+  The locale subfolder is lowercase `deltav` instead of `DeltaV`.
+- `Resources/ServerInfo/Guidebook/DeltaV/AlertProcedure.xml`
+  Note that guidebooks go in `ServerInfo/Guidebook/DeltaV` and not `ServerInfo/DeltaV`!
+
+# Changes to upstream files
+
+If you make a change to an upstream C# or YAML file **you must add comments on or around the changed lines**.
+The comments should clarify what changed, to make conflict resolution simpler when a file is changed upstream.
+
+For YAML specifically, if you add a new component to a prototype add the comment to the `type: ...` line.
+If you just modify some fields of a component, comment the fields instead.
+
+For C# files, if you are adding a lot of code try to put it in a partial class when it makes sense.
+
+The exception to this is early merging commits that are going to be cherry picked in the future regardless, there's no harm in leaving them as-is.
+
+As an aside, fluent (.ftl) files **do not support comments on the same line** as a locale value, so be careful when changing them.
+
+## Examples of comments in upstream files
+
+A single line comment on a changed yml field:
+```yml
+- type: entity
+  parent: BasePDA
+  id: SciencePDA
+  name: epistemics PDA # DeltaV - Epistemics Department replacing Science
+```
+
+A pair of comments enclosing a list of added items to starting gear:
+```yml
+  storage:
+    back:
+    - EmergencyRollerBedSpawnFolded
+    # Begin DeltaV additions
+    - BodyBagFolded
+    - Portafib
+    # End DeltaV additions
+```
+
+A comment on a new imported namespace:
+```cs
+using Content.Server.Psionics.Glimmer; // DeltaV
+```
+
+A pair of comments enclosing a block of added code:
+```cs
+private EntityUid Slice(...)
+{
+    ...
+
+    _transform.SetLocalRotation(sliceUid, 0);
+
+    // DeltaV - start of deep frier stuff
+    var slicedEv = new FoodSlicedEvent(user, uid, sliceUid);
+    RaiseLocalEvent(uid, ref slicedEv);
+    // DeltaV - end of deep frier stuff
+
+    ...
+}
+```
+
+# Additional resources
+
+If you are new to contributing to SS14 in general, have a look at the [SS14 docs](https://docs.spacestation14.io/) or ask for help in `#contribution-help` on [Discord](https://go.delta-v.org/AtDxv)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,12 @@ private EntityUid Slice(...)
 }
 ```
 
+# Changelogs
+
+By default any changelogs goes in the DeltaV changelog, you can use the DeltaV admin changelog by putting `DELTAVADMIN:` in a line after `:cl:`.
+
+Do not use `ADMIN:` as **it will mangle** the upstream admin changelog!
+
 # Additional resources
 
 If you are new to contributing to SS14 in general, have a look at the [SS14 docs](https://docs.spacestation14.io/) or ask for help in `#contribution-help` on [Discord](https://go.delta-v.org/AtDxv)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 Generally we follow [upstream's PR guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html) for code quality and such.
 
+Importantly do not make webedits, copied verbatim from above:
+> Do not use GitHub's web editor to create PRs. PRs submitted through the web editor may be closed without review.
+
 Upstream is the [space-wizards/space-station-14](https://github.com/space-wizards/space-station-14) repository that wizden runs on.
 
 # Content specific to Delta-V
@@ -74,6 +77,18 @@ private EntityUid Slice(...)
     ...
 }
 ```
+
+# Mapping
+
+If you want to make changes to a map, get in touch with its maintainer to make sure you don't both make changes at the same time.
+
+Conflicts with maps make PRs mutually exclusive so either your work on the maintainer's work will be lost, communicate to avoid this!
+
+# Before you submit
+
+Double-check your diff on GitHub before submitting: look for unintended commits or changes and remove accidental whitespace or line-ending changes.
+
+Additionally for long-lasting PRs, if you see `RobustToolbox` in the changed files you have to revert it, use `git checkout upstream/master RobustToolbox` (replacing `upstream` with the name of your DeltaV-Station/Delta-V remote)
 
 # Changelogs
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ We are happy to accept contributions from anybody. Get in Discord if you want to
 
 We are currently accepting translations of the game on our main repository. If you would like to translate the game into another language check the #localization channel in our [Discord](https://go.delta-v.org/AtDxv)
 
-If you make any contributions, please make sure to read the markers section in [MARKERS.md](https://github.com/DeltaV-Station/Delta-v/blob/master/MARKERS.md)
-Any changes made to files belonging to our upstream should be properly marked in accordance to what is specified there.
+Make sure to read [CONTRIBUTING.md](/CONTRIBUTING.md) if you are new to Delta-V!
 
 ## Building
 


### PR DESCRIPTION
## About the PR
added CONTRIBUTING.md for the PR template and for the wiki to link to
its linked at the top of the template now to make it easy to find probably.

## Why / Balance
new contributors didnt get explicitly told any deltav conventions :trollface:

also old MARKERS.md link didnt exist :trollface:

## Technical details
no

## Media
no

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
no cl no fun