### PR TITLE
make meat spike drop organs

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Body.Systems;
 using Content.Server.Kitchen.Components;
 using Content.Server.Popups;
 using Content.Shared.Chat;
+using Content.Shared.Body.Part; // DeltaV
 using Content.Shared.Damage;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
@@ -160,9 +161,12 @@ namespace Content.Server.Kitchen.EntitySystems
             _transform.SetCoordinates(victimUid, Transform(uid).Coordinates);
             // THE WHAT?
             // TODO: Need to be able to leave them on the spike to do DoT, see ss13.
-            var gibs = _bodySystem.GibBody(victimUid);
+            var gibs = _bodySystem.GibBody(victimUid, gibOrgans: true); // DeltaV: spawn organs
             foreach (var gib in gibs) {
-                QueueDel(gib);
+                // Begin DeltaV changes: Only delete limbs instead of organs
+                if (HasComp<BodyPartComponent>(gib))
+                    QueueDel(gib);
+                // End DeltaV changes
             }
 
             _audio.PlayEntity(component.SpikeSound, Filter.Pvs(uid), uid, true);


### PR DESCRIPTION
## About the PR
title

## Why / Balance
for antags either:
- you dont use meat spike and get limited in what you can do
- you do, and you completely RR your target instead of letting them get borged to continue playing

so this lets you both be flexible and nice

for chefs, this now means you get a good source of organs when butchering monkeys and stuff, which you can give to logi or turn into soap :trollface:

## Technical details
made it spawn and not delete organs

## Media
![01:32:43](https://github.com/user-attachments/assets/1ef2f1b8-7e4d-47df-bc13-4bb61017b6ae)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Butchering people now drops organs.