### PR TITLE
Nukie Steamroll Preventative

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -135,7 +135,7 @@
   discountDownTo:
     Telecrystal: 12 # DeltaV - was 4
   cost:
-    Telecrystal: 18 # DeltaV - Was 8
+    Telecrystal: 16 # DeltaV - Was 8
   categories:
   - UplinkWeaponry
   conditions:
@@ -196,7 +196,7 @@
   discountDownTo:
     Telecrystal: 35 # DeltaV - Was 20
   cost:
-    Telecrystal: 45 # DeltaV - Was 25
+    Telecrystal: 40 # DeltaV - Was 25
   categories:
   - UplinkWeaponry
 
@@ -1624,9 +1624,9 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 12
   cost:
-    Telecrystal: 30
+    Telecrystal: 20
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -133,9 +133,9 @@
   productEntity: EnergyShield
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 5 # DeltaV - was 4
+    Telecrystal: 12 # DeltaV - was 4
   cost:
-    Telecrystal: 10 # DeltaV - Was 8
+    Telecrystal: 18 # DeltaV - Was 8
   categories:
   - UplinkWeaponry
   conditions:
@@ -194,9 +194,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 20
+    Telecrystal: 40
   cost:
-    Telecrystal: 25
+    Telecrystal: 60
   categories:
   - UplinkWeaponry
 
@@ -1624,9 +1624,9 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 20
   cost:
-    Telecrystal: 12
+    Telecrystal: 30
   categories:
   - UplinkWearables
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -194,9 +194,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 38
+    Telecrystal: 35 # DeltaV - Was 20
   cost:
-    Telecrystal: 50
+    Telecrystal: 45 # DeltaV - Was 25
   categories:
   - UplinkWeaponry
 
@@ -208,9 +208,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledLMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 24
+    Telecrystal: 20 # DeltaV - Was 8
   cost:
-    Telecrystal: 30
+    Telecrystal: 24 # DeltaV - Was 12
   categories:
   - UplinkWeaponry
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -194,9 +194,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledGrenadeLauncher
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 40
+    Telecrystal: 38
   cost:
-    Telecrystal: 60
+    Telecrystal: 50
   categories:
   - UplinkWeaponry
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

right now, the nukie meta heavily favors two builds; juggsuit with eshield & esword, and juggsuit while chinalaking all of security at once. all nukies going juggsuit is also criminal. crew gets steamrolled more or less every single time nukies go for any of these. there was even a loneop i witnessed with both the jugg and chinalake who killed all of sec within like 30 seconds of boarding edge. come on

this PR changes the prices as follows:

ESHIELD
10 --> 18
its just an insane item right now. rather than nerf it, i think it should just cost more.

CHINA-LAKE
25 --> 45
feels like the chinalake is far more dangerous than the L6, similar in power with the borg minus the sustain. with surgery changes now, this is going to be even worse; people are going to be losing limbs and shit. it does the job of like 7 other items by spacing everything, breaking walls, killing everyone, etc.

JUGGSUIT
12 --> 24
say what you will about it slowing you, you are a fucking monster in this thing, it should NOT cost the same as the elite suit. i don't want it nerfed, just more expensive. nukies can afford it! just ideally less of it.

NOTE: I hereby release all changes made in this PR under MIT license.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Rebalanced the prices of the eshield, china-lake, and juggernaut suit.
