### PR TITLE
Depression RP Trait

### DIFF
--- a/Resources/Locale/en-US/_DV/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DV/traits/traits.ftl
@@ -35,3 +35,6 @@ trait-addicted-desc = You crave the substance, and your thoughts keep drifting b
 
 trait-unborgable-name = Machine Incompatible
 trait-unborgable-desc = Your brain cannot be put into a man-machine interface.
+
+trait-depression-name = Depression
+trait-depression-desc = No mechanical effect. The world is dark but there is a light somewhere, calling to you.

--- a/Resources/Prototypes/_DV/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DV/Traits/disabilities.yml
@@ -30,3 +30,11 @@
   category: Disabilities
   components:
   - type: Unborgable # Automatically gets moved to the brain
+
+- type: trait
+  id: Depression
+  name: trait-depression-name
+  description: trait-depression-desc
+  traitGear: PillCanisterNeurozenium
+  category: Disabilities
+  components: []


### PR DESCRIPTION
## About the PR
First ever PR but here we go, added the Depression trait for round start depression meds

## Why / Balance
Although this trait has no effect on gameplay for those that do RP a character having depression, having to go to the CMO or Phych round start for your meds is interesting the first time not every time, and it would not make sense for said employee to arrive on station without at least some meds

## Technical details

## Media
![PillCanisterAntidepressants](https://github.com/user-attachments/assets/dc501f1b-1bc6-4d6b-a24a-432d1fbbd4a5)
![TraitScreenAntidepressant](https://github.com/user-attachments/assets/0cfda155-db1f-47d1-8f9c-7de4d97be8c3)
## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: RP Depression trait
