### PR TITLE
Add service access to mime and clown

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -13,6 +13,7 @@
   - Theatre
   - Maintenance
   - Clown # DeltaV - Add Clown access
+  - Service # DeltaV - They work in service don't they?
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -13,6 +13,7 @@
   - Theatre
   - Maintenance
   - Mime # DeltaV - Add Mime access
+  - Service # DeltaV - They work in service don't they?
   special:
   - !type:AddComponentSpecial
     components:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Requested in [WYCI Suggestion](https://discord.com/channels/968983104247185448/1314757513580773428/1314757513580773428)

## Why / Balance
Makes no sense for them not to have basic service access, also less clowns breaking the windows to use the service lathe.

## Technical details
YAML changes.

## Media
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nope.

**Changelog**
:cl:
- tweak: Clowns and Mimes now also have basic service access, no more broken windows to get to the lathe!