### PR TITLE
Make chloral hydrate better suited for use as anesthesia

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -55,6 +55,7 @@
   physicalDesc: reagent-physical-desc-nondescript
   metabolisms:
     Poison:
+      metabolismRate: 0.25 # DeltaV: chloral hydrate should last longer for surgery
       effects:
       - !type:Emote
         emote: Yawn

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -362,7 +362,7 @@
     Water:
       amount: 1
   products:
-    ChloralHydrate: 1
+    ChloralHydrate: 3 # DeltaV: make chloral hydrate less outrageously expensive
 
 - type: reaction
   id: Pax


### PR DESCRIPTION
## About the PR
Chloral hydrate is now cheaper and metabolises faster.

## Why / Balance
As it is, chloral hydrate has two issues that prevent it from being good to roll out in surgical wards:
- it metabolises too fast (10s per 5u isn't a lot, especially considering that surgery bleeding will drain this faster)
- it requires too many source ingredients to make, with an astounding 5 ingredient to 1 result ratio that is by far the worst in the game, beating out necrosol (5 to 2) or cognizine/nocturine (3 to 1) for what is an obviously less effective and more situational chemical than those

## Technical details
- chloral hydrate has a slower metabolism rate
- adjust the reaction that produces chloral hydrate to a 5:3 ratio

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Chloral hydrate is cheaper and lasts longer
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
