### PR TITLE
Tweak hydro tray cost

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -623,14 +623,15 @@
       state: service
     - type: MachineBoard
       prototype: HydroponicsTrayEmpty
-      stackRequirements:
+      stackRequirements: # DeltaV - Removed beaker requirment and reduced glass amount, added steel to compensate.
         # replacing the console screen
-        Glass: 5
+        Glass: 2
+        Steel: 2 
         Cable: 2
-      tagRequirements:
-        GlassBeaker:
-          amount: 2
-          defaultPrototype: Beaker
+     #tagRequirements:
+       #GlassBeaker:
+         #amount: 2
+         #defaultPrototype: Beaker
 
 - type: entity
   id: SeedExtractorMachineCircuitboard


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Remove the stupid beaker requirement for hydro tray and adds steel to compensate

## Why / Balance
99% of botanists see "x2 Beaker" and give up on building more trays.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Hydro trays are easier to make