### PR TITLE
add robotics to id card console

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -90,6 +90,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "ChiefJustice",  // DeltaV - Add Chief Justice access
         "Justice",  // DeltaV - Add Justice access
         "Prosecutor", // Delta V - Add Prosecutor access
+        "Robotics", // DeltaV
         "Clerk", // Delta V - Add Clerk access
     };
 


### PR DESCRIPTION
## About the PR
hardcoded list of accesses gaming

**Changelog**
:cl:
- fix: Fixed Robotics access not being listed in ID card consoles.
