### PR TITLE
fix vent critters rarely spawning anything

### DIFF
--- a/Content.Server/DeltaV/Abilities/Psionics/PrecognitionPowerSystem.cs
+++ b/Content.Server/DeltaV/Abilities/Psionics/PrecognitionPowerSystem.cs
@@ -148,7 +148,7 @@ public sealed class PrecognitionPowerSystem : EntitySystem
         var msg = Loc.GetString(locId);
         _chat.ChatMessageToOne(ChatChannel.Server,
             msg,
-            Loc.GetString("chat-manager-server-wrap-message", ("message", message)),
+            Loc.GetString("chat-manager-server-wrap-message", ("message", msg)),
             uid,
             false,
             mindComponent.Session.Channel,

--- a/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
+++ b/Content.Server/StationEvents/Components/VentCrittersRuleComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Server.StationEvents.Events;
+using Content.Shared.EntityTable.EntitySelectors;
 using Content.Shared.Storage;
 using Robust.Shared.Map; // DeltaV
 
@@ -7,8 +8,15 @@ namespace Content.Server.StationEvents.Components;
 [RegisterComponent, Access(typeof(VentCrittersRule))]
 public sealed partial class VentCrittersRuleComponent : Component
 {
-    [DataField("entries")]
-    public List<EntitySpawnEntry> Entries = new();
+    // DeltaV: Replaced by Table
+    //[DataField("entries")]
+    //public List<EntitySpawnEntry> Entries = new();
+
+    /// <summary>
+    /// DeltaV: Table of possible entities to spawn.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityTableSelector Table = default!;
 
     /// <summary>
     /// At least one special entry is guaranteed to spawn

--- a/Content.Server/StationEvents/Events/VentCrittersRule.cs
+++ b/Content.Server/StationEvents/Events/VentCrittersRule.cs
@@ -2,6 +2,7 @@ using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Pinpointer;
 using Content.Server.StationEvents.Components;
+using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Station.Components;
 using Content.Shared.Storage;
@@ -26,6 +27,7 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
      */
 
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
+    [Dependency] private readonly EntityTableSystem _entityTable = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
     [Dependency] private readonly NavMapSystem _navMap = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
@@ -62,9 +64,10 @@ public sealed class VentCrittersRule : StationEventSystem<VentCrittersRuleCompon
         var min = comp.Min * players / comp.PlayerRatio;
         var max = comp.Max * players / comp.PlayerRatio;
         var count = Math.Max(RobustRandom.Next(min, max), 1);
+        Log.Info($"Spawning {count} critters for {ToPrettyString(uid):rule}");
         for (int i = 0; i < count; i++)
         {
-            foreach (var spawn in EntitySpawnCollection.GetSpawns(comp.Entries, RobustRandom))
+            foreach (var spawn in _entityTable.GetSpawns(comp.Table))
             {
                 Spawn(spawn, coords);
             }

--- a/Resources/Prototypes/DeltaV/GameRules/events.yml
+++ b/Resources/Prototypes/DeltaV/GameRules/events.yml
@@ -49,23 +49,24 @@
   - type: PrecognitionResult
     message: psionic-power-precognition-xeno-vents-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobXeno
-      prob: 0.08
-    - id: MobXenoRouny
-      prob: 0.01
-    - id: MobXenoDrone
-      prob: 0.01
-    - id: MobXenoSpitter
-      prob: 0.01
-    - id: MobXenoRunner
-      prob: 0.01
-    - id: MobXenoPraetorian
-      prob: 0.01
-    - id: MobXenoRavager
-      prob: 0.01
-    - id: MobXenoQueen
-      prob: 0.007
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobXeno
+        weight: 0.55
+      - id: MobXenoRouny
+        weight: 0.01
+      - id: MobXenoDrone
+        weight: 0.25
+      - id: MobXenoSpitter
+        weight: 0.05
+      - id: MobXenoRunner
+        weight: 0.08
+      - id: MobXenoPraetorian
+        weight: 0.03
+      - id: MobXenoRavager
+        weight: 0.02
+      - id: MobXenoQueen
+        weight: 0.01
 
 - type: entity
   id: MothroachSpawn
@@ -79,9 +80,8 @@
   - type: PrecognitionResult
     message: psionic-power-precognition-mothroach-spawn-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobMothroach
-      prob: 0.05
+    table: # DeltaV: EntityTable instead of spawn entries
+      id: MobMothroach
 
 - type: entity
   id: ListeningPost

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -393,13 +393,11 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-slimes-spawn-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobAdultSlimesBlueAngry
-      prob: 0.02
-    - id: MobAdultSlimesGreenAngry
-      prob: 0.02
-    - id: MobAdultSlimesYellowAngry
-      prob: 0.02
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobAdultSlimesBlueAngry
+      - id: MobAdultSlimesGreenAngry
+      - id: MobAdultSlimesYellowAngry
 
 - type: entity
   id: SnakeSpawn
@@ -416,13 +414,11 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snake-spawn-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobPurpleSnake
-      prob: 0.02
-    - id: MobSmallPurpleSnake
-      prob: 0.02
-    - id: MobCobraSpace
-      prob: 0.02
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobPurpleSnake
+      - id: MobSmallPurpleSnake
+      - id: MobCobraSpace
 
 - type: entity
   id: SpiderSpawn
@@ -439,9 +435,8 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-spawn-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobGiantSpiderAngry
-      prob: 0.05
+    table: # DeltaV: EntityTable instead of spawn entries
+      id: MobGiantSpiderAngry
 
 - type: entity
   id: SpiderClownSpawn
@@ -459,9 +454,8 @@
     message: psionic-power-precognition-spider-clown-spawn-result-message
   - type: VentCrittersRule
     playerRatio: 35 # DeltaV: Clown spiders are very robust
-    entries:
-    - id: MobClownSpider
-      prob: 0.03 # DeltaV - was 0.05
+    table: # DeltaV: EntityTable instead of spawn entries
+      id: MobClownSpider
 
 - type: entity
   id: ZombieOutbreak

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -31,15 +31,12 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-mouse-migration-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
-    #- id: MobMouseCancer # DeltaV - no
-      #prob: 0.001
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobMouse
+      - id: MobMouse1
+      - id: MobMouse2
+      #- id: MobMouseCancer # DeltaV - no
 # Events always spawn a critter regardless of Probability https://github.com/space-wizards/space-station-14/issues/28480 I added the Rat King to their own event with a player cap.
 
 - type: entity
@@ -57,15 +54,12 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-king-rat-migration-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobMouse
-      prob: 0.02
-    - id: MobMouse1
-      prob: 0.02
-    - id: MobMouse2
-      prob: 0.02
-    #- id: MobMouseCancer # DeltaV - no
-      #prob: 0.001
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobMouse
+      - id: MobMouse1
+      - id: MobMouse2
+      #- id: MobMouseCancer # DeltaV - no
     specialEntries:
     - id: SpawnPointGhostRatKing
       prob: 0.001
@@ -83,11 +77,12 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-cockroach-migration-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobCockroach
-      prob: 0.03
-    - id: MobMothroach
-      prob: 0.008
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobCockroach
+        weight: 0.79
+      - id: MobMothroach
+        weight: 0.21
 
 - type: entity
   id: SnailMigrationLowPop
@@ -102,13 +97,11 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobSnail
-      prob: 0.02
-    - id: MobSnailSpeed
-      prob: 0.002
-    - id: MobSnailMoth
-      prob: 0.002
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobSnail
+      - id: MobSnailSpeed
+      - id: MobSnailMoth
 
 - type: entity
   id: SnailMigration
@@ -125,12 +118,12 @@
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message
   - type: VentCrittersRule
-    entries:
-    - id: MobSnail
-      prob: 0.02
-    - id: MobSnailSpeed
-      prob: 0.002
-    - id: MobSnailMoth
-      prob: 0.002
-    #- id: MobSnailInstantDeath # DeltaV - no
-      #prob: 0.00001 #  ~ 1:2000 snails
+    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
+      children:
+      - id: MobSnail
+        weight: 0.84
+      - id: MobSnailSpeed
+        weight: 0.08
+      - id: MobSnailMoth
+        weight: 0.08
+      #- id: MobSnailInstantDeath # DeltaV - no


### PR DESCRIPTION
## About the PR
since it used to be applied to every vent in the game, the probability of getting anything was very low.
changed it to use an entity table for spawns instead. now every spawn will have a guaranteed spawn picked instead of entity spawn entry gambling

on simulated 80p, this is a xeno rule, mouse rule and 2 clown spider rules
![03:30:45](https://github.com/user-attachments/assets/34643a68-1277-48a2-b56e-41074f24ab1f)

also fix precog :trollface: