### PR TITLE
fix shocked door spraypaint error

### DIFF
--- a/Content.Client/Doors/DoorSystem.cs
+++ b/Content.Client/Doors/DoorSystem.cs
@@ -81,10 +81,12 @@ public sealed class DoorSystem : SharedDoorSystem
             {
                 Log.Error("Unable to load RSI '{0}'. Trace:\n{1}", baseRsi, Environment.StackTrace);
             }
+            args.Sprite.BaseRSI = res?.RSI; // DeltaV
+            /* DeltaV: just set BaseRSI instead
             foreach (var layer in args.Sprite.AllLayers)
             {
                 layer.Rsi = res?.RSI;
-            }
+            }*/
         }
 
         TryComp<AnimationPlayerComponent>(uid, out var animPlayer);


### PR DESCRIPTION
## About the PR
if you spray painted a shocked door it would error because it was bulldozing the wrong layer state
turns out spritecomponent basersi setter just handles that

## Why / Balance
bug bad

## Technical details
assigns BaseRsi instead of funny

## Media
![09:57:40](https://github.com/user-attachments/assets/97d7502b-5d9a-4a7d-b862-fb2bbf938ee9)

![09:57:45](https://github.com/user-attachments/assets/cd897ab5-3831-434c-a4d6-a44d6aef9925)
![image](https://github.com/user-attachments/assets/c97128d1-83c4-435f-8d87-ea713cb92c81)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
ive only seen this today no cl