### PR TITLE
Nerf "mini" syringes

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -414,6 +414,10 @@
     minimumSpeed: 3
     removalTime: 0.25
     embedOnThrow: false
+  - type: SolutionContainerManager # DeltaV - Nerfs the max volume to 5 (was 15)
+    solutions:
+      injector:
+        maxVol: 5 
   - type: SolutionInjectWhileEmbedded
     transferAmount: 1
     solution: injector


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Mini syringes capacity reduced to 5u

## Why / Balance
truly made no sense for "mini" syringes to have the same capacity as regular ones, also with syringe gun being AP its way over-tuned for the new chem meta.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Mini syringes now hold 5u instead of 15