### PR TITLE
add automatic panic bunker

### DIFF
--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -5,6 +5,14 @@ lobbyduration      = 240
 round_end_pacifist = true
 contraband_examine = false # Doubtful that it's desired at all, and would require going over every item in accordance with SOP
 
+# New players can't join a server without admins
+[game.panic_bunker]
+enabled = true
+disable_with_admins = true
+enable_without_admins = true
+show_reason = true
+custom_reason = "You have not played on Delta-V long enough to connect to this server. Due to administrative reasons, new accounts cannot join a server with no game admins."
+
 [infolinks]
 discord    = "https://discord.gg/deltav"
 github     = "https://github.com/DeltaV-Station/Delta-v"


### PR DESCRIPTION
## About the PR
joining a server without admins needs:
- minimum 24 hours account age from last-seen
- 10 hours playtime

if you are new you have to play with admin supervision :trollface:

## Why / Balance
raider le bad

the idea has headmin approval

## Media
![11:10:49](https://github.com/user-attachments/assets/5045d78a-5aa6-4c11-a19f-de8b90b61204)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- remove: Panic bunker is now automatically turned on for new players when there are no admins.