### PR TITLE
DeadRum, the Quest for More Rum

### DIFF
--- a/Resources/Changelog/DeltaVChangelog.yml
+++ b/Resources/Changelog/DeltaVChangelog.yml
@@ -1,10 +1,4 @@
 ﻿Entries:
-- author: FluffiestFloof
-  changes:
-  - message: Removed the carp suit bundle from the syndicate uplink.
-    type: Remove
-  id: 123
-  time: '2023-11-06T14:54:09.0000000+00:00'
 - author: Colin-Tel
   changes:
   - message: Fixed a few issues with Asterisk, including getting stuck on Epi's park
@@ -3687,3 +3681,10 @@
   id: 622
   time: '2024-10-25T00:15:01.0000000+00:00'
   url: https://github.com/DeltaV-Station/Delta-v/pull/2038
+- author: Radezolid
+  changes:
+  - message: Pie cannons can now be fired by pacifists!
+    type: Tweak
+  id: 623
+  time: '2024-10-26T01:46:26.0000000+00:00'
+  url: https://github.com/DeltaV-Station/Delta-v/pull/2046

--- a/Resources/Prototypes/DeltaV/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Reactions/drinks.yml
@@ -1,14 +1,14 @@
 - type: reaction
   id: DeadRum
   reactants:
-	TableSalt: 
-	 amount: 1
-	Saline:
-	 amount: 1
-	Rum:
-	 amount: 1
+    Saline:
+      amount: 1
+    Rum:
+      amount: 1
+    TableSalt:
+      amount: 1
   products:
-	DeadRum: 3
+    Deadrum: 3
 
 - type: reaction
   id: HealthViolation

--- a/Resources/Prototypes/DeltaV/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Reactions/drinks.yml
@@ -1,4 +1,16 @@
 - type: reaction
+  id: DeadRum
+  reactants:
+	TableSalt: 
+	 amount: 1
+	Saline:
+	 amount: 1
+	Rum:
+	 amount: 1
+  products:
+	DeadRum: 3
+
+- type: reaction
   id: HealthViolation
   reactants:
     GargleBlaster:

--- a/Resources/Prototypes/DeltaV/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Reactions/drinks.yml
@@ -8,7 +8,7 @@
     TableSalt:
       amount: 1
   products:
-    Deadrum: 3
+    DeadRum: 3
 
 - type: reaction
   id: HealthViolation


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Created a recipe for DeadRum, currently its only available at a the salvage medium pirate map, with no indication that it is a 'special' rum. 

## Why / Balance
This shall allow bartenders access to the 'Modern Daiquiri' cocktail as well as the saltiest rum to exist

## Technical details
created the recipe for deadrum
1 part saline
1 part salt
1 part rum

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Did not check to see if the recipe appears in the guidebook.

**Changelog**
add: MORE RUM! check out DeadRum!
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
