### PR TITLE
Turn Bomberjackets into wintercoats.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingOuterStorageBase
+  parent: ClothingOuterWinterCoat # DeltaV - changed from regular coat to winter coat. The bomberjacket now provides protection against cold as well as minor armour, like all wintercoats.
   id: ClothingOuterCoatBomber
   name: bomber jacket
   description: A thick, well-worn WW2 leather bomber jacket.


### PR DESCRIPTION
## About the PR
Change the parent of the bomberjacket from regular coat to wintercoat.

## Why / Balance
This is mostly aimed to provide a greater variety of viable winter clothing for the ever popular Glacier map. The bomberjacket is already in the winterdrobe and was historically designed to keep people warm, so it also makes sense in that regard. The bomberjacket would also gain some minor amour due to this change, bringing it onto the same level as other wintercoats. 

I'd also be willing to extend this PR to other clothing that should probably keep you warm, but currently do not, but I wanted to gauge people's opinions first. 

## Technical details
- Changed Bomberjacket parent from ClothingOuterStorageBase to ClothingOuterWinterCoat 
- Added Delta V comment, since this changes upstream yml 

(I'm not sure if this is the best/cleanest way to do it or if its preferably to add the TemperatureProtection manually)

## Media
![image](https://github.com/user-attachments/assets/f78c863f-903f-4c10-9187-3d3d6599d109)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
n/a

**Changelog**
:cl:
- tweak: Bomberjackets now protect from the cold!

