### PR TITLE
dump ore bag into oreproc on click

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1374,6 +1374,8 @@
       transferSound:
         path: /Audio/Effects/Cargo/ping.ogg
     - type: MiningPointsLathe # DeltaV
+    - type: PlaceableSurface # DeltaV: Allow ore bags to dump into it directly
+      isPlaceable: false # but not place on it if you just click it with a random item
 
 - type: entity
   parent: OreProcessor


### PR DESCRIPTION
## About the PR
saw this in white dream and it actually just works, with isPlaceable: false it even doesn't place random non-bag items!

## Why / Balance
so you dont have to make a table (2 steel) for basic functionality

## Technical details


## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: You can now directly dump ore bags into ore processors by clicking on them.