### PR TITLE
tweak: Make maroon towel require Justice instead of Lawyer time

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -322,8 +322,8 @@
   effects:
   - !type:JobRequirementLoadoutEffect
     requirement:
-      !type:RoleTimeRequirement
-      role: JobLawyer
+      !type:DepartmentTimeRequirement # DeltaV - Use Justice department time instead of Lawyer job time
+      department: Justice
       time: 360000 # 100hr
   storage:
     back:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The maroon towel trinket now requires 100h in the Justice department, instead of just the Lawyer job.

## Why / Balance
Makes the requirement consistent with the other towels. Justice is not a thing upstream, so they required Lawyer time.

## Technical details
swapped out the RoleTimeRequirement for a DepartmentTimeRequirement

## Media
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: DisposableCrewmember42
- tweak: Prosecutors now get the towels they deserve.
