### PR TITLE
Add back the HOS headset to warden's locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -26,6 +26,7 @@
       - id: LunchboxSecurityFilledRandom
         prob: 0.3
       - id: ClothingOuterVestPlateCarrierAdv
+      - id: ClothingHeadsetAltSecurity # Restored from upstream merge.
       # End DeltaV additions
       - id: ClothingNeckShockCollar
         amount: 2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -61,6 +61,7 @@
       - id: LunchboxSecurityFilledRandom
         prob: 0.3
       - id: ClothingOuterVestPlateCarrierAdv
+      - id: ClothingHeadsetAltSecurity # Restored from upstream merge.
       # End DeltaV additions
       - id: ClothingNeckShockCollar
         amount: 2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
[WYCI suggestion](https://discord.com/channels/968983104247185448/1323787853087641741/1323787853087641741).
Got told to re-add it.
![image](https://github.com/user-attachments/assets/d3e9da16-affe-42b2-8822-17e330f249cb)
## Technical details
2 line YAML change.

## Media
![image](https://github.com/user-attachments/assets/6daf1afe-3987-4937-812a-1888dfb9c34e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wardens got their HOS headset back into their locker.