### PR TITLE
Add Atmos alert computer board to lathe recipes and research

### DIFF
--- a/Resources/Prototypes/DeltaV/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/DeltaV/Recipes/Lathes/electronics.yml
@@ -7,3 +7,8 @@
   parent: BaseCircuitboardRecipe
   id: ComputerMassMediaCircuitboard
   result: ComputerMassMediaCircuitboard
+
+- type: latheRecipe
+  parent: BaseCircuitboardRecipe
+  id: AlertsComputerCircuitboard
+  result: AlertsComputerCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -578,6 +578,7 @@
     # Begin DeltaV additions
       - SalvageExpeditionsComputerCircuitboard
       - ComputerMassMediaCircuitboard
+      - AlertsComputerCircuitboard
     # End DeltaV additions
   - type: EmagLatheRecipes
     emagDynamicRecipes:

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -100,6 +100,7 @@
   recipeUnlocks:
   - ThermomachineFreezerMachineCircuitBoard
   - GasRecyclerMachineCircuitboard
+  - AlertsComputerCircuitboard # DeltaV - Allows atmos computers to be researched
 
 - type: technology
   id: RipleyAPLU


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added the Atmospherics alert computer board to T1 atmos research and enabled the lathe to create one.

## Why / Balance
Currently there is no way to get an atmos board unless an admin spawns on in for you. If they are exploded or dismantled then atmos techs are not able to fully do their job and it's not recoverable.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![image](https://github.com/user-attachments/assets/485f3cc0-ed96-4840-a293-2f30bc19c3c8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have tested all added content and changes.
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Added atmospherics computer board to t1 research and enabled fabrication
