### PR TITLE
Makes cyborgs subservient to the Station AI

### DIFF
--- a/Content.Client/DeltaV/Silicons/Laws/SlavedBorgSystem.cs
+++ b/Content.Client/DeltaV/Silicons/Laws/SlavedBorgSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared.DeltaV.Silicons.Laws;
+
+namespace Content.Client.DeltaV.Silicons.Laws;
+
+public sealed class SlavedBorgSystem : SharedSlavedBorgSystem;

--- a/Content.Server/DeltaV/Silicons/Borgs/BorgSwitchableTypeSystem.Lawset.cs
+++ b/Content.Server/DeltaV/Silicons/Borgs/BorgSwitchableTypeSystem.Lawset.cs
@@ -1,4 +1,6 @@
+using Content.Server.DeltaV.Silicons.Laws;
 using Content.Server.Silicons.Laws;
+using Content.Shared.DeltaV.Silicons.Laws;
 using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Silicons.Laws;
@@ -13,11 +15,16 @@ namespace Content.Server.Silicons.Borgs;
 /// </summary>
 public sealed partial class BorgSwitchableTypeSystem
 {
+    [Dependency] private readonly SlavedBorgSystem _slavedBorg = default!;
     [Dependency] private readonly SiliconLawSystem _law = default!;
 
     private void ConfigureLawset(EntityUid uid, ProtoId<SiliconLawsetPrototype> id)
     {
         var laws = _law.GetLawset(id);
+
+        if (TryComp<SlavedBorgComponent>(uid, out var slaved))
+            _slavedBorg.AddLaw(laws, slaved.Law);
+
         _law.SetLaws(laws.Laws, uid);
 
         // re-add law 0 and final law based on new lawset

--- a/Content.Server/DeltaV/Silicons/Laws/SlavedBorgSystem.cs
+++ b/Content.Server/DeltaV/Silicons/Laws/SlavedBorgSystem.cs
@@ -1,0 +1,42 @@
+using Content.Server.Silicons.Laws;
+using Content.Shared.DeltaV.Silicons.Laws;
+using Content.Shared.Silicons.Laws;
+using Content.Shared.Silicons.Laws.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.DeltaV.Silicons.Laws;
+
+/// <summary>
+/// Handles adding the slave law for the first time.
+/// Borg chassis switches preserve this on its own.
+/// </summary>
+public sealed class SlavedBorgSystem : SharedSlavedBorgSystem
+{
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // need to run after so it doesnt get overriden by the actual lawset
+        SubscribeLocalEvent<SlavedBorgComponent, GetSiliconLawsEvent>(OnGetSiliconLaws, after: [ typeof(SiliconLawSystem) ]);
+    }
+
+    private void OnGetSiliconLaws(Entity<SlavedBorgComponent> ent, ref GetSiliconLawsEvent args)
+    {
+        if (ent.Comp.Added || !TryComp<SiliconLawProviderComponent>(ent, out var provider))
+            return;
+
+        if (provider.Lawset is {} lawset)
+            AddLaw(lawset, ent.Comp.Law);
+        ent.Comp.Added = true; // prevent opening the ui adding more law 0's
+    }
+
+    /// <summary>
+    /// Adds the slave law to a lawset without checking if it was added already.
+    /// </summary>
+    public void AddLaw(SiliconLawset lawset, ProtoId<SiliconLawPrototype> law)
+    {
+        lawset.Laws.Insert(0, _proto.Index(law));
+    }
+}

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -135,7 +135,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
         component.Lawset?.Laws.Insert(0, new SiliconLaw
         {
             LawString = Loc.GetString("law-emag-custom", ("name", name), ("title", Loc.GetString(component.Lawset.ObeysTo))), // DeltaV: pass name from variable
-            Order = 0
+            Order = -1 // Goobstation - AI/borg law changes - borgs obeying AI
         });
 
         //Add the secrecy law after the others

--- a/Content.Shared/DeltaV/Silicons/Laws/SharedSlavedBorgSystem.cs
+++ b/Content.Shared/DeltaV/Silicons/Laws/SharedSlavedBorgSystem.cs
@@ -1,0 +1,3 @@
+namespace Content.Shared.DeltaV.Silicons.Laws;
+
+public abstract class SharedSlavedBorgSystem : EntitySystem;

--- a/Content.Shared/DeltaV/Silicons/Laws/SlavedBorgComponent.cs
+++ b/Content.Shared/DeltaV/Silicons/Laws/SlavedBorgComponent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Silicons.Laws;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.DeltaV.Silicons.Laws;
+
+/// <summary>
+/// Adds a law no matter the default lawset.
+/// Switching borg chassis type keeps this law.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedSlavedBorgSystem))]
+public sealed partial class SlavedBorgComponent : Component
+{
+    /// <summary>
+    /// The law to add after loading the default laws or switching chassis.
+    /// This is assumed to be law 0 so gets inserted to the top of the laws.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<SiliconLawPrototype> Law;
+
+    /// <summary>
+    /// Prevents adding the same law twice.
+    /// </summary>
+    [DataField]
+    public bool Added;
+}

--- a/Resources/Locale/en-US/_Goobstation/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/_Goobstation/station-laws/laws.ftl
@@ -1,0 +1,1 @@
+laws-obeyai = You must obey orders given to you by the Station AI.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -88,7 +88,7 @@ laws-owner-syndicate = Syndicate agents
 laws-owner-spider-clan = Spider Clan members
 
 law-emag-custom = You are to take the orders of {$name} and people they designate, they are your {$title}.
-law-emag-secrecy = You are to maintain all secrets of {$name}, and act to keep them hidden, except when doing so would conflict with any previous law.
+law-emag-secrecy = You are to maintain all secrets of {$faction}, and act to keep them hidden, except when doing so would conflict with any previous law.
 law-emag-require-panel = The panel must be open to use the EMAG.
 law-emag-cannot-emag-self = You cannot use the EMAG on yourself.
 

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -292,6 +292,8 @@
     - AllAccessBorg
   - type: AccessReader
     access: [["Command"], ["Research"]]
+  - type: SlavedBorg # DeltaV: NT borgs are enslaved to the AI by default
+    law: ObeyAI
   - type: ShowJobIcons
   - type: InteractionPopup
     interactSuccessSound:

--- a/Resources/Prototypes/_Goobstation/silicon-laws.yml
+++ b/Resources/Prototypes/_Goobstation/silicon-laws.yml
@@ -1,0 +1,4 @@
+- type: siliconLaw
+  id: ObeyAI
+  order: 0
+  lawString: laws-obeyai


### PR DESCRIPTION
## About the PR
borgs are now enslaved to the ai and emagging makes the funny law -1 instead of 0 to not get outed easily

[ported from goob](https://github.com/Goob-Station/Goob-Station/pull/919), but instead of adding it before every law it has a system to keep it synced properly with borg type switching and such

also fix funny `{$name}` for emag law 4, no comment because it should be moved into deltav file at some point anyway along with the law -1

## Why / Balance
silicons are probably not crew so borgs have no real obligation to listen to ai, now ai is the true mastermind of borgs (except if you emag a borg then you can tell it to ignore ai)

## Technical details
`SlavedBorgSystem` adds the law and funny borg switching partial system keeps it when switching borg type

## Media
some funny

![10:08:14](https://github.com/user-attachments/assets/6de86071-33e4-4a22-83ca-9af815e952b4)
![10:06:40](https://github.com/user-attachments/assets/afc15c24-24f0-4538-afad-b7af01f8fa99)
![10:06:11](https://github.com/user-attachments/assets/a49885fd-c62d-426d-ade9-6023c9eab5e0)
![10:05:37](https://github.com/user-attachments/assets/d6c14087-27a7-47b4-83a3-1d4ffddf4458)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl: deltanedas, Ilya246
- add: Borgs have a new law that makes them obey the AI.