### PR TITLE
Fix NoCargoOrderArbitrage (Seeds evil)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -174,7 +174,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockSeedsFilled
-  cost: 3600
+  cost: 3800 # DeltaV price needs to be higher because of more seeds.
   category: cargoproduct-category-name-hydroponics
   group: market
 


### PR DESCRIPTION
## Technical details
<!-- Summary of code changes for easier review. -->

#2232 broke the price because it added new seeds. Very annoying issue that has come up before... Not sure if this is the best fix but I think its OK. It would be weird to make those specific seeds cost less.