### PR TITLE
ai law changes + ion storm

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -376,7 +376,8 @@
   - type: BlockMovement
     blockInteraction: false
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: NTDefault # Goobstation - AI/borg law changes - set AI to NTDefault
+  - type: IonStormTarget # Goobstation - AI/borg law changes - ion stormable AI
   - type: SiliconLawBound
   - type: ActionGrant
     actions:


### PR DESCRIPTION
## About the PR
changed default lawset to NT default (the default hehe) and made ai ion stormable
ported from goob pr

## Why / Balance

a tider going "law 2 let me into bridge" can rightfully be told to just fuck off instead of jumping through hoops to figure out how it could cause harm to crew

ion storm good and goes with #2337 so you can have borgs enforce your newfound hatred for reporters

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl: Ilya246
- tweak: AI's default lawset is now NTDefault. This should make it more station-oriented.
- tweak: tweak: AI is now ion-stormable.