### PR TITLE
make moths 1% harder to round remove

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -192,7 +192,7 @@
   id: Moth # Slightly worse at everything but cold
   coefficients:
     Cold: 0.7
-    Heat: 1.3
+    Heat: 1.1 # DeltaV: was 1.3, too extreme
 
 - type: damageModifierSet
   id: Vox

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -66,7 +66,7 @@
         Cold : 0.05 #per second, scales with temperature & other constants
     heatDamage:
       types:
-        Heat : 3 #per second, scales with temperature & other constants
+        Heat : 1.5 #per second, scales with temperature & other constants # DeltaV: changed to normal heat damage
   - type: TemperatureSpeed
     thresholds:
       289: 0.8


### PR DESCRIPTION
## About the PR
- 1.3 heat -> 1.1 heat modifier
- fire damage is same as other species

## Why / Balance
getting 1000 damage because you happened to get lit on fire and nobody took your coat off amazing gameplay and rp

a little less cold damage is in no way worth getting round removed by any kind of fire (if you touch lava you get killed with no counter if you are just a little hurt)

fire extinguishers dont work on crit because fixture bullshit and nobody has a bottle ready just incase someone happens to get lit on fire, and if they do they always wait until the fires stopped to drench you in now-useless water

**Changelog**
:cl: moth
- tweak: Made moth's heat damage less insane.