### PR TITLE
Replace the medical biofabricator board with a flatpack

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -231,7 +231,7 @@
     - id: RubberStampCMO
     - id: MedTekCartridge
     # Shitmed
-    #- id: MedicalBiofabMachineBoard #DeltaV - Replaced with a flatpack at Prototypes\_DV\Catalog\Fills\Lockers\heads.yml
+    #- id: MedicalBiofabMachineBoard #DeltaV - Replaced with a flatpack at Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -231,7 +231,7 @@
     - id: RubberStampCMO
     - id: MedTekCartridge
     # Shitmed
-    - id: MedicalBiofabMachineBoard
+    #- id: MedicalBiofabMachineBoard #DeltaV - Replaced with a flatpack at Prototypes\_DV\Catalog\Fills\Lockers\heads.yml
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
@@ -67,6 +67,7 @@
     - id: LunchboxCommandFilledRandom
       prob: 0.3
     - id: ChemMasterFlatpack # So the chemist can make pills
+    - id: MedBioFabricatorFlatpack # Replaced the shitmed board
 
 - type: entityTable
   id: LockerFillResearchDirectorDeltaV

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/Devices/flatpack.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/Devices/flatpack.yml
@@ -6,3 +6,12 @@
   components:
   - type: Flatpack
     entity: ChemMaster
+
+- type: entity
+  parent: BaseFlatpack
+  id: MedBioFabricatorFlatpack
+  name: medical biofabricator flatpack
+  description: A flatpack used for constructing a medical biofabricator.
+  components:
+  - type: Flatpack
+    entity: MedicalBiofabricator


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Changes the body part fabricator board from CMO's locker with a flatpack version.

## Why / Balance
Requested by direction.

## Technical details
N/A, just YAML change.

## Media
![image](https://github.com/user-attachments/assets/aade65b0-5922-4a32-8d32-c9d977285656)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: CMO's locker now starts with a medical biofabricator flatpack instead of it's machine board.
