### PR TITLE
Centcomm Hotfix

### DIFF
--- a/Resources/Maps/DeltaV/centcomm.yml
+++ b/Resources/Maps/DeltaV/centcomm.yml
@@ -3240,12 +3240,6 @@ entities:
     - type: Transform
       pos: 33.5,-5.5
       parent: 1668
-    - type: Door
-      secondsUntilStateChange: -3769.445
-      state: Opening
-    - type: DeviceLinkSource
-      lastSignals:
-        DoorStatus: True
 - proto: AirlockEngineeringGlassLocked
   entities:
   - uid: 5175
@@ -28750,6 +28744,8 @@ entities:
     - type: Transform
       pos: 21.5,8.5
       parent: 1668
+    missingComponents:
+    - WarpPoint
 - proto: PlushieAtmosian
   entities:
   - uid: 6890


### PR DESCRIPTION
## About the PR
Removes one of the additional warp points on the AI Core

## Why / Balance
Bloats menu/unnecessary

## Technical details
I couldn't remove the additional `AI eye` w/out some superfluous manipulations, so, I'll leave that one for now unless someone has a better solution. 

## Media
n/a

## Breaking changes
n/a

**Changelog**
n/a
