### PR TITLE
Remove additional DoafterEvent

### DIFF
--- a/Content.Shared/Execution/DoafterEvent.cs
+++ b/Content.Shared/Execution/DoafterEvent.cs
@@ -1,9 +1,0 @@
-using Content.Shared.DoAfter;
-using Robust.Shared.Serialization;
-
-namespace Content.Shared.Execution;
-
-[Serializable, NetSerializable]
-public sealed partial class ExecutionDoAfterEvent : SimpleDoAfterEvent
-{
-}


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Deleted extra/duplicate `DoafterEvent.cs`.

## Why / Balance
Doesn't seem to be used, main repository has the upper case version still but this lower cased `after` is gone.
Tested that executions still work locally and they do.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
