### PR TITLE
make lathe items worthless

### DIFF
--- a/Content.Server/Cargo/Systems/PricingSystem.cs
+++ b/Content.Server/Cargo/Systems/PricingSystem.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Cargo.Systems;
 /// <summary>
 /// This handles calculating the price of items, and implements two basic methods of pricing materials.
 /// </summary>
-public sealed class PricingSystem : EntitySystem
+public sealed partial class PricingSystem : EntitySystem // DeltaV - Made partial
 {
     [Dependency] private readonly IComponentFactory _factory = default!;
     [Dependency] private readonly IConsoleHost _consoleHost = default!;
@@ -208,7 +208,7 @@ public sealed class PricingSystem : EntitySystem
 
         // TODO: Proper container support.
 
-        return price;
+        return ApplyPrototypePriceModifier(prototype, price); // DeltaV
     }
 
     /// <summary>
@@ -254,7 +254,7 @@ public sealed class PricingSystem : EntitySystem
             }
         }
 
-        return price;
+        return ApplyPriceModifier(uid, price); // DeltaV
     }
 
     private double GetMaterialsPrice(EntityUid uid)

--- a/Content.Server/DeltaV/Cargo/Components/PriceModifierComponent.cs
+++ b/Content.Server/DeltaV/Cargo/Components/PriceModifierComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server.DeltaV.Cargo.Components;
+
+/// <summary>
+///     This is used for modifying the sell price of an entity.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PriceModifierComponent : Component
+{
+    /// <summary>
+    ///     The price modifier.
+    /// </summary>
+    [DataField]
+    public float Modifier;
+}

--- a/Content.Server/DeltaV/Cargo/Systems/PricingSystem.Modifier.cs
+++ b/Content.Server/DeltaV/Cargo/Systems/PricingSystem.Modifier.cs
@@ -1,0 +1,41 @@
+using Content.Server.DeltaV.Cargo.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Cargo.Systems;
+
+public sealed partial class PricingSystem
+{
+    /// <summary>
+    /// Applies any price modifiers defined in the entity prototype.
+    /// </summary>
+    /// <param name="prototype">The entity prototype.</param>
+    /// <param name="basePrice">The base price before modification.</param>
+    /// <returns>The modified price.</returns>
+    private double ApplyPrototypePriceModifier(EntityPrototype prototype, double basePrice)
+    {
+        if (prototype.Components.TryGetValue(_factory.GetComponentName(typeof(PriceModifierComponent)),
+                out var modProto))
+        {
+            var priceModifier = (PriceModifierComponent)modProto.Component;
+            return basePrice * priceModifier.Modifier;
+        }
+
+        return basePrice;
+    }
+
+    /// <summary>
+    /// Applies any price modifiers to the calculated price.
+    /// </summary>
+    /// <param name="uid">The entity whose price is being modified.</param>
+    /// <param name="basePrice">The base price before modification.</param>
+    /// <returns>The modified price.</returns>
+    private double ApplyPriceModifier(EntityUid uid, double basePrice)
+    {
+        if (TryComp<PriceModifierComponent>(uid, out var modifier))
+        {
+            return basePrice * modifier.Modifier;
+        }
+
+        return basePrice;
+    }
+}

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
+using Content.Server.DeltaV.Cargo.Components; // DeltaV
 using Content.Server.Fluids.EntitySystems;
 using Content.Server.Lathe.Components;
 using Content.Server.Materials;
@@ -230,6 +231,7 @@ namespace Content.Server.Lathe
                 {
                     var result = Spawn(resultProto, Transform(uid).Coordinates);
                     _stack.TryMergeToContacts(result);
+                    EnsureComp<PriceModifierComponent>(result).Modifier = comp.PriceModifier; // DeltaV
                 }
 
                 if (comp.CurrentRecipe.ResultReagents is { } resultReagents &&

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -230,8 +230,8 @@ namespace Content.Server.Lathe
                 if (comp.CurrentRecipe.Result is { } resultProto)
                 {
                     var result = Spawn(resultProto, Transform(uid).Coordinates);
-                    _stack.TryMergeToContacts(result);
                     EnsureComp<PriceModifierComponent>(result).Modifier = comp.PriceModifier; // DeltaV
+                    _stack.TryMergeToContacts(result);
                 }
 
                 if (comp.CurrentRecipe.ResultReagents is { } resultReagents &&

--- a/Content.Shared/Lathe/LatheComponent.cs
+++ b/Content.Shared/Lathe/LatheComponent.cs
@@ -42,6 +42,12 @@ namespace Content.Shared.Lathe
         [DataField, AutoNetworkedField]
         public int DefaultProductionAmount = 1;
 
+        /// <summary>
+        /// DeltaV: The price modifier applied to all items printed by this lathe.
+        /// </summary>
+        [DataField]
+        public float PriceModifier = 0.4f;
+
         #region Visualizer info
         [DataField]
         public string? IdleState;

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1351,6 +1351,7 @@
       idleState: icon
       runningState: building
       defaultProductionAmount: 10
+      priceModifier: 1 # DeltaV
       staticRecipes:
         - BluespaceCrystal #Nyano - Summary: Bluespace Crystals can be created here.
         - SheetSteel


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
reduces the price of all printed items to 40%
doesn't affect loot, salvage crates full of random shit to sell are back on the menu
can be set per lathe, affects all for now

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
![image](https://github.com/user-attachments/assets/6b3f7fd5-6242-4209-a7a1-de78a85da7a9)

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reduced the price of all items printed from the lathes by 60%
