### PR TITLE
Buttery recipe changes

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Consumable/Food/meals.yml
@@ -14,12 +14,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 15
+        maxVol: 20
         reagents:
         - ReagentId: Nutriment
-          Quantity: 6
+          Quantity: 12
         - ReagentId: Vitamin
-          Quantity: 2
+          Quantity: 3
   - type: FoodSequenceElement # unlimited power
     entries:
       Burger: GrilledCheese

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Consumable/Food/soup.yml
@@ -16,12 +16,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 10
+        maxVol: 15
         reagents:
         - ReagentId: Nutriment
           Quantity: 5
         - ReagentId: Protein
-          Quantity: 5
+          Quantity: 10
   - type: FoodSequenceElement
     entries:
       Burger: ScrambledEggs

--- a/Resources/Prototypes/DeltaV/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Cooking/meal_recipes.yml
@@ -17,7 +17,7 @@
     TableSalt: 5
   solids:
     FoodBowlBig: 1
-    FoodEgg: 3
+    FoodEgg: 2
     FoodButterSlice: 1
 
 - type: microwaveMealRecipe

--- a/Resources/Prototypes/DeltaV/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Cooking/meal_recipes.yml
@@ -6,7 +6,7 @@
   solids:
     FoodBreadPlainSlice: 2
     FoodCheeseSlice: 1
-    FoodButter: 1
+    FoodButterSlice: 1
 
 - type: microwaveMealRecipe
   id: RecipeScrambledEggs
@@ -18,7 +18,7 @@
   solids:
     FoodBowlBig: 1
     FoodEgg: 3
-    FoodButter: 1
+    FoodButterSlice: 1
 
 - type: microwaveMealRecipe
   id: RecipeBlueTomatoSoup

--- a/Resources/Prototypes/Nyanotrasen/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Nyanotrasen/Recipes/Cooking/meal_recipes.yml
@@ -175,7 +175,7 @@
   #   Butter: 5
   solids:
     FoodMothBakedCorn: 1
-    FoodButter: 1
+    FoodButterSlice: 1
 
 - type: microwaveMealRecipe
   id: RecipeMothMozzarellaSticks


### PR DESCRIPTION
## About the PR
Tweaks recipes and/or nutrition for Grilled Cheese, Scrambled, and Buttered Baked corn.

## Why / Balance
These recipes are over the top. Too much for too little. Let the people make 500 grilled cheeses.

A whole stick of butter is just obscene. The corn specifies in a comment that it would use 5u of melted butter instead, which should reasonably be one slice, right?

Grilled cheese and scrambled eggs are really inefficient for the ingredients they use even after reducing butter to 1/3, so I buffed the numbers to almost match the sum of their parts. The eggs in particular only had the nutrition of 1 egg, so this is huge for egg eaters.

## Technical details
In Delta and Nyano meal_recipes.yml: Swap FoodButter for FoodButterSlice in the three recipes. Scrambled eggs down to 2 eggs.
In Delta soup.yml: Increase scrambled egg numbers. Double protein.
In Delta meals.yml: Increase grilled cheese numbers. Double nutriment and +1 vitamin. Mmm, cheese.

## Media
N/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl:
- tweak: Made grilled cheese, scrambled eggs, and buttered baked corn recipes use less butter. Grilled cheese and scrambled eggs are more efficiently nutritious, and scrambled eggs use one less egg.