### PR TITLE
Raise the execution damage multiplier.

### DIFF
--- a/Content.Server/Execution/ExecutionSystem.cs
+++ b/Content.Server/Execution/ExecutionSystem.cs
@@ -41,7 +41,7 @@ public sealed class ExecutionSystem : EntitySystem
     [Dependency] private readonly GunSystem _gunSystem = default!;
 
     private const float GunExecutionTime = 6.0f;
-    private const float DamageModifier = 9.0f;
+    private const float DamageModifier = 18.0f; // DeltaV - Raised damage x2 over the original 9.0f
 
     /// <inheritdoc/>
     public override void Initialize()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Raised the execution damage to x18 (a x2 increase over current multiplier) of the projectile.
Requested by a [WYCI](https://discord.com/channels/968983104247185448/1011259887759659049/1303476684132978788), While I don't fully agree with the PR, just putting their suggestion here.

## Why / Balance
It really doesn't change much for regular executions but the fact that you instantly die instead of going into critical state.
There is a problem with balance when used with beanbags though, if they do it twice on a healthy person it leaves them at 360 Blunt damage, 40 short of gibbing.

## Technical details
Modified a value in `ExecutionSystem.cs`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Executions now do x18 damage instead of x9.
