### PR TITLE
fix notary stamp objective never happening

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -22,7 +22,7 @@
     CaptainJetpackStealObjective: 0.5
     HandTeleporterStealObjective: 0.5
     #EnergyShotgunStealObjective: 0.5 # DeltaV - replaced by X-01 objective
-    SecretDocumentsStealObjective: 0.5
+    ClerkNotaryStealObjective: 0.5 # DeltaV
     LOLuckyBillStealObjective: 0.5 # DeltaV - LO steal objective, see Resources/Prototypes/DeltaV/Objectives/traitor.yml
     HoPBookIanDossierStealObjective: 1 # DeltaV - HoP steal objective, see Resources/Prototypes/DeltaV/Objectives/traitor.yml
     HoSGunStealObjective: 0.5 # DeltaV


### PR DESCRIPTION
## About the PR
also removed weight for the secret documents objective as it was removed ages ago

## Why / Balance
bug

**Changelog**
:cl:
- fix: Fixed traitors never getting the notary stamp steal objective.
