### PR TITLE
Map Edits: Tortuga

### DIFF
--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -45,8 +45,8 @@
             HeadOfSecurity: [ 1, 1 ]
             Prisoner: [ 2, 3 ]
             PrisonGuard: [ 1, 1 ]
-            SecurityOfficer: [ 6, 9 ]
-            SecurityCadet: [ 1, 1 ]
+            SecurityOfficer: [ 6, 8 ]
+            SecurityCadet: [ 2, 4 ]
             Warden: [ 1, 1 ]
           #service
             Bartender: [ 2, 2 ]
@@ -59,7 +59,7 @@
             Mime: [ 1, 2 ]
             Musician: [ 2, 3 ]
             Reporter: [ 2, 2 ]
-            ServiceWorker: [ 3, 6 ]
+            ServiceWorker: [ 1, 3 ]
           #science
             Chaplain: [ 1, 1 ]
             Borg: [ 2, 3 ]
@@ -69,7 +69,8 @@
             Roboticist: [ 1, 2 ]
             Scientist: [ 4, 5 ]
           #supply
-            CargoTechnician: [ 2, 4 ]
+            CargoAssistant: [ 1, 2 ]
+            CargoTechnician: [ 1, 3 ]
             Courier: [ 2, 2 ]
-            SalvageSpecialist: [ 3, 4 ]
+            SalvageSpecialist: [ 2, 4 ]
             Quartermaster: [ 1, 1 ]


### PR DESCRIPTION
## About the PR
Tortuga
- Permanent placement for mining shuttle
- Removes some remaining tiny fans
- Adds a Nitrogen Lounge
- Expands perma
- Adds atmos network monitor and sensors
- Adds holopads
- Morgue maints airlock
- Adds superweapon safe
- Rng solars 
- Cargo 🍑istant
- Removes duplicate chapel beacon
- Adjusts prototype a bit

## Why / Balance
🐢🍑

## Technical details
n/a

## Media
![image](https://github.com/user-attachments/assets/b2a7ebd9-57b0-476a-a9d3-40a7cd5811a8)
![image](https://github.com/user-attachments/assets/0e579e3a-cb53-4b6f-8076-29cc12e40702)

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- tweak: Tortuga is now nitrogen friendly and perma got some leg room.
