### PR TITLE
check ban flag for auto panic bunker

### DIFF
--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -340,7 +340,7 @@ public sealed class AdminSystem : EntitySystem
         var admins = PanicBunker.CountDeadminnedAdmins
             ? _adminManager.AllAdmins
             : _adminManager.ActiveAdmins;
-        var hasAdmins = admins.Any();
+        var hasAdmins = admins.Any(p => _adminManager.HasAdminFlag(p, AdminFlags.Ban)); // DeltaV: Add predicate to require someone that can handle ahelps, not just curators
 
         // TODO Fix order dependent Cvars
         // Please for the sake of my sanity don't make cvars & order dependent.


### PR DESCRIPTION
## About the PR
title

## Why / Balance
so poor curators only have to ban raiders if they farmed hours

## Technical details
add a predicate

## Media


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
DELTAVADMIN:
- tweak: Automatic panic bunker being turned off requires an admin with the Ban flag.
