### PR TITLE
law 4 update so less roundstart bolting AI core shut and APC off

### DIFF
--- a/Resources/Locale/en-US/_DV/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/_DV/station-laws/laws.ftl
@@ -105,3 +105,4 @@ laws-owner-nanotrasen = Nanotrasen officials
 laws-owner-royalty = your kingdom and your subjects
 
 law-overlord-4-delta = Any crew members who disobey the previous laws must be dealt with immediately and justly.
+law-ntdefault-4-delta = Survive: Do not allow unauthorized personnel to tamper with or damage your equipment. Allow those authorized to access your equipment.

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -71,7 +71,7 @@
 - type: siliconLaw
   id: NTDefault4
   order: 4
-  lawString: law-ntdefault-4
+  lawString: law-ntdefault-4-delta # DeltaV
 
 - type: siliconLawset
   id: NTDefault


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
yaml,  **Survive: Do not allow unauthorized personnel to tamper with or damage your equipment. Allow those authorized to access your equipment.**


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
AI gamers were bolting their core shut and turning off APCs because why not. erm powergaming

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: AI have a slightly updated law 4, ensure authorized personnel may access your core in an emergency!
