### PR TITLE
no using headsets when cuffed

### DIFF
--- a/Resources/Locale/en-US/_DV/radio/headset.ftl
+++ b/Resources/Locale/en-US/_DV/radio/headset.ftl
@@ -1,0 +1,1 @@
+headset-cant-reach = You can't reach your headset!


### PR DESCRIPTION
## About the PR
you cant use headsets if you are cuffed or if someone (admins rn) cuts your hands off

the reasoning being that if you have to push to talk, you need usable hands to push it

doesnt affect generic or syndie radio implants making them much more useful, or listening for messages.

## Why / Balance
good for sec and valids alike:
- no more pesky prisoners calling for lawyers and claiming they "have rights"
- you can actually kidnap someone now without spending 4 tc or something on a thing solely to force people to rp
  if you cuff someone now they have to actually do what you say instead of :c john smith tator help

## Technical details
trolls the headset wearer speak event

## Media
funny popup when trying to use headset while cuffed
![10:41:32](https://github.com/user-attachments/assets/f74d4049-10be-4a40-b225-d9f036a0491d)

first 2 radio mesages uncuffed, then cuffed and failed headset + succeeded with implant
![10:42:46](https://github.com/user-attachments/assets/d838bebf-f106-4c88-8531-29b2e7401e6e)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: You can no longer use headsets when cuffed, maints kidnappers rejoice! (This is a test of this feature, please leave feedback on discord.gg/deltav)
