### PR TITLE
Adds empty AI core to Centcom

### DIFF
--- a/Resources/Maps/DeltaV/centcomm.yml
+++ b/Resources/Maps/DeltaV/centcomm.yml
@@ -70,7 +70,7 @@ entities:
           version: 6
         1,0:
           ind: 1,0
-          tiles: BAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAJgAAAAAABAAAAAAABAAAAAAABAAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAWQAAAAAAWQAAAAADWQAAAAADWQAAAAADWQAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAABAAAAAAAWQAAAAADWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAABWQAAAAAAWQAAAAABBAAAAAAAWQAAAAADWQAAAAAAWQAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAABwAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAABAAAAAAAWQAAAAACWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAADWQAAAAACWQAAAAABWQAAAAAABAAAAAAAWQAAAAAABAAAAAAAWQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAHQAAAAAAHQAAAAADBAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAABwAAAAAAeQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAABwAAAAAABwAAAAAAeQAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAALwAAAAAAHQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAWQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAACHQAAAAAAHQAAAAAAHQAAAAADeQAAAAAAHQAAAAAAHQAAAAADHQAAAAABHQAAAAADHQAAAAAAHQAAAAACHQAAAAADHQAAAAACHQAAAAAAHQAAAAADHQAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABHQAAAAADHQAAAAAAdgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAADHQAAAAADHQAAAAACdgAAAAABPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAADeQAAAAAAHQAAAAAAHQAAAAABHQAAAAACHQAAAAADHQAAAAABHQAAAAAAHQAAAAACHQAAAAABHQAAAAAAHQAAAAADHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABeQAAAAAAHQAAAAACHQAAAAAAeQAAAAAAdgAAAAABdgAAAAAAdgAAAAACdgAAAAADdgAAAAACdgAAAAAAdgAAAAAA
+          tiles: BAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAJgAAAAAABAAAAAAABAAAAAAABAAAAAAAeQAAAAAAWQAAAAAAeQAAAAAAWQAAAAAAWQAAAAADWQAAAAADWQAAAAADWQAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAABAAAAAAAWQAAAAADWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAABWQAAAAAAWQAAAAABBAAAAAAAWQAAAAADWQAAAAAAWQAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAABwAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAABAAAAAAAWQAAAAACWQAAAAADWQAAAAABeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAADWQAAAAACWQAAAAABWQAAAAAABAAAAAAAWQAAAAAABAAAAAAAWQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAHQAAAAAAHQAAAAADBAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAeQAAAAAABwAAAAAAeQAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAAABwAAAAAABwAAAAAAeQAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAANgAAAAAAHQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAAAWQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADHQAAAAACHQAAAAAAHQAAAAAAHQAAAAADeQAAAAAAHQAAAAAAHQAAAAADHQAAAAABHQAAAAADHQAAAAAAHQAAAAACHQAAAAADHQAAAAACHQAAAAAAHQAAAAADHQAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABHQAAAAADHQAAAAAAdgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAADHQAAAAADHQAAAAACdgAAAAABPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAADeQAAAAAAHQAAAAAAHQAAAAABHQAAAAACHQAAAAADHQAAAAABHQAAAAAAHQAAAAACHQAAAAABHQAAAAAAHQAAAAADHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABeQAAAAAAHQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAHQAAAAABPgAAAAAAPgAAAAAAPgAAAAAAHQAAAAABeQAAAAAAHQAAAAACHQAAAAAAeQAAAAAAdgAAAAABdgAAAAAAdgAAAAACdgAAAAADdgAAAAACdgAAAAAAdgAAAAAA
           version: 6
         0,-2:
           ind: 0,-2
@@ -374,21 +374,25 @@ entities:
             id: BrickTileDarkCornerNe
           decals:
             1093: 19,15
+            1424: 23,8
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNw
           decals:
             1099: 17,15
+            1423: 19,8
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerSe
           decals:
             1097: 19,11
+            1421: 23,7
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerSw
           decals:
             1098: 17,11
+            1422: 19,7
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineE
@@ -403,11 +407,17 @@ entities:
             id: BrickTileDarkLineN
           decals:
             1101: 18,15
+            1428: 20,8
+            1429: 21,8
+            1430: 22,8
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineS
           decals:
             1100: 18,11
+            1425: 20,7
+            1431: 21,7
+            1432: 22,7
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkLineW
@@ -697,15 +707,9 @@ entities:
             color: '#FFFFFFFF'
             id: Bushe3
           decals:
-            152: 23.178217,6.861627
             315: 2,18
             458: 9.048137,8.023587
             1113: 17.154882,7.7859535
-        - node:
-            color: '#FFFFFFFF'
-            id: Bushe4
-          decals:
-            153: 18.801558,6.901756
         - node:
             color: '#FFFFFFFF'
             id: Bushf1
@@ -758,8 +762,6 @@ entities:
             color: '#FFFFFFFF'
             id: Bushi1
           decals:
-            141: 22.818914,7.5022526
-            142: 19.100164,8.142878
             173: 17.014437,2.9736261
             174: 16.998812,6.958001
             175: 17.020891,-5.0002565
@@ -802,7 +804,6 @@ entities:
             color: '#FFFFFFFF'
             id: Bushk3
           decals:
-            148: 20.972792,7.5335026
             646: -16.03368,2.0478082
         - node:
             color: '#FFFFFFFF'
@@ -1011,7 +1012,6 @@ entities:
             color: '#FFFFFFFF'
             id: Flowersbr3
           decals:
-            138: 20.33454,7.330377
             188: 6.991846,-5.004048
             209: -4.0670047,-7.975866
         - node:
@@ -1035,7 +1035,6 @@ entities:
             color: '#FFFFFFFF'
             id: Flowerspv3
           decals:
-            134: 21.940147,6.877252
             207: -8.9611025,-5.006738
             309: 4,16
             1155: -9,-8
@@ -1059,8 +1058,6 @@ entities:
             color: '#FFFFFFFF'
             id: Flowersy4
           decals:
-            132: 21.674522,8.017878
-            133: 19.190147,7.174127
             162: 18.959991,-8.985069
             182: 15.052141,-10.039338
             183: 9.052141,-9.976838
@@ -1145,8 +1142,6 @@ entities:
             color: '#FFFFFFFF'
             id: Grassd1
           decals:
-            125: 22.82111,7.9761105
-            128: 19.093754,6.9448605
             635: -12.75243,1.9384332
         - node:
             color: '#FFFFFFFF'
@@ -1159,8 +1154,6 @@ entities:
             color: '#FFFFFFFF'
             id: Grasse1
           decals:
-            118: 22.757723,7.1474113
-            119: 20.210848,7.8817863
             156: 20.2297,-9.031944
             203: -8.907109,-5.8244467
             212: 1.9943819,6.0206404
@@ -1171,8 +1164,6 @@ entities:
             color: '#FFFFFFFF'
             id: Grasse2
           decals:
-            115: 21.070223,7.2411613
-            116: 20.007723,6.9442863
             187: 7.054346,-5.004048
             204: -8.985234,-5.0900717
             205: -3.9383593,-7.9338217
@@ -1189,8 +1180,6 @@ entities:
             color: '#FFFFFFFF'
             id: Grasse3
           decals:
-            108: 21.686012,7.6161613
-            109: 19.107887,7.5067863
             155: 19.2922,-8.953819
             159: 21.444366,-8.953819
             186: 7.023096,-5.941548
@@ -3252,7 +3241,7 @@ entities:
       pos: 33.5,-5.5
       parent: 1668
     - type: Door
-      secondsUntilStateChange: -2912.9026
+      secondsUntilStateChange: -3769.445
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -4820,6 +4809,13 @@ entities:
     components:
     - type: Transform
       pos: 6.5,-21.5
+      parent: 1668
+- proto: BorgCharger
+  entities:
+  - uid: 7153
+    components:
+    - type: Transform
+      pos: 23.5,7.5
       parent: 1668
 - proto: BoxFlashbang
   entities:
@@ -11975,6 +11971,11 @@ entities:
     components:
     - type: Transform
       pos: 30.5,26.5
+      parent: 1668
+  - uid: 7177
+    components:
+    - type: Transform
+      pos: 20.5,7.5
       parent: 1668
   - uid: 7217
     components:
@@ -19336,6 +19337,13 @@ entities:
     - type: Transform
       pos: -19.5,-31.5
       parent: 1668
+- proto: CorporateCircuitBoard
+  entities:
+  - uid: 6781
+    components:
+    - type: Transform
+      pos: 19.359194,8.797944
+      parent: 1668
 - proto: CrateArmoryLaser
   entities:
   - uid: 6533
@@ -19725,11 +19733,6 @@ entities:
     components:
     - type: Transform
       pos: 10.5,2.5
-      parent: 1668
-  - uid: 3123
-    components:
-    - type: Transform
-      pos: 19.5,6.5
       parent: 1668
   - uid: 3133
     components:
@@ -27950,6 +27953,11 @@ entities:
     - type: Transform
       pos: 32.5,-14.5
       parent: 1668
+  - uid: 3123
+    components:
+    - type: Transform
+      pos: 19.5,6.5
+      parent: 1668
 - proto: HighSecDoor
   entities:
   - uid: 5932
@@ -27963,6 +27971,13 @@ entities:
     components:
     - type: Transform
       pos: -20.5,15.5
+      parent: 1668
+- proto: IntercomCommand
+  entities:
+  - uid: 7190
+    components:
+    - type: Transform
+      pos: 21.5,9.5
       parent: 1668
 - proto: JanitorialTrolley
   entities:
@@ -28100,6 +28115,13 @@ entities:
     components:
     - type: Transform
       pos: -18.379215,8.381029
+      parent: 1668
+- proto: LiveLetLiveCircuitBoard
+  entities:
+  - uid: 7144
+    components:
+    - type: Transform
+      pos: 19.499819,8.641694
       parent: 1668
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
@@ -28439,6 +28461,13 @@ entities:
     - type: Transform
       pos: 25.5,-28.5
       parent: 1668
+- proto: NTDefaultCircuitBoard
+  entities:
+  - uid: 7147
+    components:
+    - type: Transform
+      pos: 19.648256,8.532319
+      parent: 1668
 - proto: NTFlag
   entities:
   - uid: 1190
@@ -28542,6 +28571,13 @@ entities:
     components:
     - type: Transform
       pos: -17.5,9.5
+      parent: 1668
+- proto: PaladinCircuitBoard
+  entities:
+  - uid: 7148
+    components:
+    - type: Transform
+      pos: 20.015444,8.813569
       parent: 1668
 - proto: Paper
   entities:
@@ -28706,6 +28742,13 @@ entities:
     components:
     - type: Transform
       pos: -4.5,15.5
+      parent: 1668
+- proto: PlayerStationAiEmpty
+  entities:
+  - uid: 521
+    components:
+    - type: Transform
+      pos: 21.5,8.5
       parent: 1668
 - proto: PlushieAtmosian
   entities:
@@ -29722,13 +29765,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 31.5,-8.5
-      parent: 1668
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 526
-    components:
-    - type: Transform
-      pos: 21.5,8.5
       parent: 1668
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -30981,7 +31017,6 @@ entities:
   - uid: 7184
     components:
     - type: Transform
-      anchored: False
       rot: -1.5707963267948966 rad
       pos: 23.5,4.5
       parent: 1668
@@ -30996,6 +31031,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 27.5,-11.5
+      parent: 1668
+  - uid: 7201
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,7.5
       parent: 1668
 - proto: PoweredlightLED
   entities:
@@ -33491,6 +33532,13 @@ entities:
       rot: 3.141592653589793 rad
       pos: 28.5,-2.5
       parent: 1668
+- proto: RobocopCircuitBoard
+  entities:
+  - uid: 7149
+    components:
+    - type: Transform
+      pos: 20.171694,8.649507
+      parent: 1668
 - proto: RubberStampApproved
   entities:
   - uid: 385
@@ -33559,6 +33607,13 @@ entities:
     components:
     - type: Transform
       pos: -12.5634365,-3.3712668
+      parent: 1668
+- proto: ShowcaseRobot
+  entities:
+  - uid: 7152
+    components:
+    - type: Transform
+      pos: 23.5,8.5
       parent: 1668
 - proto: ShowcaseRobotAntique
   entities:
@@ -34185,6 +34240,20 @@ entities:
     - type: Transform
       pos: 11.5,-7.5
       parent: 1668
+- proto: StationAiUploadComputer
+  entities:
+  - uid: 7151
+    components:
+    - type: Transform
+      pos: 22.5,8.5
+      parent: 1668
+- proto: StationEfficiencyCircuitBoard
+  entities:
+  - uid: 7150
+    components:
+    - type: Transform
+      pos: 20.335756,8.532319
+      parent: 1668
 - proto: StationMap
   entities:
   - uid: 2823
@@ -34604,6 +34673,12 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Eng Substation
+  - uid: 7195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-29.5
+      parent: 1668
 - proto: SurveillanceCameraGeneral
   entities:
   - uid: 6830
@@ -34725,6 +34800,29 @@ entities:
       - SurveillanceCameraGeneral
       nameSet: True
       id: West Hallway
+  - uid: 7191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-2.5
+      parent: 1668
+  - uid: 7192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 32.5,-7.5
+      parent: 1668
+  - uid: 7193
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.5,8.5
+      parent: 1668
+  - uid: 7194
+    components:
+    - type: Transform
+      pos: -12.5,-19.5
+      parent: 1668
 - proto: SurveillanceCameraMedical
   entities:
   - uid: 6794
@@ -35381,6 +35479,11 @@ entities:
     - type: Transform
       pos: 14.5,2.5
       parent: 1668
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 20.5,8.5
+      parent: 1668
   - uid: 421
     components:
     - type: Transform
@@ -35420,6 +35523,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 26.5,-2.5
+      parent: 1668
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 20.5,8.5
       parent: 1668
   - uid: 596
     components:
@@ -35635,6 +35743,11 @@ entities:
     components:
     - type: Transform
       pos: -14.5,17.5
+      parent: 1668
+  - uid: 2093
+    components:
+    - type: Transform
+      pos: 19.5,8.5
       parent: 1668
   - uid: 2423
     components:
@@ -37649,11 +37762,6 @@ entities:
     components:
     - type: Transform
       pos: -9.5,-8.5
-      parent: 1668
-  - uid: 346
-    components:
-    - type: Transform
-      pos: 19.5,6.5
       parent: 1668
   - uid: 350
     components:
@@ -42924,6 +43032,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: -12.5,-9.5
       parent: 1668
+  - uid: 7174
+    components:
+    - type: Transform
+      pos: 19.5,8.5
+      parent: 1668
+  - uid: 7175
+    components:
+    - type: Transform
+      pos: 20.5,8.5
+      parent: 1668
 - proto: WindoorSecureEngineeringLocked
   entities:
   - uid: 4757
@@ -43311,6 +43429,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-17.5
+      parent: 1668
+  - uid: 7154
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,8.5
       parent: 1668
 - proto: Wrench
   entities:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
I added an empty AI code to Centcom, so that the AI can be taken from the station and uploaded to the Centcom core. I also added a few cameras in blind spots, a cyborg charger, and fixed a light that seemed to be not working.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People thought it'd be a cool idea to have the AI have it's own spot on Centcom, so it doesn't just turn into a glorified pAI after evac.
## Technical details
<!-- Summary of code changes for easier review. -->
Map yaml!
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/4ff34bc9-479e-4813-92ce-be669d69977c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Centcom now has an empty AI core that you can upload the station's AI to!
