### PR TITLE
fix borgs not having names

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Player/silicon.yml
@@ -12,6 +12,8 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+  - type: RandomMetadata
+    nameSegments: [names_borg]
 
 - type: entity
   parent: BorgChassisSecurity

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -443,6 +443,8 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellMedium
+  - type: RandomMetadata # DeltaV: give job borgs names
+    nameSegments: [names_borg]
 
 - type: entity
   id: PlayerBorgSyndicateAssaultBattery


### PR DESCRIPTION
## About the PR
job borgs now have names
newly built borgs are unaffected

**Changelog**
:cl:
- fix: Fixed borgs not having names.
