### PR TITLE
add AI defense turret + let AI unlock buttons

### DIFF
--- a/Content.Shared/Lock/LockSystem.cs
+++ b/Content.Shared/Lock/LockSystem.cs
@@ -1,10 +1,10 @@
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Construction.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
-using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
@@ -26,6 +26,7 @@ namespace Content.Shared.Lock;
 public sealed class LockSystem : EntitySystem
 {
     [Dependency] private readonly AccessReaderSystem _accessReader = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
     [Dependency] private readonly ActivatableUISystem _activatableUI = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearanceSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
@@ -246,7 +247,7 @@ public sealed class LockSystem : EntitySystem
     /// </summary>
     public bool CanToggleLock(EntityUid uid, EntityUid user, bool quiet = true)
     {
-        if (!HasComp<HandsComponent>(user))
+        if (!_actionBlocker.CanComplexInteract(user))
             return false;
 
         var ev = new LockToggleAttemptEvent(user, quiet);

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/turrets.yml
@@ -3,14 +3,13 @@
   parent: WeaponTurretAllHostile
   id: WeaponTurretAI
   name: AI defense turret
-  component: A ballistic turret that retracts into the floor. Deployable by the station AI to defend its core against urgent threats.
+  description: A ballistic turret that retracts into the floor. Deployable by the station AI to defend its core against urgent threats.
   components:
   - type: Fixtures
     fixtures:
       fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.45"
+        shape: !type:PhysShapeCircle
+          radius: 0.45
         density: 60
         mask:
         - SmallMobMask # same as mouse, lets it go under doors but not phase through walls

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/turrets.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/turrets.yml
@@ -1,0 +1,18 @@
+# Shoots anything and lets doors close over it, letting it be used in AI cores "under" blast doors.
+- type: entity
+  parent: WeaponTurretAllHostile
+  id: WeaponTurretAI
+  name: AI defense turret
+  component: A ballistic turret that retracts into the floor. Deployable by the station AI to defend its core against urgent threats.
+  components:
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.45,-0.45,0.45,0.45"
+        density: 60
+        mask:
+        - SmallMobMask # same as mouse, lets it go under doors but not phase through walls
+        layer:
+        - SmallMobLayer


### PR DESCRIPTION
## About the PR
- add AI defense turrets for mapping, they wont block blast doors from closing
  its hitbox is also a circle now so you cant make it shoot by running up to the blast door at the right angle
- let AI unlock the turret button in their core

## Why / Balance
regular turret blocks the blast door from closing

## Technical details
contains early merge of fix that lets AI unlock the turret button for their core.

## Media
no troll
![09:05:47](https://github.com/user-attachments/assets/b7f78229-afc9-465d-9b47-edf5830a7900)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: AI cores will soon have defense turrets that the AI can deploy to shoot intruders.