### PR TITLE
Clean up the loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -24,11 +24,6 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitQMFormal
 
-- type: loadout #DeltaV
-  id: QuartermasterFormalDress
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtQMFormal
-
 # Head
 - type: loadout
   id: QuartermasterHead
@@ -39,11 +34,6 @@
   id: QuartermasterBeret
   equipment:
     head: ClothingHeadHatBeretQM
-
-- type: loadout # DeltaV
-  id: LogiOfficerBeret
-  equipment:
-    head: ClothingHeadHatBeretLogi
 
 # Neck
 - type: loadout
@@ -61,9 +51,3 @@
   id: QuartermasterWintercoat
   equipment:
     outerClothing: ClothingOuterWinterQM
-
-# Shoes - DeltaV
-- type: loadout
-  id: QuartermasterWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterLogisticsOfficer

--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -25,14 +25,3 @@
   id: SalvageBoots
   equipment:
     shoes: ClothingShoesBootsSalvage
-
-- type: loadout # DeltaV
-  id: SalvageWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterMiner
-
-# Neck - DeltaV
-- type: loadout # DeltaV
-  id: SalvageCloak
-  equipment:
-    neck: ClothingNeckSalvager

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/bartender.yml
@@ -40,9 +40,3 @@
   id: BartenderWintercoat
   equipment:
     outerClothing: ClothingOuterWinterBar
-
-# Glasses - DeltaV
-- type: loadout
-  id: BartenderGlasses
-  equipment:
-    eyes: ClothingEyesHudBeer

--- a/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Civilian/passenger.yml
@@ -48,52 +48,6 @@
   equipment:
     jumpsuit: ClothingUniformColorRainbow
 
-# Rose Hoodie w/ Skirt - DeltaV
-- type: loadout
-  id: MioSkirt
-  equipment:
-    jumpsuit: ClothingCostumeMioSkirt
-
-# Turqoise Hoodie w/ Shorts - DeltaV
-- type: loadout
-  id: NaotaHoodie
-  equipment:
-    jumpsuit: ClothingCostumeNaota
-
-# Casual Blue - DeltaV
-- type: loadout
-  id: CasualRedSkirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtCasualRed
-
-- type: loadout
-  id: CasualRedSuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitCasualRed
-
-
-# Casual Blue - DeltaV
-- type: loadout
-  id: CasualBlueSkirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtCasualBlue
-
-- type: loadout
-  id: CasualBlueSuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitCasualBlue
-
-# Casual Purple - DeltaV
-- type: loadout
-  id: CasualPurpleSkirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtCasualPurple
-
-- type: loadout
-  id: CasualPurpleSuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitCasualPurple
-
 # Ancient
 - type: loadout
   id: AncientJumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Command/captain.yml
@@ -30,21 +30,11 @@
   equipment:
     head: ClothingHeadHatCapcap
 
-- type: loadout # DeltaV
-  id: CaptainBeret
-  equipment:
-    head: ClothingHeadHatBeretCap
-
 # Neck
 - type: loadout
   id: CaptainCloak
   equipment:
     neck: ClothingNeckCloakCap
-
-- type: loadout # DeltaV
-  id: CaptainCloakFormal
-  equipment:
-    neck: ClothingNeckCloakCapFormal
 
 - type: loadout
   id: CaptainMantle
@@ -77,20 +67,3 @@
   id: CaptainWintercoat
   equipment:
     outerClothing: ClothingOuterWinterCap
-
-# Gloves - DeltaV
-- type: loadout # DeltaV
-  id: CaptainGloves
-  equipment:
-    gloves: ClothingHandsGlovesCaptain
-
-- type: loadout # DeltaV
-  id: InspectionGloves
-  equipment:
-    gloves: ClothingHandsGlovesInspection
-
-# Shoes - DeltaV
-- type: loadout # DeltaV
-  id: CaptainWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterCap

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -101,11 +101,6 @@
   equipment:
     outerClothing: ClothingOuterVestHazard
 
-- type: loadout # DeltaV
-  id: StationEngineerWintercoat
-  equipment:
-    outerClothing: ClothingOuterWinterEngi
-
 # Shoes
 - type: loadout
   id: WorkBoots

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chemist.yml
@@ -1,9 +1,3 @@
-# Neck - DeltaV
-- type: loadout # DeltaV
-  id: ChemistTie
-  equipment:
-    neck: ClothingNeckTieChem
-
 # Jumpsuit
 - type: loadout
   id: ChemistJumpsuit
@@ -14,11 +8,6 @@
   id: ChemistJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtChemistry
-
-- type: loadout # DeltaV
-  id: ChemistFormalSuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitChemShirt
 
 # Back
 - type: loadout
@@ -46,27 +35,3 @@
   id: ChemistWintercoat
   equipment:
     outerClothing: ClothingOuterWinterChem
-
-## Start DeltaV Changes
-- type: loadout
-  id: ChemistApron
-  equipment:
-    outerClothing: ClothingOuterApronChemist
-
-# Gloves - DeltaV
-- type: loadout
-  id: ChemistGloves
-  equipment:
-    gloves: ClothingHandsGlovesChemist
-
-# Shoes - DeltaV
-- type: loadout
-  id: ChemistWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterChem
-
-- type: loadout
-  id: ChemistShoes
-  equipment:
-    shoes: ClothingShoesEnclosedChem
-## End DeltaV Changes

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -51,9 +51,3 @@
   id: ChiefMedicalOfficerWintercoat
   equipment:
     outerClothing: ClothingOuterWinterCMO
-
-# Shoes - DeltaV
-- type: loadout
-  id: ChiefMedicalOfficerWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterChiefMedicalOfficer

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -72,12 +72,6 @@
   equipment:
     head: ClothingHeadNurseHat
 
-# Neck - DeltaV
-- type: loadout # DeltaV
-  id: Stethoscope
-  equipment:
-    neck: ClothingNeckStethoscope
-
 # Jumpsuit
 - type: loadout
   id: MedicalDoctorJumpsuit

--- a/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Medical/paramedic.yml
@@ -31,8 +31,3 @@
   id: BlueShoes
   equipment:
     shoes: ClothingShoesColorBlue
-
-- type: loadout # DeltaV
-  id: ParamedicWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterParamedic

--- a/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/research_director.yml
@@ -4,11 +4,6 @@
   id: ResearchDirectorBeret
   startingGear: ScientificBeret
 
-- type: loadout # DeltaV
-  id: ResearchDirectorHood
-  equipment:
-    head: ClothingHeadHoodMysta
-
 # Neck
 
 - type: loadout
@@ -38,18 +33,7 @@
   equipment:
     outerClothing: ClothingOuterCoatRD
 
-- type: loadout # DeltaV
-  id: MystaLabCoat
-  equipment:
-    outerClothing: ClothingOuterCoatRndMysta
-
 - type: loadout
   id: ResearchDirectorWintercoat
   equipment:
     outerClothing: ClothingOuterWinterRD
-
-# Shoes - DeltaV
-- type: loadout # DeltaV
-  id: ResearchDirectorWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterMystagogue

--- a/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/detective.yml
@@ -9,11 +9,6 @@
   equipment:
     head: ClothingHeadHatFedoraGrey
 
-- type: loadout # DeltaV
-  id: DetBeret
-  equipment:
-    head: ClothingHeadHatBeretDet
-
 # Neck
 - type: loadout
   id: DetectiveTie
@@ -41,26 +36,6 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtDetectiveGrey
 
-- type: loadout # DeltaV
-  id: ForensicSpecJumpsuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitForensicSpec
-
-- type: loadout # DeltaV
-  id: ForensicSpecJumpskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtForensicSpec
-
-- type: loadout # DeltaV
-  id: ForensicSpecTurtlesuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitDetTurtle
-
-- type: loadout # DeltaV
-  id: ForensicSpecTurtleskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtDetTurtle
-
 # OuterClothing
 - type: loadout
   id: DetectiveArmorVest
@@ -71,8 +46,3 @@
   id: DetectiveCoat
   equipment:
     outerClothing: ClothingOuterCoatDetectiveLoadout
-
-- type: loadout # DeltaV
-  id: StasecWinterCoatDet
-  equipment:
-    outerClothing: ClothingOuterCoatStasecDet

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -9,26 +9,6 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtHoS
 
-- type: loadout # DeltaV
-  id: HeadofSecurityJumpsuitGrey
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitHoSGrey
-
-- type: loadout # DeltaV
-  id: HeadofSecurityJumpskirtGrey
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtHoSGrey
-
-- type: loadout # DeltaV
-  id: HeadofSecurityJumpsuitBlue
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitHoSBlue
-
-- type: loadout # DeltaV
-  id: HeadofSecurityJumpskirtBlue
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtHoSBlue
-
 - type: loadout
   id: HeadofSecurityTurtleneck
   equipment:
@@ -48,16 +28,6 @@
   id: HeadofSecurityFormalSkirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtHosFormal
-
-- type: loadout # DeltaV
-  id: HeadofSecurityParadeSuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitHoSParadeMale
-
-- type: loadout # DeltaV
-  id: HeadofSecurityParadeSkirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtHoSParadeMale
 
 # Head
 - type: loadout
@@ -91,14 +61,3 @@
   id: HeadofSecurityWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterHoS
-
-- type: loadout # DeltaV - security winter coat
-  id: StasecWinterCoatHoS
-  equipment:
-    outerClothing: ClothingOuterCoatStasecHoS
-
-# Shoes - DeltaV
-- type: loadout # DeltaV
-  id: HeadOfSecurityWinterBoots
-  equipment:
-    shoes: ClothingShoesBootsWinterHeadOfSecurity

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -20,36 +20,6 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtWarden
 
-- type: loadout # DeltaV
-  id: WardenJumpsuitGrey
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitWardenGrey
-
-- type: loadout # DeltaV
-  id: WardenJumpskirtGrey
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtWardenGrey
-
-- type: loadout # DeltaV
-  id: WardenJumpsuitBlue
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitWardenBlue
-
-- type: loadout # DeltaV
-  id: WardenJumpskirtBlue
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtWardenBlue
-
-- type: loadout
-  id: WardenTurtlesuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitWardenTurtle # DeltaV
-
-- type: loadout
-  id: WardenTurtleskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtWardenTurtle # DeltaV
-
 # OuterClothing
 - type: loadout
   id: WardenCoat
@@ -60,8 +30,3 @@
   id: WardenArmoredWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterWarden
-
-- type: loadout # DeltaV - security winter coat
-  id: StasecWinterCoatWarden
-  equipment:
-    outerClothing: ClothingOuterCoatStasecWarden

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -119,14 +119,6 @@
   - CaptainFormalSuit
   - CaptainFormalSkirt
 
-- type: loadoutGroup # DeltaV
-  id: CaptainGloves
-  name: loadout-group-captain-gloves
-  minLimit: 0
-  loadouts:
-  - CaptainGloves
-  - InspectionGloves
-
 - type: loadoutGroup
   id: CaptainNeck
   name: loadout-group-captain-neck
@@ -151,15 +143,6 @@
   - CaptainOuterClothing
   - CaptainWintercoat
 
-- type: loadoutGroup # DeltaV
-  id: CaptainShoes
-  name: loadout-group-captain-shoes
-  loadouts:
-  - BrownLeatherShoes
-  - WhiteLeatherShoes
-  - LaceupShoes
-  - CaptainWinterBoots
-
 - type: loadoutGroup
   id: HoPHead
   name: loadout-group-hop-head
@@ -167,25 +150,19 @@
   loadouts:
   - HoPHead
 
-- type: loadoutGroup # DeltaV
-  id: HoPGloves
-  name: loadout-group-hop-gloves
-  minLimit: 0
-  loadouts:
-  - HoPGloves
-  - InspectionGloves
-
 - type: loadoutGroup
   id: HoPJumpsuit
   name: loadout-group-hop-jumpsuit
   loadouts:
   - HoPJumpsuit
   - HoPJumpskirt
-  - HoPFormal # DeltaV
-  - HoPFormalDress # DeltaV
-  - HoPMessSkirt # DeltaV
-  - HoPMessSuit # DeltaV
-  - HoPBoatswain # DeltaV
+  # Begin DeltaV additions
+  - HoPFormal
+  - HoPFormalDress
+  - HoPMessSkirt
+  - HoPMessSuit
+  - HoPBoatswain
+  # End DeltaV additions
 
 - type: loadoutGroup
   id: HoPNeck
@@ -210,19 +187,12 @@
   name: loadout-group-hop-outerclothing
   minLimit: 0
   loadouts:
-  - HoPFormalCoat # DeltaV
-  - HoPArmoredCoat # DeltaV
-  - DuraVest # DeltaV
+  # Begin DeltaV additions
+  - HoPFormalCoat
+  - HoPArmoredCoat
+  - DuraVest
+  # End DeltaV additions
   - HoPWintercoat
-
-- type: loadoutGroup # DeltaV
-  id: HoPShoes
-  name: loadout-group-hop-shoes
-  loadouts:
-  - BrownLeatherShoes
-  - WhiteLeatherShoes
-  - LaceupShoes
-  - HoPWinterBoots
 
 # Civilian
 - type: loadoutGroup
@@ -231,14 +201,16 @@
   loadouts:
   - GreyJumpsuit
   - GreyJumpskirt
-  - MioSkirt # Start DeltaV Changes
+  # Begin DeltaV additions
+  - MioSkirt
   - NaotaHoodie
   - CasualBlueSkirt
   - CasualBlueSuit
   - CasualRedSkirt
   - CasualRedSuit
   - CasualPurpleSkirt
-  - CasualPurpleSuit # End DeltaV Changes
+  - CasualPurpleSuit
+  # Begin DeltaV additions
   - AncientJumpsuit
   - RainbowJumpsuit
 
@@ -293,23 +265,6 @@
   - BartenderHead
   - BartenderBowler
 
-- type: loadoutGroup # DeltaV
-  id: BartenderGlasses
-  name: loadout-group-bartender-glasses
-  minLimit: 0
-  loadouts:
-  - Glasses
-  - BartenderGlasses
-  - GlassesCheapSunglasses
-
-- type: loadoutGroup # DeltaV
-  id: BartenderNeck
-  name: loadout-group-bartender-neck
-  minLimit: 0
-  loadouts:
-  - ScarfBlack
-  - ScarfPurple
-
 - type: loadoutGroup
   id: BartenderJumpsuit
   name: loadout-group-bartender-jumpsuit
@@ -317,10 +272,12 @@
   - BartenderJumpsuit
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
-  - ClothingUniformNightclubSuit #imp
-  - ClothingUniformNightclubSuitSkirt #imp
-  - ClothingUniformSeniorBartender #imp
-  - ClothingUniformSeniorBartenderSkirt #imp
+  # Begin Imp additions
+  - ClothingUniformNightclubSuit
+  - ClothingUniformNightclubSuitSkirt
+  - ClothingUniformSeniorBartender
+  - ClothingUniformSeniorBartenderSkirt
+  # End Imp additions
 
 - type: loadoutGroup
   id: BartenderOuterClothing
@@ -361,13 +318,6 @@
   - ChefJacket
   - ChefWintercoat
 
-- type: loadoutGroup # DeltaV
-  id: LibrarianNeck
-  name: loadout-group-librarian-neck
-  loadouts:
-  - ScarfGreen
-  - ScarfRed
-
 - type: loadoutGroup
   id: LibrarianJumpsuit
   name: loadout-group-librarian-jumpsuit
@@ -376,8 +326,10 @@
   - LibrarianJumpskirt
   - CuratorJumpsuit
   - CuratorJumpskirt
-  - ClothingUniformCreamSuit #imp
-  - ClothingUniformCreamSuitSkirt #imp
+  # Begin Imp additions
+  - ClothingUniformCreamSuit
+  - ClothingUniformCreamSuitSkirt
+  # End Imp additions
 
 - type: loadoutGroup
   id: LawyerJumpsuit
@@ -393,8 +345,10 @@
   - LawyerJumpskirtRed
   - LawyerJumpsuitGood
   - LawyerJumpskirtGood
-  - ClothingUniformCreamSuit #imp
-  - ClothingUniformCreamSuitSkirt #imp
+  # Begin Imp additions
+  - ClothingUniformCreamSuit
+  - ClothingUniformCreamSuitSkirt
+  # End Imp additions
 
 - type: loadoutGroup
   id: LawyerNeck
@@ -402,10 +356,12 @@
   minLimit: 0
   loadouts:
   - LawyerNeck
-  - ScarfRed # Delta V
-  - ScarfBlue # Delta V
-  - ScarfBlack # Delta V
-  - ScarfPurple # Delta V
+  # Begin DeltaV additions
+  - ScarfRed
+  - ScarfBlue
+  - ScarfBlack
+  - ScarfPurple
+  # End DeltaV additions
 
 - type: loadoutGroup
   id: ChaplainHead
@@ -433,8 +389,10 @@
   - ChaplainJumpskirt
   - ChaplainRobesLight
   - ChaplainRobesDark
-  - ClothingUniformFuneralSuit #imp
-  - ClothingUniformFuneralSuitSkirt #imp
+  # Begin Imp additions
+  - ClothingUniformFuneralSuit
+  - ClothingUniformFuneralSuitSkirt
+  # End Imp additions
 
 - type: loadoutGroup
   id: ChaplainOuterClothing
@@ -467,13 +425,6 @@
   loadouts:
   - JanitorJumpsuit
   - JanitorJumpskirt
-
-- type: loadoutGroup # DeltaV
-  id: JanitorNeck
-  name: loadout-group-janitor-neck
-  minLimit: 0
-  loadouts:
-  - ScarfPurple
 
 - type: loadoutGroup
   id: JanitorGloves
@@ -521,14 +472,6 @@
   - BotanistBackpack
   - BotanistSatchel
   - BotanistDuffel
-
-- type: loadoutGroup # DeltaV
-  id: BotanistNeck
-  name: loadout-group-botanist-neck
-  minLimit: 0
-  loadouts:
-  - ScarfGreen
-  - ScarfBrown
 
 - type: loadoutGroup
   id: BotanistOuterClothing
@@ -596,14 +539,6 @@
   - MimeFrenchBeret
   - MimeCap
 
-- type: loadoutGroup # DeltaV
-  id: MimeNeck
-  name: loadout-group-mime-neck
-  minLimit: 0
-  loadouts:
-  - ScarfBlack
-  - ScarfZebra
-
 - type: loadoutGroup
   id: MimeMask
   name: loadout-group-mime-mask
@@ -634,15 +569,6 @@
   loadouts:
   - MimeWintercoat
 
-- type: loadoutGroup # DeltaV
-  id: MusicianNeck
-  name: loadout-group-musician-neck
-  minLimit: 0
-  loadouts:
-  - ScarfBlack
-  - ScarfPurple
-  - ScarfZebra
-
 - type: loadoutGroup
   id: MimeBelt
   name: loadout-group-mime-belt
@@ -667,8 +593,10 @@
   loadouts:
   - MusicianJumpsuit
   - MusicianJumpskirt
-  - ClothingUniformMrSpaceWide #imp
-  - ClothingUniformMrSpaceWideSkirt #imp
+  # Begin Imp additions
+  - ClothingUniformMrSpaceWide
+  - ClothingUniformMrSpaceWideSkirt
+  # End Imp additions
 
 - type: loadoutGroup
   id: MusicianOuterClothing
@@ -764,13 +692,6 @@
   loadouts:
   - CargoTechnicianHead
 
-- type: loadoutGroup # DeltaV
-  id: CargoTechnicianNeck
-  name: loadout-group-cargo-technician-neck
-  minLimit: 0
-  loadouts:
-  - ScarfBrown
-
 - type: loadoutGroup
   id: CargoTechnicianJumpsuit
   name: loadout-group-cargo-technician-jumpsuit
@@ -800,14 +721,6 @@
   - BlackShoes
   - CargoWinterBoots
 
-- type: loadoutGroup # DeltaV
-  id: SalvageSpecialistNeck
-  name: loadout-group-salvage-specialist-neck
-  minLimit: 0
-  loadouts:
-  - SalvageCloak
-  - ScarfBrown
-
 - type: loadoutGroup
   id: SalvageSpecialistBackpack
   name: loadout-group-salvage-specialist-backpack
@@ -828,8 +741,10 @@
   name: loadout-group-salvage-specialist-shoes
   loadouts:
   - SalvageBoots
+  # Begin DeltaV changes
   #- CargoWinterBoots
-  - SalvageWinterBoots # DeltaV
+  - SalvageWinterBoots
+  # End DeltaV changes
 
 # Engineering
 - type: loadoutGroup
@@ -890,13 +805,6 @@
   - StationEngineerHardhatRed
   - SeniorEngineerBeret
 
-- type: loadoutGroup # DeltaV
-  id: StationEngineerNeck
-  name: loadout-group-station-engineer-neck
-  minLimit: 0
-  loadouts:
-  - ScarfOrange
-
 - type: loadoutGroup
   id: StationEngineerJumpsuit
   name: loadout-group-station-engineer-jumpsuit
@@ -936,16 +844,10 @@
   loadouts:
   - StationEngineerPDA
   - SeniorEngineerPDA
-  - ElectricianPDA # DeltaV
-  - MechanicPDA # DeltaV
-
-- type: loadoutGroup # DeltaV
-  id: AtmosphericTechnicianNeck
-  name: loadout-group-atmospheric-technician-neck
-  minLimit: 0
-  loadouts:
-  - ScarfLightBlue
-  - ScarfOrange
+  # Begin DeltaV additions
+  - ElectricianPDA
+  - MechanicPDA
+  # Begin DeltaV additions
 
 - type: loadoutGroup
   id: AtmosphericTechnicianJumpsuit
@@ -1003,9 +905,11 @@
   minLimit: 0
   loadouts:
   - ResearchDirectorMantle
+  # Begin DeltaV changes
   #- ResearchDirectorCloak
-  - MystagogueCloak # DeltaV - Replaced RD cloak with MG
-  - ScarfPurple # DeltaV
+  - MystagogueCloak # Replaced RD cloak with MG
+  - ScarfPurple
+  # End DeltaV changes
 
 - type: loadoutGroup
   id: ResearchDirectorJumpsuit
@@ -1054,8 +958,10 @@
   loadouts:
   - ScientistJumpsuit
   - ScientistJumpskirt
-  #- RoboticistJumpsuit # DeltaV: Moved to RoboticistJumpsuit
-  #- RoboticistJumpskirt # DeltaV: Moved to RoboticistJumpsuit
+  # Begin DeltaV changes
+  #- RoboticistJumpsuit # Moved to RoboticistJumpsuit
+  #- RoboticistJumpskirt # Moved to RoboticistJumpsuit
+  # End DeltaV changes
   - SeniorResearcherJumpsuit
   - SeniorResearcherJumpskirt
 
@@ -1099,8 +1005,10 @@
   loadouts:
   - ScientistPDA
   - SeniorResearcherPDA
-  - LabTechPDA # DeltaV
-  - XenoarchPDA # DeltaV
+  # Begin DeltaV changes
+  - LabTechPDA
+  - XenoarchPDA
+  # End DeltaV changes
 
 - type: loadoutGroup
   id: ResearchAssistantJumpsuit
@@ -1124,16 +1032,18 @@
   loadouts:
   - HeadofSecurityJumpsuit
   - HeadofSecurityJumpskirt
-  - HeadofSecurityJumpsuitGrey # DeltaV
-  - HeadofSecurityJumpskirtGrey # DeltaV
-  - HeadofSecurityJumpsuitBlue # DeltaV
-  - HeadofSecurityJumpskirtBlue # DeltaV
   - HeadofSecurityTurtleneck
   - HeadofSecurityTurtleneckSkirt
   - HeadofSecurityFormalSuit
   - HeadofSecurityFormalSkirt
-#  - HeadofSecurityParadeSuit # DeltaV - removed for incongruence
-#  - HeadofSecurityParadeSkirt # DeltaV - removed for incongruence
+  # Begin DeltaV changes
+  - HeadofSecurityJumpsuitGrey
+  - HeadofSecurityJumpskirtGrey
+  - HeadofSecurityJumpsuitBlue
+  - HeadofSecurityJumpskirtBlue
+  #- HeadofSecurityParadeSuit # Removed for incongruence
+  #- HeadofSecurityParadeSkirt # Removed for incongruence
+  # End DeltaV changes
 
 - type: loadoutGroup
   id: HeadofSecurityNeck
@@ -1148,20 +1058,19 @@
   id: HeadofSecurityOuterClothing
   name: loadout-group-head-of-security-outerclothing
   loadouts:
-#  - HeadofSecurityCoat # DeltaV - removed for incongruence
-#  - HeadofSecurityWinterCoat # DeltaV - removed for incongruence
-  - PlateCarrier # DeltaV
-  - DuraVest # DeltaV
-  - StasecWinterCoatHoS # DeltaV
+  - HeadofSecurityCoat
+  - HeadofSecurityWinterCoat
 
 - type: loadoutGroup # DeltaV
   id: HeadofSecurityShoes
   name: loadout-group-head-of-security-shoes
   loadouts:
-#  - CombatBoots # DeltaV - removed for standardisation of equipment
-  - JackBoots # DeltaV
+  # Begin DeltaV changes
+  #- CombatBoots # Removed for standardisation of equipment
+  - JackBoots
+  - HeadOfSecurityWinterBoots
+  # End DeltaV changes
   - SecurityWinterBoots
-  - HeadOfSecurityWinterBoots # DeltaV
 
 - type: loadoutGroup
   id: WardenHead
@@ -1177,22 +1086,21 @@
   loadouts:
   - WardenJumpsuit
   - WardenJumpskirt
-  - WardenJumpsuitGrey # DeltaV
-  - WardenJumpskirtGrey # DeltaV
-  - WardenJumpsuitBlue # DeltaV
-  - WardenJumpskirtBlue # DeltaV
-  - WardenTurtlesuit # DeltaV
-  - WardenTurtleskirt # DeltaV
+  # Begin DeltaV additions
+  - WardenJumpsuitGrey
+  - WardenJumpskirtGrey
+  - WardenJumpsuitBlue
+  - WardenJumpskirtBlue
+  - WardenTurtlesuit
+  - WardenTurtleskirt
+  # End DeltaV additions
 
 - type: loadoutGroup
   id: WardenOuterClothing
   name: loadout-group-warden-outerclothing
   loadouts:
-#  - WardenCoat # DeltaV - removed for incongruence
-#  - WardenArmoredWinterCoat # DeltaV - removed for incongruence
-  - PlateCarrier # DeltaV
-  - DuraVest # DeltaV
-  - StasecWinterCoatWarden # DeltaV
+  - WardenCoat
+  - WardenArmoredWinterCoat
 
 - type: loadoutGroup
   id: SecurityHead
@@ -1212,14 +1120,16 @@
   - SecurityJumpskirt
   - SecurityJumpsuitGrey
   - SecurityJumpskirtGrey
-  - SecurityJumpsuitBlue # DeltaV
-  - SecurityJumpskirtBlue # DeltaV
-#  - SeniorOfficerJumpsuit # DeltaV - removed for incongruence
-#  - SeniorOfficerJumpskirt # DeltaV - removed for incongruence
-  - SeniorSecOfficerTurtlesuit # DeltaV
-  - SeniorSecOfficerTurtleskirt # DeltaV
-  - SeniorSecOfficerJumpsuit # DeltaV
-  - SeniorSecOfficerJumpskirt # DeltaV
+  # Begin DeltaV changes
+  - SecurityJumpsuitBlue
+  - SecurityJumpskirtBlue
+#  - SeniorOfficerJumpsuit # Removed for incongruence
+#  - SeniorOfficerJumpskirt # Removed for incongruence
+  - SeniorSecOfficerTurtlesuit
+  - SeniorSecOfficerTurtleskirt
+  - SeniorSecOfficerJumpsuit
+  - SeniorSecOfficerJumpskirt
+  # End DeltaV changes
 
 - type: loadoutGroup
   id: SecurityBackpack
@@ -1240,13 +1150,9 @@
   id: SecurityOuterClothing
   name: loadout-group-security-outerclothing
   loadouts:
-#  - ArmorVest # DeltaV - removed for incongruence
-  - PlateCarrier # DeltaV
-  - DuraVest # DeltaV
-#  - ArmorVestSlim - removed for incongruence
-#  - SecurityOfficerWintercoat - removed for incongruence
-  - StasecSweater # DeltaV
-  - StasecWinterCoat # DeltaV
+  - ArmorVest
+  - ArmorVestSlim
+  - SecurityOfficerWintercoat
 
 - type: loadoutGroup
   id: SecurityShoes
@@ -1261,13 +1167,6 @@
   loadouts:
   - SecurityPDA
   - SeniorOfficerPDA
-
-- type: loadoutGroup # DeltaV
-  id: SecurityNeck
-  name: loadout-group-security-neck
-  minLimit: 0
-  loadouts:
-  - ScarfRed
 
 - type: loadoutGroup
   id: DetectiveHead
@@ -1290,28 +1189,17 @@
   id: DetectiveJumpsuit
   name: loadout-group-detective-jumpsuit
   loadouts:
-#  - DetectiveJumpsuit # DeltaV - removed for incongruence
-#  - DetectiveJumpskirt # DeltaV - removed for incongruence
-#  - NoirJumpsuit # DeltaV - removed for incongruence
-#  - NoirJumpskirt # DeltaV - removed for incongruence
-  - ForensicSpecJumpsuit # DeltaV
-  - ForensicSpecJumpskirt # DeltaV
-  - ForensicSpecTurtlesuit # DeltaV
-  - ForensicSpecTurtleskirt # DeltaV
-  - ClothingUniformMiamiVice #imp
-  - ClothingUniformMiamiViceSkirt #imp
-  - ClothingUniformDetectiveSuit #imp
-  - ClothingUniformDetectiveSuitSkirt #imp
+  - DetectiveJumpsuit
+  - DetectiveJumpskirt
+  - NoirJumpsuit
+  - NoirJumpskirt
 
 - type: loadoutGroup
   id: DetectiveOuterClothing
   name: loadout-group-detective-outerclothing
   loadouts:
-#  - DetectiveArmorVest # DeltaV - removed for incongruence
-#  - DetectiveCoat # DeltaV - removed for incongruence
-  - StasecWinterCoatDet # DeltaV
-  - PlateCarrier # DeltaV
-  - DuraVest # DeltaV
+  - DetectiveArmorVest
+  - DetectiveCoat
 
 - type: loadoutGroup
   id: SecurityCadetJumpsuit
@@ -1393,14 +1281,6 @@
   - GreenSurgeryCap
   - PurpleSurgeryCap
   - NurseHat
-
-- type: loadoutGroup # DeltaV
-  id: MedicalDoctorNeck
-  name: loadout-group-medical-doctor-neck
-  minLimit: 0
-  loadouts:
-  - Stethoscope
-  - ScarfBlue
 
 - type: loadoutGroup
   id: MedicalDoctorJumpsuit
@@ -1494,35 +1374,6 @@
   - ChemistBackpack
   - ChemistSatchel
   - ChemistDuffel
-
-# Chemist Neck - DeltaV
-- type: loadoutGroup
-  id: ChemistNeck
-  name: loadout-group-chemist-neck
-  minLimit: 0
-  loadouts:
-  - ChemistTie # DeltaV
-  - ScarfOrange
-  - ScarfBlue
-
-# Chemist Gloves - DeltaV
-- type: loadoutGroup
-  id: ChemistGloves
-  name: loadout-group-chemist-gloves
-  minLimit: 0
-  loadouts:
-  - LatexGloves
-  - NitrileGloves
-  - ChemistGloves # DeltaV
-
-# Chemist Shoes - DeltaV
-- type: loadoutGroup
-  id: ChemistShoes
-  name: loadout-group-chemist-shoes
-  loadouts:
-  - WhiteShoes
-  - ChemistWinterBoots # DeltaV
-  - ChemistShoes # DeltaV
 
 - type: loadoutGroup
   id: ParamedicHead

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -365,7 +365,7 @@
   - HeadofSecurityJumpsuit
   - SecurityBackpack
   - SecurityBelt
-  - HeadofSecurityOuterClothing
+  - HeadofSecurityOuterClothingDeltaV # DeltaV - Switched to DeltaV version, was HeadofSecurityOuterClothing
   - HeadofSecurityShoes # DeltaV - winter boots
   - SurvivalSecurity
   - Trinkets
@@ -382,11 +382,11 @@
   - WardenJumpsuit
   - SecurityBackpack
   - SecurityBelt
-  - WardenOuterClothing
+  - WardenOuterClothingDeltaV # DeltaV - Switched to DeltaV version, was WardenOuterClothing
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
-  - SecurityStar 
+  - SecurityStar
   - GroupSpeciesBreathToolSecurity
   - SecurityAllFirearm # DeltaV - loadouts
   - SecurityAllAmmo # DeltaV - loadouts
@@ -414,9 +414,9 @@
   groups:
   - DetectiveHead
   - SecurityNeck # DeltaV - replace DetectiveNeck for incongruence
-  - DetectiveJumpsuit
+  - DetectiveJumpsuitDeltaV # DeltaV - Replaced with DeltaV version, was DetectiveJumpsuit
   - SecurityBackpack
-  - DetectiveOuterClothing
+  - DetectiveOuterClothingDeltaV # DeltaV - Replaced with DeltaV version, was DetectiveOuterClothing
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -386,7 +386,7 @@
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
-  - SecurityStar
+  - SecurityStar 
   - GroupSpeciesBreathToolSecurity
   - SecurityAllFirearm # DeltaV - loadouts
   - SecurityAllAmmo # DeltaV - loadouts

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Cargo/quartermaster.yml
@@ -1,0 +1,17 @@
+# Jumpsuit
+- type: loadout
+  id: QuartermasterFormalDress
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtQMFormal
+
+# Head
+- type: loadout
+  id: LogiOfficerBeret
+  equipment:
+    head: ClothingHeadHatBeretLogi
+
+# Shoes
+- type: loadout
+  id: QuartermasterWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterLogisticsOfficer

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -13,3 +13,15 @@
   id: ExcavatorPDA
   equipment:
     id: ExcavatorPDA
+
+# Shoes
+- type: loadout
+  id: SalvageWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterMiner
+
+# Neck
+- type: loadout
+  id: SalvageCloak
+  equipment:
+    neck: ClothingNeckSalvager

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Civilian/bartender.yml
@@ -8,3 +8,9 @@
   id: MixologistPDA
   equipment:
     id: MixologistPDA
+
+# Glasses
+- type: loadout
+  id: BartenderGlasses
+  equipment:
+    eyes: ClothingEyesHudBeer

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Civilian/passenger.yml
@@ -23,3 +23,49 @@
   id: StudentPDA
   equipment:
     id: StudentPDA
+
+# Jumpsuit
+# Rose Hoodie w/ Skirt
+- type: loadout
+  id: MioSkirt
+  equipment:
+    jumpsuit: ClothingCostumeMioSkirt
+
+# Turqoise Hoodie w/ Shorts
+- type: loadout
+  id: NaotaHoodie
+  equipment:
+    jumpsuit: ClothingCostumeNaota
+
+# Casual Red
+- type: loadout
+  id: CasualRedSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCasualRed
+
+- type: loadout
+  id: CasualRedSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCasualRed
+
+# Casual Blue
+- type: loadout
+  id: CasualBlueSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCasualBlue
+
+- type: loadout
+  id: CasualBlueSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCasualBlue
+
+# Casual Purple
+- type: loadout
+  id: CasualPurpleSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtCasualPurple
+
+- type: loadout
+  id: CasualPurpleSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitCasualPurple

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Command/captain.yml
@@ -1,0 +1,28 @@
+# Head
+- type: loadout
+  id: CaptainBeret
+  equipment:
+    head: ClothingHeadHatBeretCap
+
+# Neck
+- type: loadout
+  id: CaptainCloakFormal
+  equipment:
+    neck: ClothingNeckCloakCapFormal
+
+# Gloves
+- type: loadout
+  id: CaptainGloves
+  equipment:
+    gloves: ClothingHandsGlovesCaptain
+
+- type: loadout
+  id: InspectionGloves
+  equipment:
+    gloves: ClothingHandsGlovesInspection
+
+# Shoes
+- type: loadout
+  id: CaptainWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterCap

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -8,3 +8,9 @@
   id: MechanicPDA
   equipment:
     id: MechanicPDA
+
+# OuterClothing
+- type: loadout
+  id: StationEngineerWintercoat
+  equipment:
+    outerClothing: ClothingOuterWinterEngi

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/chemist.yml
@@ -1,0 +1,34 @@
+# Jumpsuit
+- type: loadout
+  id: ChemistFormalSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitChemShirt
+
+# OuterClothing
+- type: loadout
+  id: ChemistApron
+  equipment:
+    outerClothing: ClothingOuterApronChemist
+
+# Gloves
+- type: loadout
+  id: ChemistGloves
+  equipment:
+    gloves: ClothingHandsGlovesChemist
+
+# Shoes
+- type: loadout
+  id: ChemistWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterChem
+
+- type: loadout
+  id: ChemistShoes
+  equipment:
+    shoes: ClothingShoesEnclosedChem
+
+# Neck
+- type: loadout
+  id: ChemistTie
+  equipment:
+    neck: ClothingNeckTieChem

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/chief_medical_officer.yml
@@ -1,0 +1,5 @@
+# Shoes
+- type: loadout
+  id: ChiefMedicalOfficerWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterChiefMedicalOfficer

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/medical_doctor.yml
@@ -3,3 +3,9 @@
   id: ClinicianPDA
   equipment:
     id: ClinicianPDA
+
+# Neck
+- type: loadout
+  id: Stethoscope
+  equipment:
+    neck: ClothingNeckStethoscope

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/paramedic.yml
@@ -1,0 +1,5 @@
+# Shoes
+- type: loadout
+  id: ParamedicWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterParamedic

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/psychologist.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Medical/psychologist.yml
@@ -33,11 +33,6 @@
 
 # Head
 - type: loadout
-  id: PsychologistFrenchBeret
-  equipment:
-    head: ClothingHeadHatBeretFrench
-
-- type: loadout
   id: PsychologistGreyFlatcap
   equipment:
     head: ClothingHeadHatGreyFlatcap
@@ -49,19 +44,9 @@
 
 # OuterClothing
 - type: loadout
-  id: PsychologistMedicalWinterCoat
-  equipment:
-    outerClothing: ClothingOuterWinterMed
-
-- type: loadout
   id: PsychologistWinterCoat
   equipment:
     outerClothing: ClothingOuterWinterCoat
-
-- type: loadout
-  id: PsychologistWinterCoatPlaid
-  equipment:
-    outerClothing: ClothingOuterWinterCoatPlaid
 
 - type: loadout
   id: PsychologistCoatBomber

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Science/mystagogue.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Science/mystagogue.yml
@@ -1,9 +1,28 @@
+# Neck
 - type: loadout
   id: MystagogueCloak
   equipment:
     neck: ClothingNeckCloakMystagogue
 
+# Head
+- type: loadout # DeltaV
+  id: ResearchDirectorHood
+  equipment:
+    head: ClothingHeadHoodMysta
+
 - type: loadout
   id: MystagogueBeret
   equipment:
     head: ClothingHeadHatBeretMysta
+
+# OuterClothing
+- type: loadout
+  id: MystaLabCoat
+  equipment:
+    outerClothing: ClothingOuterCoatRndMysta
+
+# Shoes
+- type: loadout
+  id: ResearchDirectorWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterMystagogue

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/detective.yml
@@ -46,3 +46,36 @@
   id: SecurityFirearmWeaponRevolverDeckard
   equipment:
     pocket1: WeaponRevolverDeckard
+
+# Jumpsuit
+- type: loadout # DeltaV
+  id: ForensicSpecJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitForensicSpec
+
+- type: loadout # DeltaV
+  id: ForensicSpecJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtForensicSpec
+
+- type: loadout # DeltaV
+  id: ForensicSpecTurtlesuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitDetTurtle
+
+- type: loadout # DeltaV
+  id: ForensicSpecTurtleskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtDetTurtle
+
+#OuterClothing
+- type: loadout # DeltaV
+  id: StasecWinterCoatDet
+  equipment:
+    outerClothing: ClothingOuterCoatStasecDet
+
+#Head
+- type: loadout # DeltaV
+  id: DetBeret
+  equipment:
+    head: ClothingHeadHatBeretDet

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/detective.yml
@@ -48,34 +48,34 @@
     pocket1: WeaponRevolverDeckard
 
 # Jumpsuit
-- type: loadout # DeltaV
+- type: loadout
   id: ForensicSpecJumpsuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitForensicSpec
 
-- type: loadout # DeltaV
+- type: loadout
   id: ForensicSpecJumpskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtForensicSpec
 
-- type: loadout # DeltaV
+- type: loadout
   id: ForensicSpecTurtlesuit
   equipment:
     jumpsuit: ClothingUniformJumpsuitDetTurtle
 
-- type: loadout # DeltaV
+- type: loadout
   id: ForensicSpecTurtleskirt
   equipment:
     jumpsuit: ClothingUniformJumpskirtDetTurtle
 
 #OuterClothing
-- type: loadout # DeltaV
+- type: loadout
   id: StasecWinterCoatDet
   equipment:
     outerClothing: ClothingOuterCoatStasecDet
 
 #Head
-- type: loadout # DeltaV
+- type: loadout
   id: DetBeret
   equipment:
     head: ClothingHeadHatBeretDet

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/head_of_security.yml
@@ -1,0 +1,42 @@
+# Jumpsuit
+- type: loadout
+  id: HeadofSecurityJumpsuitGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoSGrey
+
+- type: loadout
+  id: HeadofSecurityJumpskirtGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtHoSGrey
+
+- type: loadout
+  id: HeadofSecurityJumpsuitBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoSBlue
+
+- type: loadout
+  id: HeadofSecurityJumpskirtBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtHoSBlue
+
+- type: loadout
+  id: HeadofSecurityParadeSuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitHoSParadeMale
+
+- type: loadout
+  id: HeadofSecurityParadeSkirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtHoSParadeMale
+
+# OuterClothing
+- type: loadout
+  id: StasecWinterCoatHoS
+  equipment:
+    outerClothing: ClothingOuterCoatStasecHoS
+
+# Shoes
+- type: loadout
+  id: HeadOfSecurityWinterBoots
+  equipment:
+    shoes: ClothingShoesBootsWinterHeadOfSecurity

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/warden.yml
@@ -1,0 +1,36 @@
+# Jumpsuit
+- type: loadout
+  id: WardenJumpsuitGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitWardenGrey
+
+- type: loadout
+  id: WardenJumpskirtGrey
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtWardenGrey
+
+- type: loadout
+  id: WardenJumpsuitBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitWardenBlue
+
+- type: loadout
+  id: WardenJumpskirtBlue
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtWardenBlue
+
+- type: loadout
+  id: WardenTurtlesuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitWardenTurtle
+
+- type: loadout
+  id: WardenTurtleskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtWardenTurtle
+
+# OuterClothing
+- type: loadout
+  id: StasecWinterCoatWarden
+  equipment:
+    outerClothing: ClothingOuterCoatStasecWarden

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -21,6 +21,68 @@
   - BartenderJumpskirt
   - BartenderJumpsuitPurple
 
+## Bartender
+- type: loadoutGroup
+  id: BartenderGlasses
+  name: loadout-group-bartender-glasses
+  minLimit: 0
+  loadouts:
+  - Glasses
+  - BartenderGlasses
+  - GlassesCheapSunglasses
+
+- type: loadoutGroup
+  id: BartenderNeck
+  name: loadout-group-bartender-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBlack
+  - ScarfPurple
+
+## Librarian
+- type: loadoutGroup
+  id: LibrarianNeck
+  name: loadout-group-librarian-neck
+  loadouts:
+  - ScarfGreen
+  - ScarfRed
+
+## Janitor
+- type: loadoutGroup
+  id: JanitorNeck
+  name: loadout-group-janitor-neck
+  minLimit: 0
+  loadouts:
+  - ScarfPurple
+
+## Botanist
+- type: loadoutGroup
+  id: BotanistNeck
+  name: loadout-group-botanist-neck
+  minLimit: 0
+  loadouts:
+  - ScarfGreen
+  - ScarfBrown
+
+## Mime
+- type: loadoutGroup
+  id: MimeNeck
+  name: loadout-group-mime-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBlack
+  - ScarfZebra
+
+## Musician
+- type: loadoutGroup
+  id: MusicianNeck
+  name: loadout-group-musician-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBlack
+  - ScarfPurple
+  - ScarfZebra
+
 # Logistics
 ## Courier
 - type: loadoutGroup
@@ -116,6 +178,23 @@
   loadouts:
   - BlackShoes
   - CargoWinterBoots
+
+## Cargo Technician
+- type: loadoutGroup
+  id: CargoTechnicianNeck
+  name: loadout-group-cargo-technician-neck
+  minLimit: 0
+  loadouts:
+  - ScarfBrown
+
+## Salvage Specialist
+- type: loadoutGroup
+  id: SalvageSpecialistNeck
+  name: loadout-group-salvage-specialist-neck
+  minLimit: 0
+  loadouts:
+  - SalvageCloak
+  - ScarfBrown
 
 # Security
 ## Brig Medic
@@ -257,6 +336,63 @@
   - SecurityFirearmSpeedLoaderSpecialRubber
   - SecurityFirearmSpeedLoaderSpecial
 
+## Security Officer
+- type: loadoutGroup
+  id: SecurityNeck
+  name: loadout-group-security-neck
+  minLimit: 0
+  loadouts:
+  - ScarfRed
+
+- type: loadoutGroup
+  id: SecurityOuterClothingDeltaV
+  name: loadout-group-security-outerclothing
+  loadouts:
+  - PlateCarrier
+  - DuraVest
+  - StasecSweater
+  - StasecWinterCoat
+
+## Warden
+- type: loadoutGroup
+  id: WardenOuterClothingDeltaV
+  name: loadout-group-warden-outerclothing
+  loadouts:
+  - PlateCarrier
+  - DuraVest
+  - StasecWinterCoatWarden
+
+## Head of Security
+- type: loadoutGroup
+  id: HeadofSecurityOuterClothingDeltaV
+  name: loadout-group-head-of-security-outerclothing
+  loadouts:
+  - PlateCarrier
+  - DuraVest
+  - StasecWinterCoatHoS
+
+## Detective
+- type: loadoutGroup
+  id: DetectiveJumpsuitDeltaV
+  name: loadout-group-detective-jumpsuit
+  loadouts:
+  - ForensicSpecJumpsuit
+  - ForensicSpecJumpskirt
+  - ForensicSpecTurtlesuit
+  - ForensicSpecTurtleskirt
+  - ClothingUniformMiamiVice #imp
+  - ClothingUniformMiamiViceSkirt #imp
+  - ClothingUniformDetectiveSuit #imp
+  - ClothingUniformDetectiveSuitSkirt #imp
+
+- type: loadoutGroup
+  id: DetectiveOuterClothing
+  name: loadout-group-detective-outerclothing
+  loadouts:
+  - StasecWinterCoatDet
+  - PlateCarrier
+  - DuraVest
+
 # Medical
 ## Psychologist
 - type: loadoutGroup
@@ -265,7 +401,7 @@
   minLimit: 0
   loadouts:
   - MedicalBeret
-  - PsychologistFrenchBeret
+  - MimeFrenchBeret
   - PsychologistGreyFlatcap
   - PsychologistBrownFlatcap
 
@@ -274,9 +410,9 @@
   name: loadout-group-psychologist-outerclothing
   minLimit: 0
   loadouts:
-  - PsychologistMedicalWinterCoat
+  - MedicalDoctorWintercoat
   - PsychologistWinterCoat
-  - PsychologistWinterCoatPlaid
+  - WinterCoatPlaid
   - PsychologistCoatBomber
   - PsychologistSweater
 
@@ -288,6 +424,42 @@
   - LaceupShoes
   - MedicalWinterBoots
   - WinterBoots
+
+## Medical Doctor
+- type: loadoutGroup
+  id: MedicalDoctorNeck
+  name: loadout-group-medical-doctor-neck
+  minLimit: 0
+  loadouts:
+  - Stethoscope
+  - ScarfBlue
+
+## Chemist
+- type: loadoutGroup
+  id: ChemistNeck
+  name: loadout-group-chemist-neck
+  minLimit: 0
+  loadouts:
+  - ChemistTie
+  - ScarfOrange
+  - ScarfBlue
+
+- type: loadoutGroup
+  id: ChemistGloves
+  name: loadout-group-chemist-gloves
+  minLimit: 0
+  loadouts:
+  - LatexGloves
+  - NitrileGloves
+  - ChemistGloves
+
+- type: loadoutGroup
+  id: ChemistShoes
+  name: loadout-group-chemist-shoes
+  loadouts:
+  - WhiteShoes
+  - ChemistWinterBoots
+  - ChemistShoes
 
 # Justice
 ## Chief Justice
@@ -329,6 +501,24 @@
   loadouts:
   - LeatherShoes
   - LaceupShoes
+
+# Engineering
+## Station Engineer
+- type: loadoutGroup
+  id: StationEngineerNeck
+  name: loadout-group-station-engineer-neck
+  minLimit: 0
+  loadouts:
+  - ScarfOrange
+
+## Atmospheric Technician
+- type: loadoutGroup
+  id: AtmosphericTechnicianNeck
+  name: loadout-group-atmospheric-technician-neck
+  minLimit: 0
+  loadouts:
+  - ScarfLightBlue
+  - ScarfOrange
 
 ## Clerk
 - type: loadoutGroup
@@ -486,6 +676,42 @@
   loadouts:
   - HoPGloves
   - InspectionGloves
+
+## Captain
+- type: loadoutGroup
+  id: CaptainGloves
+  name: loadout-group-captain-gloves
+  minLimit: 0
+  loadouts:
+  - CaptainGloves
+  - InspectionGloves
+
+- type: loadoutGroup
+  id: CaptainShoes
+  name: loadout-group-captain-shoes
+  loadouts:
+  - BrownLeatherShoes
+  - WhiteLeatherShoes
+  - LaceupShoes
+  - CaptainWinterBoots
+
+## Head of Personnel
+- type: loadoutGroup
+  id: HoPGloves
+  name: loadout-group-hop-gloves
+  minLimit: 0
+  loadouts:
+  - HoPGloves
+  - InspectionGloves
+
+- type: loadoutGroup
+  id: HoPShoes
+  name: loadout-group-hop-shoes
+  loadouts:
+  - BrownLeatherShoes
+  - WhiteLeatherShoes
+  - LaceupShoes
+  - HoPWinterBoots
 
 # PDAs
 - type: loadoutGroup

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -386,7 +386,7 @@
   - ClothingUniformDetectiveSuitSkirt #imp
 
 - type: loadoutGroup
-  id: DetectiveOuterClothing
+  id: DetectiveOuterClothingDeltaV
   name: loadout-group-detective-outerclothing
   loadouts:
   - StasecWinterCoatDet


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
New loadouts:
- Warden DeltaV loadout to untouch the upstream one as it's just filled with DeltaV comments.
- Head of Security loadout, same reason as above.
- Detective loadout, same reason.

Changes:
- Cleaned two repeated loadouts groups.
- Moved DeltaV loadout groups to the DeltaV file.
- Modified comments.

The `role_loadouts.yml` comments are a mess, and moving lines would only cause more conflicts on upstream merge, so i just let them be.
## Why / Balance
DeltaV loadouts in upstream files is bad and comments were ugly.

## Technical details
Changed `role_loadouts.yml` to reflect the three new sec DeltaV loadouts.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**

N/A
