### PR TITLE
make some ores more common on lavaland planets

### DIFF
--- a/Resources/Prototypes/DeltaV/Procedural/biome_ore_templates.yml
+++ b/Resources/Prototypes/DeltaV/Procedural/biome_ore_templates.yml
@@ -1,0 +1,46 @@
+# these have higher group size so more ores spawns
+
+# Plasma
+- type: biomeMarkerLayer
+  id: OrePlasma3
+  entityMask:
+    AsteroidRock: AsteroidRockPlasma
+    WallRock: WallRockPlasma
+    WallRockBasalt: WallRockBasaltPlasma
+    WallRockChromite: WallRockChromitePlasma
+    WallRockSand: WallRockSandPlasma
+    WallRockSnow: WallRockSnowPlasma
+  maxCount: 12
+  minGroupSize: 12
+  maxGroupSize: 24
+  radius: 4
+
+# Uranium
+- type: biomeMarkerLayer
+  id: OreUranium2
+  entityMask:
+    AsteroidRock: AsteroidRockUranium
+    WallRock: WallRockUranium
+    WallRockBasalt: WallRockBasaltUranium
+    WallRockChromite: WallRockChromiteUranium
+    WallRockSand: WallRockSandUranium
+    WallRockSnow: WallRockSnowUranium
+  maxCount: 15
+  minGroupSize: 8
+  maxGroupSize: 16
+  radius: 4
+
+# Diamond
+- type: biomeMarkerLayer
+  id: OreDiamond2
+  entityMask:
+    AsteroidRock: AsteroidRockDiamond
+    WallRock: WallRockDiamond
+    WallRockBasalt: WallRockBasaltDiamond
+    WallRockChromite: WallRockChromiteDiamond
+    WallRockSand: WallRockSandDiamond
+    WallRockSnow: WallRockSnowDiamond
+  maxCount: 6
+  minGroupSize: 2
+  maxGroupSize: 4
+  radius: 4

--- a/Resources/Prototypes/DeltaV/planets.yml
+++ b/Resources/Prototypes/DeltaV/planets.yml
@@ -20,9 +20,9 @@
   - OreCoal
   - OreGold
   - OreSilver
-  - OrePlasma
+  - OrePlasma3
   - OreUranium
-  - OreDiamond
+  - OreDiamond2
   - OreArtifactFragment
 
 - type: planet
@@ -47,7 +47,7 @@
   - OreCoal
   - OreGold
   - OreSilver
-  - OrePlasma
-  - OreUranium
+  - OrePlasma3
+  - OreUranium2
   - OreDiamond
   - OreArtifactFragment


### PR DESCRIPTION
## About the PR
- both planets have triple plasma
- lavaland has double diamonds
- glacier surface has double uranium

## Why / Balance
from experience plasma is much harder to find when its the reason NT came to lavaland anyway
lavaland = volcanic = pressure = diamond
glacier surface = ??? = uranium

**Changelog**
:cl:
- tweak: Plasma and diamonds are more abundant on lavaland.
