### PR TITLE
remove constant shuttle spam from survival

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -9,7 +9,7 @@
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
     - SpaceTrafficControlEventScheduler
-    - SpaceTrafficControlFriendlyEventScheduler
+    #- SpaceTrafficControlFriendlyEventScheduler # DeltaV: spam of garbage roles nobody takes every 10-20 minutes
     - BasicRoundstartVariation
     - GlimmerEventScheduler # DeltaV
 


### PR DESCRIPTION
## About the PR
removed the shuttle spam scheduler that sends a shuttle every 10-20 minutes from survival

## Why / Balance
its already included in the other scheduler which does 2-3 events or so per shift
getting **5-10** shuttles in a 2 hour shift is insane and makes it really, really easy to know the gamemode.
nobody ever takes these ghost roles so half the time someone drags in a ship with a few other rotting corpses

## Technical details
no

## Media