### PR TITLE
Give Detectives Roundstart Forensic Gloves

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -28,6 +28,7 @@
   equipment:
     eyes: ClothingEyesGlassesSecurity
     id: DetectivePDA
+    gloves: ClothingHandsGlovesForensic # DeltaV - roundstart detective forensic gloves
     ears: ClothingHeadsetSecurity
     belt: ClothingBeltHolster # DeltaV - loadouts
   storage:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

1 line ops

i dont know why these are locker exclusive

technically, a port of https://github.com/Goob-Station/Goob-Station/pull/1187

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

no more joining and the detective who cryo'd before you did so with the only gloves

NOTE: I hereby release all changes made in this PR under MIT license.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Detective now starts with forensic gloves.
