### PR TITLE
Add order access to cargo technicians

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -9,9 +9,9 @@
   access:
   - Cargo
   - Maintenance
+  - Orders # DeltaV - Add Orders access to cargo techs.
   extendedAccess:
   - Salvage
-  - Orders # DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml
 
 - type: startingGear
   id: CargoTechGear


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Don't merge the PR before all the maps have public cargo request consoles.
![image](https://github.com/user-attachments/assets/de4d5cbb-5d30-47e9-94e8-74cf6f30d2ae)

## Why / Balance
![image](https://github.com/user-attachments/assets/1e60a41b-b05f-447a-825b-b47d41f07860)

## Technical details
YAML change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Not needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Hopefully none.

**Changelog**
:cl:
- tweak: Now cargo technicians can approve orders.
