### PR TITLE
stop carrying if you get downed

### DIFF
--- a/Content.Shared/_DV/Carrying/CarryingSystem.cs
+++ b/Content.Shared/_DV/Carrying/CarryingSystem.cs
@@ -57,6 +57,7 @@ public sealed class CarryingSystem : EntitySystem
         SubscribeLocalEvent<CarryingComponent, BeforeThrowEvent>(OnThrow);
         SubscribeLocalEvent<CarryingComponent, EntParentChangedMessage>(OnParentChanged);
         SubscribeLocalEvent<CarryingComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<CarryingComponent, DownedEvent>(OnDowned);
         SubscribeLocalEvent<BeingCarriedComponent, InteractionAttemptEvent>(OnInteractionAttempt);
         SubscribeLocalEvent<BeingCarriedComponent, UpdateCanMoveEvent>(OnMoveAttempt);
         SubscribeLocalEvent<BeingCarriedComponent, StandAttemptEvent>(OnStandAttempt);
@@ -154,6 +155,11 @@ public sealed class CarryingSystem : EntitySystem
     }
 
     private void OnMobStateChanged(Entity<CarryingComponent> ent, ref MobStateChangedEvent args)
+    {
+        DropCarried(ent, ent.Comp.Carried);
+    }
+
+    private void OnDowned(Entity<CarryingComponent> ent, ref DownedEvent args)
     {
         DropCarried(ent, ent.Comp.Carried);
     }


### PR DESCRIPTION
## About the PR
if you get downed without going crit/dying it wouldnt make you drop the carried mob
with shitmed you can just press R and suddenly 2 sideways people crawling around all sneaky like

## Why / Balance
:bug:

## Technical details
uses DownedEvent yep

## Media
before pressing R
![04:24:20](https://github.com/user-attachments/assets/51fca72d-a670-4221-9a18-f26212700298)
after pressing R
![04:24:25](https://github.com/user-attachments/assets/538a4697-9935-4be4-b803-ef65f8e26ceb)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
no shitmed no cl