### PR TITLE
Add soretizone to starting kit of chronically ill characters

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Specific/Medical/healing.yml
@@ -1,0 +1,30 @@
+- type: entity
+  parent: Pill
+  id: PillSoretizone
+  suffix: Soretizone 10u
+  components:
+  - type: Pill
+    pillType: 14
+  - type: Sprite
+    state: pill15
+  - type: Label
+    currentLabel: soretizone 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: Soretizone
+          Quantity: 10
+
+- type: entity
+  parent: PillCanister
+  id: PillCanisterSoretizone
+  suffix: Soretizone 10u, 5
+  components:
+  - type: Label
+    currentLabel: soretizone 10u
+  - type: StorageFill
+    contents:
+    - id: PillSoretizone
+      amount: 5

--- a/Resources/Prototypes/DeltaV/Traits/disabilities.yml
+++ b/Resources/Prototypes/DeltaV/Traits/disabilities.yml
@@ -18,6 +18,7 @@
   id: InPain
   name: trait-inpain-name
   description: trait-inpain-desc
+  traitGear: PillCanisterSoretizone
   category: Disabilities
   components:
   - type: Pain


### PR DESCRIPTION
## About the PR & Why

At the start of a shift, it's quite frequent that chemists are both unable to and too busy to make painkillers for chronically ill characters for quite some time, leaving them to rot at the start of the round.

This remedies that by giving them 5 pills of soretizone when they spawn in, so that they have a buffer before they need to consult the ship's chemist.

## Technical details
- add soretizone pill entity
- add soretizone pill canister entity
- set soretizone pill canister as the trait gear of chronic pain trait

## Media
![grafik](https://github.com/user-attachments/assets/f6c362c3-47f9-4b73-ab74-c5f1157d8120)


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Characters with the "chronic pain" trait now spawn with 5 pills of 10u soretizone to tide them over at the start of a shift