### PR TITLE
enable cargo and admin assistants

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -8,7 +8,7 @@
   - Quartermaster
   - SalvageSpecialist
   - Courier # DeltaV - Courier, see Resources/Prototypes/_DV/Roles/Jobs/Cargo/courier.yml
-  #- CargoAssistant # DeltaV - Uncomment once ready to deploy.
+  - CargoAssistant # DeltaV
 
 - type: department
   id: Civilian
@@ -80,7 +80,7 @@
   - ERTEngineer
   - DeathSquad
   - StationAi # DeltaV - added for playtime trackers
-  #- AdministrativeAssistant # Delta V - Uncomment once ready to deploy. Administrative Assistant, see Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
+  - AdministrativeAssistant # Delta V - Administrative Assistant, see Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
   primary: false
   weight: 100
 


### PR DESCRIPTION
## About the PR
to be merged when all maps have it

**Changelog**
:cl: Radezolid, noctyrn
- add: Added the Cargo Assistant and Administrative Assistant to support logistics and command respectively.
