### PR TITLE
[Port]Game presets can now have cooldowns to prevent back-to-back modes

### DIFF
--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -38,11 +38,9 @@ namespace Content.Server.GameTicking.Presets
         /// Ensures that this gamemode does not get selected for a number of rounds
         /// by something like Secret. This is not considered when the preset is forced.
         /// </summary>
-        [DataField("cooldown")]
+        [DataField]
         public int Cooldown = 0;
         // End Imp
-
-
 
         [DataField("rules", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public IReadOnlyList<string> Rules { get; private set; } = Array.Empty<string>();

--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -33,6 +33,17 @@ namespace Content.Server.GameTicking.Presets
         [DataField("maxPlayers")]
         public int? MaxPlayers;
 
+        // Begin Imp
+        /// <summary>
+        /// Ensures that this gamemode does not get selected for a number of rounds
+        /// by something like Secret. This is not considered when the preset is forced.
+        /// </summary>
+        [DataField("cooldown")]
+        public int Cooldown = 0;
+        // End Imp
+
+
+
         [DataField("rules", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public IReadOnlyList<string> Rules { get; private set; } = Array.Empty<string>();
 

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules.Components;
+using Content.Shared._DV.CCVars;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
@@ -51,13 +52,16 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
         Log.Info($"Selected {preset.ID} as the secret preset.");
         _adminLogger.Add(LogType.EventStarted, $"Selected {preset.ID} as the secret preset.");
 
-        if (preset.Cooldown > 0) // Begin Imp
+        if (_configurationManager.GetCVar(DCCVars.EnableBacktoBack) == true) // DeltaV
         {
-            _nextRoundAllowed[preset.ID] = _ticker.RoundId + preset.Cooldown + 1;
-            Log.Info($"{preset.ID} is now on cooldown until {_nextRoundAllowed[preset.ID]}");
-        } // End Imp
+            if (preset.Cooldown > 0) // Begin Imp
+            {
+                _nextRoundAllowed[preset.ID] = _ticker.RoundId + preset.Cooldown + 1;
+                Log.Info($"{preset.ID} is now on cooldown until {_nextRoundAllowed[preset.ID]}");
+            } // End Imp
+        } // DeltaV
 
-        foreach (var rule in preset.Rules)
+foreach (var rule in preset.Rules)
         {
             EntityUid ruleEnt;
 
@@ -177,11 +181,15 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
             if (ruleComp.MinPlayers > players && ruleComp.CancelPresetOnTooFewPlayers)
                 return false;
         }
-        if (_nextRoundAllowed.ContainsKey(selected.ID) && _nextRoundAllowed[selected.ID] > _ticker.RoundId) // Begin Imp
+
+        if (_configurationManager.GetCVar(DCCVars.EnableBacktoBack) == true) // DeltaV
         {
-            Log.Info($"Skipping preset {selected.ID} (Not available until round {_nextRoundAllowed[selected.ID]}");
-            return false;
-        } // End Imp
+            if (_nextRoundAllowed.ContainsKey(selected.ID) && _nextRoundAllowed[selected.ID] > _ticker.RoundId) // Begin Imp
+            {
+                Log.Info($"Skipping preset {selected.ID} (Not available until round {_nextRoundAllowed[selected.ID]}");
+                return false;
+            } // End Imp
+        } // DeltaV
 
         return true;
     }

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -4,7 +4,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules.Components;
-using Content.Shared._DV.CCVars;
+using Content.Shared._DV.CCVars; // DeltaV
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
@@ -61,7 +61,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
             } // End Imp
         } // DeltaV
 
-foreach (var rule in preset.Rules)
+        foreach (var rule in preset.Rules)
         {
             EntityUid ruleEnt;
 

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -22,6 +22,11 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IComponentFactory _compFact = default!;
+    [Dependency] private readonly GameTicker _ticker = default!; // begin Imp
+
+    // Dictionary that contains the minimum round number for certain preset
+    // prototypes to be allowed to roll again
+    private static Dictionary<ProtoId<GamePresetPrototype>, int> _nextRoundAllowed = new(); // end Imp
 
     private string _ruleCompName = default!;
 
@@ -45,6 +50,12 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
 
         Log.Info($"Selected {preset.ID} as the secret preset.");
         _adminLogger.Add(LogType.EventStarted, $"Selected {preset.ID} as the secret preset.");
+
+        if (preset.Cooldown > 0) // Begin Imp
+        {
+            _nextRoundAllowed[preset.ID] = _ticker.RoundId + preset.Cooldown + 1;
+            Log.Info($"{preset.ID} is now on cooldown until {_nextRoundAllowed[preset.ID]}");
+        } // End Imp
 
         foreach (var rule in preset.Rules)
         {
@@ -166,6 +177,11 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
             if (ruleComp.MinPlayers > players && ruleComp.CancelPresetOnTooFewPlayers)
                 return false;
         }
+        if (_nextRoundAllowed.ContainsKey(selected.ID) && _nextRoundAllowed[selected.ID] > _ticker.RoundId) // Begin Imp
+        {
+            Log.Info($"Skipping preset {selected.ID} (Not available until round {_nextRoundAllowed[selected.ID]}");
+            return false;
+        } // End Imp
 
         return true;
     }

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -155,4 +155,10 @@ public sealed class DCCVars
     /// </summary>
     public static readonly CVarDef<string> DiscordReplyColor =
         CVarDef.Create("admin.discord_reply_color", string.Empty, CVar.SERVERONLY);
+
+    /// <summary>
+    ///    Whether or not to disable the preset selecting test rule from running. Should be disabled in production. DeltaV specific, attached to Impstation Secret concurrent feature.
+    /// </summary>
+    public static readonly CVarDef<bool> EnableBacktoBack =
+        CVarDef.Create("game.disable_preset_test", false, CVar.SERVERONLY);
 }

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -187,7 +187,7 @@
   name: nukeops-title
   description: nukeops-description
   showInVote: false
-  cooldown: 1 # Imp - Can't occur back to back
+  cooldown: 2 # Imp - Can't occur thrice
   rules:
     - Nukeops
     - SubGamemodesRule
@@ -225,7 +225,7 @@
   - zomber
   name: zombie-title
   description: zombie-description
-  cooldown: 1 # Imp - Can't occur thrice
+  cooldown: 2 # Imp - Can't occur thrice
   showInVote: false
   rules:
   - Zombie

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -5,6 +5,7 @@
   name: survival-title
   showInVote: true # secret # DeltaV - Me when the survival. Used for periapsis.
   description: survival-description
+  cooldown: 2 # Imp - Can't occur thrice
   rules:
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
@@ -96,7 +97,7 @@
   showInVote: true #4boring4vote # DeltaV - Enable greenshift in gamemode vote
   description: greenshift-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler 
+  - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
   - GlimmerEventScheduler # DeltaV
 
@@ -133,7 +134,7 @@
   showInVote: false #Admin Use
   description: secret-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler 
+  - SpaceTrafficControlFriendlyEventScheduler
   - BasicRoundstartVariation
   - GlimmerEventScheduler # DeltaV
 
@@ -185,6 +186,7 @@
   name: nukeops-title
   description: nukeops-description
   showInVote: false
+  cooldown: 1 # Imp - Can't occur back to back
   rules:
     - Nukeops
     - SubGamemodesRule

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -225,7 +225,7 @@
   - zomber
   name: zombie-title
   description: zombie-description
-  cooldown: 2 # Imp - Can't occur thrice
+  cooldown: 1 # Imp - Can't occur thrice
   showInVote: false
   rules:
   - Zombie

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -156,6 +156,7 @@
     - tator
   name: traitor-title
   description: traitor-description
+  cooldown: 2 # Imp - Can't occur thrice
   showInVote: false
   rules:
     - Traitor

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -97,7 +97,7 @@
   showInVote: true #4boring4vote # DeltaV - Enable greenshift in gamemode vote
   description: greenshift-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler
+  - SpaceTrafficControlFriendlyEventScheduler 
   - BasicRoundstartVariation
   - GlimmerEventScheduler # DeltaV
 
@@ -134,7 +134,7 @@
   showInVote: false #Admin Use
   description: secret-description
   rules:
-  - SpaceTrafficControlFriendlyEventScheduler
+  - SpaceTrafficControlFriendlyEventScheduler 
   - BasicRoundstartVariation
   - GlimmerEventScheduler # DeltaV
 
@@ -224,6 +224,7 @@
   - zomber
   name: zombie-title
   description: zombie-description
+  cooldown: 2 # Imp - Can't occur thrice
   showInVote: false
   rules:
   - Zombie


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
add stuff from Impstation that makes it so we cant roll nukies twice in a row :trollface: did similar for survival, now you can only have 4 hours of vent critters not 10

## Why / Balance
gamemodes bad

## Technical details
port

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl: TGRCDev, Lyndomen
- add: Gamemodes now have cooldowns to prevent back-to-back modes. Modes that have been voted on are exempt from this. 

