### PR TITLE
Make Thief and Sleeper Agent need 24hrs Playtime

### DIFF
--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -5,8 +5,8 @@
   setPreference: true
   objective: roles-antag-thief-objective
   guides: [ Thieves ]
-    requirements:
-  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+  requirements: # DeltaV - Playtime requirement
+  - !type:OverallPlaytimeRequirement 
     time: 86400 # DeltaV - 24 hours
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -5,6 +5,9 @@
   setPreference: true
   objective: roles-antag-thief-objective
   guides: [ Thieves ]
+    requirements:
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 86400 # DeltaV - 24 hours
 
 - type: startingGear
   id: ThiefGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -16,6 +16,9 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
   guides: [ Traitors ]
+    requirements:
+  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+    time: 86400 # DeltaV - 24 hours
 
 # Syndicate Operative Outfit - Monkey
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -16,8 +16,8 @@
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
   guides: [ Traitors ]
-    requirements:
-  - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+  requirements: #DeltaV - Playtime requirement
+  - !type:OverallPlaytimeRequirement 
     time: 86400 # DeltaV - 24 hours
 
 # Syndicate Operative Outfit - Monkey


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds a 24 hour playtime requirement to thief and sleeper agent

## Why / Balance
All our other antags need at least a day, barring some ghost ones. Stops new players becoming an antag before they're used to DeltaVs culture

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: Fox
- tweak: Thieves and Sleeper Agents now need 24hrs playtime

