### PR TITLE
Buff the damn shuttle cannons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -127,8 +127,8 @@
   maxLength: 60
   damage:
     types:
-      Heat: 70
-      Structural: 30
+      Heat: 70 # DeltaV buffed to 70
+      Structural: 30 # DeltaV buffed to 30
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy2

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -127,8 +127,8 @@
   maxLength: 60
   damage:
     types:
-      Heat: 45
-      Structural: 10
+      Heat: 70
+      Structural: 30
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy2

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -128,7 +128,7 @@
     color: "#03fc4e"
     energy: 0.7
   - type: Charger
-    chargeRate: 400
+    chargeRate: 400 # DeltaV buffed from 50 to 400
   - type: Sprite
     sprite: Structures/Power/cage_recharger.rsi
   - type: PowerCellSlot

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -128,7 +128,7 @@
     color: "#03fc4e"
     energy: 0.7
   - type: Charger
-    chargeRate: 50
+    chargeRate: 400
   - type: Sprite
     sprite: Structures/Power/cage_recharger.rsi
   - type: PowerCellSlot

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -76,7 +76,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 300
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame
@@ -129,7 +129,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 800
       behaviors:
         - !type:ChangeConstructionNodeBehavior
           node: machineFrame


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Shuttle cannons damage is VERY powerful
## Why / Balance
Any gun that is used to shoot other shuttles SHOULD ABSOLUTELY melt a standard person.
## Technical details
Perferator damage buffed to 70 heat and 30 structural. cage recharger now charges power cages 4x faster than a turbocharger would (seriously made no sense for the cage recharger to be as slow as it was and cost what it does). The cage recharger takes ~15 seconds to fully charge a high capacity cage, which should be fine balance wise.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: The perferator does heaps more damage
- tweak: The cage recharger is no longer worse than a basic recharger