### PR TITLE
Replace ForcedSleep with Anesthesia for surgery

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
+using Content.Shared._DV.Surgery; // DeltaV: expanded anesthesia
 using Content.Shared._Shitmed.Medical.Surgery;
 using Content.Shared._Shitmed.Medical.Surgery.Conditions;
 using Content.Shared._Shitmed.Medical.Surgery.Effects.Step;
@@ -143,7 +144,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
     private void OnSurgeryDamageChange(Entity<SurgeryDamageChangeEffectComponent> ent, ref SurgeryStepEvent args) // DeltaV
     {
         var damageChange = ent.Comp.Damage;
-        if (HasComp<ForcedSleepingComponent>(args.Body))
+        if (HasComp<AnesthesiaComponent>(args.Body)) // DeltaV: anesthesia
             damageChange = damageChange * ent.Comp.SleepModifier;
 
         SetDamage(args.Body, damageChange, 0.5f, args.User, args.Part);
@@ -162,7 +163,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
 
     private void OnStepScreamComplete(Entity<SurgeryStepEmoteEffectComponent> ent, ref SurgeryStepEvent args)
     {
-        if (HasComp<ForcedSleepingComponent>(args.Body))
+        if (HasComp<AnesthesiaComponent>(args.Body)) // DeltaV: anesthesia
             return;
 
         _chat.TryEmoteWithChat(args.Body, ent.Comp.Emote);

--- a/Content.Shared/_DV/Surgery/AnesthesiaComponent.cs
+++ b/Content.Shared/_DV/Surgery/AnesthesiaComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+///     Exists for use as a status effect. Allows surgical operations to not cause immense pain.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
+public sealed partial class AnesthesiaComponent : Component
+{
+}

--- a/Content.Shared/_DV/Surgery/AnesthesiaComponent.cs
+++ b/Content.Shared/_DV/Surgery/AnesthesiaComponent.cs
@@ -1,12 +1,9 @@
 using Robust.Shared.GameStates;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._DV.Surgery;
 
 /// <summary>
 ///     Exists for use as a status effect. Allows surgical operations to not cause immense pain.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentPause]
-public sealed partial class AnesthesiaComponent : Component
-{
-}
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AnesthesiaComponent : Component;

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -30,6 +30,7 @@
     - RadiationProtection
     - Drowsiness
     - Adrenaline
+    - Anesthesia # DeltaV - Anesthesia
   - type: Buckle
   - type: StandingState
   - type: Tag
@@ -108,6 +109,7 @@
     - RadiationProtection
     - Drowsiness
     - Adrenaline
+    - Anesthesia # DeltaV - Anesthesia
   - type: Bloodstream
     bloodMaxVolume: 150
   - type: MobPrice

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -142,6 +142,7 @@
     - SuppressAddiction # DeltaV - Psych med addictions system
     - InPain # DeltaV - Pain system
     - SuppressPain # DeltaV - Pain system
+    - Anesthesia # DeltaV - Anesthesia
   - type: Body
     prototype: Human
     requiredLegs: 2

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -284,6 +284,18 @@
         component: ForcedSleeping
         time: 200 # This reeks, but I guess it works LMAO
         type: Add
+      - !type:GenericStatusEffect # DeltaV: anesthesia changes
+        conditions:
+        - !type:ReagentThreshold
+          reagent: NitrousOxide
+          min: 1
+        - !type:OrganType
+          type: Slime
+          shouldHave: false
+        key: Anesthesia
+        component: Anesthesia
+        time: 200
+        type: Add
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -334,6 +334,11 @@
         component: ForcedSleeping
         refresh: false
         type: Add
+      - !type:GenericStatusEffect # DeltaV: anesthesia
+        key: Anesthesia
+        component: Anesthesia
+        refresh: false
+        type: Add
 
 - type: reagent
   id: MuteToxin

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -69,6 +69,16 @@
         time: 4
         type: Add
         refresh: false
+      - !type:GenericStatusEffect # DeltaV: anesthesia
+        conditions:
+        - !type:ReagentThreshold
+          reagent: ChloralHydrate
+          min: 10
+        key: Anesthesia
+        component: Anesthesia
+        refresh: false
+        time: 4.0
+        type: Add
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_DV/status_effects.yml
+++ b/Resources/Prototypes/_DV/status_effects.yml
@@ -9,3 +9,6 @@
 
 - type: statusEffect
   id: SuppressPain
+
+- type: statusEffect
+  id: Anesthesia


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Surgeries now rely on a `Anesthesia` effect which allows "incapacitate someone combatwise" and "allow painless surgery" to be different concerns.

NO2, Nocturine, and Chloral Hydrate have all been granted the new Anesthesia status effect, which allows them to serve this role in surgery.

## Why / Balance
As it is, slime people can't be anesthesised using NO2, and expanding anesthesia to include them by adding more sources of ForcedSleep is horrible for combat balance.

Relying on ForcedSleep also has other weirdness, such as narcolepsy or the psionic mass sleep being able to replace anesthesia for surgery.

The solution then is to use a new Anesthesia component and effect instead of trying to overload ForcedSleep.

## Technical details
- `AnesthesiaComponent` is added
- surgery system now checks for `AnesthesiaComponent` instead of `ForcedSleepComponent`
- add `Anesthesia` status effect
- NO2, Nocturine, and Chloral Hydrate all have the new `Anesthesia` status effect

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->


https://github.com/user-attachments/assets/38c50889-7409-4f96-b9e8-5b778ac4e3a6




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Surgery now requires anesthesia rather than forced sleep
- tweak: Chloral hydrate, nitrous oxide, and nocturine now serve as anesthesia
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
