### PR TITLE
Remove upstream shock collar migration

### DIFF
--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -402,7 +402,7 @@ FoodMeatFiestaKebab: FoodKebabSkewer
 ClothingBeltSuspenders: ClothingBeltSuspendersRed
 
 # 2024-08-19
-ClothingNeckShockCollar: ClothingBackpackElectropack
+#ClothingNeckShockCollar: ClothingBackpackElectropack #DeltaV We keep shock collar and have out own migration
 
 # 2024-08-22
 ComputerShuttleSalvage: null

--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -402,7 +402,7 @@ FoodMeatFiestaKebab: FoodKebabSkewer
 ClothingBeltSuspenders: ClothingBeltSuspendersRed
 
 # 2024-08-19
-# ClothingNeckShockCollar: ClothingBackpackElectropack # DeltaV We keep shock collar and have our own migration
+# ClothingNeckShockCollar: ClothingBackpackElectropack # DeltaV - We keep shock collar and have our own migration
 
 # 2024-08-22
 ComputerShuttleSalvage: null

--- a/Resources/Migrations/migration.yml
+++ b/Resources/Migrations/migration.yml
@@ -402,7 +402,7 @@ FoodMeatFiestaKebab: FoodKebabSkewer
 ClothingBeltSuspenders: ClothingBeltSuspendersRed
 
 # 2024-08-19
-#ClothingNeckShockCollar: ClothingBackpackElectropack #DeltaV We keep shock collar and have out own migration
+# ClothingNeckShockCollar: ClothingBackpackElectropack # DeltaV We keep shock collar and have our own migration
 
 # 2024-08-22
 ComputerShuttleSalvage: null


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
We didn't remove them and have them handled in our own migration file. This was swapping them out again redundantly. 

## Technical details
n/a

## Media
n/a

## Requirements
n/a

## Breaking changes
n/a

**Changelog**
n/a