### PR TITLE
Precog fixes

### DIFF
--- a/Content.Server/DeltaV/Abilities/Psionics/PrecognitionPowerSystem.cs
+++ b/Content.Server/DeltaV/Abilities/Psionics/PrecognitionPowerSystem.cs
@@ -45,6 +45,7 @@ public sealed class PrecognitionPowerSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
+        CachePrecognitionResults();
 
         SubscribeLocalEvent<PrecognitionPowerComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<PrecognitionPowerComponent, ComponentShutdown>(OnShutdown);
@@ -161,12 +162,12 @@ public sealed class PrecognitionPowerSystem : EntitySystem
     /// Gets the precognition result message corosponding to the passed event id.
     /// </summary>
     /// <returns>message string corosponding to the event id passed</returns>
-    private LocId GetResultMessage(EntProtoId eventId)
+    private LocId? GetResultMessage(EntProtoId eventId)
     {
         if (!Results.TryGetValue(eventId, out var result))
         {
             Log.Error($"Prototype {eventId} does not have an associated precognitionResult!");
-            return string.Empty;
+            return null;
         }
 
         return result.Message;


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixed precog results not being cached on init, resulting in result messages not being found. Empty messages are no longer sent when a result message is not found.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Precognition results not appearing when power is used.
