### PR TITLE
Updates Maintenance Lights

### DIFF
--- a/Resources/Migrations/deltaMigrations.yml
+++ b/Resources/Migrations/deltaMigrations.yml
@@ -123,3 +123,8 @@ VendingMachineAutomatrobe: null
 
 # 2024-11-08
 SuitStorageSec: SuitStorageSecDeltaV
+
+# 2024-12*17
+LightBulbMaintenanceRed: DimLightBulb
+PoweredSmallLightMaintenanceRed: PoweredDimSmallLight
+AlwaysPoweredSmallLightMaintenanceRed: PoweredDimSmallLight

--- a/Resources/Migrations/deltaMigrations.yml
+++ b/Resources/Migrations/deltaMigrations.yml
@@ -124,7 +124,7 @@ VendingMachineAutomatrobe: null
 # 2024-11-08
 SuitStorageSec: SuitStorageSecDeltaV
 
-# 2024-12*17
+# 2024-12-17
 LightBulbMaintenanceRed: DimLightBulb
 PoweredSmallLightMaintenanceRed: PoweredDimSmallLight
 AlwaysPoweredSmallLightMaintenanceRed: PoweredDimSmallLight

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Boxes/general.yml
@@ -34,7 +34,7 @@
     contents:
       - id: LightBulbMaintenance
         amount: 6
-      - id: LightBulbMaintenanceRed
+      - id: DimLightBulb
         amount: 6
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/randomitems.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Markers/Spawners/Random/randomitems.yml
@@ -166,7 +166,7 @@
         - id: ColoredLightTubeRed
         - id: ColoredLightTubeFrostyBlue
         - id: ColoredLightTubeBlackLight
-        - id: LightBulbMaintenanceRed
+        - id: DimLightBulb
         - id: LightBulbBroken
         - id: LightTubeBroken
         - id: LedLightBulb

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Power/lights.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Power/lights.yml
@@ -14,7 +14,7 @@
     PowerUse: 75
   - type: Sprite
     sprite:  Objects/Power/light_tube.rsi
-    state: normal 
+    state: normal
 
 - type: entity
   parent: BaseLightbulb
@@ -26,9 +26,13 @@
   - type: LightBulb
     bulb: Bulb
     color: "#FFD1A3" # 4000K color temp
-    lightEnergy: 0.7
-    lightRadius: 1.5
-    lightSoftness: 1.1 
+    lightEnergy: 0.05
+    lightRadius: 5
+    lightSoftness: 7
+  - type: Tag
+    tags:
+    - LightBulb
+    - Trash
 
 # Colored
 
@@ -47,7 +51,7 @@
     PowerUse: 25
   - type: Sprite
     sprite:  Objects/Power/light_tube.rsi
-    state: normal 
+    state: normal
 
 - type: entity
   parent: BaseLightbulb
@@ -64,8 +68,8 @@
     PowerUse: 25
   - type: Sprite
     sprite:  Objects/Power/light_tube.rsi
-    state: normal 
-    
+    state: normal
+
 - type: entity
   parent: BaseLightbulb
   name: black light tube
@@ -82,17 +86,3 @@
   - type: Sprite
     sprite:  Objects/Power/light_tube.rsi
     state: normal
-
-- type: entity
-  parent: BaseLightbulb
-  name: incandescent light bulb
-  suffix: Maintenance, Red
-  id: LightBulbMaintenanceRed
-  description: A dim light bulb. These emit a red hue.
-  components:
-  - type: LightBulb
-    bulb: Bulb
-    color: "#FF6666" # 4000K color temp
-    lightEnergy: 1.1
-    lightRadius: 1.5
-    lightSoftness: 1.1

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Lighting/base_lighting.yml
@@ -6,10 +6,16 @@
   components:
   - type: PoweredLight
     hasLampOnSpawn: BlueLightTube
+  - type: PointLight
+    radius: 12
+    energy: 3
+    softness: 0.5
+    color: "#B4FCF0"
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.2
+        Heat: 2
+    popupText: powered-light-component-burn-hand
 
 - type: entity
   parent: AlwaysPoweredWallLight
@@ -31,10 +37,16 @@
   components:
   - type: PoweredLight
     hasLampOnSpawn: LightBulbMaintenance
+  - type: PointLight
+    radius: 5
+    energy: 0.05
+    softness: 7
+    color: "#FFD1A3"
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.2
+        Heat: 2
+    popupText: powered-light-component-burn-hand
 
 - type: entity
   parent: SmallLight
@@ -43,9 +55,9 @@
   description: "A light fixture. Draws power and produces light when equipped with a light tube."
   components:
   - type: PointLight
-    radius: 1.5
-    energy: 0.7
-    softness: 1.1
+    radius: 5
+    energy: 0.05
+    softness: 7
     color: "#FFD1A3"
 
 #Colored lights
@@ -58,10 +70,16 @@
   components:
   - type: PoweredLight
     hasLampOnSpawn: ColoredLightTubeRed
+  - type: PointLight
+    radius: 10
+    energy: 0.9
+    softness: 0.5
+    color: "#FF6666"
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.2
+        Heat: 2
+    popupText: powered-light-component-burn-hand
 
 - type: entity
   id: AlwaysPoweredLightColoredRed
@@ -83,10 +101,16 @@
   components:
   - type: PoweredLight
     hasLampOnSpawn: ColoredLightTubeFrostyBlue
+  - type: PointLight
+    radius: 10
+    energy: 0.8
+    softness: 1
+    color: "#00FFFF"
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.2
+        Heat: 2
+    popupText: powered-light-component-burn-hand
 
 - type: entity
   id: AlwaysPoweredLightColoredFrostyBlue
@@ -108,10 +132,16 @@
   components:
   - type: PoweredLight
     hasLampOnSpawn: ColoredLightTubeBlackLight
+  - type: PointLight
+    radius: 10
+    energy: 1.1
+    softness: 1
+    color: "#5D0CED"
   - type: DamageOnInteract
     damage:
       types:
-        Heat: 0.2
+        Heat: 2
+    popupText: powered-light-component-burn-hand
 
 - type: entity
   id: AlwaysPoweredLightColoredBlack
@@ -136,10 +166,18 @@
     state: base
   - type: PoweredLight
     hasLampOnSpawn: ColoredLightTubeRed
+  - type: PointLight
+    enabled: true
+    radius: 10
+    energy: 0.9
+    softness: 1
+    offset: "0, -0.5"
+    color: "#FF6666"
   - type: DamageOnInteract
     damage:
       types:
         Heat: 2
+    popupText: powered-light-component-burn-hand
   - type: StaticPrice
     price: 75
 
@@ -157,29 +195,4 @@
     energy: 0.9
     softness: 1
     offset: "0, -0.5"
-    color: "#FF6666"
-
-- type: entity
-  parent: PoweredSmallLight
-  id: PoweredSmallLightMaintenanceRed
-  suffix: Maintenance, Red
-  description: "A light fixture. Draws power and produces light when equipped with a light bulb."
-  components:
-  - type: PoweredLight
-    hasLampOnSpawn: LightBulbMaintenanceRed
-  - type: DamageOnInteract
-    damage:
-      types:
-        Heat: 0.2
-
-- type: entity
-  parent: SmallLight
-  id: AlwaysPoweredSmallLightMaintenanceRed
-  suffix: Always Powered, Maintenance, Red
-  description: "A light fixture. Draws power and produces light when equipped with a light tube."
-  components:
-  - type: PointLight
-    radius: 1.5
-    energy: 1.1
-    softness: 1.1
     color: "#FF6666"


### PR DESCRIPTION
## About the PR
- Removes red maints light in favor of new "dim" light
- Adjusts white maints light to disperse better
- Makes Nyano-inherited lights cause the same dmg and popup text
- Fixes [#2240](https://github.com/DeltaV-Station/Delta-v/issues/2240)

## Why / Balance
- They look better
- Bug fixes
- Mapping QoL

## Technical details
Might have to adjust some maps but won't be a major issue for the most part. 

## Media
**Before**
![Screenshot 2024-12-17 204336](https://github.com/user-attachments/assets/e5d12c89-24af-4aab-9fdf-cd3799385d84)
![Screenshot 2024-12-17 204340](https://github.com/user-attachments/assets/8228a49e-114d-49df-ad86-366aafba0aa9)

**After**
![Screenshot 2024-12-17 204347](https://github.com/user-attachments/assets/d6b900b3-877f-462a-a007-8d7bf47ef80e)
![Screenshot 2024-12-17 204355](https://github.com/user-attachments/assets/71d87287-2d4f-47ff-bb79-07e7df69e12e)


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a
