### PR TITLE
add dummy versions of lavaland mapping things

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Doors/Airlocks/access.yml
@@ -7,6 +7,28 @@
   - type: PriorityDock
     tag: DockShipyard
 
+# this goes on lavaland, unlimited
+- type: entity
+  parent: AirlockGlassShuttle
+  id: AirlockExternalGlassShuttleMining
+  suffix: External, Mining, Glass, Docking
+  #components:
+  #- type: PriorityDock
+  #  tag: DockMining
+
+# 1 per map, this spawns the mining shuttle
+- type: entity
+  parent: AirlockExternalGlassShuttleMining
+  id: AirlockExternalGlassShuttleMiningFilled
+  suffix: Mining, Filled
+  #components:
+  #- type: GridFill
+  #  path: /Maps/Shuttles/DeltaV/mining.yml
+  #  addComponents:
+  #  - type: IFF
+  #    flags:
+  #    - HideLabel
+
 # Delta V specific roles
 - type: entity
   parent: AirlockScience

--- a/Resources/Prototypes/DeltaV/Entities/Structures/Machines/computers.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Machines/computers.yml
@@ -29,3 +29,8 @@
       state: request
     - map: ["computerLayerKeys"]
       state: tech_key
+
+- type: entity
+  parent: BaseComputer
+  id: ComputerShuttleMining
+  name: mining shuttle console


### PR DESCRIPTION
## About the PR
adds the airlock and console that can be mapped on stations early
wont do anything until lavaland is merged