### PR TITLE
Derotates Micro

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -9,7 +9,7 @@
   - Glacier
   - Hammurabi
   - Lighthouse
-  - Micro
+#  - Micro - to be revisited later ~Colin
   - Pebble
   - Shoukou
   - Tortuga


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Our SM station is derotated. It can still be played on via admin running `forcemap`, but besides that it will not show up in the average game.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't plan on making changes to it any time soon, and I'd rather have SM around when I do. This also comes after discussion on derotating it, which is something I considered a while ago anyways.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Micro Station has been removed from the regular map rotation.