### PR TITLE
Added binary key to the LPO

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Ears/headsets.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Ears/headsets.yml
@@ -34,6 +34,7 @@
       key_slots:
       - EncryptionKeySyndie
       - EncryptionKeyStationMaster
+      - EncryptionKeyBinarySyndicate
   - type: Sprite
     sprite: _DV/Clothing/Ears/Headsets/syndicate_listening.rsi
   - type: Clothing


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
They need it to know what the AI is doing + falsify orders.

## Technical details
1 YAML line change

## Media
![image](https://github.com/user-attachments/assets/4eb0291d-d6d7-4359-900a-b6dccf10b197)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Now listening post operatives will spawn with a binary key in their headset.
