### PR TITLE
Fix DeltaV weaponry gun safes being AA

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafePistolUniversal
   name: mk32 safe
   components:
@@ -11,7 +11,7 @@
       amount: 4
 
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeSniperGrand
   name: mark 1 rifle safe
   components:
@@ -23,7 +23,7 @@
       amount: 4
 
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeVulcanRifle
   name: vulcan safe
   components:
@@ -33,9 +33,9 @@
       amount: 2
     - id: MagazineLightRifle
       amount: 4
-      
+
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeAdjutantShotgun
   name: adjutant safe
   components:
@@ -45,9 +45,9 @@
       amount: 2
     - id: MagazineShotgun
       amount: 4
-      
+
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeEnergyGun
   name: energy gun safe
   components:
@@ -55,9 +55,9 @@
     contents:
     - id: WeaponEnergyGun
       amount: 3
-      
+
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeEnergyGunMini
   name: miniature energy gun safe
   components:
@@ -67,7 +67,7 @@
       amount: 3
 
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeM90Rifle
   name: M-90 rifle safe
   components:
@@ -79,7 +79,7 @@
       amount: 4
 
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeRocketLauncher
   name: RPG safe
   components:
@@ -90,11 +90,10 @@
       prob: 0.2
 
 - type: entity
-  parent: GunSafe
+  parent: GunSafeBaseSecure
   id: GunSafeBeamDevastator
   name: Devastator safe
   components:
   - type: StorageFill
     contents:
     - id: WeaponBeamDevastator
- 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Modified the parenting to make it armory locked + fixed whitespaces.

## Why / Balance
AA gun safe = bad.

## Technical details
All the DeltaV security weapon gun safes now parent from `GunSafeBaseSecure`

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Delta-V custom weapons gun safes being AA.
