### PR TITLE
fix vox gladiators not getting nitrogen tanks

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -75,5 +75,6 @@
   - GladiatorJumpsuit
   - CommonBackpack
   - GladiatorOuterClothing
+  - Survival
   - Trinkets
   - GroupSpeciesBreathTool


### PR DESCRIPTION
## About the PR
missing Survival

**Changelog**
:cl:
- fix: Fixed Vox gladiators not spawning with nitrogen tanks.