### PR TITLE
standarize sec hardsuit storage 

### DIFF
--- a/Resources/Migrations/deltaMigrations.yml
+++ b/Resources/Migrations/deltaMigrations.yml
@@ -125,3 +125,6 @@ BoxMagazinePistolSubMachineGunRubber: MagazineBoxPistolRubber
 
 # 2024-09-21
 VendingMachineAutomatrobe: null
+
+# 2024-11-08
+SuitStorageSec: SuitStorageSecDeltaV

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -135,17 +135,13 @@
   id: SuitStorageSec
   parent: SuitStorageBase
   suffix: Security
+  categories: [ HideSpawnMenu ] # DeltaV
   components:
   - type: StorageFill
     contents:
-        - id: OxygenTankFilled
-          amount: 2 #DeltaV - Double the tanks
-        - id: ClothingOuterHardsuitCombatOfficer # DeltaV - ClothingOuterHardsuitSecurity replaced in favour of security combat hardsuit.
-          amount: 2 #DeltaV - Double the suits
-        - id: ClothingMaskBreath
-          amount: 2 #Delta-V Double the masks
-        - id: ClothingShoesBootsSecurityMagboots # DeltaV - Added security magboots.
-          amount: 2
+    - id: OxygenTankFilled
+    - id: ClothingOuterHardsuitSecurity
+    - id: ClothingMaskBreath
   - type: AccessReader
     access: [["Security"]]
 

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/suit_storage.yml
@@ -1,0 +1,17 @@
+- type: entity
+  id: SuitStorageSecDeltaV
+  parent: SuitStorageSec
+  suffix: Security, DeltaV
+  components:
+  - type: StorageFill
+    contents:
+    - id: OxygenTankFilled
+      amount: 2
+    - id: ClothingOuterHardsuitCombatOfficer
+      amount: 2
+    - id: ClothingMaskGasSecurity
+      amount: 2
+    - id: ClothingShoesBootsSecurityMagboots
+      amount: 2
+    - id: JetpackSecurity
+      amount: 2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
reverts upstream sec storage to what it was before and adds `SuitStorageSecDeltaV` with two each of: oxygen tanks, sec magboots, deltav sec hardsuits, security jetpacks, security gas masks

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
probably makes conflicts less evil + you get the same things on all maps now, previously it was all over the place apparently
at this point its easier to just make our own version and migrate

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Adjusted security hardsuit lockers, now they all contain two jetpacks, magboots and hardsuits.

