### PR TITLE
Holopads Patch and Additions

### DIFF
--- a/Resources/Locale/en-US/deltav/holopad/holopad.ftl
+++ b/Resources/Locale/en-US/deltav/holopad/holopad.ftl
@@ -1,0 +1,32 @@
+# Command
+holopad-command-lo = Command - LO
+holopad-command-mysta = Command - Mysta
+holopad-command-cj = Command - CJ
+
+# Epistemics
+holopad-epistemics-anomaly = Epistemics - Anomaly
+holopad-epistemics-artifact = Epistemics - Artifact
+holopad-epistemics-robotics = Epistemics - Robotics
+holopad-epistemics-rnd = Epistemics - R&D
+holopad-epistemics-front = Epistemics - Front
+holopad-epistemics-breakroom = Epistemics - Breakroom
+holopad-epistemics-mantis = Epistemics - Mantis
+holopad-epistemics-oracle = Epistemics - Oracle
+
+# Logistics
+holopad-logistics-front = Logistics - Front
+holopad-logistics-cargo-bay = Logistics - Cargo Bay
+holodpad-logistics-mailroom = Logistics - Mailroom
+holodpad-logistics-mailfront = Logistics - Mail Front
+holopad-logistics-salvage-bay = Logistics - Salvage Bay
+holopad-logistics-breakroom  = Logistics - Breakroom
+holopad-logistics-ats = Logistics - ATS
+holopad-logistics-shuttle = Logistics - Shuttle
+
+# Justice
+holopad-justice-prosecutor = Justice - Prosecutor
+holopad-justice-attorney = Justice - Attorney
+holopad-justice-clerk = Justice - Clerk
+
+# Security
+holopad-security-corpsman = Security - Corpsman

--- a/Resources/Prototypes/DeltaV/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Machines/holopad.yml
@@ -36,7 +36,7 @@
 
 - type: entity
   parent: Holopad
-  id: HolopadCargoMail
+  id: HolopadCargoMailFront
   suffix: Mail Front
   components:
   - type: Label

--- a/Resources/Prototypes/DeltaV/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Structures/Machines/holopad.yml
@@ -1,0 +1,69 @@
+## Mapping prototypes
+#Command
+- type: entity
+  parent: Holopad
+  id: HolopadJusticeCJ
+  suffix: Chief Justice
+  components:
+  - type: Label
+    currentLabel: holopad-command-cj
+
+#Justice
+- type: entity
+  parent: Holopad
+  id: HolopadJusticeProsecutor
+  suffix: Prosecutor
+  components:
+  - type: Label
+    currentLabel: holopad-justice-prosecutor
+
+- type: entity
+  parent: Holopad
+  id: HolopadJusticeClerk
+  suffix: Clerk
+  components:
+  - type: Label
+    currentLabel: holopad-justice-clerk
+
+#Logistics
+- type: entity
+  parent: Holopad
+  id: HolopadCargoMail
+  suffix: Mailroom
+  components:
+  - type: Label
+    currentLabel: holodpad-logistics-mailroom
+
+- type: entity
+  parent: Holopad
+  id: HolopadCargoMail
+  suffix: Mail Front
+  components:
+  - type: Label
+    currentLabel: holodpad-logistics-mailfront
+
+#Epistemics
+- type: entity
+  parent: Holopad
+  id: HolopadEpistemicsMantis
+  suffix: Mantis
+  components:
+  - type: Label
+    currentLabel: holopad-epistemics-mantis
+
+- type: entity
+  parent: Holopad
+  id: HolopadEpistemicsOracle
+  suffix: Oracle
+  components:
+  - type: Label
+    currentLabel: holopad-epistemics-oracle
+
+#Security
+- type: entity
+  parent: Holopad
+  id: HolopadSecurityCorpsman
+  suffix: Corpsman
+  components:
+  - type: Label
+    currentLabel: holopad-security-corpsman

--- a/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/holopad.yml
@@ -318,10 +318,10 @@
 - type: entity
   parent: Holopad
   id: HolopadCommandQm
-  suffix: QM
+  suffix: LO # DeltaV - QM > LO
   components:
   - type: Label
-    currentLabel: holopad-command-qm
+    currentLabel: holopad-command-lo # DeltaV - QM > LO
 
 - type: entity
   parent: Holopad
@@ -334,10 +334,10 @@
 - type: entity
   parent: Holopad
   id: HolopadCommandRd
-  suffix: RD
+  suffix: Mysta # DeltaV - RD > Mysta
   components:
   - type: Label
-    currentLabel: holopad-command-rd
+    currentLabel: holopad-command-mysta # DeltaV - RD > Mysta
 
 - type: entity
   parent: Holopad
@@ -354,7 +354,7 @@
   suffix: Anomaly
   components:
   - type: Label
-    currentLabel: holopad-science-anomaly
+    currentLabel: holopad-epistemics-anomaly # DeltaV - Science > Epistemics
 
 - type: entity
   parent: Holopad
@@ -362,7 +362,7 @@
   suffix: Artifact
   components:
   - type: Label
-    currentLabel: holopad-science-artifact
+    currentLabel: holopad-epistemics-artifact # DeltaV - Science > Epistemics
 
 - type: entity
   parent: Holopad
@@ -370,7 +370,7 @@
   suffix: Robotics
   components:
   - type: Label
-    currentLabel: holopad-science-robotics
+    currentLabel: holopad-epistemics-robotics # DeltaV - Science > Epistemics
 
 - type: entity
   parent: Holopad
@@ -378,23 +378,23 @@
   suffix: R&D
   components:
   - type: Label
-    currentLabel: holopad-science-rnd
+    currentLabel: holopad-epistemics-rnd # DeltaV - Science > Epistemics
 
 - type: entity
   parent: Holopad
   id: HolopadScienceFront
-  suffix: Sci Front
+  suffix: Epi Front # DeltaV - Science > Epistemics
   components:
   - type: Label
-    currentLabel: holopad-science-front
+    currentLabel: holopad-epistemics-front # DeltaV - Science > Epistemics
 
 - type: entity
   parent: Holopad
   id: HolopadScienceBreakroom
-  suffix: Sci Breakroom
+  suffix: Epi Breakroom # DeltaV - Science > Epistemics
   components:
   - type: Label
-    currentLabel: holopad-science-breakroom
+    currentLabel: holopad-epistemics-breakroom # DeltaV - Science > Epistemics
 
 # Medical
 - type: entity
@@ -473,10 +473,10 @@
 - type: entity
   parent: Holopad
   id: HolopadCargoFront
-  suffix: Cargo Front
+  suffix: Logistics Front # DeltaV - Cargo > Logistics
   components:
   - type: Label
-    currentLabel: holopad-cargo-front
+    currentLabel: holopad-logistics-front # DeltaV - Cargo > Logistics
 
 - type: entity
   parent: Holopad
@@ -484,7 +484,7 @@
   suffix: Cargo Bay
   components:
   - type: Label
-    currentLabel: holopad-cargo-bay
+    currentLabel: holopad-logistics-cargo-bay # DeltaV - Cargo > Logistics
 
 - type: entity
   parent: Holopad
@@ -492,15 +492,15 @@
   suffix: Salvage Bay
   components:
   - type: Label
-    currentLabel: holopad-cargo-salvage-bay
+    currentLabel: holopad-logistics-salvage-bay # DeltaV - Cargo > Logistics
 
 - type: entity
   parent: Holopad
   id: HolopadCargoBreakroom
-  suffix: Cargo Breakroom
+  suffix: Logistics Breakroom
   components:
   - type: Label
-    currentLabel: holopad-cargo-breakroom
+    currentLabel: holopad-logistics-breakroom # DeltaV - Cargo > Logistics
 
 # Engineering
 - type: entity
@@ -635,10 +635,10 @@
 - type: entity
   parent: Holopad
   id: HolopadSecurityLawyer
-  suffix: Lawyer
+  suffix: Attorney # DeltaV - Lawyer > Attorney
   components:
   - type: Label
-    currentLabel: holopad-security-lawyer
+    currentLabel: holopad-justice-attorney # DeltaV - Lawyer > Attorney
 
 - type: entity
   parent: Holopad


### PR DESCRIPTION
## About the PR
Changes names of certain Holopads and adds new custom DeltaV holopads

## Why / Balance
(https://github.com/DeltaV-Station/Delta-v/issues/2531) Bleh

## Technical details
Yaml and FTL work, easy peasy

- Changes Cargo to Logistics
- Changes Science to Epistemics
- Adds Justice (Prosecutor, Attorney(Renamed Lawyer), Clerk, CJ)
- Adds Mailroom and Mail Front Holopad
- Adds Mantis Holopad
- Adds Oracle Holopad
- Adds Corpsman Holopad

## Media
![image](https://github.com/user-attachments/assets/33df8230-567d-4dc8-869f-e3e0ad5df1e6)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
🆑 
- tweak: Holopad names have been fixed, and new DeltaV custom holodpads have been added.