### PR TITLE
Return Detective Drip

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -187,12 +187,11 @@
     contents:
       - id: ClothingEyesGlassesSecurity
 #        prob: 0.3 # DeltaV - standardise until HUD balance worked out
-      - id: ClothingHeadHatFedoraBrown # DeltaV - removed for incongruence
-      - id: ClothingNeckTieDet # DeltaV - removed for incongruence
-      - id: ClothingOuterVestDetective # DeltaV - removed for incongruence
-      - id: ClothingOuterCoatDetective # DeltaV - removed for incongruence
+      - id: ClothingHeadHatFedoraBrown # DeltaV
+      - id: ClothingNeckTieDet # DeltaV
+      - id: ClothingOuterVestDetective # DeltaV
+      - id: ClothingOuterCoatDetective # DeltaV
       - id: ClothingHeadsetSecurity # DeltaV - add spare headset.
-      - id: FlippoEngravedLighter # DeltaV - add due to removal of trench coat
       - id: FlashlightSeclite
       - id: ForensicScanner
       - id: LogProbeCartridge

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -187,10 +187,10 @@
     contents:
       - id: ClothingEyesGlassesSecurity
 #        prob: 0.3 # DeltaV - standardise until HUD balance worked out
-#      - id: ClothingHeadHatFedoraBrown # DeltaV - removed for incongruence
-#      - id: ClothingNeckTieDet # DeltaV - removed for incongruence
-#      - id: ClothingOuterVestDetective # DeltaV - removed for incongruence
-#      - id: ClothingOuterCoatDetective # DeltaV - removed for incongruence
+      - id: ClothingHeadHatFedoraBrown # DeltaV - removed for incongruence
+      - id: ClothingNeckTieDet # DeltaV - removed for incongruence
+      - id: ClothingOuterVestDetective # DeltaV - removed for incongruence
+      - id: ClothingOuterCoatDetective # DeltaV - removed for incongruence
       - id: ClothingHeadsetSecurity # DeltaV - add spare headset.
       - id: FlippoEngravedLighter # DeltaV - add due to removal of trench coat
       - id: FlashlightSeclite

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/detdrobe.yml
@@ -3,14 +3,14 @@
   startingInventory:
 #    ClothingUniformJumpsuitDetective: 2 # DeltaV - removed for incongruence
 #    ClothingUniformJumpskirtDetective: 2 # DeltaV - removed for incongruence
-#    ClothingShoesColorBrown: 2 # DeltaV - removed for incongruence
-#    ClothingOuterCoatDetectiveLoadout: 2 # DeltaV - removed for incongruence
-#    ClothingHeadHatFedoraBrown: 2 # DeltaV - removed for incongruence
+    ClothingShoesColorBrown: 2 # DeltaV
+    ClothingOuterCoatDetectiveLoadout: 2 # DeltaV
+    ClothingHeadHatFedoraBrown: 2 # DeltaV
 #    ClothingUniformJumpsuitDetectiveGrey: 2 # DeltaV - removed for incongruence
 #    ClothingUniformJumpskirtDetectiveGrey: 2 # DeltaV - removed for incongruence
-#    ClothingOuterVestDetective: 2 # DeltaV - removed for incongruence
-#    ClothingNeckTieDet: 2 # DeltaV - removed for incongruence
-#    ClothingHeadHatFedoraGrey: 2 # DeltaV - removed for incongruence
+    ClothingOuterVestDetective: 2 # DeltaV
+    ClothingNeckTieDet: 2 # DeltaV
+    ClothingHeadHatFedoraGrey: 2 # DeltaV
     ClothingUniformJumpsuitForensicSpec: 2 # DeltaV
     ClothingUniformJumpskirtForensicSpec: 2 # DeltaV
     ClothingHandsGlovesColorBlack: 2

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -23,13 +23,13 @@
     contents:
     - id: SmokingPipeFilledTobacco
     - id: FlippoEngravedLighter
-#  - type: Armor #same as regular sec armor # DeltaV - remove armour as it is no longer security equipment.
-#    modifiers:
-#      coefficients:
-#        Blunt: 0.70
-#        Slash: 0.70
-#        Piercing: 0.70
-#        Heat: 0.80
+  - type: Armor #same as regular sec armor
+    modifiers:
+      coefficients:
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70
+        Heat: 0.80
 
 - type: entity
   parent: ClothingOuterCoatDetective
@@ -39,6 +39,13 @@
     contents:
     - id: SmokingPipeFilledTobacco
     - id: FlippoLighter #Not the steal objective, only difference from normal detective trenchcoat
+  - type: Armor #same as regular sec armor
+    modifiers:
+      coefficients:
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70
+        Heat: 0.80
 
 - type: entity
   parent: ClothingOuterStorageBase

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1254,8 +1254,8 @@
   name: loadout-group-detective-head
   minLimit: 0
   loadouts:
-#  - DetectiveFedora # DeltaV - removed for incongruence
-#  - DetectiveFedoraGrey # DeltaV - removed for incongruence
+  - DetectiveFedora # DeltaV - removed for incongruence
+  - DetectiveFedoraGrey # DeltaV - removed for incongruence
   - DetBeret # DeltaV
 
 - type: loadoutGroup
@@ -1284,8 +1284,8 @@
   name: loadout-group-detective-outerclothing
   minLimit: 0
   loadouts:
-#  - DetectiveArmorVest # DeltaV - removed for incongruence
-#  - DetectiveCoat # DeltaV - removed for incongruence
+  - DetectiveArmorVest # DeltaV
+  - DetectiveCoat # DeltaV
   - StasecWinterCoatDet # DeltaV
   - PlateCarrier # DeltaV
   - DuraVest # DeltaV

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -386,7 +386,7 @@
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
-  - SecurityStar 
+  - SecurityStar
   - GroupSpeciesBreathToolSecurity
   - SecurityAllFirearm # DeltaV - loadouts
   - SecurityAllAmmo # DeltaV - loadouts

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Vending/Inventories/repdrobe.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Vending/Inventories/repdrobe.yml
@@ -11,7 +11,6 @@
     ClothingUniformJumpskirtDetective: 2 # DeltaV - moved from detdrobe
     ClothingUniformJumpsuitDetectiveGrey: 2 # DeltaV - moved from detdrobe
     ClothingUniformJumpskirtDetectiveGrey: 2 # DeltaV - moved from detdrobe
-    ClothingOuterCoatDetectiveLoadout: 2 # DeltaV - moved from detdrobe
     ClothingNeckTieDet: 2 # DeltaV - moved from detdrobe
     ClothingHeadHatFedoraBrown: 2 # DeltaV - moved from detdrobe
     ClothingHeadHatFedoraGrey: 2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Gives the detective back their trenchcoat, vest, fedora, tie, shoes, etc in the detdrobe, as well as removes the coat from the repdrobe as it is now armored again. Adds stuff back into the loadouts as well.

Detectives without the old coat look identical to every other sec officer, and the new coat is... just strange. I like playing as a detective in the cheesy old timey coat or vest. Its fun. Can we have fun? I want to have fun.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

![Content Client_7uGIDXsfwY](https://github.com/user-attachments/assets/ac11b208-67e8-4050-ba43-9f35861b4450)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Detectives now have their cool coat and vest again.
