### PR TITLE
Nuke core container closed fail popup

### DIFF
--- a/Resources/Locale/en-US/nuke/nuke-core-container.ftl
+++ b/Resources/Locale/en-US/nuke/nuke-core-container.ftl
@@ -1,2 +1,3 @@
 nuke-core-container-whitelist-fail-popup = That doesn't fit into the container.
 nuke-core-container-sealed-popup = The {$container} is sealed shut!
+nuke-core-container-closed-fail-popup = You need to open the container first!

--- a/Resources/Prototypes/Entities/Objects/Misc/plutonium_core.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/plutonium_core.yml
@@ -47,6 +47,7 @@
         whitelist:
           tags:
           - PlutoniumCore
+        lockedFailPopup: nuke-core-container-closed-fail-popup
         whitelistFailPopup: nuke-core-container-whitelist-fail-popup
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
## About the PR
Fixes https://github.com/DeltaV-Station/Delta-v/issues/2173

## Why / Balance
To stop syndies from getting confused and dying to radiation.

## Technical details
- edited ftl files to make a new nuke core container specific error message
- integrated new error message into yaml 

## Media

https://github.com/user-attachments/assets/2831006b-a249-451b-a20a-1828536586a5


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
n/a

**Changelog**
:cl:
- fix: The nuke core container now displays an appropriate message when hasty syndicate agents try to insert the nuke core while it is still closed!
