### PR TITLE
Fix Sleepers getting nukies as kill targets

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -107,6 +107,7 @@
       - RoleSurvivalNukie
       components:
       - type: NukeOperative
+      - type: TargetObjectiveImmune
       - type: RandomMetadata
         nameSegments:
         - nukeops-role-commander
@@ -124,6 +125,7 @@
       - RoleSurvivalNukie
       components:
       - type: NukeOperative
+      - type: TargetObjectiveImmune
       - type: RandomMetadata
         nameSegments:
         - nukeops-role-agent
@@ -143,6 +145,7 @@
       - RoleSurvivalNukie
       components:
       - type: NukeOperative
+      - type: TargetObjectiveImmune
       - type: RandomMetadata
         nameSegments:
         - nukeops-role-operator

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -107,7 +107,7 @@
       - RoleSurvivalNukie
       components:
       - type: NukeOperative
-      - type: TargetObjectiveImmune
+      - type: TargetObjectiveImmune # DeltaV - Makes sleepers unable to get nukie kill objectives
       - type: RandomMetadata
         nameSegments:
         - nukeops-role-commander
@@ -125,7 +125,7 @@
       - RoleSurvivalNukie
       components:
       - type: NukeOperative
-      - type: TargetObjectiveImmune
+      - type: TargetObjectiveImmune # DeltaV - Makes sleepers unable to get nukie kill objectives
       - type: RandomMetadata
         nameSegments:
         - nukeops-role-agent
@@ -145,7 +145,7 @@
       - RoleSurvivalNukie
       components:
       - type: NukeOperative
-      - type: TargetObjectiveImmune
+      - type: TargetObjectiveImmune # DeltaV - Makes sleepers unable to get nukie kill objectives
       - type: RandomMetadata
         nameSegments:
         - nukeops-role-operator


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
RIP bootleg warops

## Why / Balance
admin request

## Technical details
yml
## Media
nope

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- fix: sleepers will no longer receive nukies as kill targets

