### PR TITLE
Maint Light Suffix

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -349,7 +349,7 @@
 
 - type: entity
   id: PoweredDimSmallLight
-  suffix: Dim
+  suffix: Dim, Maintenance, Red # DeltaV - Clarity for mappers
   parent: PoweredSmallLightEmpty
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
Just a quick change because the "maint" labeled ones were removed/replaced with these.

## Why / Balance
I want it to be clear t mappers they can use these in maints