### PR TITLE
Add External access to the prison guard role

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Security/prisonguard.yml
@@ -20,6 +20,7 @@
   - Security
   #- Brig #Delta V: Removed brig access
   - Maintenance
+  - External # DeltaV - Added external access
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
More in line with the rest of security + being unable to use the airlocks to the mining rocks and unable to rescue prisoners on Hammurabi using the airlocks to space.

## Technical details
YAML change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
No need.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Prison guards now have External access.
