### PR TITLE
fix secborg sprite

### DIFF
--- a/Resources/Prototypes/DeltaV/borg_types.yml
+++ b/Resources/Prototypes/DeltaV/borg_types.yml
@@ -37,6 +37,8 @@
   # Visual
   clientComponents:
   - type: Sprite
+    noRot: true
+    drawdepth: Mobs
     sprite: DeltaV/Mobs/Silicon/chassis.rsi
     layers:
     - state: security


### PR DESCRIPTION
## About the PR
john shitcode inventing shitcode but then john hack walks in

**Changelog**
:cl: Big Orthagonal
- fix: Diagonal secborgs are not real and were never real.