### PR TITLE
Removes cooked egg reaction

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
+++ b/Resources/Prototypes/Recipes/Reactions/single_reagent.yml
@@ -8,15 +8,15 @@
   products:
     Protein: 0.5
 
-- type: reaction
-  id: EggCooking
-  impact: Low
-  minTemp: 344
-  reactants:
-    Egg:
-      amount: 0.5
-  products:
-    EggCooked: 0.5
+#- type: reaction # Delta V - Removed this reaction due to lack of function besides punishing chefs
+#  id: EggCooking
+#  impact: Low
+#  minTemp: 344
+#  reactants:
+#    Egg:
+#      amount: 0.5
+#  products:
+#    EggCooked: 0.5
 
 - type: reaction
   id: SapBoiling


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Cooked egg reaction is gone, the reagent is no longer obtainable

## Why / Balance
chefs who dont even know what beaker temp is 99% of the time shouldnt be punished for making pancakes

## Technical details
yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
