### PR TITLE
make glimmer events trigger psionic artifacts

### DIFF
--- a/Content.Server/DeltaV/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMetapsionicTriggerSystem.cs
+++ b/Content.Server/DeltaV/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMetapsionicTriggerSystem.cs
@@ -25,7 +25,7 @@ public sealed class ArtifactMetapsionicTriggerSystem : EntitySystem
 
     private void OnGlimmerEventEnded(GlimmerEventEndedEvent args)
     {
-        var query = EntityQueryEnumerator<ArtifactMetaspionicTriggerComponent>();
+        var query = EntityQueryEnumerator<ArtifactMetapsionicTriggerComponent>();
         while (query.MoveNext(out var uid, out _))
         {
             _artifact.TryActivateArtifact(uid);

--- a/Content.Server/DeltaV/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMetapsionicTriggerSystem.cs
+++ b/Content.Server/DeltaV/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMetapsionicTriggerSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.DeltaV.Xenoarchaeology.XenoArtifacts.Triggers.Components;
-﻿using Content.Server.Xenoarchaeology.XenoArtifacts.Triggers.Systems;
+﻿using Content.Server.Nyanotrasen.StationEvents.Events;
+using Content.Server.Xenoarchaeology.XenoArtifacts.Triggers.Systems;
 using Content.Shared.Abilities.Psionics;
 
 namespace Content.Server.Xenoarchaeology.XenoArtifacts.Triggers.Systems;
@@ -13,10 +14,21 @@ public sealed class ArtifactMetapsionicTriggerSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<ArtifactMetapsionicTriggerComponent, PsionicPowerDetectedEvent>(OnPowerDetected);
+
+        SubscribeLocalEvent<GlimmerEventEndedEvent>(OnGlimmerEventEnded);
     }
 
     private void OnPowerDetected(Entity<ArtifactMetapsionicTriggerComponent> ent, ref PsionicPowerDetectedEvent args)
     {
         _artifact.TryActivateArtifact(ent);
+    }
+
+    private void OnGlimmerEventEnded(GlimmerEventEndedEvent args)
+    {
+        var query = EntityQueryEnumerator<ArtifactMetaspionicTriggerComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            _artifact.TryActivateArtifact(uid);
+        }
     }
 }


### PR DESCRIPTION
## About the PR
when a glimmer discharge event happens, metapsionic artifacts get triggered

## Why / Balance
theres already a guaranteed way to trigger it (mime), this lets it not be a complete artifact killer if mime is uncooperative or theres no other psionics, as well as another kind of unpredictable trigger

## Technical details
subscribe to the event

## Media


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Psionic discharges now trigger metapsionic artifacts.
