### PR TITLE
Fixed various issues with kill objectives

### DIFF
--- a/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
+++ b/Content.Server/Objectives/Systems/KillPersonConditionSystem.cs
@@ -41,18 +41,18 @@ public sealed class KillPersonConditionSystem : EntitySystem
 
     private void OnPersonAssigned(Entity<PickRandomPersonComponent> ent, ref ObjectiveAssignedEvent args)
     {
-        AssignRandomTarget(ent, args, _ => true);
+        AssignRandomTarget(ent, ref args, _ => true);
     }
 
     private void OnHeadAssigned(Entity<PickRandomHeadComponent> ent, ref ObjectiveAssignedEvent args)
     {
-        AssignRandomTarget(ent, args, mindId =>
+        AssignRandomTarget(ent, ref args, mindId =>
             TryComp<MindComponent>(mindId, out var mind) &&
             mind.OwnedEntity is { } ownedEnt &&
             HasComp<CommandStaffComponent>(ownedEnt));
     }
 
-    private void AssignRandomTarget(EntityUid uid, ObjectiveAssignedEvent args, Predicate<EntityUid> filter, bool fallbackToAny = true)
+    private void AssignRandomTarget(EntityUid uid, ref ObjectiveAssignedEvent args, Predicate<EntityUid> filter, bool fallbackToAny = true)
     {
         // invalid prototype
         if (!TryComp<TargetObjectiveComponent>(uid, out var target))
@@ -96,6 +96,13 @@ public sealed class KillPersonConditionSystem : EntitySystem
 
         // Pick between humans matching our filter or fall back to all humans alive
         var selectedHumans = filteredHumans.Count > 0 ? filteredHumans : allHumans;
+
+        // Still no valid targets even after the fallback
+        if (selectedHumans.Count == 0)
+        {
+            args.Cancelled = true;
+            return;
+        }
 
         _target.SetTarget(uid, _random.Pick(selectedHumans), target);
     }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
1.) When assigning a kill objective when there were no valid targets and no valid fallbacks (E.g no players) there would be a error because the SetTarget function assumed that the passed in target actually existed.
2.) The event was not passed by reference even though it was canceling the event like it was pass by reference. This caused canceling the event after it was assigned to give kill objectives without any targets.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->