### PR TITLE
Add tank harnesses to the medical techfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1053,6 +1053,7 @@
       - WhiteCane
       - AACTablet # DeltaV
       - BoneGel # Shitmed Change
+      - TankHarness # DeltaV
     dynamicRecipes:
       # Begin DeltaV additions
       - LauncherSyringe

--- a/Resources/Prototypes/_DV/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/medical.yml
@@ -22,3 +22,11 @@
   materials:
     Plastic: 150
     Steel: 50
+
+- type: latheRecipe
+  id: TankHarness
+  result: ClothingOuterVestTank
+  completetime: 2
+  materials:
+    Plastic: 300
+    Steel: 100


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Tank harnesses can be now made in the medical lathe.
<!-- What did you change? -->

## Why / Balance
Tank harnesses are relevant to surgery, as they allow mounting an NO2 tank to someone for surgical operations.

## Technical details
- add lathe recipe
- add it to the medlathe

## Media
![grafik](https://github.com/user-attachments/assets/b9244ba8-da46-45f7-8b80-dc77520ce9c9)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Tank harnesses can be now fabricated from the medical techfab

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
