### PR TITLE
Increases Minimum Hours For Command Roles

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -16,7 +16,7 @@
       time: 7200 # 2 hours
     - !type:DepartmentTimeRequirement
       department: Logistics # DeltaV - Logistics Department replacing Cargo
-      time: 43200 # DeltaV 12 hours
+      time: 90000 # DeltaV - 25 hours
     - !type:OverallPlaytimeRequirement
       time: 144000 #40 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -6,13 +6,13 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 36000 # DeltaV - 10 hours
+      time: 72000 # DeltaV - 20 hours
 #    - !type:RoleTimeRequirement # DeltaV - No Station Engineer time requirement
 #      role: JobStationEngineer
 #      time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 90000 # DeltaV - 25 hours, was 10
+      time: 108000 # DeltaV - 30 hours, was 10
 #    - !type:OverallPlaytimeRequirement
 #      time: 144000 # DeltaV - was 40 hours upstream
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -15,9 +15,9 @@
 #      time: 21600 #6 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 43200 # DeltaV - 12 hours
+      time: 90000 # DeltaV - 25 hours
     - !type:OverallPlaytimeRequirement
-      time: 72000 # DeltaV - 20 hours, was 40
+      time: 90000 # DeltaV - 25 hours, was 20
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -5,11 +5,17 @@
   playTimeTracker: JobResearchDirector
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
+    - !type:RoleTimeRequirement # DeltaV - server specific role
+      role: JobForensicMantis # DeltaV - server specific role
+      time: 7200 # DeltaV - 2 hrs
+    - !type:RoleTimeRequirement # DeltaV - server specific role
+      role: JobChaplain # DeltaV - server specific role
+      time: 7200 # DeltaV - 2 hrs
     - !type:DepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
-      time: 54000 # DeltaV - 15 hours
+      time: 90000 # DeltaV - 25 hours
     - !type:OverallPlaytimeRequirement
-      time: 72000 # DeltaV - 20 hours, was 40
+      time: 90000 # DeltaV - 25 hours, was 40
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -5,12 +5,11 @@
   playTimeTracker: JobResearchDirector
   antagAdvantage: 6 # DeltaV - Reduced TC: Head of Staff
   requirements:
-    - !type:RoleTimeRequirement # DeltaV - server specific role
-      role: JobForensicMantis # DeltaV - server specific role
-      time: 7200 # DeltaV - 2 hrs
-    - !type:RoleTimeRequirement # DeltaV - server specific role
-      role: JobChaplain # DeltaV - server specific role
-      time: 7200 # DeltaV - 2 hrs
+    # Start DeltaV additions - Server specific roles
+    - !type:RoleTimeRequirement
+      role: JobForensicMantis
+      time: 7200 # 2 hrs
+      # End DeltaV additions
     - !type:DepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
       time: 90000 # DeltaV - 25 hours

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -9,7 +9,7 @@
     - !type:RoleTimeRequirement
       role: JobForensicMantis
       time: 7200 # 2 hrs
-      # End DeltaV additions
+    # End DeltaV additions
     - !type:DepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics Department replacing Science
       time: 90000 # DeltaV - 25 hours


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

HOS requires 24 hours departmentally (warden unlocks at 16 and you need 10 warden hours) PLUS 10 command hours, which is a minimum of 34 hours. HOP, which is probably the easiest command role, requires 20. What does CMO require?

_12._

Increased command times to be more consistent and hopefully have less meme LOs/MGs/CMOs who don't know what they are doing. Increased CE time even further per Lyndo's input.

## Technical details
<!-- Summary of code changes for easier review. -->

LO
departmental 12 --> 25 hours

CE
atmos 10 --> 20
departmental 25 --> 30

CMO
departmental 12 --> 25
overall 20 --> 25

MG
added mantis, 2 hrs
added chaplain, 2 hrs
departmental 15 --> 25
overall 20 --> 25

NOTE: I hereby release all changes made in this PR under MIT license.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Command hour minimums increased across the board.
