### PR TITLE
Reduce amount of chef jobs on hive

### DIFF
--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -53,7 +53,7 @@
             Bartender: [ 2, 2 ]
             Botanist: [ 2, 3 ]
             Boxer: [ 2, 2 ]
-            Chef: [ 2, 3 ]
+            Chef: [ 1, 2 ]
             Clown: [ 1, 2 ]
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 3 ]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
1 less chef slot on hive
## Why / Balance
3 chefs for 2 smol kitchens is bad. considering that the second kitchen is all the way at evac. this was done with permission from velcro

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
