### PR TITLE
Diona immune to FTL Knockdown

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
+using Content.Server._NF.Shuttles.Components; // Frontier: FTL knockdown immunity
 using Content.Server.Shuttles.Components;
 using Content.Server.Shuttles.Events;
 using Content.Server.Station.Events;
@@ -630,6 +631,9 @@ public sealed partial class ShuttleSystem
             {
                 if (!_statusQuery.TryGetComponent(child, out var status))
                     continue;
+
+                if (HasComp<FTLKnockdownImmuneComponent>(child)) // Frontier: FTL knockdown immunity
+                    continue; // Frontier: FTL knockdown immunity
 
                 _stuns.TryParalyze(child, _hyperspaceKnockdownTime, true, status);
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.FasterThanLight.cs
@@ -632,10 +632,8 @@ public sealed partial class ShuttleSystem
                 if (!_statusQuery.TryGetComponent(child, out var status))
                     continue;
 
-                if (HasComp<FTLKnockdownImmuneComponent>(child)) // Frontier: FTL knockdown immunity
-                    continue; // Frontier: FTL knockdown immunity
-
-                _stuns.TryParalyze(child, _hyperspaceKnockdownTime, true, status);
+                if (!HasComp<FTLKnockdownImmuneComponent>(child)) // Frontier: FTL knockdown immunity
+                    _stuns.TryParalyze(child, _hyperspaceKnockdownTime, true, status);
 
                 // If the guy we knocked down is on a spaced tile, throw them too
                 if (grid != null)

--- a/Content.Server/_NF/Shuttles/Components/FTLKnockdownImmuneComponent.cs
+++ b/Content.Server/_NF/Shuttles/Components/FTLKnockdownImmuneComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Server._NF.Shuttles.Components;
+
+/// <summary>
+///     Denotes an entity as being immune from knockdown on FTL
+/// </summary>
+[RegisterComponent]
+public sealed partial class FTLKnockdownImmuneComponent : Component
+{
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -117,6 +117,7 @@
   - type: MovementSpeedModifier # DeltaV
     baseWalkSpeed: 1.0
     baseSprintSpeed: 3.0
+  - type: FTLKnockdownImmune # Frontier
 
 - type: entity
   parent: BaseSpeciesDummy


### PR DESCRIPTION
## About the PR
Give diona a stronger grip when getting hit by FTL jumps, allowing them to just stand normally without the need to sit.

## Why / Balance
Diona already slow, might as well give them an extra edge.

## Technical details
Added a new comp from Frontier that make entity skip the FTL knockdown event.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- add: Diona are now immune to the force of an FTL jump.
