### PR TITLE
Allow tank harnesses and hospital gowns to be operated through

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -283,6 +283,9 @@ public abstract partial class SharedSurgerySystem
                 if (!containerSlot.ContainedEntity.HasValue)
                     continue;
 
+                if (_tagSystem.HasTag(containerSlot.ContainedEntity.Value, "PermissibleForSurgery")) // DeltaV: allow some clothing items to be operated through
+                    continue;
+
                 args.Invalid = StepInvalidReason.Armor;
                 args.Popup = Loc.GetString("surgery-ui-window-steps-error-armor");
                 return;

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.Prototypes;
 using Content.Shared.Standing;
+using Content.Shared.Tag; // DeltaV: surgery can operate through some clothing
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -47,6 +48,7 @@ public abstract partial class SharedSurgerySystem : EntitySystem
     [Dependency] private readonly RotateToFaceSystem _rotateToFace = default!;
     [Dependency] private readonly StandingStateSystem _standing = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly TagSystem _tagSystem = default!; // DeltaV: surgery can operate through some clothing
 
     /// <summary>
     /// Cache of all surgery prototypes' singleton entities.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -265,6 +265,10 @@
     sprite: Clothing/OuterClothing/Misc/hospitalgown.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Misc/hospitalgown.rsi
+  - type: Tag # DeltaV: tank harnesses can be used for surgery
+    tags:
+    - PermissibleForSurgery
+    - WhitelistChameleon
 
 - type: entity
   parent: ClothingOuterBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -91,3 +91,7 @@
     sprite: Clothing/OuterClothing/Vests/tankharness.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Vests/tankharness.rsi
+  - type: Tag # DeltaV: tank harnesses can be used for surgery
+    tags:
+    - PermissibleForSurgery
+    - WhitelistChameleon

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -104,3 +104,6 @@
 
 - type: Tag
   id: GlassesCorpsman # Prescription corpsman glasses.
+
+- type: Tag
+  id: PermissibleForSurgery # Can be worn on the body during surgery


### PR DESCRIPTION
## About the PR
Tank harnesses and hospital gowns can now be operated through in surgery

## Why / Balance
As it stands it's impossible to keep someone anaesthetised through surgery because equipment to keep tanks on them and not fallen out blocks it.

## Technical details
- new tag for items
- add tag to tank harness and hospital gown

## Media
![grafik](https://github.com/user-attachments/assets/f00944cc-4c7a-4d7b-9d4a-a9142757ecac)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Tank harnesses and hospital gowns don't block surgery steps
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
