### PR TITLE
Increase Tesla fade time

### DIFF
--- a/Content.Server/Tesla/Components/TeslaEnergyBallComponent.cs
+++ b/Content.Server/Tesla/Components/TeslaEnergyBallComponent.cs
@@ -35,7 +35,7 @@ public sealed partial class TeslaEnergyBallComponent : Component
     /// The amount of energy to which the tesla must reach in order to be destroyed.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float EnergyToDespawn = -100f;
+    public float EnergyToDespawn = -540f; // DeltaV, make the Tesla take as long to fail as the singulo.
 
     /// <summary>
     /// Played when energy reaches the lower limit (and entity destroyed)


### PR DESCRIPTION
## About the PR
Changes the amount of energy that the Tesla ball dies at in order to make it fade from 0 in the same amount of time that the singularity does.

## Why / Balance
At present the Tesla is incredibly susceptible to fading accidentally. Events such as the power fluctuation turning off the APCs, or an antag simply unwrenching the SMESes for a couple of seconds, are enough to cause the station to lose the Tesla. This change should make for a few less cases of "Oops power wasn't perfectly stable when we started the Tesla ball, so it faded immediately."

Another way to do this would be to decrease the drain rate, but that has implications for what level the PA needs to be set at, and for how many small orbs get produced.

## Technical details
Just a single value change.

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Made the Tesla much slower to fade after power loss.
