### PR TITLE
Randomizes the appearance of Fugitives

### DIFF
--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -110,8 +110,6 @@
       - type: RandomMetadata
         nameSegments:
         - names_death_commando
-      - type: RandomHumanoidAppearance
-        randomizeName: false
       - type: AutoImplant
         implants:
         - DeathAcidifierImplant

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -110,6 +110,8 @@
       - type: RandomMetadata
         nameSegments:
         - names_death_commando
+      - type: RandomHumanoidAppearance
+        randomizeName: false
       - type: AutoImplant
         implants:
         - DeathAcidifierImplant
@@ -189,6 +191,8 @@
         nameSegments:
         - fake_human_first
         - fake_human_last
+      - type: RandomHumanoidAppearance
+        randomizeName: false
       - type: EmitSoundOnSpawn # fell out of the ceiling
         sound: /Audio/Effects/clang.ogg
       mindRoles:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Allowed Fugitives to not be your character. 1984, no more Okelte Valid. It turned out it was a one line change for both.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Me and Lyndo were not fans of how Fugitives spawn as your character that you already picked. This fixes it by spawning you as a random character that is the morphotype that you were, which helps with continuity from a story standpoint of a round, because it's weird to have John Tider die permanently from dying to a dragon and then have a dude that looks exactly like him be an escaped fugitive or an LP operator with a different name. 'Course, that can add to the story of a round, but I feel as if it makes more sense for it to be a random fucking guy.
## Technical details
<!-- Summary of code changes for easier review. -->
Adds ` - type: RandomHumanoidAppearance
        randomizeName: false` to the fugitive and therefore causes them to spawn with a random appearance of the morphotype you were. Random name is kept intact so you'll still end up as Sleve McDichael.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/dfb15768-5104-4522-91ab-8746d4af09be)
Technically is part of this because the player character was a harpy.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Not a breaking change in the sense of technicality, but it might be difficult for Vox Players, since the morphotype is inherited, to which I say:
- You get masks and oxygen tanks by default in the Listening Post, just go into the closet, grab an oxytank and then breathe through your voice mask. Easy fix.
- I think leaving Fugitive like it is helps add to the survival factor, for them.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Yes CL, yes fun.
:cl:
- tweak: Fugitives are no longer clones of people on station.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
