### PR TITLE
Remove the storage implant from the uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1261,24 +1261,24 @@
 
 # Implants
 
-- type: listing
-  id: UplinkStorageImplanter
-  name: uplink-storage-implanter-name
-  description: uplink-storage-implanter-desc
-  icon: { sprite: /Textures/Clothing/Back/Backpacks/backpack.rsi, state: icon }
-  productEntity: StorageImplanter
-  discountCategory: rareDiscounts
-  discountDownTo:
-    Telecrystal: 5 # DeltaV
-  cost:
-    Telecrystal: 10 # DeltaV - Was 8
-  categories:
-    - UplinkImplants
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink
+#- type: listing # DeltaV - Removed storage implanter.
+#  id: UplinkStorageImplanter
+#  name: uplink-storage-implanter-name
+#  description: uplink-storage-implanter-desc
+#  icon: { sprite: /Textures/Clothing/Back/Backpacks/backpack.rsi, state: icon }
+#  productEntity: StorageImplanter
+#  discountCategory: rareDiscounts
+#  discountDownTo:
+#    Telecrystal: 5 # DeltaV
+#  cost:
+#    Telecrystal: 10 # DeltaV - Was 8
+#  categories:
+#    - UplinkImplants
+#  conditions:
+#    - !type:StoreWhitelistCondition
+#      blacklist:
+#        tags:
+#          - NukeOpsUplink
 
 - type: listing
   id: UplinkFreedomImplanter


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR removes the storage implant from the uplink.

## Why / Balance
It started as simply changes to make it unable to store high risk items, but then containers happend and my smooth brain couldn't figure that out.
Storage implant with high risk item = boring, no RP.

## Technical details
YAML changes

## Media
It gone.
![image](https://github.com/user-attachments/assets/ee15be39-016b-434d-9e55-a3e45703ab79)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
:cl:
- remove: Removed the storage implant from the uplink!
