### PR TITLE
unnerf mining rig

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -697,10 +697,10 @@
     sprite: Clothing/Belt/salvagewebbing.rsi
   - type: Clothing
     sprite: Clothing/Belt/salvagewebbing.rsi
-  - type: Storage # Delta-V - Split Inventory
+  - type: Storage # Delta-V - Split Inventory, but same total size
     grid:
-    - 0,0,2,1
-    - 4,0,7,1
+    - 0,0,3,1
+    - 5,0,8,1
 
 - type: entity
   parent: [ClothingBeltStorageBase, ContentsExplosionResistanceBase, BaseSyndicateContraband]


### PR DESCRIPTION
## About the PR
unnerfed it to have total 2x8 storage like it used to, but still split because it looks nice and so you cant store shotguns

## Why / Balance
- its not a loadout item roundstart like other rigs
- currently you have to loot it, why should it be bad
- theres no slot for sidearm or medkit like other rigs, its just bad
- being able to buy a *downgrade* doesnt make sense
