### PR TITLE
Psych chems no longer stronger than nocturine 

### DIFF
--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -206,36 +206,36 @@
         damage:
           types:
             Poison: 0.5
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Tranquinase # conflicts with many other meds
-          min: 2.0
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
-        probability: 0.4
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Soretizone # conflicts with many other meds
-          min: 3.0
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
-        probability: 0.3
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Agonolexyne # conflicts with many other meds
-          min: 0.25
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
-        probability: 0.3
+     #- !type:GenericStatusEffect
+       #conditions:
+       #- !type:ReagentThreshold
+         #reagent: Tranquinase # conflicts with many other meds
+         #min: 2.0
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
+       #probability: 0.4
+     #- !type:GenericStatusEffect # DeltaV - Removed all psych med forcesleeps
+       #conditions:
+       #- !type:ReagentThreshold
+         #reagent: Soretizone # conflicts with many other meds
+         #min: 3.0
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
+       #probability: 0.3
+     #- !type:GenericStatusEffect # DeltaV - Removed all psych med forcesleeps
+       #conditions:
+       #- !type:ReagentThreshold
+         #reagent: Agonolexyne # conflicts with many other meds
+         #min: 0.25
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
+       #probability: 0.3
       - !type:PopupMessage
         type: Local
         visualType: Medium
@@ -344,15 +344,15 @@
         conditions:
         - !type:ReagentThreshold
           min: 16.5
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          min: 20.0
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
-        probability: 0.1
+     #- !type:GenericStatusEffect # DeltaV - Removed all psych med forcesleeps
+       #conditions:
+       #- !type:ReagentThreshold
+         #min: 20.0
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
+       #probability: 0.1
       - !type:HealthChange # poisons you if you take way too much
         conditions:
         - !type:ReagentThreshold
@@ -525,25 +525,25 @@
           - "reagent-effect-painkiller-normal3"
           - "reagent-effect-painkiller-normal4"
         probability: 0.085
-      - !type:GenericStatusEffect
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          min: 14.5 # overdose knocks you out
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
-      - !type:GenericStatusEffect
-        probability: 0.08
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Stubantazine
-          min: 5 # taking with other painkillers will knock you out
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
+     #- !type:GenericStatusEffect # DeltaV - Removed all psych med forcesleeps
+       #probability: 0.1
+       #conditions:
+       #- !type:ReagentThreshold
+         #min: 14.5 # overdose knocks you out
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
+     #- !type:GenericStatusEffect # DeltaV - Removed all psych med forcesleeps
+       #probability: 0.08
+       #conditions:
+       #- !type:ReagentThreshold
+         #reagent: Stubantazine
+         #min: 5 # taking with other painkillers will knock you out
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold
@@ -592,26 +592,26 @@
           - "reagent-effect-painkiller-strong5"
           - "reagent-effect-painkiller-strong6"
         probability: 0.1
-      - !type:GenericStatusEffect
-        probability: 0.1
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Stubantazine
-          min: 4 # taking with other painkillers will knock you out
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
-      - !type:GenericStatusEffect
-        probability: 0.15
-        conditions:
-        - !type:ReagentThreshold
-          reagent: Soretizone
-          min: 2 # taking with other painkillers will knock you out
-        key: ForcedSleep
-        component: ForcedSleeping
-        refresh: false
-        type: Add
+     #- !type:GenericStatusEffect # DeltaV - Removed all psych med forcesleeps
+       #probability: 0.1
+       #conditions:
+       #- !type:ReagentThreshold
+         #reagent: Stubantazine
+         #min: 4 # taking with other painkillers will knock you out
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
+     #- !type:GenericStatusEffect # DeltaV - Removed all psych med forcesleeps
+       #probability: 0.15
+       #conditions:
+       #- !type:ReagentThreshold
+         #reagent: Soretizone
+         #min: 2 # taking with other painkillers will knock you out
+       #key: ForcedSleep
+       #component: ForcedSleeping
+       #refresh: false
+       #type: Add
       - !type:AdjustReagent
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removed all forced sleeping mechanics for the psychological chems

## Why / Balance
literally 15u of a funny death mix could round remove someone for 20+ minutes. psych chems should not be the new chloral hydrate.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: psych chems are no longer stronger nocturine
