### PR TITLE
Superweapon Safe and spawner

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -87,7 +87,7 @@
     contents:
     - id: WeaponLauncherRocket
     - id: CartridgeRocket
-      prob: 0.2
+    prob: 0.2
 
 - type: entity
   parent: GunSafe

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -87,6 +87,7 @@
     contents:
     - id: WeaponLauncherRocket
     - id: CartridgeRocket
+      prob: 0.2
 
 - type: entity
   parent: GunSafe

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -77,3 +77,25 @@
       amount: 2
     - id: MagazineRifle
       amount: 4
+
+- type: entity
+  parent: GunSafe
+  id: GunSafeRocketLauncher
+  name: RPG safe
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponLauncherRocket
+      amount: 1
+    - id: CartridgeRocket
+      amount: 1
+
+- type: entity
+  parent: GunSafe
+  id: GunSafeBeamDevastator
+  name: Devastator safe
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponBeamDevastator
+      amount: 1

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -87,7 +87,6 @@
     contents:
     - id: WeaponLauncherRocket
     - id: CartridgeRocket
-    prob: 0.2
 
 - type: entity
   parent: GunSafe

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -86,9 +86,8 @@
   - type: StorageFill
     contents:
     - id: WeaponLauncherRocket
-      amount: 1
     - id: CartridgeRocket
-      amount: 1
+      prob: 0.2
 
 - type: entity
   parent: GunSafe
@@ -98,4 +97,4 @@
   - type: StorageFill
     contents:
     - id: WeaponBeamDevastator
-      amount: 1
+ 

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -59,8 +59,7 @@
   id: SuperweaponSafeSpawner
   suffix: Superweapon
   components:
-  - type: EntityTableSpawner
-    table: !type:GroupSelector
-      children:
-      - id: GunSafeRocketLauncher
-      - id: GunSafeBeamDevastator
+  - type: RandomSpawner
+    prototypes:
+      - GunSafeBeamDevastator
+      - GunSafeRocketLauncher

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -59,7 +59,8 @@
   id: SuperweaponSafeSpawner
   suffix: Superweapon
   components:
-  - type: RandomSpawner
-    prototypes:
-      - GunSafeBeamDevastator
-      - GunSafeRocketLauncher
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+      - id: GunSafeBeamDevastator
+      - id: GunSafeRocketLauncher

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -60,7 +60,13 @@
   suffix: Superweapon
   components:
   - type: EntityTableSpawner
-    table: !type:GroupSelector
-      children:
-        - id: GunSafeBeamDevastator
-        - id: GunSafeRocketLauncher
+    table: !type:NestedSelector
+      tableId: RandomSuperweaponSafeTable
+
+#Table
+- type: entityTable
+  id: RandomSuperweaponSafeTable
+  table: !type:GroupSelector
+    children:
+    - id: GunSafeRocketLauncher
+    - id: GunSafeBeamDevastator

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -60,13 +60,7 @@
   suffix: Superweapon
   components:
   - type: EntityTableSpawner
-    table: !type:NestedSelector
-      tableId: RandomSuperweaponSafeTable
-
-#Table
-- type: entityTable
-  id: RandomSuperweaponSafeTable
-  table: !type:GroupSelector
-    children:
-    - id: GunSafeRocketLauncher
-    - id: GunSafeBeamDevastator
+    table: !type:GroupSelector
+      children:
+      - id: GunSafeRocketLauncher
+      - id: GunSafeBeamDevastator

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/safes.yml
@@ -53,3 +53,14 @@
         - id: GunSafeEnergyGunMini
         - id: GunSafePistolUniversal
         - id: GunSafeSubMachineGunWt550
+
+- type: entity
+  parent: BaseGunSafeSpawner
+  id: SuperweaponSafeSpawner
+  suffix: Superweapon
+  components:
+  - type: EntityTableSpawner
+    table: !type:GroupSelector
+      children:
+        - id: GunSafeBeamDevastator
+        - id: GunSafeRocketLauncher

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
@@ -1,7 +1,7 @@
 - type: entity
+  id: LootSpawnerSecuritySuperweapon
   name: security superweapon spawner
   suffix: superweapon
-  id: LootSpawnerSecuritySuperweapon
   parent: MarkerBase
   components:
   - type: EntityTableSpawner

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
@@ -4,7 +4,17 @@
   id: LootSpawnerSecuritySuperweapon
   parent: MarkerBase
   components:
-    - type: RandomSpawner
-      prototypes:
-        - WeaponBeamDevastator
-        - WeaponLauncherRocket
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: RandomSuperweaponTable
+
+#Table
+- type: entityTable
+  id: RandomSuperweaponTable
+  table: !type:GroupSelector
+    children:
+    - !type:AllSelector
+      children:
+      - id: WeaponLauncherRocket
+      - id: CartridgeRocket
+    - id: WeaponBeamDevastator

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
@@ -17,4 +17,5 @@
       children:
       - id: WeaponLauncherRocket
       - id: CartridgeRocket
+        prob: 0.2
     - id: WeaponBeamDevastator

--- a/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Markers/Spawners/Random/security.yml
@@ -1,0 +1,10 @@
+- type: entity
+  name: security superweapon spawner
+  suffix: superweapon
+  id: LootSpawnerSecuritySuperweapon
+  parent: MarkerBase
+  components:
+    - type: RandomSpawner
+      prototypes:
+        - WeaponBeamDevastator
+        - WeaponLauncherRocket

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -298,7 +298,7 @@
 
 - type: entity
   parent: BaseWeaponBattery
-  id: WeaponBeamDevestator
+  id: WeaponBeamDevastator
   name: beam devastator
   description: A powerful energy weapon that fires multiple rapid laser beams per second
   components:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
adds a superweapon safe and groundloot spawner for mappers. it can currently either be the beam devastator or the RPG.
(also fixes a dumb typo I previously made cause im a silly goober)


## Why / Balance
I asked @IamVelcroboy  about mapping the devastator and he suggested I make this

## Technical details
<!-- Summary of code changes for easier review. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
