### PR TITLE
make disablers hitscan

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -13,3 +13,35 @@
   impactFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: impact_omni
+
+- type: hitscan
+  id: Disabler
+  staminaDamage: 26
+  damage:
+    types:
+      Heat: 5
+  muzzleFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: muzzle_omni
+  travelFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: beam_omni
+  impactFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: impact_omni
+
+- type: hitscan
+  id: DisablerPractice
+  staminaDamage: 1
+  damage:
+    types:
+      Heat: 1
+  muzzleFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: muzzle_omni
+  travelFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: beam_omni
+  impactFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: impact_omni

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -438,8 +438,8 @@
     fireRate: 2
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
-  - type: ProjectileBatteryAmmoProvider
-    proto: BulletDisablerPractice
+  - type: HitscanBatteryAmmoProvider # DeltaV
+    proto: DisablerPractice # DeltaV
     fireCost: 100
   - type: Tag
     tags:
@@ -467,8 +467,8 @@
     slots:
       - suitStorage
       - Belt
-  - type: ProjectileBatteryAmmoProvider
-    proto: BulletDisabler
+  - type: HitscanBatteryAmmoProvider # DeltaV
+    proto: Disabler # DeltaV
     fireCost: 100
   - type: GuideHelp
     guides:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
made the disabler use hitscan
reduced the damage from 30 to 26, still needs 4 hits, but slightly weaker
meant to be merged with https://github.com/DeltaV-Station/Delta-v/pull/2190
mostly checking if people like it, we can revert it anyways, but if it turns out to be good, could probably give it to other disabler guns like the x-01

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
disablers and projectiles in general are a massive joke when you can just avoid them
by buffing the disablers security might prioritize them over less lethal means
for now only affects the practice and regular disablers, disabler SMG stays the same because of it's firerate

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Disablers are now hitscan.
