### PR TITLE
hide listed ore on asteroid pulls

### DIFF
--- a/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
@@ -65,6 +65,7 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
             {
                 case AsteroidOffering asteroid:
                     option.Title = Loc.GetString($"dungeon-config-proto-{asteroid.Id}");
+                    break; // DeltaV: Skip ores since they aren't used with custom generation
                     var layerKeys = asteroid.MarkerLayers.Keys.ToList();
                     layerKeys.Sort();
 


### PR DESCRIPTION
## About the PR
title

## Why / Balance
it confuses new players into thinking it matters when in reality it has 0 effect whatsoever, only thing that matters is the shape and thats what is listed now

## Technical details
1 line ops

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- remove: Salvage magnet asteroid listings no longer include ore types as they aren't used in any way.