### PR TITLE
remove syndicats from the uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1231,19 +1231,19 @@
       tags:
       - NukeOpsUplink
 
-- type: listing
-  id: UplinkMobCatMicrobomb
-  name: uplink-mobcat-microbomb-name
-  description: uplink-mobcat-microbomb-desc
-  icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-syndicat }
-  productEntity: ReinforcementRadioSyndicateSyndiCat
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 3
-  cost:
-    Telecrystal: 6
-  categories:
-    - UplinkAllies
+#- type: listing # DeltaV - Remove syndicats
+#  id: UplinkMobCatMicrobomb
+#  name: uplink-mobcat-microbomb-name
+#  description: uplink-mobcat-microbomb-desc
+#  icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-syndicat }
+#  productEntity: ReinforcementRadioSyndicateSyndiCat
+#  discountCategory: usualDiscounts
+#  discountDownTo:
+#    Telecrystal: 3
+#  cost:
+#    Telecrystal: 6
+#  categories:
+#    - UplinkAllies
 
 - type: listing
   id: UplinkSyndicatePersonalAI


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it's inherently valid yet people still go "errrm actually it's a sophont" then pretend it's not a walking bomb 
animal reinforcements are bad in general and syndicats are pointless and almost always end up causing disproportional damage
still can be spawned in by admemes, just not available in the uplink

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed syndicats from the uplink.