### PR TITLE
Map Edits: Arena/Hive/Tortuga

### DIFF
--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -9852,7 +9852,7 @@ entities:
             4: 128
           3,-9:
             0: 65488
-            5: 32
+            4: 32
           -8,-11:
             0: 45296
           -9,-11:
@@ -10004,15 +10004,15 @@ entities:
           9,9:
             1: 4080
           9,10:
-            6: 273
-            7: 1092
+            5: 273
+            6: 1092
           9,11:
             1: 240
           10,9:
             1: 4080
           10,10:
-            8: 273
-            9: 1092
+            7: 273
+            8: 1092
           10,11:
             1: 752
             0: 28672
@@ -10021,13 +10021,13 @@ entities:
           11,9:
             1: 4080
           11,10:
-            9: 1365
+            8: 1365
           11,11:
             1: 35056
           12,9:
             1: 4080
           12,10:
-            9: 273
+            8: 273
             0: 34816
           12,11:
             1: 5936
@@ -11597,21 +11597,6 @@ entities:
           moles:
           - 20.078888
           - 75.53487
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14975
-          moles:
-          - 21.824879
-          - 82.10312
           - 0
           - 0
           - 0
@@ -17564,6 +17549,13 @@ entities:
       parent: 6747
 - proto: APCSuperCapacity
   entities:
+  - uid: 2089
+    components:
+    - type: MetaData
+      name: APC (chemistry lab/med locker room/morgue)
+    - type: Transform
+      pos: 13.5,-28.5
+      parent: 6747
   - uid: 2773
     components:
     - type: MetaData
@@ -17579,13 +17571,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -41.5,-19.5
-      parent: 6747
-  - uid: 2947
-    components:
-    - type: MetaData
-      name: APC (chemistry lab/med locker room/morgue)
-    - type: Transform
-      pos: 11.5,-28.5
       parent: 6747
   - uid: 6875
     components:
@@ -20570,6 +20555,26 @@ entities:
     - type: Transform
       pos: -0.5,-71.5
       parent: 6747
+  - uid: 29737
+    components:
+    - type: Transform
+      pos: -72.5,-71.5
+      parent: 6747
+  - uid: 29738
+    components:
+    - type: Transform
+      pos: -72.5,-67.5
+      parent: 6747
+  - uid: 29739
+    components:
+    - type: Transform
+      pos: -67.5,-68.5
+      parent: 6747
+  - uid: 29740
+    components:
+    - type: Transform
+      pos: -64.5,-68.5
+      parent: 6747
 - proto: BlastDoorOpen
   entities:
   - uid: 25316
@@ -21401,6 +21406,12 @@ entities:
       parent: 6747
 - proto: ButtonFrameCautionSecurity
   entities:
+  - uid: 18381
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -72.5,-70.5
+      parent: 6747
   - uid: 27581
     components:
     - type: Transform
@@ -21479,6 +21490,11 @@ entities:
       parent: 6747
 - proto: CableApcExtension
   entities:
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 13.5,-30.5
+      parent: 6747
   - uid: 346
     components:
     - type: Transform
@@ -21524,10 +21540,20 @@ entities:
     - type: Transform
       pos: 22.5,-52.5
       parent: 6747
+  - uid: 1964
+    components:
+    - type: Transform
+      pos: 13.5,-27.5
+      parent: 6747
   - uid: 1978
     components:
     - type: Transform
       pos: 19.5,-18.5
+      parent: 6747
+  - uid: 2090
+    components:
+    - type: Transform
+      pos: 12.5,-27.5
       parent: 6747
   - uid: 2256
     components:
@@ -31344,11 +31370,6 @@ entities:
     - type: Transform
       pos: 22.5,-22.5
       parent: 6747
-  - uid: 20889
-    components:
-    - type: Transform
-      pos: 11.5,-28.5
-      parent: 6747
   - uid: 20890
     components:
     - type: Transform
@@ -31387,17 +31408,7 @@ entities:
   - uid: 20897
     components:
     - type: Transform
-      pos: 11.5,-29.5
-      parent: 6747
-  - uid: 20898
-    components:
-    - type: Transform
-      pos: 11.5,-30.5
-      parent: 6747
-  - uid: 20899
-    components:
-    - type: Transform
-      pos: 11.5,-31.5
+      pos: 13.5,-28.5
       parent: 6747
   - uid: 20900
     components:
@@ -37938,6 +37949,11 @@ entities:
     components:
     - type: Transform
       pos: 1.5,-69.5
+      parent: 6747
+  - uid: 29732
+    components:
+    - type: Transform
+      pos: 13.5,-29.5
       parent: 6747
 - proto: CableApcStack
   entities:
@@ -45079,6 +45095,16 @@ entities:
     - type: Transform
       pos: 19.5,-10.5
       parent: 6747
+  - uid: 2023
+    components:
+    - type: Transform
+      pos: 13.5,-27.5
+      parent: 6747
+  - uid: 2077
+    components:
+    - type: Transform
+      pos: 12.5,-27.5
+      parent: 6747
   - uid: 2774
     components:
     - type: Transform
@@ -47244,11 +47270,6 @@ entities:
     - type: Transform
       pos: 11.5,-27.5
       parent: 6747
-  - uid: 18366
-    components:
-    - type: Transform
-      pos: 11.5,-28.5
-      parent: 6747
   - uid: 18367
     components:
     - type: Transform
@@ -47318,11 +47339,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,-33.5
-      parent: 6747
-  - uid: 18381
-    components:
-    - type: Transform
-      pos: 11.5,-28.5
       parent: 6747
   - uid: 18382
     components:
@@ -50918,6 +50934,11 @@ entities:
     components:
     - type: Transform
       pos: -61.5,-70.5
+      parent: 6747
+  - uid: 29731
+    components:
+    - type: Transform
+      pos: 13.5,-28.5
       parent: 6747
 - proto: CableMVStack
   entities:
@@ -62958,32 +62979,35 @@ entities:
     - type: Transform
       pos: 13.5,-34.5
       parent: 6747
-    - type: Fixtures
-      fixtures:
-        fix1:
-          shape: !type:PolygonShape
-            radius: 0.01
-            vertices:
-            - -0.4,-0.4
-            - 0.4,-0.4
-            - 0.4,0.29
-            - -0.4,0.29
-          mask:
-          - Impassable
-          - HighImpassable
-          - LowImpassable
-          layer:
-          - BulletImpassable
-          - Opaque
-          density: 50
-          hard: True
-          restitution: 0
-          friction: 0.4
     - type: EntityStorage
-      open: True
-      removedMasks: 20
-    - type: PlaceableSurface
-      isPlaceable: True
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 29728
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: CrateFunBoardGames
   entities:
   - uid: 12164
@@ -63586,6 +63610,18 @@ entities:
     - type: Transform
       pos: 11.5,19.5
       parent: 6747
+- proto: CurtainsOrangeOpen
+  entities:
+  - uid: 7345
+    components:
+    - type: Transform
+      pos: 49.5,-23.5
+      parent: 6747
+  - uid: 10583
+    components:
+    - type: Transform
+      pos: 49.5,-25.5
+      parent: 6747
 - proto: CurtainSpawner
   entities:
   - uid: 1491
@@ -63645,6 +63681,16 @@ entities:
     components:
     - type: Transform
       pos: -14.5,-6.5
+      parent: 6747
+  - uid: 5737
+    components:
+    - type: Transform
+      pos: -39.5,-9.5
+      parent: 6747
+  - uid: 7344
+    components:
+    - type: Transform
+      pos: -41.5,-9.5
       parent: 6747
 - proto: d4Dice
   entities:
@@ -127061,22 +127107,25 @@ entities:
   - uid: 2157
     components:
     - type: Transform
-      pos: -23.5,-13.5
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-18.5
+      parent: 6747
+  - uid: 2947
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-15.5
       parent: 6747
   - uid: 4060
     components:
     - type: Transform
       pos: -26.5,-58.5
       parent: 6747
-  - uid: 10583
+  - uid: 5466
     components:
     - type: Transform
-      pos: 20.5,-15.5
-      parent: 6747
-  - uid: 13925
-    components:
-    - type: Transform
-      pos: 20.5,-18.5
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-13.5
       parent: 6747
 - proto: HospitalCurtainsOpen
   entities:
@@ -127090,62 +127139,32 @@ entities:
     - type: Transform
       pos: 17.5,-19.5
       parent: 6747
-  - uid: 1964
-    components:
-    - type: Transform
-      pos: 19.5,-28.5
-      parent: 6747
-  - uid: 2023
-    components:
-    - type: Transform
-      pos: 20.5,-16.5
-      parent: 6747
-  - uid: 2089
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,-13.5
-      parent: 6747
-  - uid: 2090
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -25.5,-13.5
-      parent: 6747
   - uid: 2156
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,-13.5
+      pos: -25.5,-13.5
       parent: 6747
   - uid: 3090
     components:
     - type: Transform
-      pos: -41.5,-9.5
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-28.5
       parent: 6747
   - uid: 3108
     components:
     - type: Transform
-      pos: -39.5,-9.5
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-16.5
       parent: 6747
   - uid: 4061
     components:
     - type: Transform
       pos: -26.5,-57.5
       parent: 6747
-  - uid: 7344
+  - uid: 13925
     components:
     - type: Transform
-      pos: 49.5,-23.5
-      parent: 6747
-  - uid: 7345
-    components:
-    - type: Transform
-      pos: 49.5,-25.5
-      parent: 6747
-  - uid: 22297
-    components:
-    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: 20.5,-19.5
       parent: 6747
   - uid: 23930
@@ -128343,6 +128362,24 @@ entities:
       linkedPorts:
         564:
         - Pressed: Toggle
+- proto: LockableButtonCommand
+  entities:
+  - uid: 29742
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -72.5,-70.5
+      parent: 6747
+    - type: DeviceLinkSource
+      linkedPorts:
+        29737:
+        - Pressed: Toggle
+        29738:
+        - Pressed: Toggle
+        29739:
+        - Pressed: Toggle
+        29740:
+        - Pressed: Toggle
 - proto: LockableButtonRobotics
   entities:
   - uid: 3961
@@ -128947,6 +128984,13 @@ entities:
     components:
     - type: Transform
       pos: -35.5,-6.5
+      parent: 6747
+- proto: LockerSurgeonFilled
+  entities:
+  - uid: 20889
+    components:
+    - type: Transform
+      pos: 10.5,-30.5
       parent: 6747
 - proto: LockerWallMedicalDoctorFilled
   entities:
@@ -132631,8 +132675,10 @@ entities:
   - uid: 29728
     components:
     - type: Transform
-      pos: 13.688596,-34.6097
-      parent: 6747
+      parent: 29727
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
 - proto: OrganHumanHeart
   entities:
   - uid: 22426
@@ -161437,6 +161483,13 @@ entities:
     - type: Transform
       pos: 31.5,-61.5
       parent: 6747
+- proto: SpawnMobSmile
+  entities:
+  - uid: 29735
+    components:
+    - type: Transform
+      pos: 18.5,-58.5
+      parent: 6747
 - proto: SpawnMobWalter
   entities:
   - uid: 27989
@@ -162414,6 +162467,23 @@ entities:
     - type: Transform
       pos: 44.5,15.5
       parent: 6747
+- proto: SpawnPointSurgeon
+  entities:
+  - uid: 17310
+    components:
+    - type: Transform
+      pos: 5.5,-38.5
+      parent: 6747
+  - uid: 29437
+    components:
+    - type: Transform
+      pos: 11.5,-31.5
+      parent: 6747
+  - uid: 29730
+    components:
+    - type: Transform
+      pos: 11.5,-33.5
+      parent: 6747
 - proto: SpawnPointTechnicalAssistant
   entities:
   - uid: 18987
@@ -162600,6 +162670,12 @@ entities:
     - type: Transform
       pos: 16.5,-40.5
       parent: 6747
+  - uid: 18366
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -69.5,-68.5
+      parent: 6747
   - uid: 26661
     components:
     - type: Transform
@@ -162610,12 +162686,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -9.5,-13.5
-      parent: 6747
-  - uid: 29437
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -72.5,-70.5
       parent: 6747
   - uid: 29442
     components:
@@ -163523,16 +163593,6 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: AI Satelite Utility Room
-  - uid: 29217
-    components:
-    - type: Transform
-      pos: -64.5,-68.5
-      parent: 6747
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraCommand
-      nameSet: True
-      id: AI Satelite Main Hall
   - uid: 29218
     components:
     - type: Transform
@@ -163602,6 +163662,17 @@ entities:
       - SurveillanceCameraCommand
       nameSet: True
       id: Chief Justice Office
+  - uid: 29741
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -64.5,-64.5
+      parent: 6747
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraCommand
+      nameSet: True
+      id: AI Satelite Main Hall
 - proto: SurveillanceCameraConstructed
   entities:
   - uid: 29402
@@ -169538,10 +169609,10 @@ entities:
       parent: 6747
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 17310
+  - uid: 29733
     components:
     - type: Transform
-      pos: 10.5,-30.5
+      pos: 11.5,-29.5
       parent: 6747
 - proto: VendingMachineMNKDrobe
   entities:
@@ -170174,11 +170245,6 @@ entities:
     components:
     - type: Transform
       pos: 3.5,1.5
-      parent: 6747
-  - uid: 129
-    components:
-    - type: Transform
-      pos: 11.5,-28.5
       parent: 6747
   - uid: 134
     components:
@@ -172199,6 +172265,11 @@ entities:
     components:
     - type: Transform
       pos: 22.5,-24.5
+      parent: 6747
+  - uid: 2079
+    components:
+    - type: Transform
+      pos: 11.5,-28.5
       parent: 6747
   - uid: 2105
     components:
@@ -186475,19 +186546,29 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: WeaponTurretSyndicateBroken
+- proto: WeaponTurretAI
   entities:
-  - uid: 28429
+  - uid: 20898
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
+      pos: -64.5,-68.5
+      parent: 6747
+  - uid: 20899
+    components:
+    - type: Transform
       pos: -67.5,-68.5
       parent: 6747
-  - uid: 28430
+  - uid: 29734
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -64.5,-68.5
+      rot: 1.5707963267948966 rad
+      pos: -72.5,-71.5
+      parent: 6747
+  - uid: 29736
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -72.5,-67.5
       parent: 6747
 - proto: Welder
   entities:
@@ -188838,18 +188919,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -8.5,-47.5
       parent: 6747
-  - uid: 2077
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-13.5
-      parent: 6747
-  - uid: 2079
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,-13.5
-      parent: 6747
   - uid: 2166
     components:
     - type: Transform
@@ -190303,16 +190372,6 @@ entities:
     - type: Transform
       pos: -40.5,-4.5
       parent: 6747
-  - uid: 5466
-    components:
-    - type: Transform
-      pos: 21.5,-67.5
-      parent: 6747
-  - uid: 5737
-    components:
-    - type: Transform
-      pos: 19.5,-67.5
-      parent: 6747
   - uid: 8261
     components:
     - type: Transform
@@ -190534,6 +190593,28 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,9.5
+      parent: 6747
+  - uid: 22297
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -26.5,-13.5
+      parent: 6747
+  - uid: 28429
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-13.5
+      parent: 6747
+  - uid: 28430
+    components:
+    - type: Transform
+      pos: 19.5,-67.5
+      parent: 6747
+  - uid: 29217
+    components:
+    - type: Transform
+      pos: 21.5,-67.5
       parent: 6747
 - proto: Wirecutter
   entities:

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -305,11 +305,11 @@ entities:
           version: 6
         -5,0:
           ind: -5,0
-          tiles: fAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAATgAAAAAAawAAAAAAewAAAAAAfAAAAAAATgAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAQQAAAAAAAAAAAAAAfAAAAAAATgAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAQQAAAAAAewAAAAAAfAAAAAAATgAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAATgAAAAAAawAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAAfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAANQAAAAADNQAAAAABNQAAAAADfAAAAAAANQAAAAAANQAAAAAANQAAAAABfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAANQAAAAACNQAAAAADNQAAAAABfAAAAAAANQAAAAAANQAAAAADNQAAAAACfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAANQAAAAACfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAQQAAAAAA
+          tiles: fAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAATgAAAAAAawAAAAAAewAAAAAAfAAAAAAATgAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAQQAAAAAAAAAAAAAAfAAAAAAATgAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAQQAAAAAAewAAAAAAfAAAAAAATgAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAATgAAAAAAawAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAAfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAANQAAAAADNQAAAAABNQAAAAADfAAAAAAANQAAAAAANQAAAAAANQAAAAABfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAANQAAAAACNQAAAAADNQAAAAABfAAAAAAANQAAAAAANQAAAAADNQAAAAACfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAANQAAAAACfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAbQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAQQAAAAAA
           version: 6
         -4,0:
           ind: -4,0
-          tiles: fAAAAAAAfAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAABfAAAAAAAHgAAAAACHgAAAAABHgAAAAACHgAAAAAATgAAAAAAXAAAAAADXAAAAAADXAAAAAAAXAAAAAADfAAAAAAAfAAAAAAATgAAAAAAKwAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAXAAAAAABXAAAAAADTgAAAAAAXAAAAAACfAAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAADZQAAAAADZQAAAAADZQAAAAACZQAAAAAATgAAAAAAXAAAAAABXAAAAAADTgAAAAAAXAAAAAAAfAAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAADZQAAAAADZQAAAAACZQAAAAADZQAAAAACZQAAAAACXAAAAAADXAAAAAABfAAAAAAAXAAAAAACfAAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAADZQAAAAADZQAAAAAAZQAAAAACZQAAAAACTgAAAAAAXAAAAAABXAAAAAACfAAAAAAAXAAAAAACawAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAABZQAAAAACZQAAAAAAZQAAAAAAZQAAAAAATgAAAAAAXAAAAAAAXAAAAAADfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAXAAAAAABXAAAAAABfAAAAAAAZQAAAAABawAAAAAAfAAAAAAAYwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAXAAAAAABXAAAAAADfAAAAAAAZQAAAAAAawAAAAAAfAAAAAAAXAAAAAABXAAAAAACbQAAAAACXAAAAAACfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAATgAAAAAATgAAAAAAXAAAAAAAXAAAAAADTgAAAAAAZQAAAAAAawAAAAAAfAAAAAAAYwAAAAAAXAAAAAABXAAAAAABXAAAAAADfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAATgAAAAAATgAAAAAAXAAAAAAAXAAAAAAAZQAAAAACZQAAAAABQQAAAAAAfAAAAAAAYwAAAAAAXAAAAAACXAAAAAABYwAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAXAAAAAACXAAAAAAATgAAAAAAZQAAAAADawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAYwAAAAAAYwAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAXAAAAAAAXAAAAAABfAAAAAAAZQAAAAACawAAAAAAawAAAAAAQQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAXAAAAAACXAAAAAABfAAAAAAAfAAAAAAAQQAAAAAAawAAAAAAawAAAAAAQQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAQQAAAAAAQQAAAAAAfAAAAAAAXAAAAAABXAAAAAACfAAAAAAAUQAAAAAAQQAAAAAAQQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAXAAAAAADXAAAAAABfAAAAAAAUQAAAAAAQQAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAXAAAAAAAXAAAAAACfAAAAAAAfAAAAAAA
+          tiles: fAAAAAAAfAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAABfAAAAAAAHgAAAAACHgAAAAABHgAAAAACHgAAAAAATgAAAAAAXAAAAAADXAAAAAADXAAAAAAAXAAAAAADfAAAAAAAfAAAAAAATgAAAAAAKwAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAXAAAAAABXAAAAAADTgAAAAAAXAAAAAACfAAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAADZQAAAAADZQAAAAADZQAAAAACZQAAAAAATgAAAAAAXAAAAAABXAAAAAADTgAAAAAAXAAAAAAAfAAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAADZQAAAAADZQAAAAACZQAAAAADZQAAAAACZQAAAAACXAAAAAADXAAAAAABfAAAAAAAXAAAAAACfAAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAADZQAAAAADZQAAAAAAZQAAAAACZQAAAAACTgAAAAAAXAAAAAABXAAAAAACfAAAAAAAXAAAAAACawAAAAAAfAAAAAAAKwAAAAAAKwAAAAAAKwAAAAAAfAAAAAAAZQAAAAABZQAAAAACZQAAAAAAZQAAAAAAZQAAAAAATgAAAAAAXAAAAAAAXAAAAAADfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAXAAAAAABXAAAAAABfAAAAAAAZQAAAAABfAAAAAAAfAAAAAAAYwAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAXAAAAAABXAAAAAADfAAAAAAAZQAAAAAAfAAAAAAAfAAAAAAAXAAAAAABXAAAAAACbQAAAAACXAAAAAACfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAATgAAAAAATgAAAAAAXAAAAAAAXAAAAAADTgAAAAAAZQAAAAAAfAAAAAAAfAAAAAAAYwAAAAAAXAAAAAABXAAAAAABXAAAAAADfAAAAAAAQQAAAAAAQQAAAAAAQQAAAAAATgAAAAAATgAAAAAAXAAAAAAAXAAAAAAAZQAAAAACZQAAAAABQQAAAAAAfAAAAAAAYwAAAAAAXAAAAAACXAAAAAABYwAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAXAAAAAACXAAAAAAATgAAAAAAZQAAAAADfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAYwAAAAAAYwAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAXAAAAAAAXAAAAAABfAAAAAAAZQAAAAACfAAAAAAAawAAAAAAQQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAXAAAAAACXAAAAAABfAAAAAAAfAAAAAAAbQAAAAAAawAAAAAAawAAAAAAQQAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAQQAAAAAAQQAAAAAAfAAAAAAAXAAAAAABXAAAAAACfAAAAAAAUQAAAAAAbQAAAAAAbQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAXAAAAAADXAAAAAABfAAAAAAAUQAAAAAAQQAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAXAAAAAAAXAAAAAACfAAAAAAAfAAAAAAA
           version: 6
         -4,-2:
           ind: -4,-2
@@ -321,7 +321,7 @@ entities:
           version: 6
         -4,1:
           ind: -4,1
-          tiles: fAAAAAAAfAAAAAAAQQAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAAAXAAAAAABXAAAAAACfAAAAAAAewAAAAAAfAAAAAAAQQAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAACXAAAAAACXAAAAAADXAAAAAADfAAAAAAAewAAAAAAfAAAAAAAQQAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAACXAAAAAADXAAAAAADMwAAAAABewAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAACXAAAAAAAXAAAAAAAMwAAAAABewAAAAAAewAAAAAAfAAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAACXAAAAAADXAAAAAACXAAAAAADMwAAAAADewAAAAAAewAAAAAATgAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAAfAAAAAAAewAAAAAAewAAAAAATgAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAATgAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAQQAAAAAAQQAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAA
+          tiles: fAAAAAAAfAAAAAAAQQAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAAAXAAAAAABXAAAAAACfAAAAAAAewAAAAAAfAAAAAAAQQAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAACXAAAAAACXAAAAAADXAAAAAADfAAAAAAAewAAAAAAfAAAAAAAQQAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAACXAAAAAADXAAAAAADMwAAAAABewAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAAAXAAAAAACXAAAAAAAXAAAAAAAMwAAAAABewAAAAAAewAAAAAAfAAAAAAAawAAAAAAbQAAAAAATgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATgAAAAAAMwAAAAACXAAAAAADXAAAAAACXAAAAAADMwAAAAADewAAAAAAewAAAAAATgAAAAAAawAAAAAAbQAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAAfAAAAAAAewAAAAAAewAAAAAATgAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAATgAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAATgAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAQQAAAAAAQQAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAewAAAAAAewAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAewAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAA
           version: 6
         -3,1:
           ind: -3,1
@@ -4296,6 +4296,19 @@ entities:
             6510: -4,20
             6511: -3,20
             6512: -6,19
+        - node:
+            color: '#DE3A3A96'
+            id: Delivery
+          decals:
+            6709: 166,3
+            6710: 166,-1
+            6711: 157,2
+            6712: 136,3
+            6713: 135,-2
+            6714: 137,-2
+            6715: 138,3
+            6716: 147,3
+            6717: 146,-2
         - node:
             angle: -1.5707963267948966 rad
             color: '#FFFFFFFF'
@@ -16662,11 +16675,6 @@ entities:
     - type: Transform
       pos: 84.5,-16.5
       parent: 1
-  - uid: 8054
-    components:
-    - type: Transform
-      pos: 76.5,-19.5
-      parent: 1
   - uid: 20309
     components:
     - type: Transform
@@ -17101,6 +17109,13 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -52.5,-39.5
+      parent: 1
+- proto: AirlockSurgeryGlassLocked
+  entities:
+  - uid: 3522
+    components:
+    - type: Transform
+      pos: 76.5,-19.5
       parent: 1
 - proto: AirlockTheatreLocked
   entities:
@@ -20838,6 +20853,15 @@ entities:
     - type: Transform
       pos: 28.5,51.5
       parent: 1
+  - uid: 14965
+    components:
+    - type: Transform
+      pos: 137.5,-1.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        30107:
+        - DoorStatus: Toggle
   - uid: 16133
     components:
     - type: Transform
@@ -20872,6 +20896,54 @@ entities:
     components:
     - type: Transform
       pos: 134.5,1.5
+      parent: 1
+  - uid: 30100
+    components:
+    - type: Transform
+      pos: 157.5,2.5
+      parent: 1
+  - uid: 30101
+    components:
+    - type: Transform
+      pos: 166.5,-0.5
+      parent: 1
+  - uid: 30102
+    components:
+    - type: Transform
+      pos: 166.5,3.5
+      parent: 1
+  - uid: 30107
+    components:
+    - type: Transform
+      pos: 135.5,-1.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 30108
+    components:
+    - type: Transform
+      pos: 136.5,3.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 30109
+    components:
+    - type: Transform
+      pos: 138.5,3.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        30108:
+        - DoorStatus: Toggle
+  - uid: 30110
+    components:
+    - type: Transform
+      pos: 146.5,-1.5
+      parent: 1
+  - uid: 30111
+    components:
+    - type: Transform
+      pos: 147.5,3.5
       parent: 1
 - proto: BlastDoorOpen
   entities:
@@ -22180,6 +22252,12 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 156.5,-0.5
+      parent: 1
+  - uid: 30105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 166.5,0.5
       parent: 1
 - proto: ButtonFrameExit
   entities:
@@ -43240,6 +43318,11 @@ entities:
     - type: Transform
       pos: 18.5,-29.5
       parent: 1
+  - uid: 11591
+    components:
+    - type: Transform
+      pos: -69.5,6.5
+      parent: 1
   - uid: 11809
     components:
     - type: Transform
@@ -44025,31 +44108,6 @@ entities:
     - type: Transform
       pos: -70.5,1.5
       parent: 1
-  - uid: 14940
-    components:
-    - type: Transform
-      pos: -75.5,4.5
-      parent: 1
-  - uid: 14965
-    components:
-    - type: Transform
-      pos: -74.5,4.5
-      parent: 1
-  - uid: 15069
-    components:
-    - type: Transform
-      pos: -73.5,4.5
-      parent: 1
-  - uid: 15758
-    components:
-    - type: Transform
-      pos: -72.5,4.5
-      parent: 1
-  - uid: 15926
-    components:
-    - type: Transform
-      pos: -71.5,4.5
-      parent: 1
   - uid: 15953
     components:
     - type: Transform
@@ -44559,11 +44617,6 @@ entities:
     components:
     - type: Transform
       pos: -70.5,6.5
-      parent: 1
-  - uid: 23191
-    components:
-    - type: Transform
-      pos: -70.5,5.5
       parent: 1
   - uid: 23192
     components:
@@ -45755,6 +45808,166 @@ entities:
     - type: Transform
       pos: 153.5,4.5
       parent: 1
+  - uid: 30046
+    components:
+    - type: Transform
+      pos: -68.5,6.5
+      parent: 1
+  - uid: 30047
+    components:
+    - type: Transform
+      pos: -67.5,6.5
+      parent: 1
+  - uid: 30048
+    components:
+    - type: Transform
+      pos: -66.5,6.5
+      parent: 1
+  - uid: 30049
+    components:
+    - type: Transform
+      pos: -65.5,6.5
+      parent: 1
+  - uid: 30050
+    components:
+    - type: Transform
+      pos: -64.5,6.5
+      parent: 1
+  - uid: 30051
+    components:
+    - type: Transform
+      pos: -63.5,6.5
+      parent: 1
+  - uid: 30052
+    components:
+    - type: Transform
+      pos: -63.5,7.5
+      parent: 1
+  - uid: 30053
+    components:
+    - type: Transform
+      pos: -63.5,8.5
+      parent: 1
+  - uid: 30054
+    components:
+    - type: Transform
+      pos: -63.5,9.5
+      parent: 1
+  - uid: 30055
+    components:
+    - type: Transform
+      pos: -63.5,10.5
+      parent: 1
+  - uid: 30056
+    components:
+    - type: Transform
+      pos: -63.5,11.5
+      parent: 1
+  - uid: 30057
+    components:
+    - type: Transform
+      pos: -63.5,13.5
+      parent: 1
+  - uid: 30058
+    components:
+    - type: Transform
+      pos: -63.5,12.5
+      parent: 1
+  - uid: 30059
+    components:
+    - type: Transform
+      pos: -63.5,14.5
+      parent: 1
+  - uid: 30060
+    components:
+    - type: Transform
+      pos: -62.5,14.5
+      parent: 1
+  - uid: 30061
+    components:
+    - type: Transform
+      pos: -61.5,14.5
+      parent: 1
+  - uid: 30062
+    components:
+    - type: Transform
+      pos: -60.5,14.5
+      parent: 1
+  - uid: 30063
+    components:
+    - type: Transform
+      pos: -59.5,14.5
+      parent: 1
+  - uid: 30064
+    components:
+    - type: Transform
+      pos: -58.5,14.5
+      parent: 1
+  - uid: 30065
+    components:
+    - type: Transform
+      pos: -57.5,14.5
+      parent: 1
+  - uid: 30066
+    components:
+    - type: Transform
+      pos: -56.5,14.5
+      parent: 1
+  - uid: 30067
+    components:
+    - type: Transform
+      pos: -55.5,14.5
+      parent: 1
+  - uid: 30068
+    components:
+    - type: Transform
+      pos: -54.5,14.5
+      parent: 1
+  - uid: 30069
+    components:
+    - type: Transform
+      pos: -53.5,14.5
+      parent: 1
+  - uid: 30070
+    components:
+    - type: Transform
+      pos: -52.5,14.5
+      parent: 1
+  - uid: 30071
+    components:
+    - type: Transform
+      pos: -51.5,14.5
+      parent: 1
+  - uid: 30072
+    components:
+    - type: Transform
+      pos: -51.5,13.5
+      parent: 1
+  - uid: 30073
+    components:
+    - type: Transform
+      pos: -51.5,12.5
+      parent: 1
+  - uid: 30074
+    components:
+    - type: Transform
+      pos: -51.5,11.5
+      parent: 1
+  - uid: 30075
+    components:
+    - type: Transform
+      pos: -51.5,10.5
+      parent: 1
+  - uid: 30076
+    components:
+    - type: Transform
+      pos: -51.5,9.5
+      parent: 1
+  - uid: 30077
+    components:
+    - type: Transform
+      pos: -51.5,8.5
+      parent: 1
 - proto: CableHVStack
   entities:
   - uid: 6599
@@ -46041,6 +46254,11 @@ entities:
     - type: Transform
       pos: -1.5,-16.5
       parent: 1
+  - uid: 4754
+    components:
+    - type: Transform
+      pos: -72.5,4.5
+      parent: 1
   - uid: 5254
     components:
     - type: Transform
@@ -46161,10 +46379,20 @@ entities:
     - type: Transform
       pos: -50.5,8.5
       parent: 1
+  - uid: 7319
+    components:
+    - type: Transform
+      pos: -73.5,4.5
+      parent: 1
   - uid: 7982
     components:
     - type: Transform
       pos: 17.5,-29.5
+      parent: 1
+  - uid: 8054
+    components:
+    - type: Transform
+      pos: -74.5,4.5
       parent: 1
   - uid: 9280
     components:
@@ -46355,6 +46583,11 @@ entities:
     components:
     - type: Transform
       pos: 18.5,-29.5
+      parent: 1
+  - uid: 14940
+    components:
+    - type: Transform
+      pos: -75.5,4.5
       parent: 1
   - uid: 15998
     components:
@@ -54871,6 +55104,16 @@ entities:
     - type: Transform
       pos: 44.5,24.5
       parent: 1
+  - uid: 3523
+    components:
+    - type: Transform
+      pos: -53.5,14.5
+      parent: 1
+  - uid: 3524
+    components:
+    - type: Transform
+      pos: -52.5,14.5
+      parent: 1
   - uid: 3757
     components:
     - type: Transform
@@ -58156,11 +58399,6 @@ entities:
     - type: Transform
       pos: -70.5,6.5
       parent: 1
-  - uid: 23203
-    components:
-    - type: Transform
-      pos: -70.5,5.5
-      parent: 1
   - uid: 24560
     components:
     - type: Transform
@@ -59725,6 +59963,96 @@ entities:
     components:
     - type: Transform
       pos: 36.5,-23.5
+      parent: 1
+  - uid: 30078
+    components:
+    - type: Transform
+      pos: -54.5,14.5
+      parent: 1
+  - uid: 30079
+    components:
+    - type: Transform
+      pos: -55.5,14.5
+      parent: 1
+  - uid: 30080
+    components:
+    - type: Transform
+      pos: -56.5,14.5
+      parent: 1
+  - uid: 30081
+    components:
+    - type: Transform
+      pos: -57.5,14.5
+      parent: 1
+  - uid: 30082
+    components:
+    - type: Transform
+      pos: -58.5,14.5
+      parent: 1
+  - uid: 30083
+    components:
+    - type: Transform
+      pos: -59.5,14.5
+      parent: 1
+  - uid: 30084
+    components:
+    - type: Transform
+      pos: -60.5,14.5
+      parent: 1
+  - uid: 30085
+    components:
+    - type: Transform
+      pos: -61.5,14.5
+      parent: 1
+  - uid: 30086
+    components:
+    - type: Transform
+      pos: -63.5,12.5
+      parent: 1
+  - uid: 30087
+    components:
+    - type: Transform
+      pos: -63.5,9.5
+      parent: 1
+  - uid: 30088
+    components:
+    - type: Transform
+      pos: -63.5,8.5
+      parent: 1
+  - uid: 30089
+    components:
+    - type: Transform
+      pos: -63.5,7.5
+      parent: 1
+  - uid: 30090
+    components:
+    - type: Transform
+      pos: -63.5,6.5
+      parent: 1
+  - uid: 30091
+    components:
+    - type: Transform
+      pos: -64.5,6.5
+      parent: 1
+  - uid: 30092
+    components:
+    - type: Transform
+      pos: -66.5,6.5
+      parent: 1
+  - uid: 30093
+    components:
+    - type: Transform
+      pos: -67.5,6.5
+      parent: 1
+  - uid: 30094
+    components:
+    - type: Transform
+      pos: -68.5,6.5
+      parent: 1
+  - uid: 30095
+    components:
+    - type: Transform
+      pos: -63.5,11.5
       parent: 1
 - proto: Cautery
   entities:
@@ -64312,8 +64640,8 @@ entities:
   - uid: 20318
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 78.051445,-23.437965
+      rot: -1.5707963267948966 rad
+      pos: 79.60259,-23.370064
       parent: 1
 - proto: ClothingMaskGas
   entities:
@@ -67135,6 +67463,13 @@ entities:
     components:
     - type: Transform
       pos: 111.5,13.5
+      parent: 1
+- proto: CurtainsPurpleOpen
+  entities:
+  - uid: 17138
+    components:
+    - type: Transform
+      pos: 6.5,50.5
       parent: 1
 - proto: CurtainsRed
   entities:
@@ -134991,20 +135326,20 @@ entities:
       parent: 1
 - proto: HospitalCurtains
   entities:
-  - uid: 3522
+  - uid: 15069
     components:
     - type: Transform
-      pos: 62.5,-8.5
+      pos: 62.5,-10.5
       parent: 1
-  - uid: 3523
+  - uid: 15758
     components:
     - type: Transform
       pos: 62.5,-9.5
       parent: 1
-  - uid: 3524
+  - uid: 15926
     components:
     - type: Transform
-      pos: 62.5,-10.5
+      pos: 62.5,-8.5
       parent: 1
 - proto: HospitalCurtainsOpen
   entities:
@@ -135027,11 +135362,6 @@ entities:
     components:
     - type: Transform
       pos: 62.5,-13.5
-      parent: 1
-  - uid: 4754
-    components:
-    - type: Transform
-      pos: 6.5,50.5
       parent: 1
   - uid: 6861
     components:
@@ -135064,10 +135394,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: 74.5,-1.5
       parent: 1
-  - uid: 17138
+  - uid: 17156
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
       pos: 72.5,-1.5
       parent: 1
 - proto: hydroponicsSoil
@@ -136535,6 +136864,28 @@ entities:
         - Pressed: Toggle
         28178:
         - Pressed: Toggle
+  - uid: 28138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 166.5,0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        30102:
+        - Pressed: Toggle
+        30101:
+        - Pressed: Toggle
+        30100:
+        - Pressed: Toggle
+        30111:
+        - Pressed: Toggle
+        30110:
+        - Pressed: Toggle
+        30109:
+        - Pressed: Toggle
+        14965:
+        - Pressed: Toggle
 - proto: LockableButtonRobotics
   entities:
   - uid: 28550
@@ -137356,6 +137707,13 @@ entities:
     components:
     - type: Transform
       pos: 79.5,22.5
+      parent: 1
+- proto: LockerSurgeonFilled
+  entities:
+  - uid: 25732
+    components:
+    - type: Transform
+      pos: 77.5,-23.5
       parent: 1
 - proto: LockerWallMedicalDoctorFilled
   entities:
@@ -141419,6 +141777,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 164.5,1.5
       parent: 1
+- proto: PlasmaWindoorSecureScienceLocked
+  entities:
+  - uid: 28137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,39.5
+      parent: 1
 - proto: PlasticFlapsAirtightClear
   entities:
   - uid: 6677
@@ -142387,6 +142753,11 @@ entities:
     components:
     - type: Transform
       pos: 126.49917,-3.7744036
+      parent: 1
+  - uid: 30103
+    components:
+    - type: Transform
+      pos: 166.5,4.5
       parent: 1
 - proto: PottedPlantRandom
   entities:
@@ -145125,17 +145496,17 @@ entities:
     - type: Transform
       pos: 151.5,6.5
       parent: 1
-  - uid: 29153
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 155.5,2.5
-      parent: 1
   - uid: 29155
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 154.5,-3.5
+      parent: 1
+  - uid: 30106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 155.5,-0.5
       parent: 1
 - proto: PoweredLightBlueInterior
   entities:
@@ -145438,6 +145809,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: -37.5,-34.5
       parent: 1
+  - uid: 23191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 138.5,-0.5
+      parent: 1
+  - uid: 23203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 135.5,2.5
+      parent: 1
   - uid: 25228
     components:
     - type: Transform
@@ -145453,17 +145836,6 @@ entities:
     components:
     - type: Transform
       pos: -41.5,-44.5
-      parent: 1
-  - uid: 28180
-    components:
-    - type: Transform
-      pos: 136.5,3.5
-      parent: 1
-  - uid: 28181
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 136.5,-1.5
       parent: 1
 - proto: PoweredlightEmpty
   entities:
@@ -149311,11 +149683,6 @@ entities:
     components:
     - type: Transform
       pos: -45.5,7.5
-      parent: 1
-  - uid: 7319
-    components:
-    - type: Transform
-      pos: 25.5,42.5
       parent: 1
   - uid: 12470
     components:
@@ -156251,11 +156618,11 @@ entities:
       parent: 1
 - proto: SawImprov
   entities:
-  - uid: 17156
+  - uid: 28139
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 77.66603,-23.437965
+      pos: 78.44634,-23.432608
       parent: 1
 - proto: Scalpel
   entities:
@@ -161524,7 +161891,7 @@ entities:
   - uid: 23774
     components:
     - type: Transform
-      pos: 11.5,44.5
+      pos: 25.5,42.5
       parent: 1
 - proto: SpawnMobWalter
   entities:
@@ -162836,6 +163203,29 @@ entities:
     - type: Transform
       pos: 11.5,-48.5
       parent: 1
+- proto: SpawnPointSurgeon
+  entities:
+  - uid: 29153
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 78.5,-21.5
+      parent: 1
+  - uid: 30096
+    components:
+    - type: Transform
+      pos: 91.5,-6.5
+      parent: 1
+  - uid: 30097
+    components:
+    - type: Transform
+      pos: 90.5,-6.5
+      parent: 1
+  - uid: 30098
+    components:
+    - type: Transform
+      pos: 6.5,-46.5
+      parent: 1
 - proto: SpawnPointTechnicalAssistant
   entities:
   - uid: 12110
@@ -163101,11 +163491,10 @@ entities:
     - type: Transform
       pos: 9.5,-45.5
       parent: 1
-  - uid: 28663
+  - uid: 30104
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 166.5,0.5
+      pos: 162.5,4.5
       parent: 1
 - proto: StationMapBroken
   entities:
@@ -168141,11 +168530,6 @@ entities:
     components:
     - type: Transform
       pos: 80.5,-20.5
-      parent: 1
-  - uid: 11591
-    components:
-    - type: Transform
-      pos: 77.5,-23.5
       parent: 1
   - uid: 11705
     components:
@@ -191398,40 +191782,40 @@ entities:
       rot: 3.141592653589793 rad
       pos: 78.53835,14.484081
       parent: 1
-- proto: WeaponTurretSyndicateBroken
+- proto: WeaponTurretAI
   entities:
-  - uid: 28137
-    components:
-    - type: Transform
-      pos: 136.5,3.5
-      parent: 1
-  - uid: 28138
+  - uid: 28140
     components:
     - type: Transform
       pos: 138.5,3.5
       parent: 1
-  - uid: 28139
+  - uid: 28180
+    components:
+    - type: Transform
+      pos: 136.5,3.5
+      parent: 1
+  - uid: 28181
+    components:
+    - type: Transform
+      pos: 147.5,3.5
+      parent: 1
+  - uid: 28663
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 146.5,-1.5
+      parent: 1
+  - uid: 28720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 137.5,-1.5
       parent: 1
-  - uid: 28140
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 135.5,-1.5
-      parent: 1
-  - uid: 28720
-    components:
-    - type: Transform
-      pos: 146.5,3.5
-      parent: 1
   - uid: 28721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 147.5,-1.5
+      pos: 135.5,-1.5
       parent: 1
   - uid: 28859
     components:
@@ -191444,6 +191828,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 166.5,3.5
+      parent: 1
+  - uid: 30099
+    components:
+    - type: Transform
+      pos: 157.5,2.5
       parent: 1
 - proto: WeaponWaterBlaster
   entities:
@@ -192196,12 +192585,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 7.5,43.5
       parent: 1
-  - uid: 25732
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,39.5
-      parent: 1
 - proto: WindoorSecureSecurityLawyerLocked
   entities:
   - uid: 6085
@@ -192291,7 +192674,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -173305.89
+      secondsUntilStateChange: -179934.36
       state: Opening
   - uid: 5096
     components:
@@ -192313,7 +192696,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -173305.89
+      secondsUntilStateChange: -179934.36
       state: Opening
   - uid: 5498
     components:
@@ -192329,7 +192712,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -173029.52
+      secondsUntilStateChange: -179657.98
       state: Opening
   - uid: 8696
     components:
@@ -192362,7 +192745,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -173027.62
+      secondsUntilStateChange: -179656.1
       state: Opening
   - uid: 18835
     components:
@@ -192374,7 +192757,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -173024.62
+      secondsUntilStateChange: -179653.1
       state: Opening
   - uid: 23917
     components:

--- a/Resources/Prototypes/Maps/arena.yml
+++ b/Resources/Prototypes/Maps/arena.yml
@@ -37,10 +37,11 @@
           #medical
             Chemist: [ 2, 2 ]
             ChiefMedicalOfficer: [ 1, 1 ]
-            MedicalDoctor: [ 3, 5 ]
+            MedicalDoctor: [ 3, 4 ]
             MedicalIntern: [ 2, 3 ]
             Paramedic: [ 1, 2 ]
             Psychologist: [ 1, 1 ]
+            Surgeon: [ 1, 1 ]
           #security
             Brigmedic: [ 1, 1 ]
             Detective: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/hive.yml
+++ b/Resources/Prototypes/Maps/hive.yml
@@ -37,10 +37,11 @@
           #medical
             Chemist: [ 2, 2 ]
             ChiefMedicalOfficer: [ 1, 1 ]
-            MedicalDoctor: [ 3, 5 ]
+            MedicalDoctor: [ 3, 4 ]
             MedicalIntern: [ 1, 3 ]
             Paramedic: [ 1, 2 ]
             Psychologist: [ 1, 1 ]
+            Surgeon: [ 1, 1 ]
           #security
             Brigmedic: [ 1, 1 ]
             Detective: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -36,10 +36,11 @@
           #medical
             Chemist: [ 2, 2 ]
             ChiefMedicalOfficer: [ 1, 1 ]
-            MedicalDoctor: [ 7, 9 ]
+            MedicalDoctor: [ 6, 8 ]
             MedicalIntern: [ 2, 4 ]
             Paramedic: [ 1, 2 ]
             Psychologist: [ 1, 1 ]
+            Surgeon: [ 1, 2 ]
           #security
             Brigmedic: [ 1, 1 ]
             Detective: [ 1, 1 ]


### PR DESCRIPTION
## About the PR
Arena
- Adds AI turret defense
- Adds Surgeon [1,1]
- Adds Smile spawn
- Adjusts curtains

Hive
- Adds AI turret defense
- Adds Surgeon [1,1]
- Moves Smile spawn to inside epi
- Adjusts curtains
- Fixes [#2669](https://github.com/DeltaV-Station/Delta-v/issues/2669)

Tortuga
- Swaps in AI turrets
- Adds Surgeon [1,2]
- Adds Smile spawn
- Adjusts curtains

## Why / Balance
🥊🐝🐢

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
n/a