### PR TITLE
Hardsuits now block defibulators

### DIFF
--- a/Content.Shared/DeltaV/BlockDefibrillator/BlockDefibrillatorComponent.cs
+++ b/Content.Shared/DeltaV/BlockDefibrillator/BlockDefibrillatorComponent.cs
@@ -1,0 +1,11 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared.DeltaV.BlockDefibrillator;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BlockDefibrillatorComponent : Component
+{
+
+    [DataField]
+    public string OnBlockPopupMessage = "The defibrillator cannot find a pulse through the armor!";
+}

--- a/Content.Shared/DeltaV/BlockDefibrillator/BlockDefibrillatorSystem.cs
+++ b/Content.Shared/DeltaV/BlockDefibrillator/BlockDefibrillatorSystem.cs
@@ -1,0 +1,21 @@
+﻿using Content.Shared.Popups;
+
+namespace Content.Shared.DeltaV.BlockDefibrillator;
+
+public sealed class BlockDefibrillatorSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BlockDefibrillatorComponent, TargetBeforeDefibrillatorZapsEvent>(OnBeforeDefibrillatorZapsEvent);
+    }
+
+    private void OnBeforeDefibrillatorZapsEvent(Entity<BlockDefibrillatorComponent> entity, TargetBeforeDefibrillatorZapsEvent args)
+    {
+        args.Cancel();
+        _popupSystem.PopupClient(entity.Comp.OnBlockPopupMessage, args.User);
+    }
+}

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -146,6 +146,7 @@
       flatReductions:
         Heat: 10 # the average lightbulb only does around four damage!
     slots: OUTERCLOTHING
+  - type: BlockDefibrillator // Delta-V
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Title! Defibs now are blocked by hardsuits.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I asked in the discord, majority of people seemed to want it. It makes sense and will make medical have to think about defibbing fully armored security.

Also, requires:
https://github.com/space-wizards/space-station-14/pull/31147
To be merged before it works! (I'll also add comments and localization stuff when that happens as I want it fully merged before doing testing and stuff)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
todo

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Hardsuits now block defibrillators

