### PR TITLE
fix "teach person a lesson"

### DIFF
--- a/Content.Server/DeltaV/Objectives/Components/TeachLessonConditionComponent.cs
+++ b/Content.Server/DeltaV/Objectives/Components/TeachLessonConditionComponent.cs
@@ -1,17 +1,11 @@
-﻿using Content.Server.Objectives.Systems;
+﻿using Content.Server.DeltaV.Objectives.Systems;
+using Content.Server.Objectives.Components;
 
-namespace Content.Server.Objectives.Components;
+namespace Content.Server.DeltaV.Objectives.Components;
 
 /// <summary>
 /// Requires that a target dies once and only once.
 /// Depends on <see cref="TargetObjectiveComponent"/> to function.
 /// </summary>
 [RegisterComponent, Access(typeof(TeachLessonConditionSystem))]
-public sealed partial class TeachLessonConditionComponent : Component
-{
-    /// <summary>
-    /// Whether the target has been killed
-    /// </summary>
-    [DataField]
-    public bool WasKilled;
-}
+public sealed partial class TeachLessonConditionComponent : Component;

--- a/Content.Server/DeltaV/Objectives/Components/TeachLessonConditionComponent.cs
+++ b/Content.Server/DeltaV/Objectives/Components/TeachLessonConditionComponent.cs
@@ -7,4 +7,11 @@ namespace Content.Server.Objectives.Components;
 /// Depends on <see cref="TargetObjectiveComponent"/> to function.
 /// </summary>
 [RegisterComponent, Access(typeof(TeachLessonConditionSystem))]
-public sealed partial class TeachLessonConditionComponent : Component;
+public sealed partial class TeachLessonConditionComponent : Component
+{
+    /// <summary>
+    /// Whether the target has been killed
+    /// </summary>
+    [DataField]
+    public bool WasKilled;
+}

--- a/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
+++ b/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
@@ -1,7 +1,7 @@
 ﻿using Content.Server.Objectives.Components;
-using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
+using Content.Shared.Mobs;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -13,36 +13,42 @@ public sealed class TeachLessonConditionSystem : EntitySystem
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly TargetObjectiveSystem _target = default!;
 
-    private readonly List<EntityUid> _wasKilled = [];
-
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<TeachLessonConditionComponent, ObjectiveGetProgressEvent>(OnGetProgress);
-        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundEnd);
+        SubscribeLocalEvent<MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    // TODO: subscribe by ref at some point in the future
+    private void OnMobStateChanged(MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        // Get the mind of the entity that just died (if it has one)
+        if (!_mind.TryGetMind(args.Target, out var mindId, out _))
+            return;
+
+        // Get all TeachLessonConditionComponent entities
+        var query = EntityQueryEnumerator<TeachLessonConditionComponent, TargetObjectiveComponent>();
+
+        while (query.MoveNext(out _, out var teachLesson, out var targetObjective))
+        {
+            // Check if this objective's target matches the entity that died
+            if (targetObjective.Target != mindId)
+                continue;
+
+            teachLesson.WasKilled = true;
+        }
     }
 
     private void OnGetProgress(Entity<TeachLessonConditionComponent> ent, ref ObjectiveGetProgressEvent args)
     {
-        if (!_target.GetTarget(ent, out var target))
+        if (!_target.GetTarget(ent, out _))
             return;
 
-        args.Progress = GetProgress(target.Value);
-    }
-
-    private float GetProgress(EntityUid target)
-    {
-        if (TryComp<MindComponent>(target, out var mind) && mind.OwnedEntity != null && !_mind.IsCharacterDeadIc(mind))
-            return _wasKilled.Contains(target) ? 1f : 0f;
-
-        _wasKilled.Add(target);
-        return 1f;
-    }
-
-    // Clear the wasKilled list on round end
-    private void OnRoundEnd(RoundRestartCleanupEvent  ev)
-    {
-        _wasKilled.Clear();
+        args.Progress = ent.Comp.WasKilled ? 1f : 0f;
     }
 }

--- a/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
+++ b/Content.Server/DeltaV/Objectives/Systems/TeachLessonConditionSystem.cs
@@ -40,7 +40,7 @@ public sealed class TeachLessonConditionSystem : EntitySystem
             if (targetObjective.Target != mindId)
                 continue;
 
-            _codeCondition.SetCompleted((uid, null));
+            _codeCondition.SetCompleted(uid);
         }
     }
 }

--- a/Resources/Prototypes/DeltaV/Objectives/traitor.yml
+++ b/Resources/Prototypes/DeltaV/Objectives/traitor.yml
@@ -63,6 +63,7 @@
       sprite: Objects/Weapons/Guns/Pistols/viper.rsi
       state: icon
   - type: TeachLessonCondition
+  - type: CodeCondition
   - type: ObjectiveBlacklistRequirement
     blacklist:
       components:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
now it just subscribes to the MobStateChangedEvent, then checks if the state change is to Dead, and if the mind of the entity that died matches the mind we have as the target
also sets it in the comp rather than the funny list in the system because we have the means to do ECS properly

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
no more noobtrap redtext because you didnt know to open your objectives after killing someone

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Teach Person a Lesson objective will now register properly when your target dies.

