### PR TITLE
Moved HOPs access configurator to the administrative assistant starting gear

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -118,7 +118,7 @@
     children:
     - !type:NestedSelector # DeltaV
       tableId: LockerFillHeadOfPersonnelDeltaV
-    - id: AccessConfigurator
+    #- id: AccessConfigurator # DeltaV - They don't really need it, moved to the administrative assistant starting gear.
     - id: BoxEncryptionKeyPassenger
     - id: BoxEncryptionKeyService
     - id: BoxHeadset

--- a/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
@@ -27,6 +27,7 @@
     belt: BoxFolderClipboard
     id: AdminAssistantPDA
     pocket1: RubberStampAdminAssistant
+    pocket2: AccessConfigurator # To assist with secure closets access configurations / airlock configs should a head need it.
   storage:
     back:
     - Flash


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removed the access configurator from the HOP's locker and gave one to the admin assistant starting gear.

## Why / Balance
HOP being a service head of staff doesn't really use the access configurator, on the other hand, the administrative assistant would make more sense to be able to assist with changing accesses on doors or lockers should it be needed.

## Technical details
2 YAML line change.
Touches upstream `heads.yml`.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
No CL as the administrative assistant isn't public to the players yet.