### PR TITLE
vent critters rework

### DIFF
--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.StationEvents.Events;
 using Content.Shared.Storage;
+using Robust.Shared.Map; // DeltaV
 
 namespace Content.Server.StationEvents.Components;
 
@@ -14,4 +15,28 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// </summary>
     [DataField("specialEntries")]
     public List<EntitySpawnEntry> SpecialEntries = new();
+
+    /// <summary>
+    /// DeltaV: The location of the vent that got picked.
+    /// </summary>
+    [ViewVariables]
+    public EntityCoordinates? Location = new();
+
+    /// <summary>
+    /// DeltaV: Base minimum number of critters to spawn.
+    /// </summary>
+    [DataField]
+    public int Min = 2;
+
+    /// <summary>
+    /// DeltaV: Base maximum number of critters to spawn.
+    /// </summary>
+    [DataField]
+    public int Max = 3;
+
+    /// <summary>
+    /// DeltaV: Min and max get multiplied by the player count then divided by this.
+    /// </summary>
+    [DataField]
+    public int PlayerRatio = 25;
 }

--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class VentCrittersRuleComponent : Component
     /// DeltaV: The location of the vent that got picked.
     /// </summary>
     [ViewVariables]
-    public EntityCoordinates? Location = new();
+    public EntityCoordinates? Location;
 
     /// <summary>
     /// DeltaV: Base minimum number of critters to spawn.

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -34,7 +34,7 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
 
     protected override void Added(EntityUid uid, VentCrittersRuleComponent comp, GameRuleComponent gameRule, GameRuleAddedEvent args)
     {
-        PickLocation((uid, comp));
+        PickLocation(comp);
         if (comp.Location is not {} coords)
         {
             ForceEndSelf(uid, gameRule);
@@ -78,26 +78,22 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         Spawn(specialEntry.PrototypeId, coords);
     }
 
-    private void PickLocation(Entity<VentCrittersRuleComponent> ent)
+    private void PickLocation(VentCrittersRuleComponent comp)
     {
         if (!TryGetRandomStation(out var station))
-        {
-            Log.Warning($"{ToPrettyString(ent):rule} failed to get a station!");
             return;
-        }
 
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
         _locations.Clear();
         while (locations.MoveNext(out var uid, out _, out var transform))
         {
-            if (transform.MapID != MapId.Nullspace && CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
+            if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
             {
-                Log.Debug($"Picking {ToPrettyString(uid)}");
                 _locations.Add(transform.Coordinates);
             }
         }
 
         if (_locations.Count > 0)
-            ent.Comp.Location = RobustRandom.Pick(_locations);
+            comp.Location = RobustRandom.Pick(_locations);
     }
 }

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -1,13 +1,23 @@
-using Content.Server.StationEvents.Components;
+using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Server.Pinpointer;
+using Content.Server.StationEvents.Components;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage;
 using Robust.Shared.Map;
+using Robust.Shared.Player;
 using Robust.Shared.Random;
 
 namespace Content.Server.StationEvents.Events;
 
+/// <summary>
+/// DeltaV: Reworked vent critters to spawn a number of mobs at a single telegraphed location.
+/// This gives players time to run away and let sec do their job.
+/// </summary>
+/// <remarks>
+/// This entire file is rewritten, ignore upstream changes.
+/// </remarks>
 public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleComponent>
 {
     /*
@@ -15,45 +25,75 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
      * USE THE PROTOTYPE.
      */
 
-    protected override void Started(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleStartedEvent args)
-    {
-        base.Started(uid, component, gameRule, args);
+    [Dependency] private readonly AntagSelectionSystem _antag = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
+    [Dependency] private readonly NavMapSystem _navMap = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
 
-        if (!TryGetRandomStation(out var station))
+    private List<EntityCoordinates> _locations = new();
+
+    protected override void Added(EntityUid uid, VentCrittersRuleComponent component, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        PickLocation(component);
+        if (component.Location is not {} coords)
         {
+            ForceEndSelf(uid, gameRule);
             return;
         }
 
+        var mapCoords = _transform.ToMapCoordinates(coords);
+        if (!_navMap.TryGetNearestBeacon(mapCoords, out var beacon, out _))
+            return;
+
+        var nearest = beacon?.Comp?.Text!;
+        Comp<StationEventComponent>(uid).StartAnnouncement = Loc.GetString("station-event-vent-creatures-start-announcement-deltav", ("location", nearest));
+
+        base.Added(uid, component, gameRule, args);
+    }
+
+    protected override void Ended(EntityUid uid, VentCrittersRuleComponent comp, GameRuleComponent gameRule, GameRuleEndedEvent args)
+    {
+        base.Ended(uid, comp, gameRule, args);
+
+        if (comp.Location is not {} coords)
+            return;
+
+        var players = _antag.GetTotalPlayerCount(_player.Sessions);
+        var min = comp.Min * players / comp.PlayerRatio;
+        var max = comp.Max * players / comp.PlayerRatio;
+        var count = Math.Max(RobustRandom.Next(min, max), 1);
+        for (int i = 0; i < count; i++)
+        {
+            foreach (var spawn in EntitySpawnCollection.GetSpawns(comp.Entries, RobustRandom))
+            {
+                Spawn(spawn, coords);
+            }
+        }
+
+        if (comp.SpecialEntries.Count == 0)
+            return;
+
+        // guaranteed spawn
+        var specialEntry = RobustRandom.Pick(comp.SpecialEntries);
+        Spawn(specialEntry.PrototypeId, coords);
+    }
+
+    private void PickLocation(VentCrittersRuleComponent component)
+    {
+        if (!TryGetRandomStation(out var station))
+            return;
+
         var locations = EntityQueryEnumerator<VentCritterSpawnLocationComponent, TransformComponent>();
-        var validLocations = new List<EntityCoordinates>();
+        _locations.Clear();
         while (locations.MoveNext(out _, out _, out var transform))
         {
             if (CompOrNull<StationMemberComponent>(transform.GridUid)?.Station == station)
             {
-                validLocations.Add(transform.Coordinates);
-                foreach (var spawn in EntitySpawnCollection.GetSpawns(component.Entries, RobustRandom))
-                {
-                    Spawn(spawn, transform.Coordinates);
-                }
+                _locations.Add(transform.Coordinates);
             }
         }
 
-        if (component.SpecialEntries.Count == 0 || validLocations.Count == 0)
-        {
-            return;
-        }
-
-        // guaranteed spawn
-        var specialEntry = RobustRandom.Pick(component.SpecialEntries);
-        var specialSpawn = RobustRandom.Pick(validLocations);
-        Spawn(specialEntry.PrototypeId, specialSpawn);
-
-        foreach (var location in validLocations)
-        {
-            foreach (var spawn in EntitySpawnCollection.GetSpawns(component.SpecialEntries, RobustRandom))
-            {
-                Spawn(spawn, location);
-            }
-        }
+        if (_locations.Count > 0)
+            component.Location = RobustRandom.Pick(_locations);
     }
 }

--- a/Resources/Locale/en-US/deltav/station-events/events/vent-critters.ftl
+++ b/Resources/Locale/en-US/deltav/station-events/events/vent-critters.ftl
@@ -1,0 +1,1 @@
+﻿station-event-vent-creatures-start-announcement-deltav = Attention. A large influx of unknown life forms has been detected in ventilation systems near {$location}. All personnel must vacate the area immediately.

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -45,7 +45,7 @@
     earliestStart: 45
     minimumPlayers: 20
     weight: 1
-    duration: 60
+    duration: 30
   - type: PrecognitionResult
     message: psionic-power-precognition-xeno-vents-result-message
   - type: VentCrittersRule
@@ -75,7 +75,7 @@
     earliestStart: 15
     minimumPlayers: 15
     weight: 4
-    duration: 60
+    duration: 30
   - type: PrecognitionResult
     message: psionic-power-precognition-mothroach-spawn-result-message
   - type: VentCrittersRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -389,7 +389,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 15 # DeltaV: was 60, used as a delay now
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-slimes-spawn-result-message
   - type: VentCrittersRule
@@ -412,7 +412,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 15 # DeltaV: was 60, used as a delay now
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snake-spawn-result-message
   - type: VentCrittersRule
@@ -435,7 +435,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 15 # DeltaV: was 60, used as a delay now
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-spawn-result-message
   - type: VentCrittersRule
@@ -454,7 +454,7 @@
     earliestStart: 45 # DeltaV - was 20
     minimumPlayers: 30 # DeltaV - was 20
     weight: 1 # DeltaV - was 1.5
-    duration: 15 # DeltaV: was 60, used as a delay now
+    duration: 30 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-clown-spawn-result-message
   - type: VentCrittersRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -389,7 +389,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 15 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-slimes-spawn-result-message
   - type: VentCrittersRule
@@ -412,7 +412,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 15 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snake-spawn-result-message
   - type: VentCrittersRule
@@ -435,7 +435,7 @@
     earliestStart: 20
     minimumPlayers: 15
     weight: 5
-    duration: 60
+    duration: 15 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-spawn-result-message
   - type: VentCrittersRule
@@ -454,10 +454,11 @@
     earliestStart: 45 # DeltaV - was 20
     minimumPlayers: 30 # DeltaV - was 20
     weight: 1 # DeltaV - was 1.5
-    duration: 60
+    duration: 15 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-clown-spawn-result-message
   - type: VentCrittersRule
+    playerRatio: 35 # DeltaV: Clown spiders are very robust
     entries:
     - id: MobClownSpider
       prob: 0.03 # DeltaV - was 0.05

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -27,7 +27,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 15 # DeltaV: was 50, used as a delay now
+    duration: 30 # DeltaV: was 50, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-mouse-migration-result-message
   - type: VentCrittersRule
@@ -52,7 +52,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 15 # DeltaV: was 50, used as a delay now
+    duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-king-rat-migration-result-message
@@ -79,7 +79,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 15 # DeltaV: was 50, used as a delay now
+    duration: 30 # DeltaV: was 50, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-cockroach-migration-result-message
   - type: VentCrittersRule
@@ -98,7 +98,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 15 # DeltaV: was 50, used as a delay now
+    duration: 30 # DeltaV: was 50, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message
   - type: VentCrittersRule
@@ -120,7 +120,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 15 # DeltaV: was 50, used as a delay now
+    duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -27,7 +27,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 15 # DeltaV: was 50, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-mouse-migration-result-message
   - type: VentCrittersRule
@@ -52,7 +52,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 15 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-king-rat-migration-result-message
@@ -79,7 +79,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 50
+    duration: 15 # DeltaV: was 50, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-cockroach-migration-result-message
   - type: VentCrittersRule
@@ -98,7 +98,7 @@
     startAudio:
       path: /Audio/Announcements/attention.ogg
     weight: 6
-    duration: 50
+    duration: 15 # DeltaV: was 50, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message
   - type: VentCrittersRule
@@ -120,7 +120,7 @@
       path: /Audio/Announcements/attention.ogg
     earliestStart: 15
     weight: 6
-    duration: 50
+    duration: 15 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message


### PR DESCRIPTION
## About the PR
actually didnt take that long didnt need the nuking pr at all :trollface:

this makes vent critters better for everyone, sec and crew alike:
- 1 vent is picked for all mobs to spawn from
- the station gets 30 seconds advance warning before they spawn, giving crew time to run away and sec to arm up
- number of critters scales with player count so lowpop doesnt get as many as highpop
- false alarm, its just mice!!!

current numbers can go up to like 9 slimes on highpop, requiring good sec coordination to deal with

## Why / Balance
makes vent critters less ass and more fair to new players that dont have a spear ready to not get killed by simplemobs
now that you can run away, sec actually has something to do instead of "oops the crew killed all the simplemobs to not fucking die, just run around looking for stragglers in unlit maints"

## Technical details
vent critters rule was completely rewritten :trollface:

## Media
so real
![08:31:59](https://github.com/user-attachments/assets/9bc6a328-b254-4235-a19f-cf962d324821)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
any future vent critter events will need duration lowered to 30

**Changelog**
:cl:
- tweak: Reworked vent critters, now after a 30 second delay all the mobs spawn from 1 vent from the announcement.
