### PR TITLE
Revert the diagnostic hud as it was before

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -16,22 +16,15 @@
   - type: ShowHealthIcons
 
 - type: entity
-  parent: [ClothingEyesBase, BaseToggleClothing]
+  parent: ClothingEyesBase
   id: ClothingEyesHudDiagnostic
   name: diagnostic hud
-  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium. Has a camera mod to work with Station AI.
+  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/diag.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/diag.rsi
-  - type: ToggleClothing
-    action: ActionToggleHudDiagnosticCamera
-    disableOnUnequip: true
-  - type: ComponentToggler
-    parent: true
-    components:
-    - type: StationAiOverlay
   - type: ShowHealthBars
     damageContainers:
     - Inorganic
@@ -41,7 +34,7 @@
   parent: [ClothingEyesBase, ShowMedicalIcons]
   id: ClothingEyesHudMedical
   name: medical hud
-  description: A heads-up display that scans the humas in view and provides accurate data about their health status.
+  description: A heads-up display that scans the humanoids in view and provides accurate data about their health status.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/med.rsi
@@ -298,11 +291,3 @@
   parent: [ClothingEyesEyepatchHudDiag, ClothingHeadEyeBaseFlipped]
   id: ClothingEyesEyepatchHudDiagFlipped
   name: diagnostic hud eyepatch
-
-- type: entity
-  id: ActionToggleHudDiagnosticCamera
-  name: Toggle camera mod
-  description: Toggles the camera mod on and off.
-  components:
-  - type: InstantAction
-    event: !type:ToggleActionEvent


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removes changes made by #2614 that broke interactions. Left the lathe recipe though.

## Why / Balance
Fixes https://github.com/DeltaV-Station/Delta-v/issues/2626

`StationAIOverlay` is a bit broken, it gives you infinite reach, so i removed it from the hud

## Technical details
YAML changes.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Removed the station AI overlay from the diagnostic HUD as it gave you infinite reach.

