### PR TITLE
Buff beanbags shells

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -26,7 +26,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 40 # 3 hits to stun
+    damage: 55 # DeltaV - Modified the beanbag stamina damage, was 40.
 
 - type: entity
   id: PelletShotgun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -26,7 +26,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 55 # DeltaV - Modified the beanbag stamina damage, was 40.
+    damage: 50 # DeltaV - Modified the beanbag stamina damage, was 40.
 
 - type: entity
   id: PelletShotgun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -26,7 +26,7 @@
       types:
         Blunt: 10
   - type: StaminaDamageOnCollide
-    damage: 50 # DeltaV - Modified the beanbag stamina damage, was 40.
+    damage: 55 # DeltaV - Modified the beanbag stamina damage, was 40.
 
 - type: entity
   id: PelletShotgun


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Made the beanbag stamina damage as it was before the upstream nerf. My goal is to bring back the usefulness of the double barrel shotgun as a tool to stop bar fights and it being a better weapon for syndie bartenders.

## Why / Balance
Armored targets now have resistance to stamina damage, so this change makes the bartender be able to actually use their shotgun on disruptive people in the bar.

Balance tested with a enforcer without missing a shot:
Blood red took 70 stamina damage.
Juggernaut took 35 stamina damage.
Durathread vest goes down in 3 shots.
Plate carrier goes down in 4 shots.

## Technical details
1 line change of YAML.

## Media
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Beanbags hits hard again, bartenders rejoice!
