### PR TITLE
Allow ChemMaster to draw from inserted container for pillmaking

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterBoundUserInterface.cs
@@ -47,6 +47,13 @@ namespace Content.Client.Chemistry.UI
                 new ChemMasterOutputToBottleMessage(
                     (uint) _window.BottleDosage.Value, _window.LabelLine));
 
+            // Begin DeltaV - chemmaster sources
+            _window.SourceBufferButton.OnPressed += _ => SendMessage(
+                new ChemMasterSetSourceMessage(ChemMasterSource.InternalBuffer));
+            _window.SourceInsertedButton.OnPressed += _ => SendMessage(
+                new ChemMasterSetSourceMessage(ChemMasterSource.InsertedContainer));
+            // End DeltaV - chemmaster sources
+
             for (uint i = 0; i < _window.PillTypeButtons.Length; i++)
             {
                 var pillType = i;

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -125,6 +125,16 @@
                         <SpinBox MinSize="100 0" Name="BottleDosage" Access="Public" Value="0" />
                         <Button MinSize="80 0" Name="CreateBottleButton" Access="Public" Text="{Loc 'chem-master-window-create-button'}" />
                     </BoxContainer>
+
+                    <!-- Begin DeltaV - chemmaster sources -->
+                    <BoxContainer Orientation="Horizontal">
+                        <Label Text="{Loc 'chem-master-window-source-label'}" />
+                        <Control HorizontalExpand="True" MinSize="50 0" />
+
+                        <Button MinSize="80 0" Name="SourceBufferButton" Access="Public" Text="{Loc 'chem-master-source-buffer-button'}" Pressed="True" />
+                        <Button MinSize="80 0" Name="SourceInsertedButton" Access="Public" Text="{Loc 'chem-master-source-inserted-button'}" />
+                    </BoxContainer>
+                    <!-- End DeltaV - chemmaster sources -->
                 </BoxContainer>
             </PanelContainer>
         </BoxContainer>

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -81,6 +81,12 @@ namespace Content.Client.Chemistry.UI
             PillNumber.InitDefaultButtons();
             BottleDosage.InitDefaultButtons();
 
+            // Begin DeltaV - chemmaster sources
+            var sourceGroup = new ButtonGroup(false);
+            SourceBufferButton.Group = sourceGroup;
+            SourceInsertedButton.Group = sourceGroup;
+            // End DeltaV - chemmaster sources
+
             // Ensure label length is within the character limit.
             LabelLineEdit.IsValid = s => s.Length <= SharedChemMaster.LabelMaxLength;
 
@@ -125,6 +131,14 @@ namespace Content.Client.Chemistry.UI
             PillNumber.IsValid = x => x >= 0 && x <= pillNumberMax;
             PillDosage.IsValid = x => x > 0 && x <= castState.PillDosageLimit;
             BottleDosage.IsValid = x => x >= 0 && x <= bottleAmountMax;
+
+            // Begin DeltaV - chemmaster sources
+            var activeButton = castState.Source switch {
+                ChemMasterSource.InternalBuffer => SourceBufferButton,
+                ChemMasterSource.InsertedContainer => SourceInsertedButton,
+            };
+            activeButton.Pressed = true;
+            // End DeltaV - chemmaster sources
 
             if (PillNumber.Value > pillNumberMax)
                 PillNumber.Value = pillNumberMax;

--- a/Content.Server/Chemistry/Components/ChemMasterComponent.cs
+++ b/Content.Server/Chemistry/Components/ChemMasterComponent.cs
@@ -18,6 +18,11 @@ namespace Content.Server.Chemistry.Components
         [DataField("mode"), ViewVariables(VVAccess.ReadWrite)]
         public ChemMasterMode Mode = ChemMasterMode.Transfer;
 
+        // Begin DeltaV - chemmaster sources
+        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        public ChemMasterSource Source = ChemMasterSource.InternalBuffer;
+        // End DeltaV - chemmaster sources
+
         [DataField("pillDosageLimit", required: true), ViewVariables(VVAccess.ReadWrite)]
         public uint PillDosageLimit;
 

--- a/Content.Shared/Chemistry/SharedChemMaster.cs
+++ b/Content.Shared/Chemistry/SharedChemMaster.cs
@@ -29,6 +29,19 @@ namespace Content.Shared.Chemistry
         }
     }
 
+    // Begin DeltaV - chemmaster sources
+    [Serializable, NetSerializable]
+    public sealed class ChemMasterSetSourceMessage : BoundUserInterfaceMessage
+    {
+        public readonly ChemMasterSource ChemMasterSource;
+
+        public ChemMasterSetSourceMessage(ChemMasterSource source)
+        {
+            ChemMasterSource = source;
+        }
+    }
+    // End DeltaV - chemmaster sources
+
     [Serializable, NetSerializable]
     public sealed class ChemMasterSetPillTypeMessage : BoundUserInterfaceMessage
     {
@@ -82,6 +95,14 @@ namespace Content.Shared.Chemistry
             Label = label;
         }
     }
+
+    // Begin DeltaV - chemmaster sources
+    public enum ChemMasterSource
+    {
+        InternalBuffer,
+        InsertedContainer,
+    }
+    // End DeltaV - chemmaster sources
 
     public enum ChemMasterMode
     {
@@ -159,6 +180,7 @@ namespace Content.Shared.Chemistry
         public readonly IReadOnlyList<ReagentQuantity> BufferReagents;
 
         public readonly ChemMasterMode Mode;
+        public readonly ChemMasterSource Source; // DeltaV - chemmaster sources
 
         public readonly FixedPoint2? BufferCurrentVolume;
         public readonly uint SelectedPillType;
@@ -170,7 +192,7 @@ namespace Content.Shared.Chemistry
         public ChemMasterBoundUserInterfaceState(
             ChemMasterMode mode, ContainerInfo? inputContainerInfo, ContainerInfo? outputContainerInfo,
             IReadOnlyList<ReagentQuantity> bufferReagents, FixedPoint2 bufferCurrentVolume,
-            uint selectedPillType, uint pillDosageLimit, bool updateLabel)
+            uint selectedPillType, uint pillDosageLimit, bool updateLabel, ChemMasterSource source) // DeltaV - chemmaster sources
         {
             InputContainerInfo = inputContainerInfo;
             OutputContainerInfo = outputContainerInfo;
@@ -180,6 +202,7 @@ namespace Content.Shared.Chemistry
             SelectedPillType = selectedPillType;
             PillDosageLimit = pillDosageLimit;
             UpdateLabel = updateLabel;
+            Source = source; // DeltaV - chemmaster sources
         }
     }
 

--- a/Resources/Locale/en-US/deltav/chemistry/chem-master.ftl
+++ b/Resources/Locale/en-US/deltav/chemistry/chem-master.ftl
@@ -1,0 +1,3 @@
+chem-master-window-source-label = Draw from:
+chem-master-source-buffer-button = Internal Buffer
+chem-master-source-inserted-button = Inserted Container


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The ChemMaster now has a UI toggle in order to draw from the inserted container for pillmaking.

## Why / Balance
The ChemMaster is often used as a general purpose solution storage due to its ability to separate reagents and its 3000u internal buffer. This often results in the chemist doing this being unable to create pills when asked to.

## Technical details
- ChemMaster UI: add the buttons and wire it up to component state
- ChemMaster component: add the Source field
- ChemMaster system: add messages & draw from different locations depending on selected source

## Media

https://github.com/user-attachments/assets/380e2b71-15d8-4137-8afe-522ac6881e6d



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added the ability for ChemMaster to make pills and bottles from an inserted beaker.