### PR TITLE
Add 8 Directional Movement For Sec Borg

### DIFF
--- a/Resources/Prototypes/DeltaV/borg_types.yml
+++ b/Resources/Prototypes/DeltaV/borg_types.yml
@@ -37,8 +37,6 @@
   # Visual
   clientComponents:
   - type: Sprite
-    noRot: true
-    drawdepth: Mobs
     sprite: DeltaV/Mobs/Silicon/chassis.rsi
     layers:
     - state: security


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
It is not a bug it is a feature

## Why / Balance
8 directional walk is fun and does not affect game balance at all.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added Fun Eight Directional Movement To Sec Borgs