### PR TITLE
make wrecks cost mining points to pull

### DIFF
--- a/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
+++ b/Content.Client/Salvage/UI/SalvageMagnetBoundUserInterface.cs
@@ -1,7 +1,9 @@
 using System.Linq;
 using Content.Client.Message;
+using Content.Shared.DeltaV.Salvage.Systems; // DeltaV
 using Content.Shared.Salvage;
 using Content.Shared.Salvage.Magnet;
+using Robust.Client.Player; // DeltaV
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
 
@@ -10,12 +12,16 @@ namespace Content.Client.Salvage.UI;
 public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
 {
     [Dependency] private readonly IEntityManager _entManager = default!;
+    [Dependency] private readonly IPlayerManager _player = default!; // DeltaV
+
+    private readonly MiningPointsSystem _points; // DeltaV
 
     private OfferingWindow? _window;
 
     public SalvageMagnetBoundUserInterface(EntityUid owner, Enum uiKey) : base(owner, uiKey)
     {
         IoCManager.InjectDependencies(this);
+        _points = _entManager.System<MiningPointsSystem>(); // DeltaV
     }
 
     protected override void Open()
@@ -60,6 +66,21 @@ public sealed class SalvageMagnetBoundUserInterface : BoundUserInterface
                     Index = claimIndex
                 });
             };
+
+            // Begin DeltaV Additions: Mining points cost for wrecks
+            if (offer.Cost > 0)
+            {
+                if (_player.LocalSession?.AttachedEntity is not {} user || !_points.UserHasPoints(user, offer.Cost))
+                    option.Disabled = true;
+
+                var label = new Label
+                {
+                    Text = Loc.GetString("salvage-magnet-mining-points-cost", ("points", offer.Cost)),
+                    HorizontalAlignment = Control.HAlignment.Center
+                };
+                option.AddContent(label);
+            }
+            // End DeltaV Additions
 
             switch (offer)
             {

--- a/Content.Server/Salvage/SalvageSystem.Magnet.cs
+++ b/Content.Server/Salvage/SalvageSystem.Magnet.cs
@@ -45,7 +45,7 @@ public sealed partial class SalvageSystem
             return;
         }
 
-        TakeMagnetOffer((station.Value, dataComp), args.Index, (uid, component));
+        TakeMagnetOffer((station.Value, dataComp), args.Index, (uid, component), args.Actor); // DeltaV: pass the user entity
     }
 
     private void OnMagnetStartup(EntityUid uid, SalvageMagnetComponent component, ComponentStartup args)
@@ -250,11 +250,15 @@ public sealed partial class SalvageSystem
         }
     }
 
-    private async Task TakeMagnetOffer(Entity<SalvageMagnetDataComponent> data, int index, Entity<SalvageMagnetComponent> magnet)
+    private async Task TakeMagnetOffer(Entity<SalvageMagnetDataComponent> data, int index, Entity<SalvageMagnetComponent> magnet, EntityUid user) // DeltaV: add user param
     {
         var seed = data.Comp.Offered[index];
 
         var offering = GetSalvageOffering(seed);
+        // Begin DeltaV Addition: make wrecks cost mining points to pull
+        if (offering.Cost > 0 && !(_points.TryFindIdCard(user) is {} idCard && _points.RemovePoints(idCard, offering.Cost)))
+            return;
+        // End DeltaV Addition
         var salvMap = _mapSystem.CreateMap();
         var salvMapXform = Transform(salvMap);
 

--- a/Content.Server/Salvage/SalvageSystem.cs
+++ b/Content.Server/Salvage/SalvageSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Cargo.Systems;
 using Content.Server.Construction;
 using Content.Server.GameTicking;
 using Content.Server.Radio.EntitySystems;
+using Content.Shared.DeltaV.Salvage.Systems; // DeltaV
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
@@ -52,6 +53,7 @@ namespace Content.Server.Salvage
         [Dependency] private readonly LabelSystem _labelSystem = default!;
         [Dependency] private readonly MapLoaderSystem _map = default!;
         [Dependency] private readonly MetaDataSystem _metaData = default!;
+        [Dependency] private readonly MiningPointsSystem _points = default!; // DeltaV
         [Dependency] private readonly RadioSystem _radioSystem = default!;
         [Dependency] private readonly SharedAudioSystem _audio = default!;
         [Dependency] private readonly SharedTransformSystem _transform = default!;

--- a/Content.Shared/DeltaV/Salvage/Systems/MiningPointsSystem.cs
+++ b/Content.Shared/DeltaV/Salvage/Systems/MiningPointsSystem.cs
@@ -62,6 +62,17 @@ public sealed class MiningPointsSystem : EntitySystem
     }
 
     /// <summary>
+    /// Returns true if the user has at least some number of points on their ID card.
+    /// </summary>
+    public bool UserHasPoints(EntityUid user, uint points)
+    {
+        if (TryFindIdCard(user)?.Comp is not {} comp)
+            return false;
+
+        return comp.Points >= points;
+    }
+
+    /// <summary>
     /// Removes points from a holder, returning true if it succeeded.
     /// </summary>
     public bool RemovePoints(Entity<MiningPointsComponent?> ent, uint amount)

--- a/Content.Shared/Salvage/Magnet/AsteroidOffering.cs
+++ b/Content.Shared/Salvage/Magnet/AsteroidOffering.cs
@@ -15,4 +15,6 @@ public record struct AsteroidOffering : ISalvageMagnetOffering
     /// Calculated marker layers for the asteroid.
     /// </summary>
     public Dictionary<string, int> MarkerLayers;
+
+    uint ISalvageMagnetOffering.Cost => 0; // DeltaV
 }

--- a/Content.Shared/Salvage/Magnet/DebrisOffering.cs
+++ b/Content.Shared/Salvage/Magnet/DebrisOffering.cs
@@ -6,4 +6,6 @@ namespace Content.Shared.Salvage.Magnet;
 public record struct DebrisOffering : ISalvageMagnetOffering
 {
     public string Id;
+
+    uint ISalvageMagnetOffering.Cost => 0; // DeltaV: Debris is a very good source of materials for the station, so no cost
 }

--- a/Content.Shared/Salvage/Magnet/ISalvageMagnetOffering.cs
+++ b/Content.Shared/Salvage/Magnet/ISalvageMagnetOffering.cs
@@ -2,5 +2,8 @@ namespace Content.Shared.Salvage.Magnet;
 
 public interface ISalvageMagnetOffering
 {
-
+    /// <summary>
+    /// DeltaV: How many mining points this offering costs to accept.
+    /// </summary>
+    public uint Cost { get; }
 }

--- a/Content.Shared/Salvage/Magnet/SalvageOffering.cs
+++ b/Content.Shared/Salvage/Magnet/SalvageOffering.cs
@@ -6,4 +6,6 @@ namespace Content.Shared.Salvage.Magnet;
 public record struct SalvageOffering : ISalvageMagnetOffering
 {
     public SalvageMapPrototype SalvageMap;
+
+    uint ISalvageMagnetOffering.Cost => 1000; // DeltaV: Station gets next to no benefit from you pulling wrecks, force you to mine first.
 }

--- a/Resources/Locale/en-US/deltav/salvage/salvage-magnet.ftl
+++ b/Resources/Locale/en-US/deltav/salvage/salvage-magnet.ftl
@@ -1,1 +1,3 @@
 ﻿salvage-map-wreck-size-unknown = [color=purple]Unidentified[/color]
+
+salvage-magnet-mining-points-cost = Cost: {$points} Mining Points


### PR DESCRIPTION
## About the PR
wrecks now cost 1000 mining points to pull
it also means borgs cant pull wrecks :trollface:
could let mining borgs store mining points on their chassis in the future

## Why / Balance
you can easily get 2-3k points from 1 asteroid pull so this isnt a serious nerf to real gamers, just shitters that only pull wrecks to try get funny gamer loot and let the station starve, now they are actually forced to mine :smiling_imp:  :smiling_imp:  :smiling_imp:  :smiling_imp: :trollface:

## Technical details
Cost field on ISalvageMagnetOffering that makes it remove mining points when you pull it

## Media
too broke...
![05:39:43](https://github.com/user-attachments/assets/09385c98-22a1-405e-8b9a-7e7a83568864)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Pulling wrecks on the salvage magnet now costs mining points. GO MINE!!!