### PR TITLE
buff ore box

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -51,7 +51,7 @@
           False: { visible: true }
   - type: Storage
     grid:
-    - 0,0,9,5
+    - 0,0,19,9 # DeltaV: Expanded to ore bag of holding storage
     maxItemSize: Normal
     storageOpenSound: /Audio/Effects/closetopen.ogg
     storageCloseSound: /Audio/Effects/closetclose.ogg


### PR DESCRIPTION
## About the PR
made it the same size as ore bag of holding instead of literally 1 and a half ore bags

## Why / Balance
theres no reason to use it with such terrible storage, holding a second ore bag shouldnt completely outclass it. not to mention to smelt it you have to take the ore out 1 by 1

in ss13 it has no limit so this is still "underkill"

## Technical details
no

## Media


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Made the ore box hold much more ore.