### PR TITLE
stamina damage resist

### DIFF
--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -224,7 +224,7 @@ public sealed partial class GunSystem : SharedGunSystem
                     {
                         var hitEntity = lastHit.Value;
                         if (hitscan.StaminaDamage > 0f)
-                            _stamina.TakeStaminaDamage(hitEntity, hitscan.StaminaDamage, source: user);
+                            _stamina.TakeStaminaDamageWithProjectileCoefficient(hitEntity, hitscan.StaminaDamage, source: user); // DeltaV - Cope with hitscan not being an entity
 
                         var dmg = hitscan.Damage;
 

--- a/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Server/Weapons/Ranged/Systems/GunSystem.cs
@@ -224,7 +224,7 @@ public sealed partial class GunSystem : SharedGunSystem
                     {
                         var hitEntity = lastHit.Value;
                         if (hitscan.StaminaDamage > 0f)
-                            _stamina.TakeStaminaDamageWithProjectileCoefficient(hitEntity, hitscan.StaminaDamage, source: user); // DeltaV - Cope with hitscan not being an entity
+                            _stamina.TakeProjectileStaminaDamage(hitEntity, hitscan.StaminaDamage, source: user); // DeltaV - Cope with hitscan not being an entity
 
                         var dmg = hitscan.Damage;
 

--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -24,10 +24,35 @@ public sealed partial class ArmorComponent : Component
     public float PriceMultiplier = 1;
 
     /// <summary>
-    /// DeltaV: The incoming stamina damage will get multiplied by this value.
+    /// DeltaV: The incoming stamina projectile damage will get multiplied by this value.
     /// </summary>
     [DataField]
     public float StaminaDamageCoefficient = 1;
+
+    /// <summary>
+    /// DeltaV: The configured stamina melee damage coefficient. The actual value used
+    /// will be this or the blunt damage coefficient, whichever provides better protection.
+    /// </summary>
+    [DataField]
+    private float _staminaMeleeDamageCoefficient = 1;
+
+    /// <summary>
+    /// DeltaV: Gets or sets the effective stamina melee damage coefficient, using either the configured
+    /// value or the blunt damage coefficient, whichever provides better protection (lower value).
+    /// </summary>
+    [Access(typeof(SharedArmorSystem))]
+    public float StaminaMeleeDamageCoefficient
+    {
+        get
+        {
+            // Try to get the blunt damage coefficient from modifiers
+            var bluntCoefficient = Modifiers.Coefficients.GetValueOrDefault("Blunt", 1.0f);
+
+            // Return whichever provides better protection (lower coefficient)
+            return Math.Min(bluntCoefficient, _staminaMeleeDamageCoefficient);
+        }
+        set => _staminaMeleeDamageCoefficient = value;
+    }
 }
 
 /// <summary>

--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -22,6 +22,12 @@ public sealed partial class ArmorComponent : Component
     /// </summary>
     [DataField]
     public float PriceMultiplier = 1;
+
+    /// <summary>
+    /// DeltaV: The incoming stamina damage will get multiplied by this value.
+    /// </summary>
+    [DataField]
+    public float StaminaDamageCoefficient = 1;
 }
 
 /// <summary>

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -40,7 +40,7 @@ public abstract class SharedArmorSystem : EntitySystem
         if (!args.CanInteract || !args.CanAccess)
             return;
 
-        var examineMarkup = GetArmorExamine(component.Modifiers);
+        var examineMarkup = GetArmorExamine(component); // DeltaV - Changed argument type to ArmorComponent
 
         var ev = new ArmorExamineEvent(examineMarkup);
         RaiseLocalEvent(uid, ref ev);
@@ -50,12 +50,13 @@ public abstract class SharedArmorSystem : EntitySystem
             Loc.GetString("armor-examinable-verb-message"));
     }
 
-    private FormattedMessage GetArmorExamine(DamageModifierSet armorModifiers)
+    // DeltaV - Changed to take ArmorComponent instead of DamageModifierSet
+    private FormattedMessage GetArmorExamine(ArmorComponent component)
     {
         var msg = new FormattedMessage();
         msg.AddMarkupOrThrow(Loc.GetString("armor-examine"));
 
-        foreach (var coefficientArmor in armorModifiers.Coefficients)
+        foreach (var coefficientArmor in component.Modifiers.Coefficients) // DeltaV
         {
             msg.PushNewline();
 
@@ -66,7 +67,7 @@ public abstract class SharedArmorSystem : EntitySystem
             ));
         }
 
-        foreach (var flatArmor in armorModifiers.FlatReduction)
+        foreach (var flatArmor in component.Modifiers.FlatReduction) // DeltaV
         {
             msg.PushNewline();
 
@@ -76,6 +77,26 @@ public abstract class SharedArmorSystem : EntitySystem
                 ("value", flatArmor.Value)
             ));
         }
+
+        // DeltaV - Add stamina resistance information if it differs from default
+        if (!MathHelper.CloseTo(component.StaminaDamageCoefficient, 1.0f))
+        {
+            msg.PushNewline();
+            var reduction = (1 - component.StaminaDamageCoefficient) * 100;
+            msg.AddMarkupOrThrow(Loc.GetString("armor-stamina-projectile-coefficient-value",
+                ("value", MathF.Round(reduction, 1))
+            ));
+        }
+
+        if (!MathHelper.CloseTo(component.StaminaMeleeDamageCoefficient, 1.0f))
+        {
+            msg.PushNewline();
+            var reduction = (1 - component.StaminaMeleeDamageCoefficient) * 100;
+            msg.AddMarkupOrThrow(Loc.GetString("armor-stamina-melee-coefficient-value",
+                ("value", MathF.Round(reduction, 1))
+            ));
+        }
+        // End DeltaV
 
         return msg;
     }

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -171,7 +171,28 @@ public sealed partial class StaminaSystem : EntitySystem
 
         foreach (var (ent, comp) in toHit)
         {
-            TakeStaminaDamage(ent, damage / toHit.Count, comp, source: args.User, with: args.Weapon, sound: component.Sound);
+            // Begin DeltaV code - melee stamina resistance from armor
+            var finalDamage = damage / toHit.Count;
+
+            if (_inventory.TryGetSlots(ent, out var slots))
+            {
+                var coefficient = 1.0f;
+
+                foreach (var slot in slots)
+                {
+                    if (!_inventory.TryGetSlotEntity(ent, slot.Name, out var equipped))
+                        continue;
+
+                    if (TryComp<ArmorComponent>(equipped, out var armor))
+                    {
+                        coefficient *= armor.StaminaMeleeDamageCoefficient;
+                    }
+                }
+
+                finalDamage *= coefficient;
+            }
+            TakeStaminaDamage(ent, finalDamage, comp, source: args.User, with: args.Weapon, sound: component.Sound);
+            // End DeltaV code
         }
     }
 

--- a/Content.Shared/Damage/Systems/StaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/StaminaSystem.cs
@@ -169,7 +169,7 @@ public sealed partial class StaminaSystem : EntitySystem
         foreach (var (ent, comp) in toHit)
         {
             // DeltaV - Stamina damage coefficient
-            TakeStaminaDamageWithMeleeCoefficient(ent, damage, comp, source: args.User, with: args.Weapon, sound: component.Sound);
+            TakeMeleeStaminaDamage(ent, damage, comp, source: args.User, with: args.Weapon, sound: component.Sound);
         }
     }
 
@@ -204,7 +204,7 @@ public sealed partial class StaminaSystem : EntitySystem
             return;
 
         // DeltaV - Stamina damage coefficient
-        TakeStaminaDamageWithProjectileCoefficient(target, component.Damage, source: uid, sound: component.Sound);
+        TakeProjectileStaminaDamage(target, component.Damage, source: uid, sound: component.Sound);
     }
 
     private void SetStaminaAlert(EntityUid uid, StaminaComponent? component = null)

--- a/Content.Shared/DeltaV/Damage/StaminaSystem.Resist.cs
+++ b/Content.Shared/DeltaV/Damage/StaminaSystem.Resist.cs
@@ -60,7 +60,13 @@ public sealed partial class StaminaSystem
     /// <summary>
     /// Applies stamina damage from melee attacks with armor resistance calculations
     /// </summary>
-    public void TakeStaminaDamageWithMeleeCoefficient(EntityUid target, float damage, StaminaComponent? stamina = null, EntityUid? source = null, EntityUid? with = null, bool visual = true, SoundSpecifier? sound = null)
+    public void TakeMeleeStaminaDamage(EntityUid target,
+        float damage,
+        StaminaComponent? stamina = null,
+        EntityUid? source = null,
+        EntityUid? with = null,
+        bool visual = true,
+        SoundSpecifier? sound = null)
     {
         if (!Resolve(target, ref stamina))
             return;
@@ -74,7 +80,13 @@ public sealed partial class StaminaSystem
     /// <summary>
     /// Applies stamina damage from projectiles with armor resistance calculations
     /// </summary>
-    public void TakeStaminaDamageWithProjectileCoefficient(EntityUid target, float damage, StaminaComponent? stamina = null, EntityUid? source = null, EntityUid? with = null, bool visual = true, SoundSpecifier? sound = null)
+    public void TakeProjectileStaminaDamage(EntityUid target,
+        float damage,
+        StaminaComponent? stamina = null,
+        EntityUid? source = null,
+        EntityUid? with = null,
+        bool visual = true,
+        SoundSpecifier? sound = null)
     {
         if (!Resolve(target, ref stamina))
             return;

--- a/Content.Shared/DeltaV/Damage/StaminaSystem.Resist.cs
+++ b/Content.Shared/DeltaV/Damage/StaminaSystem.Resist.cs
@@ -1,0 +1,87 @@
+using Content.Shared.Armor;
+using Content.Shared.Damage.Components;
+using Content.Shared.Inventory;
+using Robust.Shared.Audio;
+
+namespace Content.Shared.Damage.Systems;
+
+public sealed partial class StaminaSystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    /// <summary>
+    /// Gets the combined stamina protection coefficients from all armor worn by an entity
+    /// </summary>
+    private float GetMeleeCoefficient(EntityUid target)
+    {
+        var coefficient = 1.0f;
+
+        if (!_inventory.TryGetSlots(target, out var slots))
+            return coefficient;
+
+        foreach (var slot in slots)
+        {
+            if (!_inventory.TryGetSlotEntity(target, slot.Name, out var equipped))
+                continue;
+
+            if (TryComp<ArmorComponent>(equipped, out var armor))
+            {
+                coefficient *= armor.StaminaMeleeDamageCoefficient;
+            }
+        }
+
+        return coefficient;
+    }
+
+    /// <summary>
+    /// Gets the combined stamina protection coefficients from all armor worn by an entity
+    /// </summary>
+    private float GetProjectileCoefficient(EntityUid target)
+    {
+        var coefficient = 1.0f;
+
+        if (!_inventory.TryGetSlots(target, out var slots))
+            return coefficient;
+
+        foreach (var slot in slots)
+        {
+            if (!_inventory.TryGetSlotEntity(target, slot.Name, out var equipped))
+                continue;
+
+            if (TryComp<ArmorComponent>(equipped, out var armor))
+            {
+                coefficient *= armor.StaminaDamageCoefficient;
+            }
+        }
+
+        return coefficient;
+    }
+
+    /// <summary>
+    /// Applies stamina damage from melee attacks with armor resistance calculations
+    /// </summary>
+    public void TakeStaminaDamageWithMeleeCoefficient(EntityUid target, float damage, StaminaComponent? stamina = null, EntityUid? source = null, EntityUid? with = null, bool visual = true, SoundSpecifier? sound = null)
+    {
+        if (!Resolve(target, ref stamina))
+            return;
+
+        var coefficient = GetMeleeCoefficient(target);
+        var finalDamage = damage * coefficient;
+
+        TakeStaminaDamage(target, finalDamage, stamina, source, with, visual, sound);
+    }
+
+    /// <summary>
+    /// Applies stamina damage from projectiles with armor resistance calculations
+    /// </summary>
+    public void TakeStaminaDamageWithProjectileCoefficient(EntityUid target, float damage, StaminaComponent? stamina = null, EntityUid? source = null, EntityUid? with = null, bool visual = true, SoundSpecifier? sound = null)
+    {
+        if (!Resolve(target, ref stamina))
+            return;
+
+        var coefficient = GetProjectileCoefficient(target);
+        var finalDamage = damage * coefficient;
+
+        TakeStaminaDamage(target, finalDamage, stamina, source, with, visual, sound);
+    }
+}

--- a/Resources/Locale/en-US/deltav/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/deltav/armor/armor-examine.ftl
@@ -1,0 +1,2 @@
+armor-stamina-projectile-coefficient-value = - [color=yellow]Stamina projectile[/color] damage reduced by [color=lightblue]{$value}%[/color].
+armor-stamina-melee-coefficient-value = - [color=yellow]Stamina melee[/color] damage reduced by [color=lightblue]{$value}%[/color].

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/armor.yml
@@ -16,6 +16,7 @@
         Slash: 0.80
         Piercing: 0.50
         Heat: 0.80
+    staminaDamageCoefficient: 0.6 # Decent at stopping disablers
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
@@ -44,6 +45,7 @@
         Slash: 0.60
         Piercing: 0.90
         Heat: 0.90
+    staminaDamageCoefficient: 0.9
   - type: ExplosionResistance # Better than nothing against a blast or shockwave.
     damageCoefficient: 0.90
   - type: AllowSuitStorage
@@ -68,6 +70,7 @@
         Slash: 0.40
         Piercing: 0.70
         Heat: 0.70
+    staminaDamageCoefficient: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -23,6 +23,7 @@
         Radiation: 0.75
         Caustic: 0.75
         Heat: 0.75
+    staminaDamageCoefficient: 0.3 # It's a hardsuit, duh
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -68,6 +69,7 @@
         Radiation: 0.80
         Caustic: 0.80
         Heat: 0.80
+    staminaDamageCoefficient: 0.3 # still a hardsuit
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85
@@ -113,6 +115,7 @@
         Radiation: 0.70
         Caustic: 0.70
         Heat: 0.70
+    staminaDamageCoefficient: 0.2
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -158,6 +161,7 @@
         Radiation: 0.75
         Caustic: 0.75
         Heat: 0.75
+    staminaDamageCoefficient: 0.2
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80

--- a/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Clothing/OuterClothing/vests.yml
@@ -67,6 +67,7 @@
         Piercing: 0.5
         Shock: 0.8
         Heat: 0.7
+    staminaDamageCoefficient: 0.6
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 0.85

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -19,6 +19,7 @@
         Slash: 0.70
         Piercing: 0.70 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
         Heat: 0.80
+    staminaDamageCoefficient: 0.75 # DeltaV - Decent at stopping disablers
   - type: ExplosionResistance
     damageCoefficient: 0.90
 
@@ -122,6 +123,7 @@
         Piercing: 0.35
         Heat: 0.35
         Caustic: 0.5
+    staminaDamageCoefficient: 0.35 # DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.35
   - type: ClothingSpeedModifier
@@ -209,6 +211,7 @@
         Heat: 0.5
         Radiation: 0
         Caustic: 0.75
+    staminaDamageCoefficient: 0.1 # DeltaV
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
@@ -275,6 +278,7 @@
         Piercing: 0.6
         Heat: 0.5
         Caustic: 0.9
+    staminaDamageCoefficient: 0.7 # DeltaV - Some protection against disablers, but you're better off with a vest
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -21,6 +21,7 @@
         Slash: 0.9
         Piercing: 0.9
         Caustic: 0.9
+    staminaDamageCoefficient: 0.9 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.80
     sprintModifier: 0.80
@@ -211,6 +212,7 @@
         Slash: 0.6
         Piercing: 0.6
         Caustic: 0.7
+    staminaDamageCoefficient: 0.3 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -238,6 +240,7 @@
         Blunt: 0.8
         Slash: 0.8
         Piercing: 0.7
+    staminaDamageCoefficient: 0.3 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -268,6 +271,7 @@
         Slash: 0.6
         Piercing: 0.6
         Caustic: 0.7
+    staminaDamageCoefficient: 0.3 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
@@ -300,6 +304,7 @@
         Heat: 0.5
         Radiation: 0.5
         Caustic: 0.6
+    staminaDamageCoefficient: 0.3 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -435,6 +440,7 @@
         Piercing: 0.5
         Radiation: 0.5
         Caustic: 0.6
+    staminaDamageCoefficient: 0.3 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -501,6 +507,7 @@
         Heat: 0.5
         Radiation: 0.5
         Caustic: 0.5
+    staminaDamageCoefficient: 0.2 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -568,6 +575,7 @@
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5
+    staminaDamageCoefficient: 0.3 # DeltaV
   - type: Item
     size: Huge
   - type: ClothingSpeedModifier
@@ -602,6 +610,7 @@
         Heat: 0.5
         Radiation: 0.25
         Caustic: 0.4
+    staminaDamageCoefficient: 0.2 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
@@ -634,6 +643,7 @@
         Heat: 0.2
         Radiation: 0.2
         Caustic: 0.2
+    staminaDamageCoefficient: 0.1 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.65

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -16,6 +16,7 @@
         Slash: 0.6
         Piercing: 0.3
         Heat: 0.9
+    staminaDamageCoefficient: 0.8 # DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.9
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
adds a resist to incoming projectile stamina damage
most hardsuits provide a 10% protection, sec and syndicate hardsuits provide 70% protection, with exceptions for raid suits, jugg, elite, hos, warden, etc, whatever makes sense to be higher
melee damage like batongs either takes the blunt damage coefficient or the melee stamina damage coefficient on the armor, whichever one provides more resist

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
stumeta bad and i'm cooking

## Media

![image](https://github.com/user-attachments/assets/164d1a34-5579-450c-bab5-c843e62455e9)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Hardsuits and armor vests now provide protection against incoming stamina damage.


