### PR TITLE
fix: allow AI to hear speech in holopad calls

### DIFF
--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -676,7 +676,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
         var callOptions = new TelephoneCallOptions()
         {
             ForceConnect = true,
-            MuteReceiver = true
+            MuteReceiver = false // DeltaV - Set to false, allowing AI to hear speech when connecting to a holopad.
         };
 
         _telephoneSystem.CallTelephone(source, receiver, user, callOptions);

--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -675,7 +675,8 @@ public sealed class HolopadSystem : SharedHolopadSystem
 
         var callOptions = new TelephoneCallOptions()
         {
-            ForceConnect = true
+            ForceConnect = true,
+            MuteReceiver = false // DeltaV - Set to false, allowing AI to hear speech when connecting to a holopad.
         };
 
         _telephoneSystem.CallTelephone(source, receiver, user, callOptions);

--- a/Content.Server/Holopad/HolopadSystem.cs
+++ b/Content.Server/Holopad/HolopadSystem.cs
@@ -675,8 +675,7 @@ public sealed class HolopadSystem : SharedHolopadSystem
 
         var callOptions = new TelephoneCallOptions()
         {
-            ForceConnect = true,
-            MuteReceiver = false // DeltaV - Set to false, allowing AI to hear speech when connecting to a holopad.
+            ForceConnect = true
         };
 
         _telephoneSystem.CallTelephone(source, receiver, user, callOptions);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Allowed the AI to hear speech during regular calls. I'll PR this upstream as well. Closes #2602.

## Why / Balance
One-way transmissions for regular calls seemed unintentional.

## Technical details
Set MuteReceiver to false in TelephoneCallOptions for AI projection.

## Media



https://github.com/user-attachments/assets/ab0d9693-44de-440d-b1f0-0ba881d0b08c




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: DisposableCrewmember42
- fix: The AI can now hear you during holopad calls.