### PR TITLE
Update recycler.yml

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -69,6 +69,7 @@
       - PhysicalComposition
       - MobState
       - SpaceGarbage
+      - SpawnItemsOnUse # DeltaV: TODO Remove this one when the bug is fixed.
       tags:
       - Trash
       - Recyclable


### PR DESCRIPTION
## About the PR
Attempt to stop server lags.

## Why / Balance
Lags start when the game try to eat any items with ``SpawnItemsOnUse`` comp on it, dont know why but this issue is coming from upstream.

There might be more stuff that adding to the issue, but I could only find this.

## Technical details
Spawn 200 ``FoodPSB`` on the recycler and see its actually eating them without killing the server.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Honestly this allows deleting any ``SpawnItemsOnUse`` entity but there is nothing I can find on that list that can be abused.

**Changelog**
N/A
