### PR TITLE
Give Captain's PDA Useful Apps

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -548,6 +548,16 @@
     borderColor: "#7C5D00"
   - type: Icon
     state: pda-captain
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+    - CrewManifestCartridge
+    - NotekeeperCartridge
+    - NewsReaderCartridge
+    - SecWatchCartridge # DeltaV: SecWatch replaces WantedList
+    - AstroNavCartridge
+    - StockTradingCartridge # Delta-V
+    - GlimmerMonitorCartridge
 
 - type: entity
   parent: BasePDA

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -548,6 +548,7 @@
     borderColor: "#7C5D00"
   - type: Icon
     state: pda-captain
+  # Begin DeltaV additions
   - type: CartridgeLoader
     uiKey: enum.PdaUiKey.Key
     preinstalled:
@@ -558,6 +559,7 @@
     - AstroNavCartridge
     - StockTradingCartridge # Delta-V
     - GlimmerMonitorCartridge
+  # End DeltaV additions
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
This is my first PR, please let me know if I did anything wrong or stuff I can do better.

## About the PR
I added the SecWatch, AstroNav, StockTrading, And Glimmer Monitor apps to the captain's PDA.

## Why / Balance
The captain should have these apps so they can keep an eye on how each department is doing, and in the case of the Astro Nav, get back to the station if they end up lost in space with their jetpack. (This has happened to me once)

Feedback from the Discord led me to exclude the MedTek app from being added, which would let the captain use their PDA as a health analyzer. If you think it should be added, let me know I guess.

## Technical details
Modifies `Resources/Prototypes/Entities/Objects/Devices/pda.yml`

## Media
<img width="399" alt="Screenshot 2024-11-28 085137" src="https://github.com/user-attachments/assets/74b464c7-74cb-4616-9b15-d4959bef5b5a">


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None. Hopefully.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Captain's PDA now comes with more apps.