### PR TITLE
fix precognition spamming late round events

### DIFF
--- a/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/BasicStationEventSchedulerSystem.cs
@@ -41,7 +41,7 @@ namespace Content.Server.StationEvents
                 && _event.TryGenerateRandomEvent(component.ScheduledGameRules, TimeSpan.FromSeconds(component.TimeUntilNextEvent)) is {} firstEvent)
             {
                 _chatManager.SendAdminAlert(Loc.GetString("station-event-system-run-event-delayed", ("eventName", firstEvent), ("seconds", (int)component.TimeUntilNextEvent)));
-                _next.UpdateNextEvent(nextEventComponent, firstEvent, TimeSpan.FromSeconds(component.TimeUntilNextEvent));
+                _next.UpdateNextEvent(nextEventComponent, firstEvent, GameTicker.RoundDuration() + TimeSpan.FromSeconds(component.TimeUntilNextEvent));
             }
             // End DeltaV Additions
         }
@@ -76,7 +76,7 @@ namespace Content.Server.StationEvents
                 if (TryComp<NextEventComponent>(uid, out var nextEventComponent)) // If there is a nextEventComponent use the stashed event instead of running it directly.
                 {
                     ResetTimer(eventScheduler); // Time needs to be reset ahead of time since we need to chose events based on the next time it will run.
-                    var nextEventTime = _timing.CurTime + TimeSpan.FromSeconds(eventScheduler.TimeUntilNextEvent);
+                    var nextEventTime = GameTicker.RoundDuration() + TimeSpan.FromSeconds(eventScheduler.TimeUntilNextEvent);
                     if (_event.TryGenerateRandomEvent(eventScheduler.ScheduledGameRules, nextEventTime) is not {} generatedEvent)
                         continue;
 

--- a/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
+++ b/Content.Server/StationEvents/RampingStationEventSchedulerSystem.cs
@@ -48,7 +48,7 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
             && _event.TryGenerateRandomEvent(component.ScheduledGameRules, TimeSpan.FromSeconds(component.TimeUntilNextEvent)) is {} firstEvent)
         {
             _chatManager.SendAdminAlert(Loc.GetString("station-event-system-run-event-delayed", ("eventName", firstEvent), ("seconds", (int)component.TimeUntilNextEvent)));
-            _next.UpdateNextEvent(nextEventComponent, firstEvent, TimeSpan.FromSeconds(component.TimeUntilNextEvent));
+            _next.UpdateNextEvent(nextEventComponent, firstEvent, GameTicker.RoundDuration() + TimeSpan.FromSeconds(component.TimeUntilNextEvent));
         }
         // End DeltaV Additions: init NextEventComp
     }
@@ -76,7 +76,7 @@ public sealed class RampingStationEventSchedulerSystem : GameRuleSystem<RampingS
             if (TryComp<NextEventComponent>(uid, out var nextEventComponent)) // If there is a nextEventComponent use the stashed event instead of running it directly.
             {
                 PickNextEventTime(uid, scheduler);
-                var nextEventTime = _timing.CurTime + TimeSpan.FromSeconds(scheduler.TimeUntilNextEvent);
+                var nextEventTime = GameTicker.RoundDuration() + TimeSpan.FromSeconds(scheduler.TimeUntilNextEvent);
                 if (_event.TryGenerateRandomEvent(scheduler.ScheduledGameRules, nextEventTime) is not {} generatedEvent)
                     continue;
 


### PR DESCRIPTION
## About the PR
it was using server time instead of round time so after a round it would think that its rolling events for 2+ hours in and spam loneops etc roundstart

## Why / Balance
fixes #2590

## Technical details
use RoundDuration instead of CurTime, simple

## Media
no

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed loneops, ninja, etc spawning way too early in the round.
