### PR TITLE
Modify clown and mime sexy masks and add them to the autodrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -100,11 +100,17 @@
     ClothingShoesBootsCowboyWhite: 1
     ClothingHeadTechPriest: 2 #Delta V: Added Techpriest Robe to Inventory
     ClothingOuterRobeTechPriest: 2
+# Begin DeltaV  modifications - Moved to regular inventory.
+    ClothingMaskSexyClown: 1
+    ClothingMaskSexyMime: 1
+# End of DeltaV modifications.
 
   emaggedInventory:
     ClothingShoesBling: 1
     ClothingShoesBootsCowboyFancy: 1
     ClothingOuterDogi: 1
-    ClothingMaskSexyClown: 1
-    ClothingMaskSexyMime: 1
+# Begin DeltaV  modifications - Moved to regular inventory.
+#    ClothingMaskSexyClown: 1
+#    ClothingMaskSexyMime: 1
+# End of DeltaV modifications.
     ClothingHeadHatCowboyBountyHunter: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -100,10 +100,10 @@
     ClothingShoesBootsCowboyWhite: 1
     ClothingHeadTechPriest: 2 #Delta V: Added Techpriest Robe to Inventory
     ClothingOuterRobeTechPriest: 2
-# Begin DeltaV  modifications - Moved to regular inventory.
+    # Begin DeltaV  modifications - Moved to regular inventory.
     ClothingMaskSexyClown: 1
     ClothingMaskSexyMime: 1
-# End of DeltaV modifications.
+    # End of DeltaV modifications.
 
   emaggedInventory:
     ClothingShoesBling: 1

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -591,8 +591,8 @@
 - type: entity
   parent: ClothingMaskClownBase
   id: ClothingMaskSexyClown
-  name: sexy clown mask
-  description: Some naughty clowns think this is what the Honkmother looks like.
+  name: purple clown mask # DeltaV - Modified name, was "sexy clown mask".
+  description: Some clowns think this is what the Honkmother looks like. # DeltaV - Modified description, removed "naughty" from "Some naughty clowns [...]".
   components:
   - type: Sprite
     sprite: Clothing/Mask/sexyclown.rsi
@@ -602,7 +602,7 @@
 - type: entity
   parent: ClothingMaskMime
   id: ClothingMaskSexyMime
-  name: sexy mime mask
+  name: blushing mime mask # DeltaV - Modified name was "sexy mime mask".
   description: Those ruddy cheeks just want to be rubbed.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Someone requested this to be done and was simple enough.

## Why / Balance
More content + less EMAG locked clothing.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML changes.

## Media
![image](https://github.com/user-attachments/assets/0f9e5c5b-5783-4733-ab5b-821f96db1577)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Hopefully nothing.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The blushing mime mask and the purple clown mask can now be obtained at an autodrobe.
