### PR TITLE
Drunkard accent

### DIFF
--- a/Content.Server/_DV/Speech/Components/DrunkardAccentComponent.cs
+++ b/Content.Server/_DV/Speech/Components/DrunkardAccentComponent.cs
@@ -1,0 +1,4 @@
+﻿namespace Content.Server._DV.Speech.Components;
+
+[RegisterComponent]
+public sealed partial class DrunkardAccentComponent : Component;

--- a/Content.Server/_DV/Speech/EntitySystems/DrunkardAccentSystem.cs
+++ b/Content.Server/_DV/Speech/EntitySystems/DrunkardAccentSystem.cs
@@ -8,10 +8,9 @@ using Robust.Shared.Timing;
 
 namespace Content.Server._DV.Speech.EntitySystems;
 
-
 public sealed class DrunkardAccentSystem : EntitySystem
 {
-    [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
 
@@ -64,17 +63,17 @@ public sealed class DrunkardAccentSystem : EntitySystem
         return sb.ToString();
     }
 
-    private void OnAccent(EntityUid uid, DrunkardAccentComponent component, AccentGetEvent args)
+    private void OnAccent( Entity<DrunkardAccentComponent> ent, ref AccentGetEvent args)
     {
         // Drunk status effect calculations, ripped directly from SlurredSystem B)
-        if (!_statusEffectsSystem.TryGetTime(uid, SharedDrunkSystem.DrunkKey, out var time))
+        if (!_statusEffects.TryGetTime(ent.Owner, SharedDrunkSystem.DrunkKey, out var time))
         {
             args.Message = Accentuate(args.Message, 0.25f);
         }
         else
         {
             var curTime = _timing.CurTime;
-            var timeLeft = (float) (time.Value.Item2 - curTime).TotalSeconds;
+            var timeLeft = (float)(time.Value.Item2 - curTime).TotalSeconds;
             var drunkScale = Math.Clamp((timeLeft - 80) / 1100, 0f, 1f);
 
             args.Message = Accentuate(args.Message, Math.Max(0.25f, drunkScale));

--- a/Content.Server/_DV/Speech/EntitySystems/DrunkardAccentSystem.cs
+++ b/Content.Server/_DV/Speech/EntitySystems/DrunkardAccentSystem.cs
@@ -63,7 +63,7 @@ public sealed class DrunkardAccentSystem : EntitySystem
         return sb.ToString();
     }
 
-    private void OnAccent( Entity<DrunkardAccentComponent> ent, ref AccentGetEvent args)
+    private void OnAccent(Entity<DrunkardAccentComponent> ent, ref AccentGetEvent args)
     {
         // Drunk status effect calculations, ripped directly from SlurredSystem B)
         if (!_statusEffects.TryGetTime(ent.Owner, SharedDrunkSystem.DrunkKey, out var time))

--- a/Content.Server/_DV/Speech/EntitySystems/DrunkardAccentSystem.cs
+++ b/Content.Server/_DV/Speech/EntitySystems/DrunkardAccentSystem.cs
@@ -1,0 +1,83 @@
+﻿using System.Text;
+using Content.Server._DV.Speech.Components;
+using Content.Server.Speech;
+using Content.Shared.Drunk;
+using Content.Shared.StatusEffect;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._DV.Speech.EntitySystems;
+
+
+public sealed class DrunkardAccentSystem : EntitySystem
+{
+    [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DrunkardAccentComponent, AccentGetEvent>(OnAccent);
+    }
+
+    // A modified copy of SlurredSystem's Accentuate.
+    public string Accentuate(string message, float scale)
+    {
+        var sb = new StringBuilder();
+
+        foreach (var character in message)
+        {
+            if (_random.Prob(scale / 3))
+            {
+                var lower = char.ToLowerInvariant(character);
+                var newString = lower switch
+                {
+                    'o' => "u",
+                    's' => "ch",
+                    'a' => "ah",
+                    'u' => "oo",
+                    'c' => "k",
+                    _ => $"{character}",
+                };
+
+                sb.Append(newString);
+            }
+
+            if (!_random.Prob(scale * 3 / 20))
+            {
+                sb.Append(character);
+                continue;
+            }
+
+            var next = _random.Next(1, 3) switch
+            {
+                1 => "'",
+                2 => $"{character}{character}",
+                _ => $"{character}{character}{character}",
+            };
+
+            sb.Append(next);
+        }
+
+        return sb.ToString();
+    }
+
+    private void OnAccent(EntityUid uid, DrunkardAccentComponent component, AccentGetEvent args)
+    {
+        // Drunk status effect calculations, ripped directly from SlurredSystem B)
+        if (!_statusEffectsSystem.TryGetTime(uid, SharedDrunkSystem.DrunkKey, out var time))
+        {
+            args.Message = Accentuate(args.Message, 0.25f);
+        }
+        else
+        {
+            var curTime = _timing.CurTime;
+            var timeLeft = (float) (time.Value.Item2 - curTime).TotalSeconds;
+            var drunkScale = Math.Clamp((timeLeft - 80) / 1100, 0f, 1f);
+
+            args.Message = Accentuate(args.Message, Math.Max(0.25f, drunkScale));
+        }
+    }
+}

--- a/Resources/Locale/en-US/_DV/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DV/traits/traits.ftl
@@ -38,3 +38,6 @@ trait-unborgable-desc = Your brain cannot be put into a man-machine interface.
 
 trait-depression-name = Depression
 trait-depression-desc = No mechanical effect. The world is dark but there is a light somewhere, calling to you.
+
+trait-drunkard-accent-name = Drunkard accent
+trait-drunkard-accent-desc = You always sound like you're drunk.

--- a/Resources/Prototypes/_DV/Traits/neutral.yml
+++ b/Resources/Prototypes/_DV/Traits/neutral.yml
@@ -45,3 +45,12 @@
   cost: 2 # Changed weight to 2 in accordance with other accents
   components:
     - type: IrishAccent
+
+- type: trait
+  id: DrunkardAccent
+  name: trait-drunkard-accent-name
+  description: trait-drunkard-accent-desc
+  category: SpeechTraits
+  cost: 2
+  components:
+  - type: DrunkardAccent


### PR DESCRIPTION
## About the PR

Adds a "drunkard accent", a trait that makes a character's speech slurred like they're drunk.

Port of https://github.com/Fansana/floofstation1/pull/476

## Why / Balance

There are a few alcoholic characters that would benefit from being "constantly drunk" without the actual status effect. This could be a good effect for other characters that have a speech impediment.

## Technical details

This uses a modified version of SlurredSystem's Accentuate for the trait with hardcoded values and removing the burping and "huh" additions. The functionality could be extracted into a static method, however it would require changing code in non-DeltaV code when this works perfectly fine; reducing changes to the codebase is preferable.

If the character is drunk past a certain point, the SlurredSpeech effect will take precedence over DrunkardAccent.

## Media

![image](https://github.com/user-attachments/assets/af5dcf4a-dc20-44ee-80f4-7c0c0d2d8605)

## Requirements

- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- add: Added a "drunkard accent", a trait that makes a character's speech slurred like they're drunk.
