### PR TITLE
use job whitelist for warden not blanket whitelist

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -10,12 +10,12 @@
     - !type:RoleTimeRequirement # DeltaV - JobDetective time requirement. Give them an understanding of basic forensics.
       role: JobDetective
       time: 21600 # DeltaV - 6 hours
-    - !type:WhitelistRequirement # DeltaV - Whitelist requirement
   startingGear: WardenGear
   icon: "JobIconWarden"
   requireAdminNotify: true
   supervisors: job-supervisors-hos
   canBeAntag: false
+  whitelisted: true # DeltaV
   access:
   - Security
   #- Brig # Delta V: Removed


### PR DESCRIPTION
## About the PR
so its like every other important job
oversight in the warden pr

## Why / Balance
lets admins whitelist people for playing warden specifically instead of having to blanket whitelist every job

people blanket whitelisted can automatically still play it, no negative changes

**Changelog**
:cl:
DELTAVADMIN:
- tweak: Changed warden from blanket whitelist to job whitelist.
