### PR TITLE
fix ash storms not doing damage

### DIFF
--- a/Content.Shared/Weather/SharedWeatherSystem.cs
+++ b/Content.Shared/Weather/SharedWeatherSystem.cs
@@ -137,6 +137,10 @@ public abstract class SharedWeatherSystem : EntitySystem
                     {
                         SetState(uid, WeatherState.Starting, comp, weather, weatherProto);
                     }
+                    else // DeltaV: Set state to Running when it finishes the starting time
+                    {
+                        SetState(uid, WeatherState.Running, comp, weather, weatherProto);
+                    }
                 }
 
                 // Run whatever code we need.


### PR DESCRIPTION
## About the PR
title

## Why / Balance
fixes #2493

## Technical details
weather state never actually got set to Running (except for infinite weather) so the logic didnt work without manual intervention which i was using when testing to not wait 30 seconds :trollface:

so this just sets it to running

## Media
patiently waited for this :trollface:
![01:50:46](https://github.com/user-attachments/assets/ce263473-9cc9-4461-b211-cabea873b54e)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed ash storms not doing damage.