### PR TITLE
Update "snipers" to require weilding

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -46,6 +46,7 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
+  - type: GunRequiresWield # Delta-V | Firing a bolt action is.. incredibly unweildy with one hand.
 
 - type: entity
   name: Hristov
@@ -63,6 +64,8 @@
       - CartridgeAntiMateriel
     capacity: 5
     proto: CartridgeAntiMateriel
+  - type: GunRequiresWield # Delta-V | Firing an antimateriel rifle is.. incredibly unweildy with one hand.
+
 
 - type: entity
   name: musket
@@ -101,6 +104,7 @@
     animation: WeaponArcThrust
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
+  - type: GunRequiresWield # Delta-V | Firing a muzzle loader is.. incredibly unweildy with one hand.
 
 - type: entity
   name: flintlock pistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -46,7 +46,7 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
-  - type: GunRequiresWield # Delta-V | Firing a bolt action is.. incredibly unweildy with one hand.
+  - type: GunRequiresWield # Delta-V - Firing a bolt action is.. incredibly unweildy with one hand.
 
 - type: entity
   name: Hristov
@@ -64,8 +64,7 @@
       - CartridgeAntiMateriel
     capacity: 5
     proto: CartridgeAntiMateriel
-  - type: GunRequiresWield # Delta-V | Firing an antimateriel rifle is.. incredibly unweildy with one hand.
-
+  - type: GunRequiresWield # Delta-V - Firing an antimateriel rifle is.. incredibly unweildy with one hand.
 
 - type: entity
   name: musket
@@ -104,7 +103,7 @@
     animation: WeaponArcThrust
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
-  - type: GunRequiresWield # Delta-V | Firing a muzzle loader is.. incredibly unweildy with one hand.
+  - type: GunRequiresWield # Delta-V - Firing a muzzle loader is.. incredibly unweildy with one hand.
 
 - type: entity
   name: flintlock pistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -46,7 +46,7 @@
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi
-  - type: GunRequiresWield # Delta-V - Firing a bolt action is.. incredibly unweildy with one hand.
+  - type: GunRequiresWield # DeltaV - Firing a bolt action is.. incredibly unweildy with one hand.
 
 - type: entity
   name: Hristov
@@ -64,7 +64,7 @@
       - CartridgeAntiMateriel
     capacity: 5
     proto: CartridgeAntiMateriel
-  - type: GunRequiresWield # Delta-V - Firing an antimateriel rifle is.. incredibly unweildy with one hand.
+  - type: GunRequiresWield # DeltaV - Firing an antimateriel rifle is.. incredibly unweildy with one hand.
 
 - type: entity
   name: musket
@@ -103,7 +103,7 @@
     animation: WeaponArcThrust
     soundHit:
       path: /Audio/Weapons/bladeslice.ogg
-  - type: GunRequiresWield # Delta-V - Firing a muzzle loader is.. incredibly unweildy with one hand.
+  - type: GunRequiresWield # DeltaV - Firing a muzzle loader is.. incredibly unweildy with one hand.
 
 - type: entity
   name: flintlock pistol

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -22,6 +22,7 @@
     whitelist:
       tags:
       - CartridgeLightRifle
+  - type: GunRequiresWield
 
 - type: entity
   name: ceremonial rifle
@@ -47,3 +48,4 @@
     whitelist:
       tags:
       - CartridgeLightRifle
+  - type: GunRequiresWield


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
gave items in the "sniper" category wielding requirements (except flintlock)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Try firing a bolt-action with one hand to the efficiency of a spess man, you cant. Also shotguns already require wielding. So the Hristov definitely should given a bullet generally has more powder than behind it than shot

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: You now have to hold a rifle with TWO hands to operate it.