### PR TITLE
Gives AI Delta V radio channels

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -16,6 +16,10 @@
     - Security
     - Service
     - Supply
+    - # Begin DeltaV additions
+    - Justice
+    - Prison
+    - # End DeltaV additions
   - type: ActiveRadio
     channels:
     - Binary
@@ -27,6 +31,10 @@
     - Security
     - Service
     - Supply
+    - # Begin DeltaV additions
+    - Justice
+    - Prison
+    - # End DeltaV additions
   - type: IgnoreUIRange
   - type: StationAiHeld
   - type: StationAiOverlay

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -16,10 +16,10 @@
     - Security
     - Service
     - Supply
-    - # Begin DeltaV additions
+    # Begin DeltaV additions
     - Justice
     - Prison
-    - # End DeltaV additions
+    # End DeltaV additions
   - type: ActiveRadio
     channels:
     - Binary
@@ -31,10 +31,10 @@
     - Security
     - Service
     - Supply
-    - # Begin DeltaV additions
+    # Begin DeltaV additions
     - Justice
     - Prison
-    - # End DeltaV additions
+    # End DeltaV additions
   - type: IgnoreUIRange
   - type: StationAiHeld
   - type: StationAiOverlay


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Gave the station AI the Justice and Prison radio channels, since it did not have any of our Delta V radios.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
So it can talk on the radios.
## Technical details
<!-- Summary of code changes for easier review. -->
I just added the radio channels to the list. Easy.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/cd91ca41-ca2d-40b6-82fc-641b69a7e0f9)
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Station AI can now use the Prison and Justice radio channels.
