### PR TITLE
Make stocks trading require LO access.

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/cartridges.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/cartridges.yml
@@ -82,7 +82,7 @@
       state: stock_trading
   - type: BankClient
   - type: AccessReader # This is so that we can restrict who can buy stocks
-    access: [["Orders"]]
+    access: [["Quartermaster"]] # Was Orders, should be reverted if order access is removed from cargo technicians.
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This should be reverted if cargo techies lose order access.

## Why / Balance
The logistics officers complain about techies wasting money on stocks constantly.

## Technical details
YAML change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Not needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Hopefully nothing.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The stocks cartridge now requires Logistic Officer access.
