### PR TITLE
Cold res for blood reds

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -507,6 +507,7 @@
         Heat: 0.5
         Radiation: 0.5
         Caustic: 0.5
+        Cold: 0.8 # DeltaV - Cold res
     staminaDamageCoefficient: 0.2 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.9
@@ -575,6 +576,7 @@
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5
+        Cold: 0.4 # DeltaV - Cold res
     staminaDamageCoefficient: 0.3 # DeltaV
   - type: Item
     size: Huge
@@ -610,6 +612,7 @@
         Heat: 0.5
         Radiation: 0.25
         Caustic: 0.4
+        Cold: 0.8 # DeltaV - Cold res
     staminaDamageCoefficient: 0.2 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 1.0
@@ -643,6 +646,7 @@
         Heat: 0.2
         Radiation: 0.2
         Caustic: 0.2
+        Cold: 0.6 # DeltaV - Cold res
     staminaDamageCoefficient: 0.1 # DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.9


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds cold res to bloodreds in order to slightly tune back ICEE effectiveness
Standard blood red and commander get 20% res
Juggersuit gets 40% res
Elite suit gets 60% res
## Why / Balance
Spoke with lyndo about the ICEE being slightly overtuned. the cold res is low as the ICEE is a T3 and if epi gets that before nukies show up its a skill issue. 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: In response to Nanotrasen's new cryogenic firearms, the syndicate has updated their armor to resist them better