### PR TITLE
feat: cleanbots can now go beneath tables

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -260,7 +260,19 @@
   name: cleanbot
   description: The creep of automation now threatening space janitors.
   components:
+  - type: Fixtures # DeltaV - cleanbots can go beneath tables
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.35
+        density: 50
+        mask:
+        - SmallMobMask
+        layer:
+        - SmallMobLayer
   - type: Sprite
+    drawdepth: SmallMobs # DeltaV - cleanbots can go beneath tables
     sprite: Mobs/Silicon/Bots/cleanbot.rsi
     state: cleanbot
   - type: Construction


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Cleanbots are now able to move beneath tables.

## Why / Balance
They are presumably small enough to fit and are less likely to get stuck this way. Requested [in #wyci-suggestions](https://discord.com/channels/968983104247185448/1152625672020316200/1319039757271175281).

## Technical details
Replaced Mob fixture mask and layer with SmallMob equivalent and set drawdepth of Sprite to SmallMobs.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/b5d7dca2-eb27-4f71-8772-5cdaf5cb3e1c


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: DisposableCrewmember42
- tweak: Cleanbots can now move beneath tables
