### PR TITLE
Add a bionic voice mask implanter to Nukeop inventory

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -70,7 +70,7 @@
     - WeaponPistolViper
     - PinpointerSyndicateNuclear
     - DeathAcidifierImplanter
-    - BionicVoiceMaskImplanter
+    - BionicVoiceMaskImplanter # Delta-V - Voice masking implant
 
 #Nuclear Operative Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -28,9 +28,9 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 108000 # DeltaV - 30 hours
-  - !type:RoleTimeRequirement #Delta V - they should be able to make basic chems 
+  - !type:RoleTimeRequirement #Delta V - they should be able to make basic chems
     role: JobChemist
-    time: 14400 # DeltaV- 4 hours 
+    time: 14400 # DeltaV- 4 hours
 
 - type: antag
   id: NukeopsCommander
@@ -70,6 +70,7 @@
     - WeaponPistolViper
     - PinpointerSyndicateNuclear
     - DeathAcidifierImplanter
+    - BionicVoiceMaskImplanter
 
 #Nuclear Operative Gear
 - type: startingGear

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
@@ -1,5 +1,13 @@
 - type: entity
   parent: BaseImplantOnlyImplanterSyndi
+  id: BionicVoiceMaskImplanter
+  suffix: bionic voice mask
+  components:
+  - type: Implanter
+    implant: BionicVoiceMaskImplant
+
+- type: entity
+  parent: BionicVoiceMaskImplanter
   id: BionicSyrinxImplanter
   suffix: bionic syrinx
   components:

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
@@ -1,6 +1,21 @@
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
   parent: BaseSubdermalImplant
+  id: BionicVoiceMaskImplant
+  name: bionic voice mask implant
+  description: This implant lets its user adjust their voice to whoever they can think of.
+  components:
+  - type: SubdermalImplant
+    implantAction: ActionChangeVoiceMask
+  - type: VoiceMask
+  - type: UserInterface
+    interfaces:
+      enum.VoiceMaskUIKey.Key:
+        type: VoiceMaskBoundUserInterface
+
+- type: entity
+  categories: [ HideSpawnMenu, Spawner ]
+  parent: BionicVoiceMaskImplant
   id: BionicSyrinxImplant
   name: bionic syrinx implant
   description: This implant lets a harpy adjust their voice to whoever they can think of.
@@ -10,11 +25,6 @@
     whitelist:
       components:
       - HarpySinger # Ensure this is only for harpies and if this component gets renamed, CHANGE IT TO THE NEW VALUE!!!
-  - type: VoiceMask
-  - type: UserInterface
-    interfaces:
-      enum.VoiceMaskUIKey.Key:
-        type: VoiceMaskBoundUserInterface
 
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]


### PR DESCRIPTION
## About the PR

A new _bionic voice mask implant_ is given to Nukies on spawn. This voice mask implant works the exact same as the _bionic syrinx implant_ for Syndicate Harpies, except it is (for now) exclusive to Nukies.

Oh, and I didn't notice it when I committed, but my editor removed two trailing spaces in `nukeops.yml`. Sorry.

## Why / Balance

This idea was brought up after discussion in the Discord about players using the chat-based nature of the the game to acquire personal details of Nukies (i.e. name).

Nukies have a way to hide their identity or presence in the round by default now. This could affect how rounds play out if Nukies decide to use someone else's name for a stealth op, but it could be quickly reported as suspicious if done incorrectly.

## Technical details

`BionicVoiceMaskImplant` contains a `SubdermalImplant` component linked to `ActionChangeVoiceMask`. `BionicSyrinxImplant` inherits from `BionicVoiceMaskImplant`, rather than `BaseSubdermalImplant`.

Another implanter was added to accommodate. `BionicSyrinxImplanter` inherits from that.

## Media

This could probably use a new icon, but I am not much of an artist:

![The action icon for the bionic voice mask implant](https://github.com/user-attachments/assets/1a720b5a-6876-4612-9c06-60c7d145079f)

![Name getting changed to Bingus through this menu](https://github.com/user-attachments/assets/f27d395e-65bb-4f5b-9222-9e556a20262b)

## Requirements

- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

Extremely minor: `BionicSyrinxImplant` is no longer directly based on `BaseSubdermalImplant` but instead inherits from `BionicVoiceMaskImplant`.

**Changelog**

:cl:
- add: Nukies get a bionic voice mask implant on spawn that allows them to change their chat name and accent.

