### PR TITLE
Omega Particles buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -618,7 +618,7 @@
   - type: AnomalousParticle
     particleType: Default
     severityOverride: true
-    severityPerSeverityHit: 0.1
+    severityPerSeverityHit: 0.3 # DeltaV raised to .3 from .1
     stabilityPerDestabilizingHit: 0.05
     healthPerWeakeningeHit: 1
     stabilityPerWeakeningeHit: -0.05
@@ -626,7 +626,7 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Heat: 20
+        Heat: 30 # DeltaV raised to 30 from 20
 
 - type: entity
   parent: AnomalousParticleDelta


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Buff the omega particles to deal more damage and make anoms crit faster
## Why / Balance
To be honest these are never used outside of surplus crates because they suck so much


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Omega particles are more deadly, Mystagogues beware!

