### PR TITLE
Make survival the only gamemode ever

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,8 +1,5 @@
 - type: weightedRandom
   id: Secret
   weights:
-    Survival: 0.35
-    Nukeops: 0.15
-    Zombie: 0.07
-    Traitor: 0.43
+    Survival: 1.0 #DeltaV one gamemode to rule them all
     #Pirates: 0.15 #ahoy me bucko


### PR DESCRIPTION


## About the PR
I wanna test out making survival the only gamemode, spawning in more sleepers, adding random nukie ghost roles, etc. one gamemode to rule them all. Ideally this has all the normal antags and shit just like, more spread out and less defined. Maybe you get a shift that spawns 3 nukies into revs idk

## Why / Balance
Roundstart zombies is nrp, nukies are barely better. 

## Technical details
Webedit but not real

## Media
No
## Requirements

- [x]I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
yes

**Changelog**
:cl:
- tweak: oops only survival 