### PR TITLE
disable vent fauna events

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -20,11 +20,11 @@
     - id: MouseMigration
     - id: PowerGridCheck
     #- id: RandomSentience # DeltaV - replaced with RandomSentienceGlimmer
-    - id: SlimesSpawn
+    #- id: SlimesSpawn # DeltaV - disabled hostile fauna events
     - id: SolarFlare
-    - id: SnakeSpawn
-    - id: SpiderClownSpawn
-    - id: SpiderSpawn
+    #- id: SnakeSpawn # DeltaV
+    #- id: SpiderClownSpawn # DeltaV
+    #- id: SpiderSpawn # DeltaV
     - id: VentClog
 
 - type: entityTable


### PR DESCRIPTION
## About the PR
"removed pending rework" is reminiscent of a certain repo but there are good ideas floated like picking 1 vent, announcing the location and giving it a good delay for people to run away then sec has something to do instead of everyone needing bats to defend themselves from simplemobs that spawn on them with 0 telegraphing

## Why / Balance
it promotes absolute no RP, preys on new players and doesnt really provide sec anything to do unless they are the ones slimes etc spawn on
if you are slowed at all you cant outrun slimes so you can't leave them for sec to kill, you either kill them there or die

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- remove: Removed vent fauna (spiders, slimes, snakes) events pending rework.
