### PR TITLE
Tweaks to the paperwork belt

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Belt/belts.yml
@@ -102,5 +102,7 @@
       - Document
       - Flashlight
       - Radio
+      - HandLabeler
       components:
       - FitsInDispenser
+      - Stamp


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added the capability for carrying hand labelers and stamps

## Why / Balance
Forgor to add it when I originally PRed it

## Technical details
Added `HandLabeler` as a whitelisted tag to the belt.
Added `Stamp` as a whitelisted component to the belt.

## Media
![image](https://github.com/user-attachments/assets/dfa0572b-cf79-4e8b-ade3-4ab3ba904c56)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Paperwork belts are now capable of holding hand labelers and stamps.