### PR TITLE
Aco fix round 2

### DIFF
--- a/Content.Server/DeltaV/Station/Systems/CaptainStateSystem.cs
+++ b/Content.Server/DeltaV/Station/Systems/CaptainStateSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.DeltaV.Cabinet;
 using Content.Server.DeltaV.Station.Components;
 using Content.Server.DeltaV.Station.Events;
 using Content.Server.GameTicking;
+using Content.Server.GameTicking.Events;
 using Content.Server.Station.Components;
 using Content.Shared.Access.Components;
 using Content.Shared.Access;
@@ -10,7 +11,6 @@ using Content.Shared.DeltaV.CCVars;
 using Robust.Shared.Configuration;
 using Robust.Shared.Prototypes;
 using System.Linq;
-using Content.Server.GameTicking.Events;
 
 namespace Content.Server.DeltaV.Station.Systems;
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
After more testing I found that the StandardNanotrasenStation does not shutdown and reinit between rounds in release environment. Thats why I was unable to find the bug before but this should fix it now.

## Why / Balance
Millions condemned

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
