### PR TITLE
Unused announcer line is now used

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -127,7 +127,7 @@
   - type: StationEvent
     startAnnouncement: station-event-bureaucratic-error-announcement
     startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
-    path: /Audio/Announcements/bureaucratic_error.ogg 
+      path: /Audio/Announcements/bureaucratic_error.ogg 
     minimumPlayers: 25
     weight: 5
     duration: 1

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -132,6 +132,8 @@
   - type: BureaucraticErrorRule
     ignoredJobs:
     - StationAi
+    startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
+      path: /Audio/Announcements/bureaucratic_error.ogg 
 
 - type: entity
   id: ClericalError

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -126,14 +126,14 @@
   components:
   - type: StationEvent
     startAnnouncement: station-event-bureaucratic-error-announcement
+    startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
+    path: /Audio/Announcements/bureaucratic_error.ogg 
     minimumPlayers: 25
     weight: 5
     duration: 1
   - type: BureaucraticErrorRule
     ignoredJobs:
     - StationAi
-    startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
-      path: /Audio/Announcements/bureaucratic_error.ogg 
 
 - type: entity
   id: ClericalError


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Did you know there's a line in the announcer's sound files for the bureaucratic error? I didn't until I played elsewhere (an EE fork.) Initially I thought "Oh, they commissioned that dude that did the announcer voicelines again" but it's just hiding in our own repo, it turns out. This enables that line to be played.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's in the files waiting to be used, it just wasn't hooked up. This fixes that.
## Technical details
<!-- Summary of code changes for easier review. -->
This touches the upstream events.yml file for the purpose of starting this audio. It is an easy one line change.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Not player facing except for the announcement itself.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or **it does not require an ingame showcase.**
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
May break the upstream merge if bureaucratic error ever gets changed. If it is, simply move the comp for startAudio. If not, you should be fine.

**Changelog**
No CL no fun. It will be a fun surprise for people to hear this now.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
