### PR TITLE
Map Edits: Arena/Hive

### DIFF
--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -210,11 +210,11 @@ entities:
           version: 6
         0,-3:
           ind: 0,-3
-          tiles: XgAAAAACXgAAAAACXgAAAAABXgAAAAADXgAAAAAAXgAAAAABXgAAAAADXgAAAAADXgAAAAAAXgAAAAAAXgAAAAADXgAAAAAAXgAAAAAAXgAAAAABXgAAAAAAXgAAAAABXgAAAAACXgAAAAABXgAAAAABXgAAAAACXgAAAAADXgAAAAAAXgAAAAACXgAAAAABXgAAAAABXgAAAAADXgAAAAADXgAAAAABXgAAAAABXgAAAAABXgAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAACMwAAAAABMwAAAAAAMwAAAAABMwAAAAAAMwAAAAACMwAAAAAAMwAAAAACMwAAAAABMwAAAAABMwAAAAADMwAAAAABMwAAAAADMwAAAAACXgAAAAABXgAAAAADXgAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAABMwAAAAABMwAAAAABMwAAAAACMwAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAAAMwAAAAABXgAAAAABXgAAAAAAXgAAAAACMwAAAAAAMwAAAAABMwAAAAAAMwAAAAADMwAAAAADMwAAAAACMwAAAAAAMwAAAAACMwAAAAACMwAAAAACMwAAAAAAMwAAAAABMwAAAAAAXgAAAAABXgAAAAACXgAAAAABXgAAAAADXgAAAAAAXgAAAAADXgAAAAADXgAAAAAAXgAAAAACXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAADXgAAAAADXgAAAAABXgAAAAADXgAAAAACXgAAAAABXgAAAAABXgAAAAADXgAAAAABXgAAAAAAXgAAAAADXgAAAAAAXgAAAAAAXgAAAAABXgAAAAAAXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAAAXgAAAAADXgAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAACXgAAAAAAfwAAAAAAcQAAAAACcQAAAAACcQAAAAAAcQAAAAABcQAAAAADUAAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAXgAAAAAAXgAAAAACXgAAAAACfwAAAAAAcQAAAAACcQAAAAABcQAAAAACcQAAAAABcQAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAXgAAAAADXgAAAAACXgAAAAACfwAAAAAAcQAAAAABcQAAAAAAcQAAAAABcQAAAAAAcQAAAAADUAAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAXgAAAAACXgAAAAADXgAAAAAAfwAAAAAAcQAAAAACcQAAAAAAcQAAAAADcQAAAAADcQAAAAABUAAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAcQAAAAADcQAAAAAAcQAAAAADcQAAAAACcQAAAAAAcQAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAcQAAAAACcQAAAAADfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAcQAAAAADcQAAAAAC
+          tiles: XgAAAAACXgAAAAACXgAAAAABXgAAAAADXgAAAAAAXgAAAAABXgAAAAADXgAAAAADXgAAAAAAXgAAAAAAXgAAAAADXgAAAAAAXgAAAAAAXgAAAAABXgAAAAAAXgAAAAABXgAAAAACXgAAAAABXgAAAAABXgAAAAACXgAAAAADXgAAAAAAXgAAAAACXgAAAAABXgAAAAABXgAAAAADXgAAAAADXgAAAAABXgAAAAABXgAAAAABXgAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAACMwAAAAABMwAAAAAAMwAAAAABMwAAAAAAMwAAAAACMwAAAAAAMwAAAAACMwAAAAABMwAAAAABMwAAAAADMwAAAAABMwAAAAADMwAAAAACXgAAAAABXgAAAAADXgAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAABMwAAAAABMwAAAAABMwAAAAACMwAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAAAMwAAAAABXgAAAAABXgAAAAAAXgAAAAACMwAAAAAAMwAAAAABMwAAAAAAMwAAAAADMwAAAAADMwAAAAACMwAAAAAAMwAAAAACMwAAAAACMwAAAAACMwAAAAAAMwAAAAABMwAAAAAAXgAAAAABXgAAAAACXgAAAAABXgAAAAADXgAAAAAAXgAAAAADXgAAAAADXgAAAAAAXgAAAAACXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAADXgAAAAADXgAAAAABXgAAAAADXgAAAAACXgAAAAABXgAAAAABXgAAAAADXgAAAAABXgAAAAAAXgAAAAADXgAAAAAAXgAAAAAAXgAAAAABXgAAAAAAXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAAAXgAAAAADXgAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAACXgAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAfwAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAXgAAAAAAXgAAAAACXgAAAAACfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAXgAAAAADXgAAAAACXgAAAAACfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAfwAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAXgAAAAACXgAAAAADXgAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAfwAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAcQAAAAADcQAAAAAAcQAAAAADcQAAAAACcQAAAAAAcQAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAcQAAAAACcQAAAAADfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAEQAAAAAAcQAAAAADcQAAAAAC
           version: 6
         1,-3:
           ind: 1,-3
-          tiles: XgAAAAADXgAAAAAAXgAAAAACXgAAAAAAXgAAAAADXgAAAAADXgAAAAAAXgAAAAAAXgAAAAADXgAAAAABXgAAAAADXgAAAAACXgAAAAADXgAAAAADXgAAAAACXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAADMwAAAAABMwAAAAAAMwAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAADMwAAAAACXgAAAAADXgAAAAACXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAABMwAAAAABMwAAAAABMwAAAAADMwAAAAACMwAAAAABMwAAAAAAMwAAAAADMwAAAAADXgAAAAAAXgAAAAABUwAAAAAAUwAAAAAAUwAAAAAAXgAAAAAAXgAAAAACXgAAAAAAMwAAAAADMwAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAACMwAAAAACMwAAAAACXgAAAAABXgAAAAADUwAAAAAAUwAAAAAAUwAAAAAAXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAABXgAAAAAAXgAAAAABXgAAAAAAXgAAAAADXgAAAAACXgAAAAABXgAAAAACXgAAAAACXgAAAAACXgAAAAABXgAAAAABXgAAAAABXgAAAAAAXgAAAAAAXgAAAAADXgAAAAADXgAAAAABXgAAAAAAXgAAAAACXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAAAXgAAAAADXgAAAAACXgAAAAADXgAAAAADXgAAAAAAXgAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAAAXgAAAAACXgAAAAADXgAAAAAAXgAAAAABXgAAAAABXgAAAAAAXgAAAAAAXgAAAAADUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAbAAAAAACbAAAAAAAUAAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAfwAAAAAAIAAAAAACIAAAAAABIAAAAAACIAAAAAAAIAAAAAACUAAAAAAAbAAAAAACbAAAAAABbAAAAAACbAAAAAADUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAIAAAAAAAIAAAAAABIAAAAAAAIAAAAAABIAAAAAABIAAAAAADIAAAAAAAbAAAAAACbAAAAAACbAAAAAAAbAAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAUgAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAACIAAAAAACUAAAAAAAbAAAAAABbAAAAAABbAAAAAABbAAAAAABXgAAAAABfwAAAAAAfwAAAAAAXgAAAAABfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAABIAAAAAAAIAAAAAAAfwAAAAAAbAAAAAAAbAAAAAABbAAAAAAAbAAAAAADcQAAAAADfwAAAAAAcQAAAAACcQAAAAADcQAAAAAAcQAAAAABcQAAAAADfwAAAAAAIAAAAAADIAAAAAAAIAAAAAADUAAAAAAAbAAAAAACbAAAAAABbAAAAAACZgAAAAACcQAAAAADcQAAAAABcQAAAAACcQAAAAAAcQAAAAABcQAAAAABcQAAAAADIAAAAAABIAAAAAADIAAAAAADIAAAAAAAUAAAAAAAbAAAAAACbAAAAAADbAAAAAACbAAAAAADcQAAAAABfwAAAAAAcQAAAAAAcQAAAAACcQAAAAADcQAAAAABcQAAAAABfwAAAAAAIAAAAAADIAAAAAACIAAAAAABUAAAAAAAZgAAAAADawAAAAAAawAAAAAAZgAAAAAD
+          tiles: XgAAAAADXgAAAAAAXgAAAAACXgAAAAAAXgAAAAADXgAAAAADXgAAAAAAXgAAAAAAXgAAAAADXgAAAAABXgAAAAADXgAAAAACXgAAAAADXgAAAAADXgAAAAACXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAACXgAAAAACXgAAAAADXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAADMwAAAAABMwAAAAAAMwAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAADMwAAAAACXgAAAAADXgAAAAACXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAABXgAAAAABMwAAAAABMwAAAAABMwAAAAADMwAAAAACMwAAAAABMwAAAAAAMwAAAAADMwAAAAADXgAAAAAAXgAAAAABUwAAAAAAUwAAAAAAUwAAAAAAXgAAAAAAXgAAAAACXgAAAAAAMwAAAAADMwAAAAACMwAAAAADMwAAAAADMwAAAAABMwAAAAACMwAAAAACMwAAAAACXgAAAAABXgAAAAADUwAAAAAAUwAAAAAAUwAAAAAAXgAAAAAAXgAAAAABXgAAAAACXgAAAAAAXgAAAAABXgAAAAAAXgAAAAABXgAAAAAAXgAAAAADXgAAAAACXgAAAAABXgAAAAACXgAAAAACXgAAAAACXgAAAAABXgAAAAABXgAAAAABXgAAAAAAXgAAAAAAXgAAAAADXgAAAAADXgAAAAABXgAAAAAAXgAAAAACXgAAAAAAXgAAAAACXgAAAAAAXgAAAAABXgAAAAAAXgAAAAADXgAAAAACXgAAAAADXgAAAAADXgAAAAAAXgAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAXgAAAAACXgAAAAAAXgAAAAACXgAAAAADXgAAAAAAXgAAAAABXgAAAAABXgAAAAAAXgAAAAAAXgAAAAADUgAAAAAAfwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAbAAAAAACbAAAAAAAUAAAAAAAUgAAAAAAUAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAfwAAAAAAIAAAAAACIAAAAAABIAAAAAACIAAAAAAAIAAAAAACUAAAAAAAbAAAAAACbAAAAAABbAAAAAACbAAAAAADUgAAAAAAUAAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAIAAAAAAAIAAAAAABIAAAAAAAIAAAAAABIAAAAAABIAAAAAADIAAAAAAAbAAAAAACbAAAAAACbAAAAAAAbAAAAAAAUgAAAAAAfwAAAAAAcQAAAAAAcQAAAAAAcQAAAAAAfwAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAACIAAAAAACUAAAAAAAbAAAAAABbAAAAAABbAAAAAABbAAAAAABXgAAAAABfwAAAAAAfwAAAAAAcQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAIAAAAAABIAAAAAAAIAAAAAAAfwAAAAAAbAAAAAAAbAAAAAABbAAAAAAAbAAAAAADcQAAAAADfwAAAAAAcQAAAAACcQAAAAADcQAAAAAAcQAAAAABcQAAAAADfwAAAAAAIAAAAAADIAAAAAAAIAAAAAADUAAAAAAAbAAAAAACbAAAAAABbAAAAAACZgAAAAACcQAAAAADcQAAAAABcQAAAAACcQAAAAAAcQAAAAABcQAAAAABcQAAAAADIAAAAAABIAAAAAADIAAAAAADIAAAAAAAUAAAAAAAbAAAAAACbAAAAAADbAAAAAACbAAAAAADcQAAAAABfwAAAAAAcQAAAAAAcQAAAAACcQAAAAADcQAAAAABcQAAAAABfwAAAAAAIAAAAAADIAAAAAACIAAAAAABUAAAAAAAZgAAAAADawAAAAAAawAAAAAAZgAAAAAD
           version: 6
         0,2:
           ind: 0,2
@@ -1027,7 +1027,6 @@ entities:
             890: 15,-19
             891: 15,-22
             947: 18,-33
-            997: 10,-30
             3387: 21,-22
         - node:
             color: '#FFFFFFFF'
@@ -1224,7 +1223,6 @@ entities:
             893: 15,-20
             894: 15,-17
             948: 18,-35
-            1012: 10,-31
             3349: 10,-28
         - node:
             color: '#FFFFFFFF'
@@ -1324,7 +1322,6 @@ entities:
             color: '#F9FFFEFF'
             id: BrickTileWhiteEndW
           decals:
-            998: 10,-35
             3403: 21,-23
         - node:
             color: '#1D1D21FF'
@@ -1504,7 +1501,6 @@ entities:
           decals:
             922: 18,-19
             923: 18,-22
-            1004: 14,-35
         - node:
             color: '#1D1D21FF'
             id: BrickTileWhiteInnerSe
@@ -1667,7 +1663,6 @@ entities:
             902: 18,-28
             903: 18,-20
             904: 18,-17
-            1008: 14,-31
         - node:
             color: '#169C9CC4'
             id: BrickTileWhiteLineE
@@ -1909,12 +1904,6 @@ entities:
             874: 19,-27
             875: 19,-29
             876: 19,-30
-            1013: 16,-32
-            1014: 16,-33
-            1043: 15,-34
-            1044: 15,-33
-            1045: 15,-32
-            1046: 15,-31
             3344: 13,-24
             3345: 13,-26
             3362: 13,-27
@@ -2277,14 +2266,6 @@ entities:
             944: 21,-33
             945: 20,-33
             946: 19,-33
-            989: 15,-30
-            990: 14,-30
-            991: 13,-30
-            992: 12,-30
-            993: 11,-30
-            994: 11,-35
-            995: 12,-35
-            996: 13,-35
             3388: 22,-22
             3389: 23,-22
             3390: 24,-22
@@ -2620,14 +2601,6 @@ entities:
             917: 17,-17
             941: 20,-35
             942: 21,-35
-            999: 11,-35
-            1000: 12,-35
-            1001: 13,-35
-            1002: 14,-35
-            1003: 15,-35
-            1009: 13,-31
-            1010: 12,-31
-            1011: 11,-31
             3347: 12,-28
             3348: 11,-28
             3393: 24,-24
@@ -2913,13 +2886,6 @@ entities:
             883: 15,-27
             884: 18,-21
             885: 18,-18
-            1005: 14,-34
-            1006: 14,-33
-            1007: 14,-32
-            1039: 15,-31
-            1040: 15,-32
-            1041: 15,-33
-            1042: 15,-34
             3350: 10,-27
             3351: 10,-26
             3352: 10,-25
@@ -5812,10 +5778,6 @@ entities:
             color: '#52B4E996'
             id: FullTileOverlayGreyscale
           decals:
-            976: 10,-35
-            977: 11,-35
-            978: 12,-35
-            979: 13,-35
             1015: 10,-32
             1016: 10,-33
             1017: 10,-34
@@ -5826,9 +5788,6 @@ entities:
             1022: 11,-32
             1031: 11,-34
             1032: 12,-34
-            1035: 15,-32
-            1036: 15,-33
-            1037: 15,-34
             3396: 21,-23
             3397: 22,-23
             3398: 23,-23
@@ -6094,11 +6053,6 @@ entities:
             933: 21,-33
             934: 20,-33
             935: 19,-33
-            968: 11,-30
-            969: 12,-30
-            970: 13,-30
-            971: 14,-30
-            972: 15,-30
             3379: 22,-22
             3380: 23,-22
             3381: 24,-22
@@ -6123,24 +6077,6 @@ entities:
             409: 4,-54
             410: 5,-54
         - node:
-            color: '#D4D4D496'
-            id: HalfTileOverlayGreyscale
-          decals:
-            5697: 15,-31
-            5698: 15,-31
-        - node:
-            color: '#EAEBEE93'
-            id: HalfTileOverlayGreyscale
-          decals:
-            4726: 15,-31
-            4727: 15,-31
-            4728: 15,-31
-        - node:
-            color: '#F9FFFEFF'
-            id: HalfTileOverlayGreyscale
-          decals:
-            1047: 15,-31
-        - node:
             color: '#52B4E996'
             id: HalfTileOverlayGreyscale180
           decals:
@@ -6164,11 +6100,6 @@ entities:
             858: 17,-28
             938: 20,-35
             939: 21,-35
-            975: 15,-35
-            985: 11,-31
-            986: 12,-31
-            987: 13,-31
-            1038: 15,-31
             3384: 22,-24
             3385: 23,-24
             3386: 24,-24
@@ -6219,9 +6150,6 @@ entities:
             851: 18,-21
             856: 15,-27
             860: 18,-30
-            981: 14,-34
-            982: 14,-33
-            983: 14,-32
             3382: 15,-24
             3383: 15,-26
         - node:
@@ -6273,8 +6201,6 @@ entities:
             808: 19,-21
             862: 19,-30
             863: 19,-29
-            973: 16,-32
-            974: 16,-33
             3401: 26,-23
             5750: 19,-18
         - node:
@@ -6959,7 +6885,6 @@ entities:
             845: 18,-17
             846: 18,-20
             859: 18,-28
-            984: 14,-31
         - node:
             color: '#9FED5896'
             id: QuarterTileOverlayGreyscale270
@@ -8162,6 +8087,94 @@ entities:
             77: 0,34
             5665: -12,34
         - node:
+            color: '#52B4E996'
+            id: ThickCornerNorthEastOverlayTrimline
+          decals:
+            5921: 5,-38
+        - node:
+            color: '#52B4E996'
+            id: ThickCornerNorthWestTrimline
+          decals:
+            5919: 7,-38
+        - node:
+            color: '#52B4E996'
+            id: ThickCornerSouthEastOverlayTrimline
+          decals:
+            5920: 5,-39
+        - node:
+            color: '#52B4E996'
+            id: ThickCornerSouthWestOverlayTrimline
+          decals:
+            5922: 7,-39
+        - node:
+            color: '#52B4E996'
+            id: ThickNorthOverlayTrimline
+          decals:
+            5914: 10,-30
+            5915: 11,-30
+            5916: 12,-30
+            5917: 13,-30
+            5918: 14,-30
+            5923: 6,-38
+        - node:
+            color: '#52B4E996'
+            id: ThickSouthOverlayTrimline
+          decals:
+            5909: 12,-30
+            5910: 11,-30
+            5911: 10,-30
+            5912: 13,-30
+            5913: 14,-30
+            5924: 6,-39
+        - node:
+            color: '#52B4E996'
+            id: ThinCornerInnerNorthEastOverlayTrimline
+          decals:
+            5895: 15,-35
+        - node:
+            color: '#52B4E996'
+            id: ThinCornerInnerNorthWestOverlayTrimline
+          decals:
+            5896: 16,-35
+        - node:
+            color: '#52B4E996'
+            id: ThinCornerInnerSouthEastOverlayTrimline
+          decals:
+            5894: 15,-30
+        - node:
+            color: '#52B4E996'
+            id: ThinCornerInnerSouthWestOverlayTrimline
+          decals:
+            5893: 16,-30
+        - node:
+            color: '#52B4E996'
+            id: ThinEastOverlayTrimline
+          decals:
+            5885: 15,-34
+            5886: 15,-33
+            5887: 15,-32
+            5888: 15,-31
+            5903: 16,-30
+            5904: 16,-31
+            5905: 16,-32
+            5906: 16,-33
+            5907: 16,-34
+            5908: 16,-35
+        - node:
+            color: '#52B4E996'
+            id: ThinWestOverlayTrimline
+          decals:
+            5889: 16,-31
+            5890: 16,-32
+            5891: 16,-33
+            5892: 16,-34
+            5897: 15,-30
+            5898: 15,-31
+            5899: 15,-32
+            5900: 15,-33
+            5901: 15,-34
+            5902: 15,-35
+        - node:
             color: '#0E7F1BCE'
             id: ThreeQuarterTileOverlayGreyscale
           decals:
@@ -8178,7 +8191,6 @@ entities:
             830: 15,-19
             855: 15,-22
             936: 18,-33
-            967: 10,-30
             3376: 21,-22
             3756: -21,-10
         - node:
@@ -8244,8 +8256,6 @@ entities:
             832: 15,-17
             857: 15,-28
             937: 18,-35
-            980: 14,-35
-            988: 10,-31
             3402: 21,-24
             3757: -21,-11
         - node:
@@ -8963,7 +8973,9 @@ entities:
           -9,0:
             0: 61377
           -8,1:
-            0: 30577
+            0: 6001
+            1: 8192
+            2: 16384
           -9,1:
             0: 61160
           -8,2:
@@ -9040,35 +9052,35 @@ entities:
             0: 30591
           -4,6:
             0: 307
-            1: 34952
+            3: 34952
           -5,6:
             0: 65535
           -4,7:
-            1: 63624
+            3: 63624
           -4,8:
-            1: 4369
+            3: 4369
             0: 61166
           -3,5:
             0: 65535
           -3,6:
-            1: 4369
+            3: 4369
             0: 140
           -3,7:
-            1: 29457
+            3: 29457
           -3,8:
             0: 13115
-            1: 17476
+            3: 17476
           -2,5:
             0: 65535
           -2,6:
             0: 19
-            1: 34944
+            3: 34944
           -2,8:
             0: 28799
           -1,5:
             0: 4095
           -1,6:
-            1: 30576
+            3: 30576
           -1,7:
             0: 13107
           -1,8:
@@ -9333,18 +9345,18 @@ entities:
             0: 65535
           15,0:
             0: 4369
-            1: 49164
+            3: 49164
           15,1:
             0: 28672
-            1: 8
+            3: 8
           15,2:
             0: 61559
           15,-1:
             0: 4369
           16,0:
-            1: 61455
+            3: 61455
           16,1:
-            1: 15
+            3: 15
             0: 65280
           16,2:
             0: 57599
@@ -9401,7 +9413,8 @@ entities:
           5,-6:
             0: 3838
           5,-9:
-            0: 32624
+            4: 16
+            0: 32608
           5,-8:
             0: 61156
           6,-8:
@@ -9527,7 +9540,7 @@ entities:
           -1,-7:
             0: 65535
           -1,-6:
-            2: 65520
+            5: 65520
             0: 4
           -1,-9:
             0: 64160
@@ -9538,7 +9551,7 @@ entities:
           0,-7:
             0: 57305
           0,-6:
-            2: 4368
+            5: 4368
             0: 52416
           -8,-8:
             0: 65535
@@ -9624,7 +9637,7 @@ entities:
             0: 63231
           -12,4:
             0: 63
-            1: 2048
+            3: 2048
           -11,0:
             0: 61183
           -11,1:
@@ -9633,11 +9646,11 @@ entities:
             0: 24695
           -11,3:
             0: 255
-            1: 49152
+            3: 49152
           -11,-1:
             0: 65294
           -11,4:
-            1: 53198
+            3: 53198
           -10,0:
             0: 60943
           -10,1:
@@ -9646,11 +9659,11 @@ entities:
             0: 4095
           -10,3:
             0: 255
-            1: 28672
+            3: 28672
           -10,-1:
             0: 65473
           -10,4:
-            1: 4471
+            3: 4471
             0: 51336
           -8,-16:
             0: 4080
@@ -9730,13 +9743,13 @@ entities:
             0: 61166
           14,-8:
             0: 65416
-            1: 1
+            3: 1
           14,-7:
             0: 15
-            3: 60928
+            6: 60928
           14,-6:
             0: 61440
-            3: 238
+            6: 238
           14,-5:
             0: 30222
           14,-4:
@@ -9747,17 +9760,17 @@ entities:
             0: 65315
           15,-7:
             0: 47
-            3: 26112
+            6: 26112
           15,-6:
             0: 28673
-            3: 102
+            6: 102
           15,-5:
             0: 30583
           15,-9:
             0: 16383
           16,-8:
             0: 65416
-            1: 1
+            3: 1
           16,-7:
             0: 34831
           8,-12:
@@ -9812,17 +9825,17 @@ entities:
             0: 61166
           14,-10:
             0: 14
-            1: 256
+            3: 256
           14,-13:
             0: 52428
-            1: 256
+            3: 256
           15,-12:
             0: 65535
           15,-11:
             0: 65535
           15,-10:
             0: 15
-            1: 256
+            3: 256
           15,-13:
             0: 20479
           16,-12:
@@ -9962,19 +9975,19 @@ entities:
           -1,9:
             0: 65535
           0,10:
-            1: 29760
+            3: 29760
             0: 34944
           0,11:
             0: 153
-            1: 29542
+            3: 29542
           -1,10:
-            1: 61440
+            3: 61440
           -1,11:
             0: 52462
-            1: 13073
+            3: 13073
           0,12:
             0: 785
-            1: 29794
+            3: 29794
           1,10:
             0: 4912
           1,11:
@@ -9991,89 +10004,89 @@ entities:
             0: 3272
           8,9:
             0: 816
-            1: 2176
+            3: 2176
           8,10:
             0: 30583
           8,11:
             0: 880
-            1: 128
+            3: 128
           7,12:
-            1: 8
+            3: 8
           8,12:
-            1: 4371
+            3: 4371
           9,9:
-            1: 4080
+            3: 4080
           9,10:
-            5: 273
-            6: 1092
-          9,11:
-            1: 240
-          10,9:
-            1: 4080
-          10,10:
             7: 273
             8: 1092
+          9,11:
+            3: 240
+          10,9:
+            3: 4080
+          10,10:
+            9: 273
+            10: 1092
           10,11:
-            1: 752
+            3: 752
             0: 28672
           10,12:
             0: 119
           11,9:
-            1: 4080
+            3: 4080
           11,10:
-            8: 1365
+            10: 1365
           11,11:
-            1: 35056
+            3: 35056
           12,9:
-            1: 4080
+            3: 4080
           12,10:
-            8: 273
+            10: 273
             0: 34816
           12,11:
-            1: 5936
+            3: 5936
             0: 136
           11,12:
-            1: 34952
+            3: 34952
           -4,9:
-            1: 143
+            3: 143
           -4,10:
-            1: 49152
+            3: 49152
           -4,11:
-            1: 33860
+            3: 33860
             0: 2184
           -3,9:
-            1: 13175
+            3: 13175
             0: 8
           -3,10:
-            1: 62259
+            3: 62259
           -3,11:
             0: 947
-            1: 29772
+            3: 29772
           -2,9:
             0: 15
           -2,10:
-            1: 63616
+            3: 63616
           -2,11:
-            1: 32863
+            3: 32863
             0: 160
           -1,12:
-            1: 61457
+            3: 61457
             0: 4078
           0,13:
-            1: 13107
+            3: 13107
           0,14:
-            1: 51
+            3: 51
           -2,12:
-            1: 34944
+            3: 34944
           -1,13:
-            1: 13107
+            3: 13107
           -1,14:
-            1: 51
+            3: 51
           -12,-4:
             0: 65134
           -13,-4:
             0: 56780
-            1: 1
+            3: 1
           -12,-3:
             0: 65103
           -13,-3:
@@ -10211,13 +10224,13 @@ entities:
           -12,-7:
             0: 26214
           -13,-7:
-            1: 52431
+            3: 52431
           -12,-6:
             0: 26214
           -13,-6:
-            1: 52974
+            3: 52974
           -13,-5:
-            1: 8140
+            3: 8140
             0: 49152
           -11,-8:
             0: 48050
@@ -10253,10 +10266,10 @@ entities:
             0: 34952
           16,-5:
             0: 136
-            1: 16384
+            3: 16384
           16,-9:
             0: 34952
-            1: 8192
+            3: 8192
           17,-8:
             0: 65315
           17,-7:
@@ -10267,7 +10280,7 @@ entities:
             0: 52479
           17,-9:
             0: 13107
-            1: 32768
+            3: 32768
           17,-4:
             0: 204
           18,-8:
@@ -10282,22 +10295,22 @@ entities:
             0: 61166
           19,-7:
             0: 28672
-            1: 32
+            3: 32
           19,-5:
             0: 7
-            1: 4608
+            3: 4608
           16,-11:
             0: 61166
           16,-10:
             0: 14
-            1: 8448
+            3: 8448
           17,-12:
             0: 61439
           17,-11:
             0: 61166
           17,-10:
             0: 14
-            1: 33024
+            3: 33024
           17,-13:
             0: 43690
           18,-12:
@@ -10310,13 +10323,13 @@ entities:
             0: 61440
           19,-11:
             0: 15
-            1: 2048
+            3: 2048
           19,-10:
             0: 61440
-            1: 136
+            3: 136
           19,-9:
             0: 15
-            1: 512
+            3: 512
           20,-12:
             0: 28672
           20,-11:
@@ -10370,10 +10383,10 @@ entities:
           5,-18:
             0: 47887
           5,-20:
-            1: 1
+            3: 1
             0: 34952
           5,-21:
-            1: 4369
+            3: 4369
             0: 34816
           6,-20:
             0: 57297
@@ -10413,22 +10426,22 @@ entities:
             0: 30476
           -13,-12:
             0: 28535
-            1: 8
+            3: 8
           -12,-11:
             0: 65319
           -13,-11:
             0: 56640
-            1: 16
+            3: 16
           -12,-10:
             0: 65295
           -13,-10:
             0: 52236
-            1: 4097
+            3: 4097
           -13,-9:
             0: 52364
           -12,-13:
             0: 25275
-            1: 4096
+            3: 4096
           -11,-11:
             0: 65280
           -11,-10:
@@ -10451,7 +10464,7 @@ entities:
             0: 47935
           -13,-16:
             0: 52972
-            1: 12560
+            3: 12560
           -12,-15:
             0: 6827
           -13,-15:
@@ -10462,10 +10475,10 @@ entities:
             0: 36588
           -13,-13:
             0: 26608
-            1: 38912
+            3: 38912
           -12,-17:
             0: 60544
-            1: 15
+            3: 15
           -11,-16:
             0: 65518
           -11,-15:
@@ -10520,7 +10533,7 @@ entities:
             0: 30578
           2,-21:
             0: 17408
-            1: 238
+            3: 238
           -5,-20:
             0: 44643
           -4,-19:
@@ -10571,16 +10584,16 @@ entities:
             0: 3
           -17,3:
             0: 15
-            1: 34816
+            3: 34816
           -15,0:
             0: 65399
           -15,1:
             0: 1911
           -15,-1:
             0: 28672
-            1: 68
+            3: 68
           -15,2:
-            1: 17476
+            3: 17476
           -15,3:
             0: 34944
           -14,0:
@@ -10600,9 +10613,9 @@ entities:
           -13,4:
             0: 255
           -13,3:
-            1: 512
+            3: 512
           -16,-4:
-            1: 4096
+            3: 4096
           -16,-2:
             0: 4915
           -17,-2:
@@ -10610,12 +10623,12 @@ entities:
           -17,-1:
             0: 47295
           -15,-2:
-            1: 19456
+            3: 19456
           -14,-4:
-            1: 1
+            3: 1
             0: 65024
           -14,-5:
-            1: 7953
+            3: 7953
             0: 204
           -14,-3:
             0: 65166
@@ -10625,19 +10638,19 @@ entities:
             0: 13056
           13,-13:
             0: 819
-            1: 2048
+            3: 2048
           14,-14:
             0: 49152
           15,-14:
             0: 61440
           16,-13:
-            1: 10
+            3: 10
           17,-14:
             0: 43680
           18,-13:
-            1: 2
+            3: 2
           19,-13:
-            1: 8448
+            3: 8448
           0,-23:
             0: 8191
           -1,-23:
@@ -10649,41 +10662,41 @@ entities:
           1,-22:
             0: 4369
           1,-24:
-            1: 17988
+            3: 17988
           1,-25:
-            1: 61263
+            3: 61263
           2,-23:
-            1: 63624
+            3: 63624
           2,-22:
-            1: 59528
+            3: 59528
           2,-24:
-            1: 34952
+            3: 34952
           2,-25:
-            1: 36623
+            3: 36623
           3,-24:
-            1: 16
+            3: 16
             0: 3822
           3,-23:
-            1: 16
+            3: 16
             0: 3822
           3,-22:
-            1: 16
+            3: 16
             0: 3822
           3,-21:
-            1: 16
+            3: 16
             0: 3822
           4,-24:
             0: 1911
-            1: 128
+            3: 128
           4,-23:
             0: 1911
-            1: 128
+            3: 128
           4,-22:
             0: 1911
-            1: 128
+            3: 128
           4,-21:
             0: 1911
-            1: 128
+            3: 128
           -4,-24:
             0: 65382
           -4,-23:
@@ -10708,7 +10721,7 @@ entities:
             0: 57580
           -2,-25:
             0: 57344
-            1: 3822
+            3: 3822
           -1,-24:
             0: 272
           -1,-22:
@@ -10764,23 +10777,23 @@ entities:
           -6,-18:
             0: 16352
           -12,-20:
-            1: 46
+            3: 46
           -13,-20:
             0: 34952
-            1: 35
+            3: 35
           -13,-19:
             0: 34952
-            1: 4896
+            3: 4896
           -12,-19:
-            1: 36384
+            3: 36384
           -12,-18:
             0: 3891
-            1: 32904
+            3: 32904
           -13,-18:
             0: 3276
-            1: 4369
+            3: 4369
           -13,-17:
-            1: 15
+            3: 15
           -11,-18:
             0: 52673
           -11,-19:
@@ -10792,105 +10805,105 @@ entities:
           -10,-20:
             0: 32768
           16,-4:
-            1: 32768
+            3: 32768
           16,-3:
-            1: 8
+            3: 8
           17,-3:
             0: 65518
           17,-2:
             0: 239
           16,-2:
-            1: 2048
+            3: 2048
           18,-3:
             0: 13073
-            1: 4
+            3: 4
           18,-2:
             0: 19
-            1: 1024
+            3: 1024
           18,-4:
-            1: 16384
+            3: 16384
           -16,-7:
-            1: 1103
+            3: 1103
           -17,-7:
-            1: 15
+            3: 15
           -16,-6:
-            1: 1525
+            3: 1525
           -17,-6:
-            1: 1525
+            3: 1525
           -16,-8:
             0: 3822
-            1: 16384
+            3: 16384
           -16,-9:
             0: 61152
-            1: 4
+            3: 4
           -15,-7:
-            1: 47
+            3: 47
             0: 34816
           -15,-6:
-            1: 20016
+            3: 20016
             0: 8
           -15,-8:
             0: 3822
-            1: 16384
+            3: 16384
           -15,-9:
             0: 61152
-            1: 4
+            3: 4
           -15,-5:
-            1: 19524
+            3: 19524
           -14,-7:
-            1: 15
+            3: 15
             0: 65472
           -14,-6:
             0: 52431
-            1: 4352
+            3: 4352
           -14,-8:
             0: 3822
-            1: 16384
+            3: 16384
           -14,-9:
             0: 61152
-            1: 4
+            3: 4
           -16,-12:
-            1: 29218
+            3: 29218
           -17,-12:
-            1: 63078
+            3: 63078
           -16,-11:
-            1: 30562
+            3: 30562
           -17,-11:
-            1: 65382
+            3: 65382
           -16,-10:
-            1: 61444
+            3: 61444
           -17,-10:
-            1: 61440
+            3: 61440
           -16,-13:
-            1: 61440
+            3: 61440
             0: 4081
           -15,-10:
-            1: 61440
+            3: 61440
             0: 14
           -15,-12:
-            1: 819
+            3: 819
           -15,-13:
-            1: 61442
+            3: 61442
             0: 4080
           -15,-11:
             0: 61152
           -14,-10:
-            1: 61452
+            3: 61452
           -14,-12:
-            1: 36650
+            3: 36650
           -14,-13:
-            1: 61440
+            3: 61440
             0: 4080
           -14,-11:
-            1: 192
+            3: 192
             0: 52224
           12,12:
-            1: 28945
+            3: 28945
           13,9:
             0: 26470
           13,10:
             0: 65286
-            1: 240
+            3: 240
           13,11:
             0: 4095
           13,12:
@@ -10899,81 +10912,81 @@ entities:
             0: 32628
           14,10:
             0: 4352
-            1: 26208
+            3: 26208
           14,11:
             0: 17
-            1: 1638
+            3: 1638
           15,9:
             0: 65520
           15,10:
             0: 65535
           16,9:
-            1: 240
+            3: 240
             0: 13056
           16,10:
             0: 13107
           12,13:
-            1: 61713
+            3: 61713
           11,13:
-            1: 63624
+            3: 63624
           12,14:
-            1: 31
+            3: 31
           11,14:
-            1: 63624
+            3: 63624
           13,13:
-            1: 61440
+            3: 61440
           13,14:
-            1: 15
+            3: 15
           14,13:
-            1: 62063
+            3: 62063
           14,14:
-            1: 255
+            3: 255
           14,12:
-            1: 24576
+            3: 24576
           15,13:
-            1: 15
+            3: 15
           15,14:
-            1: 15
+            3: 15
           16,13:
-            1: 15
+            3: 15
           16,14:
-            1: 15
+            3: 15
           -20,-6:
-            1: 2296
+            3: 2296
           -21,-6:
-            1: 240
+            3: 240
           -19,-6:
-            1: 2039
+            3: 2039
           -19,-8:
-            1: 40857
+            3: 40857
           -19,-9:
-            1: 39417
+            3: 39417
           -19,-7:
-            1: 4383
+            3: 4383
           -18,-7:
-            1: 17487
+            3: 17487
           -18,-6:
-            1: 244
+            3: 244
           -18,-8:
             0: 3822
-            1: 16384
+            3: 16384
           -18,-9:
             0: 61152
-            1: 4
+            3: 4
           -17,-8:
             0: 3822
-            1: 16384
+            3: 16384
           -17,-9:
             0: 61152
-            1: 4
+            3: 4
           -10,5:
             0: 52972
           -10,6:
             0: 136
           -16,-20:
-            1: 15
+            3: 15
           -17,-20:
-            1: 8
+            3: 8
           -16,-19:
             0: 54519
           -17,-19:
@@ -10989,7 +11002,7 @@ entities:
           -16,-16:
             0: 3942
           -15,-20:
-            1: 7
+            3: 7
           -15,-19:
             0: 65280
           -15,-18:
@@ -10997,7 +11010,7 @@ entities:
           -15,-17:
             0: 63675
           -15,-21:
-            1: 17408
+            3: 17408
             0: 287
           -14,-19:
             0: 4096
@@ -11006,49 +11019,49 @@ entities:
           -14,-17:
             0: 273
           -14,-20:
-            1: 8
+            3: 8
           -13,-21:
             0: 36863
           -16,-22:
-            1: 15
+            3: 15
             0: 61184
           -17,-22:
-            1: 34952
+            3: 34952
           -16,-21:
             0: 3838
           -17,-21:
-            1: 34952
+            3: 34952
           -15,-22:
-            1: 1095
+            3: 1095
             0: 4352
           -14,-21:
             0: 15
           -14,-22:
-            1: 1216
+            3: 1216
           -13,-22:
             0: 61440
           -12,-22:
             0: 61440
-            1: 128
+            3: 128
           -12,-21:
             0: 1911
           -11,-22:
-            1: 16
+            3: 16
             0: 61440
           -10,-22:
             0: 64704
-            1: 17
+            3: 17
           -10,-23:
-            1: 61440
+            3: 61440
           -10,-21:
-            1: 61712
+            3: 61712
             0: 204
           -9,-23:
-            1: 12288
+            3: 12288
           -9,-21:
-            1: 12834
+            3: 12834
           -9,-22:
-            1: 8738
+            3: 8738
           -17,-16:
             0: 28671
           -16,-15:
@@ -11059,17 +11072,17 @@ entities:
             0: 13117
           -17,-13:
             0: 4086
-            1: 61440
+            3: 61440
           -15,-16:
             0: 25344
-            1: 2048
+            3: 2048
           -15,-14:
             0: 3
-            1: 8736
+            3: 8736
           -15,-15:
             0: 26214
           -14,-16:
-            1: 36608
+            3: 36608
           -20,-20:
             0: 65280
           -20,-19:
@@ -11118,83 +11131,83 @@ entities:
             0: 60943
           9,-24:
             0: 4369
-            1: 136
+            3: 136
           9,-23:
             0: 24593
           9,-22:
             0: 61159
           9,-25:
-            1: 53007
+            3: 53007
           10,-24:
-            1: 9010
+            3: 9010
           10,-23:
-            1: 30498
+            3: 30498
           10,-22:
             0: 13104
           10,-25:
-            1: 26487
+            3: 26487
           5,-24:
-            1: 39385
+            3: 39385
           5,-23:
-            1: 7577
+            3: 7577
           5,-22:
-            1: 4369
+            3: 4369
             0: 3276
           5,-25:
-            1: 57231
+            3: 57231
           6,-23:
-            1: 256
+            3: 256
             0: 49356
           6,-22:
             0: 52703
           6,-24:
             0: 52428
           -2,-26:
-            1: 57344
+            3: 57344
           -1,-25:
-            1: 3855
+            3: 3855
           0,-25:
-            1: 3855
+            3: 3855
           3,-25:
-            1: 3855
+            3: 3855
           4,-25:
-            1: 3855
+            3: 3855
           6,-25:
-            1: 7951
+            3: 7951
           7,-25:
-            1: 3855
+            3: 3855
           8,-25:
-            1: 3855
+            3: 3855
           10,-26:
-            1: 28672
+            3: 28672
           -16,4:
-            1: 16
+            3: 16
           -15,5:
-            1: 4
+            3: 4
           8,13:
-            1: 63249
+            3: 63249
           7,13:
-            1: 34816
+            3: 34816
           8,14:
-            1: 50247
+            3: 50247
           7,14:
-            1: 8
+            3: 8
           8,15:
-            1: 50244
+            3: 50244
           8,16:
-            1: 50244
+            3: 50244
           9,13:
-            1: 12288
+            3: 12288
             0: 52224
           9,14:
-            1: 12288
+            3: 12288
             0: 52236
           9,15:
-            1: 12288
+            3: 12288
             0: 52236
           9,16:
             0: 52236
-            1: 12288
+            3: 12288
           10,13:
             0: 65280
           10,14:
@@ -11204,41 +11217,41 @@ entities:
           10,16:
             0: 65295
           11,15:
-            1: 63624
+            3: 63624
           11,16:
-            1: 63624
+            3: 63624
           -20,-11:
-            1: 2184
+            3: 2184
           -19,-11:
-            1: 65331
+            3: 65331
           -19,-12:
-            1: 61713
+            3: 61713
           -19,-13:
-            1: 61940
+            3: 61940
           -19,-10:
-            1: 61713
+            3: 61713
           -18,-12:
-            1: 62259
+            3: 62259
           -18,-11:
-            1: 65331
+            3: 65331
           -18,-10:
-            1: 62532
+            3: 62532
           -18,-13:
             0: 65528
           -24,-6:
-            1: 497
+            3: 497
           -23,-6:
-            1: 240
+            3: 240
           -22,-6:
-            1: 240
+            3: 240
           -25,-6:
-            1: 1863
+            3: 1863
           -20,0:
-            1: 49664
+            3: 49664
           -20,1:
-            1: 2
+            3: 2
           -19,0:
-            1: 4096
+            3: 4096
             0: 52428
           -19,1:
             0: 3276
@@ -11253,15 +11266,15 @@ entities:
           -18,2:
             0: 12
           -17,4:
-            1: 72
+            3: 72
           -17,-4:
-            1: 16384
+            3: 16384
           -17,-3:
-            1: 2184
+            3: 2184
           17,0:
-            1: 61999
+            3: 61999
           17,1:
-            1: 15
+            3: 15
             0: 56576
           17,2:
             0: 61661
@@ -11270,9 +11283,9 @@ entities:
           17,4:
             0: 36863
           18,0:
-            1: 61455
+            3: 61455
           18,1:
-            1: 15
+            3: 15
             0: 30464
           18,2:
             0: 12407
@@ -11281,19 +11294,19 @@ entities:
           18,4:
             0: 3067
           19,0:
-            1: 12847
+            3: 12847
           19,1:
-            1: 13107
+            3: 13107
           19,2:
-            1: 3891
+            3: 3891
           19,3:
             0: 1911
           19,4:
             0: 52733
           20,0:
-            1: 15
+            3: 15
           20,3:
-            1: 4096
+            3: 4096
           16,7:
             0: 61166
           16,8:
@@ -11304,7 +11317,7 @@ entities:
             0: 4369
           17,8:
             0: 4369
-            1: 50176
+            3: 50176
           17,5:
             0: 3276
           18,5:
@@ -11313,41 +11326,41 @@ entities:
             0: 30583
           20,4:
             0: 4369
-            1: 3808
+            3: 3808
           17,9:
-            1: 244
+            3: 244
           18,8:
-            1: 61440
+            3: 61440
           18,9:
-            1: 245
+            3: 245
           19,8:
-            1: 61440
+            3: 61440
           19,9:
-            1: 36080
+            3: 36080
           20,8:
-            1: 61440
+            3: 61440
           20,9:
-            1: 40176
+            3: 40176
           8,17:
-            1: 60996
+            3: 60996
           8,18:
-            1: 14
+            3: 14
           9,17:
-            1: 61440
+            3: 61440
             0: 12
           10,17:
             0: 15
-            1: 61440
+            3: 61440
           11,17:
-            1: 64648
+            3: 64648
           11,18:
-            1: 12
+            3: 12
           12,17:
-            1: 4352
+            3: 4352
           12,18:
-            1: 1
+            3: 1
           21,4:
-            1: 36856
+            3: 36856
           21,5:
             0: 52428
           21,6:
@@ -11355,7 +11368,7 @@ entities:
           21,3:
             0: 52428
           22,4:
-            1: 36856
+            3: 36856
           22,5:
             0: 56797
           22,6:
@@ -11363,7 +11376,7 @@ entities:
           22,3:
             0: 56797
           23,4:
-            1: 36856
+            3: 36856
           23,5:
             0: 56797
           23,6:
@@ -11371,7 +11384,7 @@ entities:
           23,3:
             0: 56797
           24,4:
-            1: 36856
+            3: 36856
           24,5:
             0: 56797
           24,6:
@@ -11379,150 +11392,150 @@ entities:
           24,3:
             0: 56797
           25,4:
-            1: 4080
+            3: 4080
           25,5:
             0: 4369
           25,6:
             0: 17
           27,7:
-            1: 25668
+            3: 25668
           27,8:
-            1: 29783
+            3: 29783
           27,4:
-            1: 17476
+            3: 17476
           27,3:
-            1: 17476
+            3: 17476
           27,5:
-            1: 17476
+            3: 17476
           27,6:
-            1: 17476
+            3: 17476
           21,0:
-            1: 15
+            3: 15
           21,2:
             0: 52224
           22,0:
-            1: 143
+            3: 143
           22,2:
             0: 56576
           22,-1:
-            1: 32768
+            3: 32768
           23,0:
-            1: 62335
+            3: 62335
           23,2:
             0: 56576
           23,-1:
-            1: 29491
+            3: 29491
           24,0:
-            1: 61455
+            3: 61455
           24,2:
             0: 56576
           24,-1:
-            1: 17476
+            3: 17476
           25,0:
-            1: 61455
+            3: 61455
           25,2:
             0: 4352
           25,3:
             0: 4369
           26,0:
-            1: 61455
+            3: 61455
           26,1:
-            1: 140
+            3: 140
           27,0:
-            1: 29303
+            3: 29303
           27,1:
-            1: 26452
+            3: 26452
           27,-1:
-            1: 28672
+            3: 28672
           27,2:
-            1: 17476
+            3: 17476
           23,-4:
-            1: 13107
+            3: 13107
           23,-5:
-            1: 13107
+            3: 13107
           23,-3:
-            1: 13107
+            3: 13107
           23,-2:
-            1: 13299
+            3: 13299
           24,-2:
-            1: 17524
+            3: 17524
           23,-6:
-            1: 61440
+            3: 61440
           24,-6:
-            1: 28672
+            3: 28672
           24,-4:
-            1: 17476
+            3: 17476
           24,-5:
-            1: 17476
+            3: 17476
           24,-3:
-            1: 17476
+            3: 17476
           24,8:
-            1: 61440
+            3: 61440
           23,8:
-            1: 61440
+            3: 61440
           24,9:
-            1: 240
+            3: 240
           23,9:
-            1: 240
+            3: 240
           25,8:
-            1: 61440
+            3: 61440
           25,9:
-            1: 240
+            3: 240
           26,8:
-            1: 64640
+            3: 64640
           26,9:
-            1: 240
+            3: 240
           27,9:
-            1: 116
+            3: 116
           20,10:
-            1: 35051
+            3: 35051
           21,8:
-            1: 61440
+            3: 61440
           21,9:
-            1: 9968
+            3: 9968
           20,11:
-            1: 34952
+            3: 34952
           20,12:
-            1: 51336
+            3: 51336
           21,10:
-            1: 8814
+            3: 8814
           21,11:
-            1: 8738
+            3: 8738
           21,12:
-            1: 12834
+            3: 12834
           22,8:
-            1: 61440
+            3: 61440
           22,9:
-            1: 14064
+            3: 14064
           22,10:
-            1: 1
+            3: 1
           17,13:
-            1: 15
+            3: 15
           17,14:
-            1: 15
+            3: 15
           18,13:
-            1: 15
+            3: 15
           18,14:
-            1: 15
+            3: 15
           19,13:
-            1: 15
+            3: 15
           19,14:
-            1: 15
+            3: 15
           20,13:
-            1: 51407
+            3: 51407
           20,14:
-            1: 207
+            3: 207
           21,13:
-            1: 4115
+            3: 4115
           21,14:
-            1: 17
+            3: 17
           -21,-16:
             0: 14
           -19,-15:
             0: 26214
           -19,-14:
             0: 12
-            1: 17472
+            3: 17472
           -18,-15:
             0: 4095
           -18,-14:
@@ -11548,10 +11561,55 @@ entities:
           - 0
           - 0
         - volume: 2500
+          temperature: 293.14978
+          moles:
+          - 21.813705
+          - 82.06108
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 21.6852
+          - 81.57766
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
           immutable: True
           moles:
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.078888
+          - 75.53487
           - 0
           - 0
           - 0
@@ -11582,21 +11640,6 @@ entities:
           moles:
           - 0
           - 103.92799
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.14975
-          moles:
-          - 20.078888
-          - 75.53487
           - 0
           - 0
           - 0
@@ -11795,23 +11838,6 @@ entities:
       - 21751
       - 13451
       - 13162
-  - uid: 3694
-    components:
-    - type: Transform
-      pos: 17.5,-35.5
-      parent: 6747
-    - type: DeviceList
-      devices:
-      - 22175
-      - 22174
-      - 22173
-      - 21775
-      - 22292
-      - 21906
-      - 13952
-      - 13867
-      - 13866
-      - 13951
   - uid: 4754
     components:
     - type: Transform
@@ -11856,6 +11882,20 @@ entities:
       - 27297
       - 27396
       - 27395
+  - uid: 8702
+    components:
+    - type: Transform
+      pos: 20.5,-35.5
+      parent: 6747
+    - type: DeviceList
+      devices:
+      - 22175
+      - 22173
+      - 21775
+      - 22292
+      - 21906
+      - 13866
+      - 13951
   - uid: 8860
     components:
     - type: Transform
@@ -11927,16 +11967,19 @@ entities:
       parent: 6747
     - type: DeviceList
       devices:
-      - 21772
-      - 22179
-      - 22173
-      - 22174
-      - 22178
-      - 21909
-      - 13868
-      - 13953
-      - 13874
+      - 3740
       - 13954
+      - 13874
+      - 13953
+      - 13868
+      - 21909
+      - 22178
+      - 22173
+      - 22179
+      - 21772
+      - 3737
+      - 29764
+      - 29763
   - uid: 13485
     components:
     - type: Transform
@@ -13384,6 +13427,23 @@ entities:
       - 29267
       - 29265
       - 29313
+  - uid: 29754
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-37.5
+      parent: 6747
+    - type: DeviceList
+      devices:
+      - 2160
+      - 13951
+      - 13866
+      - 21906
+      - 22292
+      - 21775
+      - 22173
+      - 22175
+      - 2159
 - proto: AirAlarmVox
   entities:
   - uid: 29635
@@ -15685,11 +15745,6 @@ entities:
     - type: Transform
       pos: 20.5,-27.5
       parent: 6747
-  - uid: 2158
-    components:
-    - type: Transform
-      pos: 9.5,-38.5
-      parent: 6747
   - uid: 3521
     components:
     - type: Transform
@@ -15726,6 +15781,11 @@ entities:
     components:
     - type: Transform
       pos: 43.5,-8.5
+      parent: 6747
+  - uid: 29727
+    components:
+    - type: Transform
+      pos: 9.5,-38.5
       parent: 6747
 - proto: AirlockMedicalMorgueLocked
   entities:
@@ -16393,6 +16453,11 @@ entities:
     - type: Transform
       pos: 16.5,-37.5
       parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 8702
+      - 29748
+      - 29754
   - uid: 21907
     components:
     - type: Transform
@@ -16417,6 +16482,7 @@ entities:
       - 10592
       - 10590
       - 131
+      - 22118
   - uid: 21910
     components:
     - type: Transform
@@ -16611,6 +16677,11 @@ entities:
     - type: Transform
       pos: 6.5,-38.5
       parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 8702
+      - 29748
+      - 29754
   - uid: 22295
     components:
     - type: Transform
@@ -17537,6 +17608,22 @@ entities:
     - type: Transform
       pos: -3.5,-48.5
       parent: 6747
+  - uid: 29779
+    components:
+    - type: MetaData
+      name: APC (surgery/morgue)
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-30.5
+      parent: 6747
+  - uid: 29780
+    components:
+    - type: MetaData
+      name: APC (chemistry lab)
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-20.5
+      parent: 6747
 - proto: APCHyperCapacity
   entities:
   - uid: 4019
@@ -17549,13 +17636,6 @@ entities:
       parent: 6747
 - proto: APCSuperCapacity
   entities:
-  - uid: 2089
-    components:
-    - type: MetaData
-      name: APC (chemistry lab/med locker room/morgue)
-    - type: Transform
-      pos: 13.5,-28.5
-      parent: 6747
   - uid: 2773
     components:
     - type: MetaData
@@ -20697,10 +20777,11 @@ entities:
       parent: 6747
 - proto: BookMedicalReferenceBook
   entities:
-  - uid: 22542
+  - uid: 29732
     components:
     - type: Transform
-      pos: 4.2310553,-36.34688
+      rot: 3.141592653589793 rad
+      pos: 18.993603,-39.4487
       parent: 6747
 - proto: BookRandom
   entities:
@@ -20951,23 +21032,23 @@ entities:
   - uid: 3370
     components:
     - type: Transform
-      parent: 3258
+      parent: 2019
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 3441
     components:
     - type: Transform
-      parent: 3385
+      parent: 1964
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: BoxBodyBag
   entities:
-  - uid: 3732
+  - uid: 3813
     components:
     - type: Transform
-      pos: 17.461784,-39.303867
+      pos: 10.399912,-36.269756
       parent: 6747
 - proto: BoxBottle
   entities:
@@ -21234,28 +21315,28 @@ entities:
   - uid: 3369
     components:
     - type: Transform
-      parent: 3258
+      parent: 2019
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 3377
     components:
     - type: Transform
-      parent: 3258
+      parent: 2019
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 3442
     components:
     - type: Transform
-      parent: 3385
+      parent: 1964
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 3443
     components:
     - type: Transform
-      parent: 3385
+      parent: 1964
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -21540,20 +21621,35 @@ entities:
     - type: Transform
       pos: 22.5,-52.5
       parent: 6747
-  - uid: 1964
+  - uid: 1749
     components:
     - type: Transform
-      pos: 13.5,-27.5
+      pos: 10.5,-30.5
       parent: 6747
   - uid: 1978
     components:
     - type: Transform
       pos: 19.5,-18.5
       parent: 6747
-  - uid: 2090
+  - uid: 2100
     components:
     - type: Transform
-      pos: 12.5,-27.5
+      pos: 11.5,-34.5
+      parent: 6747
+  - uid: 2101
+    components:
+    - type: Transform
+      pos: 12.5,-34.5
+      parent: 6747
+  - uid: 2158
+    components:
+    - type: Transform
+      pos: 13.5,-34.5
+      parent: 6747
+  - uid: 2162
+    components:
+    - type: Transform
+      pos: 9.5,-30.5
       parent: 6747
   - uid: 2256
     components:
@@ -21564,6 +21660,16 @@ entities:
     components:
     - type: Transform
       pos: 50.5,13.5
+      parent: 6747
+  - uid: 2478
+    components:
+    - type: Transform
+      pos: 14.5,-20.5
+      parent: 6747
+  - uid: 2479
+    components:
+    - type: Transform
+      pos: 13.5,-20.5
       parent: 6747
   - uid: 2776
     components:
@@ -31370,11 +31476,6 @@ entities:
     - type: Transform
       pos: 22.5,-22.5
       parent: 6747
-  - uid: 20890
-    components:
-    - type: Transform
-      pos: 11.5,-27.5
-      parent: 6747
   - uid: 20891
     components:
     - type: Transform
@@ -31404,26 +31505,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-23.5
-      parent: 6747
-  - uid: 20897
-    components:
-    - type: Transform
-      pos: 13.5,-28.5
-      parent: 6747
-  - uid: 20900
-    components:
-    - type: Transform
-      pos: 11.5,-32.5
-      parent: 6747
-  - uid: 20901
-    components:
-    - type: Transform
-      pos: 12.5,-32.5
-      parent: 6747
-  - uid: 20902
-    components:
-    - type: Transform
-      pos: 13.5,-32.5
       parent: 6747
   - uid: 20903
     components:
@@ -31649,16 +31730,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,-37.5
-      parent: 6747
-  - uid: 20948
-    components:
-    - type: Transform
-      pos: 17.5,-37.5
-      parent: 6747
-  - uid: 20949
-    components:
-    - type: Transform
-      pos: 18.5,-37.5
       parent: 6747
   - uid: 20950
     components:
@@ -37950,10 +38021,40 @@ entities:
     - type: Transform
       pos: 1.5,-69.5
       parent: 6747
-  - uid: 29732
+  - uid: 29772
     components:
     - type: Transform
-      pos: 13.5,-29.5
+      pos: 19.5,-34.5
+      parent: 6747
+  - uid: 29774
+    components:
+    - type: Transform
+      pos: 19.5,-36.5
+      parent: 6747
+  - uid: 29775
+    components:
+    - type: Transform
+      pos: 19.5,-37.5
+      parent: 6747
+  - uid: 29776
+    components:
+    - type: Transform
+      pos: 20.5,-34.5
+      parent: 6747
+  - uid: 29777
+    components:
+    - type: Transform
+      pos: 19.5,-35.5
+      parent: 6747
+  - uid: 29781
+    components:
+    - type: Transform
+      pos: 11.5,-30.5
+      parent: 6747
+  - uid: 29782
+    components:
+    - type: Transform
+      pos: 12.5,-30.5
       parent: 6747
 - proto: CableApcStack
   entities:
@@ -45095,15 +45196,60 @@ entities:
     - type: Transform
       pos: 19.5,-10.5
       parent: 6747
-  - uid: 2023
-    components:
-    - type: Transform
-      pos: 13.5,-27.5
-      parent: 6747
   - uid: 2077
     components:
     - type: Transform
-      pos: 12.5,-27.5
+      pos: 12.5,-30.5
+      parent: 6747
+  - uid: 2089
+    components:
+    - type: Transform
+      pos: 10.5,-30.5
+      parent: 6747
+  - uid: 2090
+    components:
+    - type: Transform
+      pos: 14.5,-20.5
+      parent: 6747
+  - uid: 2099
+    components:
+    - type: Transform
+      pos: 14.5,-30.5
+      parent: 6747
+  - uid: 2476
+    components:
+    - type: Transform
+      pos: 13.5,-30.5
+      parent: 6747
+  - uid: 2477
+    components:
+    - type: Transform
+      pos: 11.5,-30.5
+      parent: 6747
+  - uid: 2480
+    components:
+    - type: Transform
+      pos: 12.5,-21.5
+      parent: 6747
+  - uid: 2481
+    components:
+    - type: Transform
+      pos: 12.5,-20.5
+      parent: 6747
+  - uid: 2482
+    components:
+    - type: Transform
+      pos: 13.5,-20.5
+      parent: 6747
+  - uid: 2483
+    components:
+    - type: Transform
+      pos: 9.5,-30.5
+      parent: 6747
+  - uid: 2484
+    components:
+    - type: Transform
+      pos: 15.5,-30.5
       parent: 6747
   - uid: 2774
     components:
@@ -47239,36 +47385,6 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-22.5
-      parent: 6747
-  - uid: 18350
-    components:
-    - type: Transform
-      pos: 11.5,-22.5
-      parent: 6747
-  - uid: 18361
-    components:
-    - type: Transform
-      pos: 11.5,-23.5
-      parent: 6747
-  - uid: 18362
-    components:
-    - type: Transform
-      pos: 11.5,-24.5
-      parent: 6747
-  - uid: 18363
-    components:
-    - type: Transform
-      pos: 11.5,-25.5
-      parent: 6747
-  - uid: 18364
-    components:
-    - type: Transform
-      pos: 11.5,-26.5
-      parent: 6747
-  - uid: 18365
-    components:
-    - type: Transform
-      pos: 11.5,-27.5
       parent: 6747
   - uid: 18367
     components:
@@ -50935,11 +51051,6 @@ entities:
     - type: Transform
       pos: -61.5,-70.5
       parent: 6747
-  - uid: 29731
-    components:
-    - type: Transform
-      pos: 13.5,-28.5
-      parent: 6747
 - proto: CableMVStack
   entities:
   - uid: 1271
@@ -51321,6 +51432,11 @@ entities:
       parent: 6747
 - proto: CarpetBlack
   entities:
+  - uid: 2490
+    components:
+    - type: Transform
+      pos: 19.5,-38.5
+      parent: 6747
   - uid: 2575
     components:
     - type: Transform
@@ -51330,6 +51446,11 @@ entities:
     components:
     - type: Transform
       pos: -5.5,-65.5
+      parent: 6747
+  - uid: 4358
+    components:
+    - type: Transform
+      pos: 20.5,-38.5
       parent: 6747
   - uid: 4376
     components:
@@ -51365,6 +51486,16 @@ entities:
     components:
     - type: Transform
       pos: -7.5,-66.5
+      parent: 6747
+  - uid: 5667
+    components:
+    - type: Transform
+      pos: 19.5,-39.5
+      parent: 6747
+  - uid: 7170
+    components:
+    - type: Transform
+      pos: 18.5,-39.5
       parent: 6747
   - uid: 8718
     components:
@@ -51446,6 +51577,11 @@ entities:
     - type: Transform
       pos: -19.5,6.5
       parent: 6747
+  - uid: 18364
+    components:
+    - type: Transform
+      pos: 18.5,-38.5
+      parent: 6747
   - uid: 18455
     components:
     - type: Transform
@@ -51510,6 +51646,11 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-48.5
+      parent: 6747
+  - uid: 29745
+    components:
+    - type: Transform
+      pos: 20.5,-39.5
       parent: 6747
 - proto: CarpetBlue
   entities:
@@ -57318,30 +57459,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,-43.5
       parent: 6747
-  - uid: 2485
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,-36.5
-      parent: 6747
-  - uid: 2486
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-37.5
-      parent: 6747
-  - uid: 2487
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-36.5
-      parent: 6747
-  - uid: 2488
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-36.5
-      parent: 6747
   - uid: 2656
     components:
     - type: Transform
@@ -59000,6 +59117,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -45.5,-35.5
       parent: 6747
+  - uid: 13856
+    components:
+    - type: Transform
+      pos: 18.564568,-38.66691
+      parent: 6747
+  - uid: 14240
+    components:
+    - type: Transform
+      pos: 19.49165,-38.635635
+      parent: 6747
   - uid: 15038
     components:
     - type: Transform
@@ -60644,20 +60771,16 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingMaskBreathMedical
   entities:
-  - uid: 3740
-    components:
-    - type: Transform
-      pos: 13.543918,-32.32793
-      parent: 6747
-  - uid: 3741
-    components:
-    - type: Transform
-      pos: 13.50225,-32.50514
-      parent: 6747
   - uid: 11198
     components:
     - type: Transform
       pos: 38.483875,-84.61417
+      parent: 6747
+  - uid: 29752
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.1823225,-39.441753
       parent: 6747
 - proto: ClothingMaskGas
   entities:
@@ -60761,15 +60884,15 @@ entities:
       parent: 6747
 - proto: ClothingNeckStethoscope
   entities:
+  - uid: 2491
+    components:
+    - type: Transform
+      pos: 6.846137,-39.320812
+      parent: 6747
   - uid: 3749
     components:
     - type: Transform
       pos: 15.441949,-15.36942
-      parent: 6747
-  - uid: 4358
-    components:
-    - type: Transform
-      pos: 13.546214,-33.268925
       parent: 6747
   - uid: 6123
     components:
@@ -61848,11 +61971,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 58.5,-12.5
       parent: 6747
-  - uid: 20882
+  - uid: 13943
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,-32.5
+      pos: 12.5,-29.5
       parent: 6747
 - proto: ComputerId
   entities:
@@ -62974,40 +63096,11 @@ entities:
         - 0
 - proto: CrateFreezer
   entities:
-  - uid: 29727
+  - uid: 18365
     components:
     - type: Transform
-      pos: 13.5,-34.5
+      pos: 14.353385,-29.497513
       parent: 6747
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 293.14673
-        moles:
-        - 1.7459903
-        - 6.568249
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-    - type: ContainerContainer
-      containers:
-        entity_storage: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 29728
-        paper_label: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
 - proto: CrateFunBoardGames
   entities:
   - uid: 12164
@@ -63580,6 +63673,18 @@ entities:
     components:
     - type: Transform
       pos: -16.5,5.5
+      parent: 6747
+- proto: CurtainsBlueOpen
+  entities:
+  - uid: 16878
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 6747
+  - uid: 29444
+    components:
+    - type: Transform
+      pos: 17.5,-37.5
       parent: 6747
 - proto: CurtainsCyanOpen
   entities:
@@ -75407,11 +75512,6 @@ entities:
       parent: 6747
 - proto: DonkpocketBoxSpawner
   entities:
-  - uid: 2490
-    components:
-    - type: Transform
-      pos: 5.5,-39.5
-      parent: 6747
   - uid: 3118
     components:
     - type: Transform
@@ -75427,6 +75527,11 @@ entities:
     components:
     - type: Transform
       pos: 9.5,26.5
+      parent: 6747
+  - uid: 9087
+    components:
+    - type: Transform
+      pos: 18.5,-36.5
       parent: 6747
   - uid: 12875
     components:
@@ -75975,10 +76080,10 @@ entities:
       parent: 6747
 - proto: DrinkMugRainbow
   entities:
-  - uid: 21848
+  - uid: 13861
     components:
     - type: Transform
-      pos: 4.631568,-36.221367
+      pos: 18.462353,-39.219376
       parent: 6747
 - proto: DrinkSakeBottleFull
   entities:
@@ -76152,16 +76257,6 @@ entities:
     - type: Transform
       pos: -15.45827,2.5335972
       parent: 6747
-  - uid: 3747
-    components:
-    - type: Transform
-      pos: 7.656001,-39.42155
-      parent: 6747
-  - uid: 3748
-    components:
-    - type: Transform
-      pos: 7.656001,-39.21307
-      parent: 6747
   - uid: 4335
     components:
     - type: Transform
@@ -76298,6 +76393,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -21.5,-58.5
+      parent: 6747
+  - uid: 3731
+    components:
+    - type: Transform
+      pos: 13.5,-36.5
       parent: 6747
   - uid: 4719
     components:
@@ -76630,14 +76730,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 16.5,-31.5
-      parent: 6747
-    - type: PointLight
-      enabled: True
-    - type: ActiveEmergencyLight
-  - uid: 17185
-    components:
-    - type: Transform
-      pos: 17.5,-36.5
       parent: 6747
     - type: PointLight
       enabled: True
@@ -77165,6 +77257,13 @@ entities:
       parent: 8368
     - type: Physics
       canCollide: False
+- proto: EpinephrineChemistryBottle
+  entities:
+  - uid: 9088
+    components:
+    - type: Transform
+      pos: 6.387803,-39.1853
+      parent: 6747
 - proto: ExosuitFabricator
   entities:
   - uid: 9073
@@ -77652,7 +77751,6 @@ entities:
     - type: DeviceList
       devices:
       - 22175
-      - 22174
       - 22173
       - 21775
       - 22292
@@ -78070,12 +78168,11 @@ entities:
       parent: 6747
     - type: DeviceList
       devices:
-      - 21772
-      - 22179
-      - 22173
-      - 22174
-      - 22178
       - 21909
+      - 22178
+      - 22173
+      - 22179
+      - 21772
   - uid: 22120
     components:
     - type: Transform
@@ -78812,6 +78909,19 @@ entities:
       - 25234
       - 25233
       - 25236
+  - uid: 29748
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-36.5
+      parent: 6747
+    - type: DeviceList
+      devices:
+      - 21906
+      - 22292
+      - 21775
+      - 22173
+      - 22175
 - proto: FireAlarmElectronics
   entities:
   - uid: 7654
@@ -79992,6 +80102,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 10592
+      - 22118
   - uid: 21773
     components:
     - type: Transform
@@ -80015,6 +80126,11 @@ entities:
     - type: Transform
       pos: 13.5,-40.5
       parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 8702
+      - 29748
+      - 29754
   - uid: 21776
     components:
     - type: Transform
@@ -80202,19 +80318,20 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 10592
-  - uid: 22174
-    components:
-    - type: Transform
-      pos: 19.5,-35.5
-      parent: 6747
-    - type: DeviceNetwork
-      deviceLists:
-      - 10592
+      - 8702
+      - 29748
+      - 29754
+      - 22118
   - uid: 22175
     components:
     - type: Transform
       pos: 21.5,-37.5
       parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 8702
+      - 29748
+      - 29754
   - uid: 22176
     components:
     - type: Transform
@@ -80235,6 +80352,7 @@ entities:
       - 10592
       - 10590
       - 131
+      - 22118
   - uid: 22179
     components:
     - type: Transform
@@ -80245,6 +80363,7 @@ entities:
       - 10592
       - 10590
       - 131
+      - 22118
   - uid: 22180
     components:
     - type: Transform
@@ -81412,6 +81531,11 @@ entities:
     - type: Transform
       pos: 15.72746,-60.379566
       parent: 6747
+  - uid: 29765
+    components:
+    - type: Transform
+      pos: -40.531376,2.6492875
+      parent: 6747
 - proto: FoodBowlBigTrash
   entities:
   - uid: 10080
@@ -81784,10 +81908,10 @@ entities:
       parent: 6747
 - proto: FoodPieBaklava
   entities:
-  - uid: 3745
+  - uid: 25585
     components:
     - type: Transform
-      pos: 7.4926186,-36.385815
+      pos: 19.514439,-39.354885
       parent: 6747
 - proto: FoodPieBananaCream
   entities:
@@ -82534,6 +82658,22 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 3743
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 3745
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-38.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 4773
     components:
     - type: Transform
@@ -85019,12 +85159,26 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF3333FF'
+  - uid: 29758
+    components:
+    - type: Transform
+      pos: 19.5,-33.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
 - proto: GasPipeFourway
   entities:
   - uid: 360
     components:
     - type: Transform
       pos: 11.5,26.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 3746
+    components:
+    - type: Transform
+      pos: 28.5,-37.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -85686,6 +85840,21 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-13.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 3732
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 3738
+    components:
+    - type: Transform
+      pos: 13.5,-38.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -90447,13 +90616,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 13849
-    components:
-    - type: Transform
-      pos: 15.5,-31.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 13850
     components:
     - type: Transform
@@ -90496,14 +90658,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 13856
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,-38.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 13857
     components:
     - type: Transform
@@ -90533,14 +90687,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 11.5,-38.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 13861
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,-38.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -90981,22 +91127,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 13936
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 13937
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 13938
     components:
     - type: Transform
@@ -91032,14 +91162,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 14.5,-37.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 13943
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,-37.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -110947,6 +111069,86 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 29744
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 29747
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 29753
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 29755
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 29756
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 29757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 29759
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-33.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 29760
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-33.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 29761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-34.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 29762
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-35.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
 - proto: GasPipeTJunction
   entities:
   - uid: 293
@@ -111030,6 +111232,45 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 19.5,-15.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 3739
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-38.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 3741
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-33.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 3742
+    components:
+    - type: Transform
+      pos: 13.5,-37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 3747
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-32.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 3748
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-31.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
@@ -111890,22 +112131,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 13804
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,-37.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 13805
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-38.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 13891
     components:
     - type: Transform
@@ -112013,14 +112238,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 14240
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 28.5,-37.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 14241
     components:
     - type: Transform
@@ -115058,6 +115275,17 @@ entities:
       - 131
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 2160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-39.5
+      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 29754
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 3675
     components:
     - type: Transform
@@ -115067,6 +115295,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 7456
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 3737
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-32.5
+      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 10592
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 4982
@@ -115346,14 +115585,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,-37.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 13952
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-37.5
-      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 8702
+      - 29754
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 13953
@@ -117062,6 +117297,17 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 29763
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-36.5
+      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 10592
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
 - proto: GasVentPumpVox
   entities:
   - uid: 29596
@@ -117077,6 +117323,16 @@ entities:
       color: '#FF3333FF'
 - proto: GasVentScrubber
   entities:
+  - uid: 2159
+    components:
+    - type: Transform
+      pos: 10.5,-37.5
+      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 29754
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 2472
     components:
     - type: Transform
@@ -117097,6 +117353,17 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 7456
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 3740
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-31.5
+      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 10592
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 3755
@@ -117426,14 +117693,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,-38.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 13867
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 17.5,-38.5
-      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 8702
+      - 29754
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 13868
@@ -119110,6 +119373,17 @@ entities:
       - 29421
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 29764
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-37.5
+      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 10592
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
 - proto: GasVentScrubberVox
   entities:
   - uid: 29609
@@ -120525,25 +120799,10 @@ entities:
     - type: Transform
       pos: 30.5,-30.5
       parent: 6747
-  - uid: 2159
-    components:
-    - type: Transform
-      pos: 9.5,-39.5
-      parent: 6747
-  - uid: 2160
-    components:
-    - type: Transform
-      pos: 9.5,-37.5
-      parent: 6747
   - uid: 2161
     components:
     - type: Transform
       pos: 64.5,33.5
-      parent: 6747
-  - uid: 2162
-    components:
-    - type: Transform
-      pos: 9.5,-36.5
       parent: 6747
   - uid: 2227
     components:
@@ -125695,6 +125954,16 @@ entities:
     - type: Transform
       pos: 60.5,-24.5
       parent: 6747
+  - uid: 29773
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 6747
+  - uid: 29778
+    components:
+    - type: Transform
+      pos: 17.5,-37.5
+      parent: 6747
 - proto: GrilleBroken
   entities:
   - uid: 9970
@@ -125927,18 +126196,18 @@ entities:
     - type: Transform
       pos: 57.935726,57.403614
       parent: 6747
-- proto: GunSafe
+- proto: GunSafeBaseSecure
   entities:
-  - uid: 3258
+  - uid: 1964
     components:
     - type: Transform
-      pos: -30.5,7.5
+      pos: -29.5,7.5
       parent: 6747
     - type: EntityStorage
       air:
         volume: 200
         immutable: False
-        temperature: 293.14673
+        temperature: 293.14697
         moles:
         - 1.8856695
         - 7.0937095
@@ -125958,28 +126227,28 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 3371
-          - 3377
-          - 3370
-          - 3369
-          - 3367
+          - 3443
+          - 3444
+          - 3446
+          - 3441
+          - 3442
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 3385
+  - uid: 2019
     components:
     - type: Transform
-      pos: -29.5,7.5
+      pos: -30.5,7.5
       parent: 6747
     - type: EntityStorage
       air:
         volume: 200
         immutable: False
-        temperature: 293.14673
+        temperature: 293.14703
         moles:
-        - 1.7459903
-        - 6.568249
+        - 1.8968438
+        - 7.1357465
         - 0
         - 0
         - 0
@@ -125996,11 +126265,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 3442
-          - 3441
-          - 3446
-          - 3444
-          - 3443
+          - 3371
+          - 3367
+          - 3369
+          - 3370
+          - 3377
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
@@ -126205,16 +126474,20 @@ entities:
     - type: Transform
       pos: 1.3405766,38.626003
       parent: 6747
+  - uid: 6580
+    components:
+    - type: Transform
+      parent: 2040
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 7169
     components:
     - type: Transform
-      pos: 13.259391,-32.870655
-      parent: 6747
-  - uid: 7170
-    components:
-    - type: Transform
-      pos: 13.519809,-32.839382
-      parent: 6747
+      parent: 2040
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
   - uid: 7171
     components:
     - type: Transform
@@ -126243,10 +126516,10 @@ entities:
     - type: Transform
       pos: 10.528759,-32.0083
       parent: 6747
-  - uid: 3731
+  - uid: 5668
     components:
     - type: Transform
-      pos: 10.5016,-36.36708
+      pos: 10.483246,-39.219723
       parent: 6747
   - uid: 9673
     components:
@@ -126648,6 +126921,13 @@ entities:
     - type: Transform
       pos: -33.5,-45.5
       parent: 6747
+- proto: HolopadEngineeringAME
+  entities:
+  - uid: 29783
+    components:
+    - type: Transform
+      pos: 65.5,13.5
+      parent: 6747
 - proto: HolopadEngineeringAtmosMain
   entities:
   - uid: 29496
@@ -126675,6 +126955,13 @@ entities:
     components:
     - type: Transform
       pos: 44.5,11.5
+      parent: 6747
+- proto: HolopadEngineeringMain
+  entities:
+  - uid: 29784
+    components:
+    - type: Transform
+      pos: 57.5,19.5
       parent: 6747
 - proto: HolopadEngineeringStorage
   entities:
@@ -126797,10 +127084,10 @@ entities:
       parent: 6747
 - proto: HolopadMedicalBreakroom
   entities:
-  - uid: 29534
+  - uid: 5669
     components:
     - type: Transform
-      pos: 6.5,-37.5
+      pos: 19.5,-37.5
       parent: 6747
 - proto: HolopadMedicalChemistry
   entities:
@@ -127834,11 +128121,6 @@ entities:
     - type: Transform
       pos: -24.5,-4.5
       parent: 6747
-  - uid: 2489
-    components:
-    - type: Transform
-      pos: 6.5,-39.5
-      parent: 6747
   - uid: 2699
     components:
     - type: Transform
@@ -127913,6 +128195,11 @@ entities:
     components:
     - type: Transform
       pos: 49.5,23.5
+      parent: 6747
+  - uid: 13849
+    components:
+    - type: Transform
+      pos: 18.5,-36.5
       parent: 6747
   - uid: 17762
     components:
@@ -128112,6 +128399,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 38.918972,-49.78948
       parent: 6747
+  - uid: 9089
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5373125,-33.15561
+      parent: 6747
   - uid: 9126
     components:
     - type: Transform
@@ -128146,6 +128439,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 48.56912,-50.90788
+      parent: 6747
+  - uid: 20881
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5060625,-30.945742
       parent: 6747
   - uid: 23608
     components:
@@ -128847,6 +129146,36 @@ entities:
     - type: Transform
       pos: 20.5,-34.5
       parent: 6747
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 6580
+          - 7169
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
 - proto: LockerPsychologistFilled
   entities:
   - uid: 540
@@ -128987,10 +129316,10 @@ entities:
       parent: 6747
 - proto: LockerSurgeonFilled
   entities:
-  - uid: 20889
+  - uid: 3385
     components:
     - type: Transform
-      pos: 10.5,-30.5
+      pos: 10.5,-34.5
       parent: 6747
 - proto: LockerWallMedicalDoctorFilled
   entities:
@@ -129008,10 +129337,10 @@ entities:
           - 3202
 - proto: LockerWallMedicalFilled
   entities:
-  - uid: 3695
+  - uid: 18361
     components:
     - type: Transform
-      pos: 20.5,-35.5
+      pos: 5.5,-35.5
       parent: 6747
   - uid: 23938
     components:
@@ -129197,10 +129526,10 @@ entities:
     - type: Transform
       pos: -36.5,-85.5
       parent: 6747
-  - uid: 20881
+  - uid: 13937
     components:
     - type: Transform
-      pos: 14.5,-31.5
+      pos: 13.5,-29.5
       parent: 6747
 - proto: MachineFrameDestroyed
   entities:
@@ -129938,24 +130267,24 @@ entities:
       parent: 6747
 - proto: MedicalBiofabricator
   entities:
-  - uid: 29444
+  - uid: 20901
     components:
     - type: Transform
-      pos: 11.5,-34.5
+      pos: 10.5,-29.5
       parent: 6747
 - proto: MedicalScanner
   entities:
-  - uid: 20883
+  - uid: 13952
     components:
     - type: Transform
-      pos: 14.5,-33.5
+      pos: 11.5,-29.5
       parent: 6747
 - proto: MedicalTechFab
   entities:
-  - uid: 3736
+  - uid: 3694
     components:
     - type: Transform
-      pos: 20.5,-38.5
+      pos: 4.5,-37.5
       parent: 6747
 - proto: MedicalTechFabCircuitboard
   entities:
@@ -130066,22 +130395,22 @@ entities:
       parent: 6747
 - proto: MedkitRadiationFilled
   entities:
-  - uid: 3727
+  - uid: 29749
     components:
     - type: Transform
-      pos: 13.549136,-31.569992
+      pos: 5.4948225,-39.264545
       parent: 6747
 - proto: MedkitToxinFilled
   entities:
-  - uid: 3728
-    components:
-    - type: Transform
-      pos: 13.424136,-31.861862
-      parent: 6747
   - uid: 3963
     components:
     - type: Transform
       pos: -29.464008,-48.231915
+      parent: 6747
+  - uid: 29751
+    components:
+    - type: Transform
+      pos: 5.6302385,-39.4626
       parent: 6747
 - proto: Memorial
   entities:
@@ -132563,10 +132892,10 @@ entities:
       parent: 6747
 - proto: NitrousOxideTankFilled
   entities:
-  - uid: 3743
+  - uid: 9085
     components:
     - type: Transform
-      pos: 10.502254,-34.43969
+      pos: 14.441907,-32.405785
       parent: 6747
 - proto: NoticeBoard
   entities:
@@ -132641,6 +132970,16 @@ entities:
     - type: Transform
       pos: 1.5,-69.5
       parent: 6747
+  - uid: 9090
+    components:
+    - type: Transform
+      pos: 13.5,-31.5
+      parent: 6747
+  - uid: 13867
+    components:
+    - type: Transform
+      pos: 13.5,-33.5
+      parent: 6747
 - proto: Oracle
   entities:
   - uid: 8917
@@ -132670,15 +133009,6 @@ entities:
     - type: Transform
       pos: -2.4960773,-75.40111
       parent: 6747
-- proto: OrganAnimalRuminantStomach
-  entities:
-  - uid: 29728
-    components:
-    - type: Transform
-      parent: 29727
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: OrganHumanHeart
   entities:
   - uid: 22426
@@ -138683,6 +139013,13 @@ entities:
     - type: Transform
       pos: 52.5,-26.5
       parent: 6747
+- proto: PosterContrabandYoutoolpia
+  entities:
+  - uid: 29771
+    components:
+    - type: Transform
+      pos: 58.5,-18.5
+      parent: 6747
 - proto: PosterLegit12Gauge
   entities:
   - uid: 16297
@@ -138703,6 +139040,23 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 60.5,-48.5
+      parent: 6747
+- proto: PosterLegitCalendar
+  entities:
+  - uid: 29766
+    components:
+    - type: Transform
+      pos: -43.5,2.5
+      parent: 6747
+  - uid: 29767
+    components:
+    - type: Transform
+      pos: 21.5,-38.5
+      parent: 6747
+  - uid: 29768
+    components:
+    - type: Transform
+      pos: 41.5,-30.5
       parent: 6747
 - proto: PosterLegitCohibaRobustoAd
   entities:
@@ -138747,6 +139101,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-7.5
+      parent: 6747
+- proto: PosterLegitEyeChart
+  entities:
+  - uid: 29770
+    components:
+    - type: Transform
+      pos: 22.5,-17.5
       parent: 6747
 - proto: PosterLegitHelpOthers
   entities:
@@ -139565,6 +139926,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 38.5,-50.5
       parent: 6747
+  - uid: 20882
+    components:
+    - type: Transform
+      pos: 7.5,-39.5
+      parent: 6747
   - uid: 22507
     components:
     - type: Transform
@@ -140208,6 +140574,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 16.5,-13.5
+      parent: 6747
+  - uid: 10593
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-39.5
       parent: 6747
   - uid: 11135
     components:
@@ -141303,16 +141675,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-58.5
-      parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 16906
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-39.5
       parent: 6747
     - type: PointLight
       enabled: False
@@ -143158,6 +143520,12 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 13805
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-39.5
+      parent: 6747
   - uid: 16432
     components:
     - type: Transform
@@ -143178,30 +143546,10 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 16878
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-39.5
-      parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 16944
     components:
     - type: Transform
       pos: 29.5,-12.5
-      parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 16947
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,-39.5
       parent: 6747
     - type: PointLight
       enabled: False
@@ -143225,6 +143573,12 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 29728
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-39.5
+      parent: 6747
 - proto: PoweredLightColoredRed
   entities:
   - uid: 808
@@ -144750,6 +145104,11 @@ entities:
     - type: Transform
       pos: -42.5,11.5
       parent: 6747
+  - uid: 1748
+    components:
+    - type: Transform
+      pos: 14.5,-32.5
+      parent: 6747
   - uid: 1777
     components:
     - type: Transform
@@ -144779,21 +145138,6 @@ entities:
     components:
     - type: Transform
       pos: -13.5,-34.5
-      parent: 6747
-  - uid: 2477
-    components:
-    - type: Transform
-      pos: 18.5,-39.5
-      parent: 6747
-  - uid: 2478
-    components:
-    - type: Transform
-      pos: 19.5,-39.5
-      parent: 6747
-  - uid: 2479
-    components:
-    - type: Transform
-      pos: 20.5,-39.5
       parent: 6747
   - uid: 2705
     components:
@@ -144882,11 +145226,6 @@ entities:
     components:
     - type: Transform
       pos: 21.5,-23.5
-      parent: 6747
-  - uid: 3742
-    components:
-    - type: Transform
-      pos: 10.5,-34.5
       parent: 6747
   - uid: 3853
     components:
@@ -145556,6 +145895,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 74.5,9.5
       parent: 6747
+  - uid: 18362
+    components:
+    - type: Transform
+      pos: 4.5,-36.5
+      parent: 6747
   - uid: 19034
     components:
     - type: Transform
@@ -145565,6 +145909,16 @@ entities:
     components:
     - type: Transform
       pos: -5.5,6.5
+      parent: 6747
+  - uid: 20889
+    components:
+    - type: Transform
+      pos: 4.5,-39.5
+      parent: 6747
+  - uid: 20900
+    components:
+    - type: Transform
+      pos: 4.5,-38.5
       parent: 6747
   - uid: 21020
     components:
@@ -147301,6 +147655,11 @@ entities:
     - type: Transform
       pos: -10.5,-55.5
       parent: 6747
+  - uid: 13936
+    components:
+    - type: Transform
+      pos: -52.5,7.5
+      parent: 6747
   - uid: 16300
     components:
     - type: Transform
@@ -147335,11 +147694,6 @@ entities:
     components:
     - type: Transform
       pos: 43.5,-22.5
-      parent: 6747
-  - uid: 24540
-    components:
-    - type: Transform
-      pos: -43.5,2.5
       parent: 6747
   - uid: 29719
     components:
@@ -156297,20 +156651,25 @@ entities:
     - type: Transform
       pos: -28.565948,-13.381782
       parent: 6747
-  - uid: 2019
+  - uid: 3695
     components:
     - type: Transform
-      pos: 13.492375,-29.078419
-      parent: 6747
-  - uid: 10593
-    components:
-    - type: Transform
-      pos: 14.502791,-29.067995
+      pos: 7.5,-36
       parent: 6747
   - uid: 17311
     components:
     - type: Transform
-      pos: 12.492375,-29.088842
+      pos: 7.5,-36.5
+      parent: 6747
+  - uid: 20883
+    components:
+    - type: Transform
+      pos: 6.5,-36
+      parent: 6747
+  - uid: 20948
+    components:
+    - type: Transform
+      pos: 6.5,-36.5
       parent: 6747
 - proto: SalvageCanisterSpawner
   entities:
@@ -156478,6 +156837,13 @@ entities:
     components:
     - type: Transform
       pos: 27.524822,34.178925
+      parent: 6747
+- proto: Scalpel
+  entities:
+  - uid: 2489
+    components:
+    - type: Transform
+      pos: 14.433146,-31.362698
       parent: 6747
 - proto: SchoolgirlUniformSpawner
   entities:
@@ -156801,6 +157167,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 60.38245,-16.485804
       parent: 6747
+- proto: SentientSmileCore
+  entities:
+  - uid: 29735
+    components:
+    - type: Transform
+      pos: 18.5,-58.5
+      parent: 6747
 - proto: ShardGlass
   entities:
   - uid: 3806
@@ -156859,11 +157232,6 @@ entities:
       parent: 6747
 - proto: SheetGlass
   entities:
-  - uid: 3738
-    components:
-    - type: Transform
-      pos: 19.536514,-39.348763
-      parent: 6747
   - uid: 4396
     components:
     - type: Transform
@@ -156878,6 +157246,12 @@ entities:
     components:
     - type: Transform
       pos: 50.472504,16.50103
+      parent: 6747
+  - uid: 17309
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.564595,-39.418255
       parent: 6747
   - uid: 25679
     components:
@@ -156994,10 +157368,11 @@ entities:
       parent: 6747
 - proto: SheetPlastic
   entities:
-  - uid: 3737
+  - uid: 2485
     components:
     - type: Transform
-      pos: 20.484428,-39.442577
+      rot: 1.5707963267948966 rad
+      pos: 4.564595,-38.375866
       parent: 6747
   - uid: 3866
     components:
@@ -157053,10 +157428,11 @@ entities:
       parent: 6747
 - proto: SheetSteel
   entities:
-  - uid: 3739
+  - uid: 1752
     components:
     - type: Transform
-      pos: 18.505264,-39.38003
+      rot: 1.5707963267948966 rad
+      pos: 4.512513,-36.450493
       parent: 6747
   - uid: 3868
     components:
@@ -159231,6 +159607,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,-50.5
+      parent: 6747
+- proto: SignBrigmed
+  entities:
+  - uid: 29769
+    components:
+    - type: Transform
+      pos: -27.5,-13.5
       parent: 6747
 - proto: SignCargo
   entities:
@@ -161441,13 +161824,6 @@ entities:
     - type: Transform
       pos: -25.5,-5.5
       parent: 6747
-- proto: SpawnMobMedibot
-  entities:
-  - uid: 8702
-    components:
-    - type: Transform
-      pos: 17.5,-36.5
-      parent: 6747
 - proto: SpawnMobMonkeyPunpun
   entities:
   - uid: 25509
@@ -161482,13 +161858,6 @@ entities:
     components:
     - type: Transform
       pos: 31.5,-61.5
-      parent: 6747
-- proto: SpawnMobSmile
-  entities:
-  - uid: 29735
-    components:
-    - type: Transform
-      pos: 18.5,-58.5
       parent: 6747
 - proto: SpawnMobWalter
   entities:
@@ -161681,10 +162050,10 @@ entities:
     - type: Transform
       pos: 12.5,-26.5
       parent: 6747
-  - uid: 25585
+  - uid: 29731
     components:
     - type: Transform
-      pos: 7.5,-37.5
+      pos: 19.5,-38.5
       parent: 6747
 - proto: SpawnPointChiefEngineer
   entities:
@@ -161945,26 +162314,6 @@ entities:
     - type: Transform
       pos: -20.5,-11.5
       parent: 6747
-  - uid: 5667
-    components:
-    - type: Transform
-      pos: 5.5,-36.5
-      parent: 6747
-  - uid: 5668
-    components:
-    - type: Transform
-      pos: 6.5,-36.5
-      parent: 6747
-  - uid: 5669
-    components:
-    - type: Transform
-      pos: 4.5,-37.5
-      parent: 6747
-  - uid: 5670
-    components:
-    - type: Transform
-      pos: 8.5,-36.5
-      parent: 6747
   - uid: 6582
     components:
     - type: Transform
@@ -161984,6 +162333,11 @@ entities:
     components:
     - type: Transform
       pos: 20.5,-33.5
+      parent: 6747
+  - uid: 20890
+    components:
+    - type: Transform
+      pos: 18.5,-37.5
       parent: 6747
   - uid: 21422
     components:
@@ -162090,15 +162444,25 @@ entities:
     - type: Transform
       pos: -23.5,-11.5
       parent: 6747
-  - uid: 6580
+  - uid: 3727
     components:
     - type: Transform
-      pos: 6.5,-38.5
+      pos: 25.5,-21.5
+      parent: 6747
+  - uid: 3728
+    components:
+    - type: Transform
+      pos: 25.5,-23.5
       parent: 6747
   - uid: 6581
     components:
     - type: Transform
       pos: 46.5,-42.5
+      parent: 6747
+  - uid: 20897
+    components:
+    - type: Transform
+      pos: 18.5,-38.5
       parent: 6747
 - proto: SpawnPointPassenger
   entities:
@@ -162469,10 +162833,10 @@ entities:
       parent: 6747
 - proto: SpawnPointSurgeon
   entities:
-  - uid: 17310
+  - uid: 5670
     components:
     - type: Transform
-      pos: 5.5,-38.5
+      pos: 19.5,-37.5
       parent: 6747
   - uid: 29437
     components:
@@ -164169,7 +164533,7 @@ entities:
       setupAvailableNetworks:
       - SurveillanceCameraMedical
       nameSet: True
-      id: Medbay Breakroom
+      id: Storage Closet
   - uid: 21406
     components:
     - type: Transform
@@ -164181,6 +164545,16 @@ entities:
       - SurveillanceCameraMedical
       nameSet: True
       id: Outpost (Arena)
+  - uid: 24540
+    components:
+    - type: Transform
+      pos: 18.5,-39.5
+      parent: 6747
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraMedical
+      nameSet: True
+      id: Breakroom
   - uid: 26890
     components:
     - type: Transform
@@ -165161,10 +165535,10 @@ entities:
     - type: Transform
       pos: 10.5,-39.5
       parent: 6747
-  - uid: 2476
+  - uid: 2487
     components:
     - type: Transform
-      pos: 17.5,-39.5
+      pos: 6.5,-39.5
       parent: 6747
   - uid: 2693
     components:
@@ -165383,6 +165757,16 @@ entities:
     components:
     - type: Transform
       pos: -37.5,-32.5
+      parent: 6747
+  - uid: 13804
+    components:
+    - type: Transform
+      pos: 7.5,-39.5
+      parent: 6747
+  - uid: 17310
+    components:
+    - type: Transform
+      pos: 5.5,-39.5
       parent: 6747
   - uid: 22942
     components:
@@ -166052,21 +166436,6 @@ entities:
     - type: Transform
       pos: 10.5,-33.5
       parent: 6747
-  - uid: 2099
-    components:
-    - type: Transform
-      pos: 13.5,-32.5
-      parent: 6747
-  - uid: 2100
-    components:
-    - type: Transform
-      pos: 13.5,-31.5
-      parent: 6747
-  - uid: 2101
-    components:
-    - type: Transform
-      pos: 13.5,-33.5
-      parent: 6747
   - uid: 2153
     components:
     - type: Transform
@@ -166312,6 +166681,11 @@ entities:
     - type: Transform
       pos: 25.5,2.5
       parent: 6747
+  - uid: 18350
+    components:
+    - type: Transform
+      pos: 14.5,-33.5
+      parent: 6747
   - uid: 23546
     components:
     - type: Transform
@@ -166412,6 +166786,11 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 58.5,-22.5
+      parent: 6747
+  - uid: 29750
+    components:
+    - type: Transform
+      pos: 14.5,-31.5
       parent: 6747
 - proto: TablePlasmaGlass
   entities:
@@ -167402,6 +167781,11 @@ entities:
     - type: Transform
       pos: -20.5,-17.5
       parent: 6747
+  - uid: 1723
+    components:
+    - type: Transform
+      pos: 19.5,-39.5
+      parent: 6747
   - uid: 1800
     components:
     - type: Transform
@@ -167467,31 +167851,6 @@ entities:
     components:
     - type: Transform
       pos: 25.5,-34.5
-      parent: 6747
-  - uid: 2480
-    components:
-    - type: Transform
-      pos: 7.5,-36.5
-      parent: 6747
-  - uid: 2481
-    components:
-    - type: Transform
-      pos: 4.5,-36.5
-      parent: 6747
-  - uid: 2482
-    components:
-    - type: Transform
-      pos: 5.5,-39.5
-      parent: 6747
-  - uid: 2483
-    components:
-    - type: Transform
-      pos: 6.5,-39.5
-      parent: 6747
-  - uid: 2484
-    components:
-    - type: Transform
-      pos: 7.5,-39.5
       parent: 6747
   - uid: 2721
     components:
@@ -168057,6 +168416,16 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 58.5,-50.5
+      parent: 6747
+  - uid: 29743
+    components:
+    - type: Transform
+      pos: 18.5,-36.5
+      parent: 6747
+  - uid: 29746
+    components:
+    - type: Transform
+      pos: 18.5,-39.5
       parent: 6747
 - proto: TableWoodReinforced
   entities:
@@ -169482,11 +169851,6 @@ entities:
     - type: Transform
       pos: -22.5,-21.5
       parent: 6747
-  - uid: 2491
-    components:
-    - type: Transform
-      pos: 4.5,-39.5
-      parent: 6747
   - uid: 2941
     components:
     - type: Transform
@@ -169496,6 +169860,11 @@ entities:
     components:
     - type: Transform
       pos: 67.5,-25.5
+      parent: 6747
+  - uid: 16906
+    components:
+    - type: Transform
+      pos: 20.5,-36.5
       parent: 6747
 - proto: VendingMachineClothing
   entities:
@@ -169609,10 +169978,10 @@ entities:
       parent: 6747
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 29733
+  - uid: 2486
     components:
     - type: Transform
-      pos: 11.5,-29.5
+      pos: 8.5,-39.5
       parent: 6747
 - proto: VendingMachineMNKDrobe
   entities:
@@ -169743,10 +170112,10 @@ entities:
       parent: 6747
 - proto: VendingMachineViroDrobe
   entities:
-  - uid: 17309
+  - uid: 17185
     components:
     - type: Transform
-      pos: 10.5,-29.5
+      pos: 8.5,-36.5
       parent: 6747
 - proto: VendingMachineWallMedical
   entities:
@@ -169891,11 +170260,6 @@ entities:
     components:
     - type: Transform
       pos: -35.5,-34.5
-      parent: 6747
-  - uid: 22463
-    components:
-    - type: Transform
-      pos: 4.5,-35.5
       parent: 6747
   - uid: 22464
     components:
@@ -171916,11 +172280,6 @@ entities:
     - type: Transform
       pos: -18.5,-7.5
       parent: 6747
-  - uid: 1723
-    components:
-    - type: Transform
-      pos: 3.5,-37.5
-      parent: 6747
   - uid: 1728
     components:
     - type: Transform
@@ -171936,25 +172295,10 @@ entities:
     - type: Transform
       pos: 3.5,-35.5
       parent: 6747
-  - uid: 1748
-    components:
-    - type: Transform
-      pos: 3.5,-36.5
-      parent: 6747
-  - uid: 1749
-    components:
-    - type: Transform
-      pos: 3.5,-38.5
-      parent: 6747
   - uid: 1751
     components:
     - type: Transform
       pos: 9.5,-30.5
-      parent: 6747
-  - uid: 1752
-    components:
-    - type: Transform
-      pos: 3.5,-39.5
       parent: 6747
   - uid: 1789
     components:
@@ -183177,6 +183521,16 @@ entities:
     - type: Transform
       pos: 50.5,-16.5
       parent: 6747
+  - uid: 3814
+    components:
+    - type: Transform
+      pos: 9.5,-36.5
+      parent: 6747
+  - uid: 3815
+    components:
+    - type: Transform
+      pos: 9.5,-39.5
+      parent: 6747
   - uid: 3816
     components:
     - type: Transform
@@ -185082,6 +185436,11 @@ entities:
     - type: Transform
       pos: 43.5,-52.5
       parent: 6747
+  - uid: 16947
+    components:
+    - type: Transform
+      pos: 17.5,-39.5
+      parent: 6747
   - uid: 17250
     components:
     - type: Transform
@@ -185147,6 +185506,11 @@ entities:
     - type: Transform
       pos: 21.5,-94.5
       parent: 6747
+  - uid: 20949
+    components:
+    - type: Transform
+      pos: 3.5,-38.5
+      parent: 6747
   - uid: 21080
     components:
     - type: Transform
@@ -185172,6 +185536,11 @@ entities:
     - type: Transform
       pos: 58.5,4.5
       parent: 6747
+  - uid: 21848
+    components:
+    - type: Transform
+      pos: 3.5,-39.5
+      parent: 6747
   - uid: 21852
     components:
     - type: Transform
@@ -185187,6 +185556,11 @@ entities:
     - type: Transform
       pos: -22.5,-56.5
       parent: 6747
+  - uid: 22174
+    components:
+    - type: Transform
+      pos: 3.5,-37.5
+      parent: 6747
   - uid: 22207
     components:
     - type: Transform
@@ -185201,6 +185575,16 @@ entities:
     components:
     - type: Transform
       pos: 60.5,-4.5
+      parent: 6747
+  - uid: 22463
+    components:
+    - type: Transform
+      pos: 3.5,-36.5
+      parent: 6747
+  - uid: 22542
+    components:
+    - type: Transform
+      pos: 17.5,-36.5
       parent: 6747
   - uid: 22928
     components:
@@ -185246,6 +185630,11 @@ entities:
     components:
     - type: Transform
       pos: 35.5,12.5
+      parent: 6747
+  - uid: 29534
+    components:
+    - type: Transform
+      pos: 9.5,-37.5
       parent: 6747
   - uid: 29668
     components:
@@ -186282,11 +186671,6 @@ entities:
     - type: Transform
       pos: -14.5,2.5
       parent: 6747
-  - uid: 3746
-    components:
-    - type: Transform
-      pos: 8.5,-39.5
-      parent: 6747
   - uid: 4131
     components:
     - type: Transform
@@ -186326,6 +186710,11 @@ entities:
     components:
     - type: Transform
       pos: 57.5,-41.5
+      parent: 6747
+  - uid: 29733
+    components:
+    - type: Transform
+      pos: 20.5,-39.5
       parent: 6747
 - proto: WatermelonSeeds
   entities:
@@ -186521,28 +186910,28 @@ entities:
   - uid: 3367
     components:
     - type: Transform
-      parent: 3258
+      parent: 2019
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 3371
     components:
     - type: Transform
-      parent: 3258
+      parent: 2019
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 3444
     components:
     - type: Transform
-      parent: 3385
+      parent: 1964
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
   - uid: 3446
     components:
     - type: Transform
-      parent: 3385
+      parent: 1964
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
@@ -187183,24 +187572,6 @@ entities:
     - type: Transform
       pos: 25.5,-20.5
       parent: 6747
-  - uid: 9088
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-39.5
-      parent: 6747
-  - uid: 9089
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-39.5
-      parent: 6747
-  - uid: 9090
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-38.5
-      parent: 6747
   - uid: 16796
     components:
     - type: Transform
@@ -187302,6 +187673,20 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -38.5,0.5
+      parent: 6747
+- proto: WindoorSecureSurgeryLocked
+  entities:
+  - uid: 2488
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-30.5
+      parent: 6747
+  - uid: 3736
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-34.5
       parent: 6747
 - proto: WindoorServiceLocked
   entities:
@@ -187546,6 +187931,11 @@ entities:
     - type: Transform
       pos: -22.5,-27.5
       parent: 6747
+  - uid: 2023
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 6747
   - uid: 2043
     components:
     - type: Transform
@@ -187745,21 +188135,6 @@ entities:
     components:
     - type: Transform
       pos: 31.5,-48.5
-      parent: 6747
-  - uid: 3813
-    components:
-    - type: Transform
-      pos: 9.5,-36.5
-      parent: 6747
-  - uid: 3814
-    components:
-    - type: Transform
-      pos: 9.5,-37.5
-      parent: 6747
-  - uid: 3815
-    components:
-    - type: Transform
-      pos: 9.5,-39.5
       parent: 6747
   - uid: 3847
     components:
@@ -188380,6 +188755,11 @@ entities:
     components:
     - type: Transform
       pos: -7.5,-60.5
+      parent: 6747
+  - uid: 18363
+    components:
+    - type: Transform
+      pos: 17.5,-37.5
       parent: 6747
   - uid: 18424
     components:
@@ -189228,30 +189608,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,-45.5
-      parent: 6747
-  - uid: 9084
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 20.5,-38.5
-      parent: 6747
-  - uid: 9085
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 20.5,-39.5
-      parent: 6747
-  - uid: 9086
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 19.5,-39.5
-      parent: 6747
-  - uid: 9087
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-39.5
       parent: 6747
   - uid: 10394
     components:
@@ -190503,6 +190859,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -5.5,-5.5
       parent: 6747
+  - uid: 3258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-31.5
+      parent: 6747
   - uid: 4231
     components:
     - type: Transform
@@ -190582,6 +190944,18 @@ entities:
     - type: Transform
       pos: -51.5,10.5
       parent: 6747
+  - uid: 9084
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-29.5
+      parent: 6747
+  - uid: 9086
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-32.5
+      parent: 6747
   - uid: 17305
     components:
     - type: Transform
@@ -190593,6 +190967,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -43.5,9.5
+      parent: 6747
+  - uid: 20902
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-33.5
       parent: 6747
   - uid: 22297
     components:

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -13262,8 +13262,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 30129
       - 30130
+      - 30131
       - 14165
       - 12638
       - 14170
@@ -13288,8 +13288,8 @@ entities:
       - 14228
       - 1871
       - 22156
-      - 30128
-      - 30131
+      - 30129
+      - 30132
   - uid: 22187
     components:
     - type: Transform
@@ -20381,15 +20381,15 @@ entities:
     - type: Transform
       pos: -20.5,19.5
       parent: 1
-  - uid: 25196
-    components:
-    - type: Transform
-      pos: 77.5,7.5
-      parent: 1
   - uid: 25299
     components:
     - type: Transform
       pos: 4.5,-9.5
+      parent: 1
+  - uid: 26621
+    components:
+    - type: Transform
+      pos: 77.5,7.5
       parent: 1
   - uid: 26644
     components:
@@ -22356,7 +22356,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 68.5,-2.5
       parent: 1
-  - uid: 29070
+  - uid: 29071
     components:
     - type: Transform
       pos: 64.5,-1.5
@@ -61441,16 +61441,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 78.735176,31.755037
       parent: 1
-  - uid: 28473
-    components:
-    - type: Transform
-      pos: -20.502268,-4.4860387
-      parent: 1
   - uid: 28517
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.30682,22.872543
+      parent: 1
+  - uid: 29045
+    components:
+    - type: Transform
+      pos: -20.502268,-4.4860387
       parent: 1
 - proto: ChairFoldingSpawnFolded
   entities:
@@ -65697,7 +65697,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 166.5,-2.5
       parent: 1
-  - uid: 30120
+  - uid: 30121
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -67874,7 +67874,7 @@ entities:
       parent: 1
 - proto: DefaultStationBeaconCorpsman
   entities:
-  - uid: 30132
+  - uid: 30133
     components:
     - type: Transform
       pos: -22.5,-5.5
@@ -87125,7 +87125,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 152.5,-4.5
       parent: 1
-  - uid: 30112
+  - uid: 30113
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -91488,7 +91488,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 30126
+  - uid: 30127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -118638,18 +118638,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 29142
+  - uid: 29448
     components:
     - type: Transform
       pos: 151.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 29448
-    components:
-    - type: Transform
-      pos: 154.5,-4.5
-      parent: 1
   - uid: 29556
     components:
     - type: Transform
@@ -119051,9 +119046,14 @@ entities:
   - uid: 29799
     components:
     - type: Transform
+      pos: 154.5,-4.5
+      parent: 1
+  - uid: 30112
+    components:
+    - type: Transform
       pos: 154.5,-5.5
       parent: 1
-  - uid: 30127
+  - uid: 30128
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124985,7 +124985,7 @@ entities:
       - 1163
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 30128
+  - uid: 30129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124996,7 +124996,7 @@ entities:
       - 22182
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 30129
+  - uid: 30130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -127197,7 +127197,7 @@ entities:
       - 1163
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 30130
+  - uid: 30131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -127208,7 +127208,7 @@ entities:
       - 22182
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 30131
+  - uid: 30132
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -135175,7 +135175,7 @@ entities:
       parent: 1
 - proto: HolopadEngineeringAME
   entities:
-  - uid: 30133
+  - uid: 30134
     components:
     - type: Transform
       pos: -46.5,-17.5
@@ -135403,6 +135403,13 @@ entities:
     components:
     - type: Transform
       pos: 82.5,14.5
+      parent: 1
+- proto: HolopadSecurityArrivalsCheckpoint
+  entities:
+  - uid: 25195
+    components:
+    - type: Transform
+      pos: 12.5,-31.5
       parent: 1
 - proto: HolopadSecurityBreakroom
   entities:
@@ -137247,7 +137254,7 @@ entities:
           ent: null
 - proto: LockerBrigmedicFilledHardsuit
   entities:
-  - uid: 30125
+  - uid: 30126
     components:
     - type: Transform
       pos: -22.5,-4.5
@@ -139233,7 +139240,7 @@ entities:
       parent: 1
 - proto: MedicatedSuture
   entities:
-  - uid: 30115
+  - uid: 30116
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -143003,7 +143010,7 @@ entities:
       parent: 1
 - proto: PottedPlant8
   entities:
-  - uid: 30116
+  - uid: 30117
     components:
     - type: Transform
       pos: 60.265957,22.364315
@@ -158648,7 +158655,7 @@ entities:
       linkedPorts:
         22428:
         - Pressed: Toggle
-  - uid: 29071
+  - uid: 29142
     components:
     - type: Transform
       pos: 64.5,-1.5
@@ -162296,19 +162303,19 @@ entities:
       parent: 1
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 30118
+  - uid: 30119
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 1
-  - uid: 30119
+  - uid: 30120
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-6.5
       parent: 1
-  - uid: 30134
+  - uid: 30135
     components:
     - type: Transform
       pos: 5.5,-46.5
@@ -163052,7 +163059,7 @@ entities:
     - type: Transform
       pos: -0.5,-46.5
       parent: 1
-  - uid: 30135
+  - uid: 30136
     components:
     - type: Transform
       pos: 26.5,-43.5
@@ -163848,12 +163855,12 @@ entities:
     - type: Transform
       pos: 80.5,34.5
       parent: 1
-  - uid: 26621
+  - uid: 28472
     components:
     - type: Transform
       pos: -23.5,-6.5
       parent: 1
-  - uid: 30114
+  - uid: 30115
     components:
     - type: Transform
       pos: -24.5,-6.5
@@ -167225,7 +167232,7 @@ entities:
     - type: Transform
       pos: 102.5,-19.5
       parent: 1
-  - uid: 28472
+  - uid: 28473
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -191292,7 +191299,7 @@ entities:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 25195
+  - uid: 25196
     components:
     - type: Transform
       pos: 76.5,9.5
@@ -192817,7 +192824,7 @@ entities:
       parent: 1
 - proto: WindoorSecureCorpsmanLocked
   entities:
-  - uid: 30121
+  - uid: 30122
     components:
     - type: Transform
       pos: -21.5,-3.5
@@ -192999,7 +193006,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -186176.19
+      secondsUntilStateChange: -186655.08
       state: Opening
   - uid: 5096
     components:
@@ -193016,7 +193023,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -186176.19
+      secondsUntilStateChange: -186655.08
       state: Opening
   - uid: 5498
     components:
@@ -193032,7 +193039,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -185899.81
+      secondsUntilStateChange: -186378.7
       state: Opening
   - uid: 8696
     components:
@@ -193065,7 +193072,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -185897.92
+      secondsUntilStateChange: -186376.81
       state: Opening
   - uid: 18835
     components:
@@ -193077,7 +193084,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -185894.92
+      secondsUntilStateChange: -186373.81
       state: Opening
   - uid: 23917
     components:
@@ -193085,7 +193092,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 71.5,24.5
       parent: 1
-  - uid: 29045
+  - uid: 29070
     components:
     - type: Transform
       pos: -23.5,-4.5
@@ -194702,30 +194709,30 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 64.5,-4.5
       parent: 1
-  - uid: 30113
+  - uid: 30114
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-6.5
       parent: 1
-  - uid: 30117
+  - uid: 30118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-5.5
       parent: 1
-  - uid: 30122
+  - uid: 30123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-4.5
       parent: 1
-  - uid: 30123
+  - uid: 30124
     components:
     - type: Transform
       pos: -20.5,-3.5
       parent: 1
-  - uid: 30124
+  - uid: 30125
     components:
     - type: Transform
       pos: -22.5,-3.5

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -9535,7 +9535,8 @@ entities:
           -6,3:
             0: 65295
           -6,-1:
-            0: 65535
+            0: 65527
+            3: 8
           -6,4:
             0: 47887
           -5,0:
@@ -13262,8 +13263,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 30130
-      - 30131
+      - 30128
+      - 30129
       - 14165
       - 12638
       - 14170
@@ -13288,8 +13289,8 @@ entities:
       - 14228
       - 1871
       - 22156
-      - 30129
-      - 30132
+      - 30127
+      - 30130
   - uid: 22187
     components:
     - type: Transform
@@ -14303,7 +14304,7 @@ entities:
       parent: 1
 - proto: AirlockArmoryLocked
   entities:
-  - uid: 25190
+  - uid: 25188
     components:
     - type: Transform
       pos: 77.5,9.5
@@ -20381,15 +20382,15 @@ entities:
     - type: Transform
       pos: -20.5,19.5
       parent: 1
+  - uid: 25195
+    components:
+    - type: Transform
+      pos: 77.5,7.5
+      parent: 1
   - uid: 25299
     components:
     - type: Transform
       pos: 4.5,-9.5
-      parent: 1
-  - uid: 26621
-    components:
-    - type: Transform
-      pos: 77.5,7.5
       parent: 1
   - uid: 26644
     components:
@@ -20411,7 +20412,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 1
-  - uid: 25191
+  - uid: 25189
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -20738,7 +20739,7 @@ entities:
       parent: 1
 - proto: BedsheetWarden
   entities:
-  - uid: 25185
+  - uid: 25182
     components:
     - type: Transform
       pos: 77.5,7.5
@@ -22356,7 +22357,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 68.5,-2.5
       parent: 1
-  - uid: 29071
+  - uid: 29045
     components:
     - type: Transform
       pos: 64.5,-1.5
@@ -35073,6 +35074,11 @@ entities:
     - type: Transform
       pos: 22.5,14.5
       parent: 1
+  - uid: 22570
+    components:
+    - type: Transform
+      pos: 77.5,10.5
+      parent: 1
   - uid: 22618
     components:
     - type: Transform
@@ -36607,11 +36613,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,53.5
-      parent: 1
-  - uid: 25180
-    components:
-    - type: Transform
-      pos: 77.5,10.5
       parent: 1
   - uid: 25221
     components:
@@ -61441,16 +61442,16 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 78.735176,31.755037
       parent: 1
+  - uid: 28472
+    components:
+    - type: Transform
+      pos: -20.502268,-4.4860387
+      parent: 1
   - uid: 28517
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -59.30682,22.872543
-      parent: 1
-  - uid: 29045
-    components:
-    - type: Transform
-      pos: -20.502268,-4.4860387
       parent: 1
 - proto: ChairFoldingSpawnFolded
   entities:
@@ -65137,20 +65138,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 20.695349,-10.445904
       parent: 1
-- proto: ClothingUniformJumpsuitSecGrey
-  entities:
-  - uid: 22570
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.430426,-2.3343182
-      parent: 1
-  - uid: 22571
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.472092,-2.5219486
-      parent: 1
 - proto: ClothingUniformJumpsuitTshirtJeans
   entities:
   - uid: 7576
@@ -65260,7 +65247,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,49.5
       parent: 1
-  - uid: 4772
+  - uid: 5105
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -65697,7 +65684,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 166.5,-2.5
       parent: 1
-  - uid: 30121
+  - uid: 30119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -67874,7 +67861,7 @@ entities:
       parent: 1
 - proto: DefaultStationBeaconCorpsman
   entities:
-  - uid: 30133
+  - uid: 30131
     components:
     - type: Transform
       pos: -22.5,-5.5
@@ -68320,10 +68307,10 @@ entities:
       parent: 1
 - proto: DeployableBarrier
   entities:
-  - uid: 5121
+  - uid: 4772
     components:
     - type: Transform
-      pos: -24.5,-4.5
+      pos: -20.5,-2.5
       parent: 1
   - uid: 9306
     components:
@@ -68359,6 +68346,11 @@ entities:
     components:
     - type: Transform
       pos: 94.5,0.5
+      parent: 1
+  - uid: 25183
+    components:
+    - type: Transform
+      pos: -20.5,-3.5
       parent: 1
   - uid: 28085
     components:
@@ -78387,7 +78379,7 @@ entities:
       parent: 1
 - proto: DresserWardenFilled
   entities:
-  - uid: 5125
+  - uid: 5124
     components:
     - type: Transform
       pos: 76.5,7.5
@@ -87125,7 +87117,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 152.5,-4.5
       parent: 1
-  - uid: 30113
+  - uid: 29799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -91488,7 +91480,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 30127
+  - uid: 30125
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -91554,7 +91546,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 12641
+  - uid: 12640
     components:
     - type: Transform
       pos: 151.5,1.5
@@ -93181,7 +93173,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 5183
+  - uid: 5127
     components:
     - type: Transform
       pos: 77.5,9.5
@@ -96937,11 +96929,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 12639
+  - uid: 12637
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 73.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 12641
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-4.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -100666,8 +100666,7 @@ entities:
   - uid: 13647
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-4.5
+      pos: 77.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -100722,13 +100721,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 78.5,11.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 13655
-    components:
-    - type: Transform
-      pos: 77.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -102895,6 +102887,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 14164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 14171
     components:
     - type: Transform
@@ -102991,14 +102991,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 14183
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-3.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 14186
     components:
     - type: Transform
@@ -111864,6 +111856,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 22571
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 22592
     components:
     - type: Transform
@@ -113175,14 +113175,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 25181
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,-6.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 25192
     components:
     - type: Transform
@@ -118143,6 +118135,13 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 29071
+    components:
+    - type: Transform
+      pos: 151.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 29072
     components:
     - type: Transform
@@ -118638,13 +118637,16 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 29142
+    components:
+    - type: Transform
+      pos: 154.5,-4.5
+      parent: 1
   - uid: 29448
     components:
     - type: Transform
-      pos: 151.5,0.5
+      pos: 154.5,-5.5
       parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 29556
     components:
     - type: Transform
@@ -119043,17 +119045,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 29799
-    components:
-    - type: Transform
-      pos: 154.5,-4.5
-      parent: 1
-  - uid: 30112
-    components:
-    - type: Transform
-      pos: 154.5,-5.5
-      parent: 1
-  - uid: 30128
+  - uid: 30126
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -119294,7 +119286,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 5122
+  - uid: 5121
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -119302,14 +119294,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 5123
+  - uid: 5122
     components:
     - type: Transform
       pos: 76.5,11.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 5124
+  - uid: 5123
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -119941,7 +119933,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 12640
+  - uid: 12639
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -122735,7 +122727,7 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 5589
+  - uid: 5183
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -122743,6 +122735,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 5589
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 141.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 6477
     components:
     - type: Transform
@@ -122762,14 +122762,6 @@ entities:
     - type: AtmosPipeColor
       color: '#B266FFFF'
   - uid: 6778
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 141.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
-  - uid: 12637
     components:
     - type: Transform
       pos: 151.5,-0.5
@@ -122837,7 +122829,7 @@ entities:
       - 9433
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 5105
+  - uid: 5106
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -123906,6 +123898,14 @@ entities:
       - 22450
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 13655
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 76.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 13698
     components:
     - type: Transform
@@ -124000,14 +124000,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-27.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 14164
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 76.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -124985,7 +124977,7 @@ entities:
       - 1163
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 30129
+  - uid: 30127
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -124996,7 +124988,7 @@ entities:
       - 22182
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 30130
+  - uid: 30128
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -127197,7 +127189,7 @@ entities:
       - 1163
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 30131
+  - uid: 30129
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -127208,7 +127200,7 @@ entities:
       - 22182
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 30132
+  - uid: 30130
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -131535,6 +131527,11 @@ entities:
     - type: Transform
       pos: -73.5,-0.5
       parent: 1
+  - uid: 14183
+    components:
+    - type: Transform
+      pos: 76.5,6.5
+      parent: 1
   - uid: 14241
     components:
     - type: Transform
@@ -131864,11 +131861,6 @@ entities:
     components:
     - type: Transform
       pos: 74.5,-16.5
-      parent: 1
-  - uid: 17164
-    components:
-    - type: Transform
-      pos: 76.5,6.5
       parent: 1
   - uid: 17306
     components:
@@ -135175,7 +135167,7 @@ entities:
       parent: 1
 - proto: HolopadEngineeringAME
   entities:
-  - uid: 30134
+  - uid: 30132
     components:
     - type: Transform
       pos: -46.5,-17.5
@@ -135406,7 +135398,7 @@ entities:
       parent: 1
 - proto: HolopadSecurityArrivalsCheckpoint
   entities:
-  - uid: 25195
+  - uid: 25190
     components:
     - type: Transform
       pos: 12.5,-31.5
@@ -135420,7 +135412,7 @@ entities:
       parent: 1
 - proto: HolopadSecurityCorpsman
   entities:
-  - uid: 5106
+  - uid: 5118
     components:
     - type: Transform
       pos: -21.5,-5.5
@@ -135525,7 +135517,7 @@ entities:
       parent: 1
 - proto: HolopadServiceGameRoom
   entities:
-  - uid: 25179
+  - uid: 17164
     components:
     - type: Transform
       pos: 3.5,-14.5
@@ -137121,7 +137113,7 @@ entities:
         - Pressed: Toggle
         28178:
         - Pressed: Toggle
-  - uid: 25189
+  - uid: 25186
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -137254,7 +137246,7 @@ entities:
           ent: null
 - proto: LockerBrigmedicFilledHardsuit
   entities:
-  - uid: 30126
+  - uid: 30124
     components:
     - type: Transform
       pos: -22.5,-4.5
@@ -137369,10 +137361,10 @@ entities:
       parent: 1
 - proto: LockerEvidence
   entities:
-  - uid: 5119
+  - uid: 5107
     components:
     - type: Transform
-      pos: -20.478746,-3.1434608
+      pos: -24.666817,-4.2662525
       parent: 1
   - uid: 9313
     components:
@@ -139240,7 +139232,7 @@ entities:
       parent: 1
 - proto: MedicatedSuture
   entities:
-  - uid: 30116
+  - uid: 30114
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -140831,7 +140823,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -29.48827,38.71972
       parent: 1
-  - uid: 25182
+  - uid: 25179
     components:
     - type: Transform
       pos: 25.418808,42.739098
@@ -143010,7 +143002,7 @@ entities:
       parent: 1
 - proto: PottedPlant8
   entities:
-  - uid: 30117
+  - uid: 30115
     components:
     - type: Transform
       pos: 60.265957,22.364315
@@ -146287,7 +146279,7 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 5107
+  - uid: 5119
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -147808,12 +147800,6 @@ entities:
     components:
     - type: Transform
       pos: 84.5,17.5
-      parent: 1
-  - uid: 5118
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-2.5
       parent: 1
   - uid: 5249
     components:
@@ -158567,7 +158553,7 @@ entities:
       linkedPorts:
         25833:
         - Pressed: Toggle
-  - uid: 25183
+  - uid: 25180
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -158575,7 +158561,7 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        5107:
+        5119:
         - Pressed: Toggle
   - uid: 25800
     components:
@@ -158655,7 +158641,7 @@ entities:
       linkedPorts:
         22428:
         - Pressed: Toggle
-  - uid: 29142
+  - uid: 29070
     components:
     - type: Transform
       pos: 64.5,-1.5
@@ -162303,19 +162289,19 @@ entities:
       parent: 1
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 30119
+  - uid: 30117
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-5.5
       parent: 1
-  - uid: 30120
+  - uid: 30118
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -20.5,-6.5
       parent: 1
-  - uid: 30135
+  - uid: 30133
     components:
     - type: Transform
       pos: 5.5,-46.5
@@ -163059,7 +163045,7 @@ entities:
     - type: Transform
       pos: -0.5,-46.5
       parent: 1
-  - uid: 30136
+  - uid: 30134
     components:
     - type: Transform
       pos: 26.5,-43.5
@@ -163845,6 +163831,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 100.5,1.5
       parent: 1
+  - uid: 25196
+    components:
+    - type: Transform
+      pos: -23.5,-6.5
+      parent: 1
   - uid: 26290
     components:
     - type: Transform
@@ -163855,12 +163846,7 @@ entities:
     - type: Transform
       pos: 80.5,34.5
       parent: 1
-  - uid: 28472
-    components:
-    - type: Transform
-      pos: -23.5,-6.5
-      parent: 1
-  - uid: 30115
+  - uid: 30113
     components:
     - type: Transform
       pos: -24.5,-6.5
@@ -167232,7 +167218,7 @@ entities:
     - type: Transform
       pos: 102.5,-19.5
       parent: 1
-  - uid: 28473
+  - uid: 26621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -169777,12 +169763,12 @@ entities:
     - type: Transform
       pos: 61.5,-18.5
       parent: 1
-  - uid: 25186
+  - uid: 25184
     components:
     - type: Transform
       pos: 70.5,-1.5
       parent: 1
-  - uid: 25188
+  - uid: 25185
     components:
     - type: Transform
       pos: 76.5,6.5
@@ -170712,7 +170698,7 @@ entities:
       parent: 1
 - proto: VendingMachineDetDrobe
   entities:
-  - uid: 25184
+  - uid: 25181
     components:
     - type: Transform
       pos: 59.5,16.5
@@ -177412,7 +177398,7 @@ entities:
     - type: Transform
       pos: 47.5,-21.5
       parent: 1
-  - uid: 5127
+  - uid: 5125
     components:
     - type: Transform
       pos: 75.5,8.5
@@ -191299,7 +191285,7 @@ entities:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 25196
+  - uid: 25191
     components:
     - type: Transform
       pos: 76.5,9.5
@@ -192824,7 +192810,7 @@ entities:
       parent: 1
 - proto: WindoorSecureCorpsmanLocked
   entities:
-  - uid: 30122
+  - uid: 30120
     components:
     - type: Transform
       pos: -21.5,-3.5
@@ -193006,7 +192992,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -186655.08
+      secondsUntilStateChange: -187062.5
       state: Opening
   - uid: 5096
     components:
@@ -193023,7 +193009,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -186655.08
+      secondsUntilStateChange: -187062.5
       state: Opening
   - uid: 5498
     components:
@@ -193039,7 +193025,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -186378.7
+      secondsUntilStateChange: -186786.12
       state: Opening
   - uid: 8696
     components:
@@ -193072,7 +193058,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -186376.81
+      secondsUntilStateChange: -186784.23
       state: Opening
   - uid: 18835
     components:
@@ -193084,7 +193070,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -186373.81
+      secondsUntilStateChange: -186781.23
       state: Opening
   - uid: 23917
     components:
@@ -193092,7 +193078,7 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 71.5,24.5
       parent: 1
-  - uid: 29070
+  - uid: 28473
     components:
     - type: Transform
       pos: -23.5,-4.5
@@ -194709,30 +194695,30 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 64.5,-4.5
       parent: 1
-  - uid: 30114
+  - uid: 30112
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-6.5
       parent: 1
-  - uid: 30118
+  - uid: 30116
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-5.5
       parent: 1
-  - uid: 30123
+  - uid: 30121
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,-4.5
       parent: 1
-  - uid: 30124
+  - uid: 30122
     components:
     - type: Transform
       pos: -20.5,-3.5
       parent: 1
-  - uid: 30125
+  - uid: 30123
     components:
     - type: Transform
       pos: -22.5,-3.5

--- a/Resources/Maps/hive.yml
+++ b/Resources/Maps/hive.yml
@@ -177,7 +177,7 @@ entities:
           version: 6
         4,0:
           ind: 4,0
-          tiles: bwAAAAACbwAAAAADbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAADbwAAAAADbwAAAAADbwAAAAABbwAAAAADbwAAAAABTgAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAbwAAAAAAbwAAAAACfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAXAAAAAADXAAAAAABXAAAAAADXAAAAAAAXAAAAAABXAAAAAADXAAAAAACXAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAeQAAAAADeQAAAAADeQAAAAAAXAAAAAACXAAAAAABTQAAAAACXAAAAAACXAAAAAAATQAAAAACXAAAAAADXAAAAAACTgAAAAAAZwAAAAACZwAAAAAAZwAAAAACTgAAAAAAeQAAAAAATQAAAAACeQAAAAAAXAAAAAACTQAAAAABXAAAAAAAXAAAAAAATQAAAAACXAAAAAAAXAAAAAACXAAAAAACTgAAAAAAZwAAAAADZwAAAAAAZwAAAAADTgAAAAAAeQAAAAADTQAAAAADeQAAAAABXAAAAAACXAAAAAADXAAAAAABXAAAAAAAXAAAAAABXAAAAAACXAAAAAACXAAAAAADTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAeQAAAAABeQAAAAAAeQAAAAABZwAAAAACZwAAAAADTgAAAAAATgAAAAAAfAAAAAAAZwAAAAABZwAAAAADfAAAAAAATgAAAAAAZwAAAAACTgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAATgAAAAAAZwAAAAABZwAAAAAATgAAAAAATgAAAAAAfAAAAAAAZwAAAAABZwAAAAAAfAAAAAAATgAAAAAAZwAAAAABTgAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAewAAAAAAZwAAAAABZwAAAAABZwAAAAAATgAAAAAAfAAAAAAAZwAAAAAAZwAAAAACfAAAAAAATgAAAAAAZwAAAAACTgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAewAAAAAAZwAAAAADfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAZwAAAAAAZwAAAAADfAAAAAAATgAAAAAAZwAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAZwAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAADZwAAAAACTgAAAAAATgAAAAAAZwAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAAATgAAAAAATgAAAAAAZwAAAAAAZwAAAAADZwAAAAADZwAAAAADZwAAAAADZwAAAAABZwAAAAABZwAAAAACTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAACfAAAAAAATgAAAAAAZwAAAAADZwAAAAAAZwAAAAACZwAAAAABZwAAAAADZwAAAAABZwAAAAADTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAADZwAAAAABZwAAAAABZwAAAAABZwAAAAACZwAAAAACZwAAAAADZwAAAAADZwAAAAABZwAAAAABTgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAZwAAAAACZwAAAAACZwAAAAABZwAAAAAAZwAAAAABZwAAAAACZwAAAAADZwAAAAABZwAAAAADZwAAAAACTgAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAZwAAAAABfAAAAAAAZwAAAAABTgAAAAAAfAAAAAAATgAAAAAAZwAAAAAAZwAAAAACZwAAAAABZwAAAAADTgAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAA
+          tiles: bwAAAAACbwAAAAADbwAAAAAAbwAAAAAAbwAAAAAAbwAAAAADbwAAAAADbwAAAAADbwAAAAABbwAAAAADbwAAAAABTgAAAAAAewAAAAAAewAAAAAAewAAAAAAewAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAbwAAAAAAbwAAAAACfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAATgAAAAAAXAAAAAADXAAAAAABXAAAAAADXAAAAAAAXAAAAAABXAAAAAADXAAAAAACXAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAeQAAAAADeQAAAAADeQAAAAAAXAAAAAACXAAAAAABTQAAAAACXAAAAAACXAAAAAAATQAAAAACXAAAAAADXAAAAAACTgAAAAAAZwAAAAACZwAAAAAAZwAAAAACTgAAAAAAeQAAAAAATQAAAAACeQAAAAAAXAAAAAACTQAAAAABXAAAAAAAXAAAAAAATQAAAAACXAAAAAAAXAAAAAACXAAAAAACTgAAAAAAZwAAAAADZwAAAAAAZwAAAAADTgAAAAAAeQAAAAADTQAAAAADeQAAAAABXAAAAAACXAAAAAADXAAAAAABXAAAAAAAXAAAAAABXAAAAAACXAAAAAACXAAAAAADTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAeQAAAAABeQAAAAAAeQAAAAABZwAAAAACZwAAAAADTgAAAAAATgAAAAAAfAAAAAAAZwAAAAABZwAAAAADfAAAAAAATgAAAAAAZwAAAAACTgAAAAAAfAAAAAAATgAAAAAAfAAAAAAAfAAAAAAATgAAAAAAZwAAAAABZwAAAAAATgAAAAAATgAAAAAAfAAAAAAAZwAAAAABZwAAAAAAfAAAAAAATgAAAAAAZwAAAAABTgAAAAAAfAAAAAAAeQAAAAAAeQAAAAAAfAAAAAAAewAAAAAAZwAAAAABZwAAAAABZwAAAAAATgAAAAAAfAAAAAAAZwAAAAAAZwAAAAACfAAAAAAATgAAAAAAZwAAAAACTgAAAAAAfAAAAAAAeQAAAAAAeQAAAAAAfAAAAAAAewAAAAAAZwAAAAADfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAZwAAAAAAZwAAAAADfAAAAAAATgAAAAAAZwAAAAAATgAAAAAAfAAAAAAAfAAAAAAAeQAAAAAAfAAAAAAAfAAAAAAAZwAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAADZwAAAAACTgAAAAAATgAAAAAAZwAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAAATgAAAAAATgAAAAAAZwAAAAAAZwAAAAADZwAAAAADZwAAAAADZwAAAAADZwAAAAABZwAAAAABZwAAAAACTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAACfAAAAAAATgAAAAAAZwAAAAADZwAAAAAAZwAAAAACZwAAAAABZwAAAAADZwAAAAABZwAAAAADTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAZwAAAAADZwAAAAABZwAAAAABZwAAAAABZwAAAAACZwAAAAACZwAAAAADZwAAAAADZwAAAAABZwAAAAABTgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAZwAAAAACZwAAAAACZwAAAAABZwAAAAAAZwAAAAABZwAAAAACZwAAAAADZwAAAAABZwAAAAADZwAAAAACTgAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAZwAAAAABfAAAAAAAZwAAAAABTgAAAAAAfAAAAAAATgAAAAAAZwAAAAAAZwAAAAACZwAAAAABZwAAAAADTgAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAA
           version: 6
         5,0:
           ind: 5,0
@@ -509,11 +509,11 @@ entities:
           version: 6
         9,0:
           ind: 9,0
-          tiles: TwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAHgAAAAADTwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAATwAAAAAAHgAAAAADTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATQAAAAACTQAAAAABTQAAAAADTQAAAAAATQAAAAACTQAAAAADTQAAAAABfAAAAAAAHgAAAAABHgAAAAABHgAAAAACNwAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAHgAAAAABHgAAAAADHgAAAAACNwAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAHgAAAAAAHgAAAAADTQAAAAACTQAAAAACfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAHgAAAAAAHgAAAAACTQAAAAAATQAAAAADAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAHgAAAAADHgAAAAADHgAAAAAAHgAAAAADfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: TwAAAAAATwAAAAAATwAAAAAATwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAHgAAAAADTwAAAAAATwAAAAAATwAAAAAATwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAIwAAAAAAHgAAAAADTgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATQAAAAACTQAAAAABTQAAAAADTQAAAAAATQAAAAACTQAAAAADTQAAAAABfAAAAAAAHgAAAAABHgAAAAABHgAAAAACNwAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAHgAAAAABHgAAAAADHgAAAAACNwAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAHgAAAAAAHgAAAAADTQAAAAACTQAAAAACfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAfAAAAAAAHgAAAAAAHgAAAAACTQAAAAAATQAAAAADAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAawAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAHgAAAAADHgAAAAADHgAAAAAAHgAAAAADfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         9,-1:
           ind: 9,-1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAHgAAAAADHgAAAAAAHgAAAAABHgAAAAABfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAHgAAAAADHgAAAAAATQAAAAAATQAAAAACNwAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAHgAAAAADHgAAAAAATQAAAAACTQAAAAADNwAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAATgAAAAAATgAAAAAABwAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAHgAAAAACHgAAAAABHgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATQAAAAABTQAAAAAATQAAAAACTQAAAAACTQAAAAADTQAAAAABTQAAAAACfAAAAAAAHgAAAAADHgAAAAAAHgAAAAAB
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAAAAAAAAAewAAAAAAAAAAAAAAAAAAAAAAfAAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAAHgAAAAADHgAAAAAAHgAAAAABHgAAAAABfAAAAAAAfAAAAAAAAAAAAAAAAAAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAHgAAAAADHgAAAAAATQAAAAAATQAAAAACNwAAAAAAfAAAAAAATgAAAAAATgAAAAAAfAAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAawAAAAAAfAAAAAAAHgAAAAADHgAAAAAATQAAAAACTQAAAAADNwAAAAAATgAAAAAATgAAAAAATgAAAAAAfAAAAAAATgAAAAAATgAAAAAABwAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAfAAAAAAAHgAAAAACHgAAAAABHgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATgAAAAAATQAAAAABTQAAAAAATQAAAAACTQAAAAACTQAAAAADTQAAAAABTQAAAAACfAAAAAAAHgAAAAADHgAAAAAAHgAAAAAB
           version: 6
         -4,-4:
           ind: -4,-4
@@ -1021,6 +1021,7 @@ entities:
             1216: 22,42
             6265: 161,6
             6266: 161,-4
+            6718: 158,1
         - node:
             color: '#DC801DBF'
             id: BrickTileWhiteCornerNe
@@ -1275,6 +1276,7 @@ entities:
             1219: 22,39
             6273: 161,-5
             6280: 161,5
+            6719: 158,0
         - node:
             color: '#DC801DBF'
             id: BrickTileWhiteCornerSe
@@ -2871,6 +2873,16 @@ entities:
             6287: 159,6
             6288: 158,6
             6289: 157,6
+            6720: 157,1
+            6721: 156,1
+            6722: 155,1
+            6723: 154,1
+            6724: 153,1
+            6725: 152,1
+            6726: 151,1
+            6727: 150,1
+            6728: 149,1
+            6729: 148,1
         - node:
             color: '#DC801DBF'
             id: BrickTileWhiteLineN
@@ -3314,6 +3326,16 @@ entities:
             6292: 158,-5
             6293: 159,-5
             6294: 160,-5
+            6730: 148,0
+            6731: 149,0
+            6732: 150,0
+            6733: 151,0
+            6734: 152,0
+            6735: 153,0
+            6736: 154,0
+            6737: 155,0
+            6738: 156,0
+            6739: 157,0
         - node:
             color: '#DC801DBF'
             id: BrickTileWhiteLineS
@@ -10194,10 +10216,12 @@ entities:
             1: 15
             0: 65280
           19,1:
-            0: 12543
+            0: 4351
+            3: 8192
             1: 32768
           19,2:
-            0: 65283
+            0: 65027
+            4: 256
             1: 8
           19,3:
             0: 30479
@@ -11217,7 +11241,7 @@ entities:
             0: 140
           -15,5:
             0: 4369
-            3: 2048
+            5: 2048
           -15,6:
             0: 64735
           -15,7:
@@ -11225,27 +11249,27 @@ entities:
           -15,8:
             0: 65535
           -14,5:
-            3: 1792
+            5: 1792
             0: 8
           -14,6:
             0: 65535
           -14,7:
             0: 4383
-            4: 17408
+            6: 17408
           -14,8:
             0: 65297
-            4: 4
+            6: 4
           -13,5:
             0: 65311
           -13,6:
             0: 65535
           -13,7:
             0: 15
-            5: 4352
-            3: 17408
+            7: 4352
+            5: 17408
           -13,8:
-            5: 1
-            3: 4
+            7: 1
+            5: 4
             0: 65280
           -12,5:
             0: 65280
@@ -11254,11 +11278,11 @@ entities:
             0: 65535
           -12,7:
             0: 15
-            6: 4352
-            3: 17408
+            8: 4352
+            5: 17408
           -12,8:
-            6: 1
-            3: 4
+            8: 1
+            5: 4
             0: 65280
           -11,5:
             1: 3
@@ -11267,9 +11291,9 @@ entities:
             0: 65535
           -11,7:
             0: 52431
-            3: 4352
+            5: 4352
           -11,8:
-            3: 1
+            5: 1
             0: 65484
           -10,5:
             0: 65283
@@ -12188,11 +12212,11 @@ entities:
             1: 8192
           37,-2:
             1: 80
-            4: 57344
+            6: 57344
           37,-3:
             1: 32768
           38,-2:
-            5: 28672
+            7: 28672
           38,-3:
             1: 16384
           39,-2:
@@ -12278,6 +12302,36 @@ entities:
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14975
+          moles:
+          - 20.078888
+          - 75.53487
           - 0
           - 0
           - 0
@@ -13208,32 +13262,34 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 22156
-      - 1871
-      - 14228
-      - 15839
-      - 1560
-      - 22159
-      - 9293
-      - 22142
-      - 22171
-      - 22173
-      - 7030
-      - 7029
-      - 22055
-      - 22172
-      - 22174
-      - 9301
-      - 14185
-      - 12650
-      - 14169
-      - 12629
-      - 12628
-      - 14170
-      - 12638
+      - 30129
+      - 30130
       - 14165
-      - 14164
-      - 12637
+      - 12638
+      - 14170
+      - 12628
+      - 12629
+      - 14169
+      - 12650
+      - 14185
+      - 9301
+      - 22174
+      - 22172
+      - 22055
+      - 7029
+      - 7030
+      - 22173
+      - 22171
+      - 22142
+      - 9293
+      - 22159
+      - 1560
+      - 15839
+      - 14228
+      - 1871
+      - 22156
+      - 30128
+      - 30131
   - uid: 22187
     components:
     - type: Transform
@@ -13537,19 +13593,18 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 22342
-      - 22445
-      - 22446
-      - 22442
-      - 22449
-      - 13699
-      - 14928
-      - 14885
-      - 13646
-      - 14884
-      - 13645
       - 14838
-      - 13647
+      - 13645
+      - 14884
+      - 13646
+      - 14885
+      - 14928
+      - 13699
+      - 22449
+      - 22442
+      - 22446
+      - 22445
+      - 22342
   - uid: 22456
     components:
     - type: Transform
@@ -14246,6 +14301,13 @@ entities:
     - type: Transform
       pos: 75.5,11.5
       parent: 1
+- proto: AirlockArmoryLocked
+  entities:
+  - uid: 25190
+    components:
+    - type: Transform
+      pos: 77.5,9.5
+      parent: 1
 - proto: AirlockAssembly
   entities:
   - uid: 16516
@@ -14533,13 +14595,6 @@ entities:
     components:
     - type: Transform
       pos: 140.5,1.5
-      parent: 1
-- proto: AirlockCorpsmanLocked
-  entities:
-  - uid: 1723
-    components:
-    - type: Transform
-      pos: 75.5,8.5
       parent: 1
 - proto: AirlockDetectiveLocked
   entities:
@@ -17309,6 +17364,7 @@ entities:
       deviceLists:
       - 6959
       - 4
+      - 22182
   - uid: 22062
     components:
     - type: Transform
@@ -17432,6 +17488,7 @@ entities:
       - 29641
       - 513
       - 6964
+      - 22182
   - uid: 22143
     components:
     - type: Transform
@@ -17459,11 +17516,15 @@ entities:
       deviceLists:
       - 513
       - 6964
+      - 22182
   - uid: 22159
     components:
     - type: Transform
       pos: -16.5,10.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 22160
     components:
     - type: Transform
@@ -17478,11 +17539,17 @@ entities:
     - type: Transform
       pos: -33.5,4.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 22174
     components:
     - type: Transform
       pos: -16.5,-3.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 22179
     components:
     - type: Transform
@@ -17632,6 +17699,7 @@ entities:
       deviceLists:
       - 9788
       - 685
+      - 22450
   - uid: 22353
     components:
     - type: Transform
@@ -17684,6 +17752,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 87.5,17.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
   - uid: 23611
     components:
     - type: Transform
@@ -20310,6 +20381,11 @@ entities:
     - type: Transform
       pos: -20.5,19.5
       parent: 1
+  - uid: 25196
+    components:
+    - type: Transform
+      pos: 77.5,7.5
+      parent: 1
   - uid: 25299
     components:
     - type: Transform
@@ -20329,10 +20405,17 @@ entities:
       parent: 1
 - proto: BedsheetBrigmedic
   entities:
-  - uid: 25184
+  - uid: 4711
     components:
     - type: Transform
-      pos: 77.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-5.5
+      parent: 1
+  - uid: 25191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-6.5
       parent: 1
 - proto: BedsheetCaptain
   entities:
@@ -20653,6 +20736,13 @@ entities:
     - type: Transform
       pos: -20.5,19.5
       parent: 1
+- proto: BedsheetWarden
+  entities:
+  - uid: 25185
+    components:
+    - type: Transform
+      pos: 77.5,7.5
+      parent: 1
 - proto: BenchBlueComfy
   entities:
   - uid: 29714
@@ -20858,10 +20948,6 @@ entities:
     - type: Transform
       pos: 137.5,-1.5
       parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        30107:
-        - DoorStatus: Toggle
   - uid: 16133
     components:
     - type: Transform
@@ -20917,6 +21003,8 @@ entities:
     - type: Transform
       pos: 135.5,-1.5
       parent: 1
+    - type: WirelessNetworkConnection
+      range: 2000
     - type: DeviceLinkSink
       invokeCounter: 1
   - uid: 30108
@@ -20931,10 +21019,6 @@ entities:
     - type: Transform
       pos: 138.5,3.5
       parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        30108:
-        - DoorStatus: Toggle
   - uid: 30110
     components:
     - type: Transform
@@ -22272,6 +22356,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 68.5,-2.5
       parent: 1
+  - uid: 29070
+    components:
+    - type: Transform
+      pos: 64.5,-1.5
+      parent: 1
 - proto: ButtonFrameJanitor
   entities:
   - uid: 12982
@@ -22578,6 +22667,11 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-5.5
+      parent: 1
+  - uid: 1723
+    components:
+    - type: Transform
+      pos: 77.5,9.5
       parent: 1
   - uid: 1801
     components:
@@ -36514,15 +36608,10 @@ entities:
     - type: Transform
       pos: -3.5,53.5
       parent: 1
-  - uid: 25195
+  - uid: 25180
     components:
     - type: Transform
-      pos: 74.5,8.5
-      parent: 1
-  - uid: 25196
-    components:
-    - type: Transform
-      pos: 75.5,8.5
+      pos: 77.5,10.5
       parent: 1
   - uid: 25221
     components:
@@ -60148,24 +60237,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 86.5,17.5
       parent: 1
-  - uid: 5122
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-6.5
-      parent: 1
-  - uid: 5124
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,-6.5
-      parent: 1
-  - uid: 5125
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,-6.5
-      parent: 1
   - uid: 5301
     components:
     - type: Transform
@@ -61370,6 +61441,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 78.735176,31.755037
       parent: 1
+  - uid: 28473
+    components:
+    - type: Transform
+      pos: -20.502268,-4.4860387
+      parent: 1
   - uid: 28517
     components:
     - type: Transform
@@ -61737,11 +61813,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 46.583893,8.237314
-      parent: 1
-  - uid: 25181
-    components:
-    - type: Transform
-      pos: 76.5,8.5
       parent: 1
   - uid: 28708
     components:
@@ -65189,6 +65260,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 4.5,49.5
       parent: 1
+  - uid: 4772
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 76.5,8.5
+      parent: 1
   - uid: 5242
     components:
     - type: Transform
@@ -65614,17 +65691,17 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 122.5,-0.5
       parent: 1
-  - uid: 25180
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 76.5,7.5
-      parent: 1
   - uid: 28837
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 166.5,-2.5
+      parent: 1
+  - uid: 30120
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-5.5
       parent: 1
 - proto: ComputerCriminalRecords
   entities:
@@ -67797,10 +67874,10 @@ entities:
       parent: 1
 - proto: DefaultStationBeaconCorpsman
   entities:
-  - uid: 26621
+  - uid: 30132
     components:
     - type: Transform
-      pos: 76.5,7.5
+      pos: -22.5,-5.5
       parent: 1
 - proto: DefaultStationBeaconCourtroom
   entities:
@@ -68247,11 +68324,6 @@ entities:
     components:
     - type: Transform
       pos: -24.5,-4.5
-      parent: 1
-  - uid: 5123
-    components:
-    - type: Transform
-      pos: -23.5,-4.5
       parent: 1
   - uid: 9306
     components:
@@ -78315,10 +78387,10 @@ entities:
       parent: 1
 - proto: DresserWardenFilled
   entities:
-  - uid: 6778
+  - uid: 5125
     components:
     - type: Transform
-      pos: 77.5,10.5
+      pos: 76.5,7.5
       parent: 1
 - proto: Drill
   entities:
@@ -82273,11 +82345,17 @@ entities:
     - type: Transform
       pos: -26.5,6.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 22172
     components:
     - type: Transform
       pos: -26.5,1.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 22189
     components:
     - type: Transform
@@ -83232,11 +83310,17 @@ entities:
     - type: Transform
       pos: -14.5,2.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 1871
     components:
     - type: Transform
       pos: -14.5,5.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 2117
     components:
     - type: Transform
@@ -83403,11 +83487,17 @@ entities:
     - type: Transform
       pos: -28.5,3.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 7030
     components:
     - type: Transform
       pos: -28.5,4.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 7032
     components:
     - type: Transform
@@ -83719,6 +83809,9 @@ entities:
     - type: Transform
       pos: -17.5,6.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 9294
     components:
     - type: Transform
@@ -83754,6 +83847,9 @@ entities:
     - type: Transform
       pos: -16.5,1.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 9302
     components:
     - type: Transform
@@ -83802,6 +83898,9 @@ entities:
     - type: Transform
       pos: -14.5,4.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 14388
     components:
     - type: Transform
@@ -83850,6 +83949,9 @@ entities:
     - type: Transform
       pos: -14.5,3.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
   - uid: 16866
     components:
     - type: Transform
@@ -84098,11 +84200,17 @@ entities:
     - type: Transform
       pos: 75.5,17.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
   - uid: 22446
     components:
     - type: Transform
       pos: 75.5,11.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
   - uid: 22447
     components:
     - type: Transform
@@ -84130,6 +84238,7 @@ entities:
       deviceLists:
       - 9788
       - 685
+      - 22450
   - uid: 22455
     components:
     - type: Transform
@@ -87015,6 +87124,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 152.5,-4.5
+      parent: 1
+  - uid: 30112
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 154.5,-6.5
       parent: 1
 - proto: GasPipeBend
   entities:
@@ -91373,6 +91488,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 30126
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
 - proto: GasPipeFourway
   entities:
   - uid: 904
@@ -91428,6 +91551,13 @@ entities:
     components:
     - type: Transform
       pos: 10.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 12641
+    components:
+    - type: Transform
+      pos: 151.5,1.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -93043,6 +93173,21 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 5120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 5183
+    components:
+    - type: Transform
+      pos: 77.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 5231
     components:
     - type: Transform
@@ -96792,17 +96937,11 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 12640
+  - uid: 12639
     components:
     - type: Transform
-      pos: -23.5,-4.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 12641
-    components:
-    - type: Transform
-      pos: -23.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: 73.5,8.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -100524,6 +100663,14 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 13647
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 13648
     components:
     - type: Transform
@@ -100581,8 +100728,7 @@ entities:
   - uid: 13655
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 76.5,11.5
+      pos: 77.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -102849,10 +102995,10 @@ entities:
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -21.5,-4.5
+      pos: -23.5,-3.5
       parent: 1
     - type: AtmosPipeColor
-      color: '#FF1212FF'
+      color: '#0335FCFF'
   - uid: 14186
     components:
     - type: Transform
@@ -113029,27 +113175,11 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 25189
+  - uid: 25181
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 76.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 25190
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 75.5,8.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 25191
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 74.5,8.5
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -118013,22 +118143,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 29070
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 141.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 29071
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 141.5,0.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 29072
     components:
     - type: Transform
@@ -118524,14 +118638,18 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 29448
+  - uid: 29142
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 151.5,-0.5
+      pos: 151.5,0.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 29448
+    components:
+    - type: Transform
+      pos: 154.5,-4.5
+      parent: 1
   - uid: 29556
     components:
     - type: Transform
@@ -118930,6 +119048,19 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 29799
+    components:
+    - type: Transform
+      pos: 154.5,-5.5
+      parent: 1
+  - uid: 30127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
 - proto: GasPipeTJunction
   entities:
   - uid: 253
@@ -119163,14 +119294,29 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 5183
+  - uid: 5122
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 73.5,8.5
+      rot: 3.141592653589793 rad
+      pos: -23.5,-6.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 5123
+    components:
+    - type: Transform
+      pos: 76.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 5124
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
   - uid: 5563
     components:
     - type: Transform
@@ -119795,7 +119941,7 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 12639
+  - uid: 12640
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -122128,14 +122274,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 29045
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 151.5,1.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
   - uid: 29046
     components:
     - type: Transform
@@ -122597,6 +122735,14 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 5589
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 141.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
   - uid: 6477
     components:
     - type: Transform
@@ -122615,6 +122761,23 @@ entities:
       open: False
     - type: AtmosPipeColor
       color: '#B266FFFF'
+  - uid: 6778
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 141.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 12637
+    components:
+    - type: Transform
+      pos: 151.5,-0.5
+      parent: 1
+    - type: GasValve
+      open: False
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
 - proto: GasVentPump
   entities:
   - uid: 59
@@ -122672,6 +122835,14 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 9433
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 5105
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 77.5,8.5
+      parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 6721
@@ -123080,6 +123251,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -23.5,7.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 12629
@@ -123087,14 +123261,9 @@ entities:
     - type: Transform
       pos: -23.5,11.5
       parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 12637
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,-5.5
-      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 12638
@@ -123103,6 +123272,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -22.5,-2.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 12650
@@ -123111,6 +123283,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -22.5,4.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 12676
@@ -123716,6 +123891,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 83.5,11.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 13646
@@ -123723,14 +123901,9 @@ entities:
     - type: Transform
       pos: 80.5,15.5
       parent: 1
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 13647
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 77.5,10.5
-      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 13698
@@ -123747,6 +123920,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 77.5,16.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 13700
@@ -123824,6 +124000,14 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -59.5,-27.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 14164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 76.5,10.5
       parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
@@ -124216,14 +124400,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 26192
-    - type: AtmosPipeColor
-      color: '#0335FCFF'
-  - uid: 25188
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 77.5,8.5
-      parent: 1
     - type: AtmosPipeColor
       color: '#0335FCFF'
   - uid: 25331
@@ -124809,6 +124985,28 @@ entities:
       - 1163
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 30128
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,-6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
+  - uid: 30129
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -24.5,-6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
+    - type: AtmosPipeColor
+      color: '#0335FCFF'
 - proto: GasVentScrubber
   entities:
   - uid: 642
@@ -125189,20 +125387,15 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 14164
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -21.5,-5.5
-      parent: 1
-    - type: AtmosPipeColor
-      color: '#FF1212FF'
   - uid: 14165
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -22.5,-3.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14169
@@ -125210,6 +125403,9 @@ entities:
     - type: Transform
       pos: -21.5,11.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14170
@@ -125218,6 +125414,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: -21.5,7.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14185
@@ -125225,6 +125424,9 @@ entities:
     - type: Transform
       pos: -22.5,3.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14195
@@ -125477,6 +125679,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 79.5,12.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14839
@@ -125516,6 +125721,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: 83.5,12.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14885
@@ -125524,6 +125732,9 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 82.5,17.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14886
@@ -125554,6 +125765,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 77.5,17.5
       parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22450
     - type: AtmosPipeColor
       color: '#FF1212FF'
   - uid: 14943
@@ -126981,6 +127195,28 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 1163
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 30130
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -23.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 30131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 22182
     - type: AtmosPipeColor
       color: '#FF1212FF'
 - proto: GasVolumePump
@@ -134937,6 +135173,13 @@ entities:
     - type: Transform
       pos: 105.5,-12.5
       parent: 1
+- proto: HolopadEngineeringAME
+  entities:
+  - uid: 30133
+    components:
+    - type: Transform
+      pos: -46.5,-17.5
+      parent: 1
 - proto: HolopadEngineeringAtmosMain
   entities:
   - uid: 29462
@@ -135168,6 +135411,13 @@ entities:
     - type: Transform
       pos: 87.5,16.5
       parent: 1
+- proto: HolopadSecurityCorpsman
+  entities:
+  - uid: 5106
+    components:
+    - type: Transform
+      pos: -21.5,-5.5
+      parent: 1
 - proto: HolopadSecurityCourtroom
   entities:
   - uid: 29480
@@ -135266,6 +135516,13 @@ entities:
     - type: Transform
       pos: 25.5,-33.5
       parent: 1
+- proto: HolopadServiceGameRoom
+  entities:
+  - uid: 25179
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
 - proto: HolopadServiceJanitor
   entities:
   - uid: 29494
@@ -135293,13 +135550,6 @@ entities:
     components:
     - type: Transform
       pos: 40.5,-10.5
-      parent: 1
-- proto: HolopadServiceToolroom
-  entities:
-  - uid: 29799
-    components:
-    - type: Transform
-      pos: 3.5,-14.5
       parent: 1
 - proto: HoloprojectorSecurity
   entities:
@@ -136864,6 +137114,34 @@ entities:
         - Pressed: Toggle
         28178:
         - Pressed: Toggle
+  - uid: 25189
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 156.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        29141:
+        - Pressed: Toggle
+        29140:
+        - Pressed: Toggle
+        29139:
+        - Pressed: Toggle
+        29138:
+        - Pressed: Toggle
+        30107:
+        - Pressed: Toggle
+        30108:
+        - Pressed: Toggle
+        30109:
+        - Pressed: Toggle
+        14965:
+        - Pressed: Toggle
+        30111:
+        - Pressed: Toggle
+        30110:
+        - Pressed: Toggle
   - uid: 28138
     components:
     - type: Transform
@@ -136878,14 +137156,7 @@ entities:
         - Pressed: Toggle
         30100:
         - Pressed: Toggle
-        30111:
-        - Pressed: Toggle
-        30110:
-        - Pressed: Toggle
-        30109:
-        - Pressed: Toggle
-        14965:
-        - Pressed: Toggle
+        30108: []
 - proto: LockableButtonRobotics
   entities:
   - uid: 28550
@@ -136976,10 +137247,10 @@ entities:
           ent: null
 - proto: LockerBrigmedicFilledHardsuit
   entities:
-  - uid: 25183
+  - uid: 30125
     components:
     - type: Transform
-      pos: 77.5,7.5
+      pos: -22.5,-4.5
       parent: 1
 - proto: LockerCaptainFilledNoLaser
   entities:
@@ -137095,11 +137366,6 @@ entities:
     components:
     - type: Transform
       pos: -20.478746,-3.1434608
-      parent: 1
-  - uid: 5120
-    components:
-    - type: Transform
-      pos: -20.478746,-4.071189
       parent: 1
   - uid: 9313
     components:
@@ -137736,6 +138002,26 @@ entities:
     - type: Transform
       pos: 76.5,10.5
       parent: 1
+    - type: Lock
+      locked: False
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
 - proto: LockerWeldingSuppliesFilled
   entities:
   - uid: 6388
@@ -138871,6 +139157,16 @@ entities:
       parent: 1
 - proto: MedicalBed
   entities:
+  - uid: 1767
+    components:
+    - type: Transform
+      pos: -20.5,-6.5
+      parent: 1
+  - uid: 2677
+    components:
+    - type: Transform
+      pos: -20.5,-5.5
+      parent: 1
   - uid: 3163
     components:
     - type: Transform
@@ -138900,11 +139196,6 @@ entities:
     components:
     - type: Transform
       pos: 58.5,-7.5
-      parent: 1
-  - uid: 25182
-    components:
-    - type: Transform
-      pos: 77.5,8.5
       parent: 1
   - uid: 29268
     components:
@@ -138942,12 +139233,12 @@ entities:
       parent: 1
 - proto: MedicatedSuture
   entities:
-  - uid: 28473
+  - uid: 30115
     components:
     - type: Transform
-      parent: 28472
-    - type: Physics
-      canCollide: False
+      rot: 1.5707963267948966 rad
+      pos: -22.450184,-6.476698
+      parent: 1
 - proto: MedkitAdvancedFilled
   entities:
   - uid: 3496
@@ -140533,6 +140824,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -29.48827,38.71972
       parent: 1
+  - uid: 25182
+    components:
+    - type: Transform
+      pos: 25.418808,42.739098
+      parent: 1
+    - type: Paper
+      content: "Test Log #979\n\nAttempt to make fully sentient slime.\n\nComponents:\n     - 20u slime\n     - 10u weh juice\n     - 4u happiness\n     - 1 slime core\n\nMethod: Mixing liquids at room temperature. Injecting mixture into core.\n\nSuccess: Negative\n\nNotes: I feel like I'm close. All previous tests have indicated the components are correct. However, it seems we've been missing a step. \n\nSynopsis: Further testing and analysis needed. "
   - uid: 25573
     components:
     - type: Transform
@@ -142097,6 +142395,14 @@ entities:
     - type: Transform
       pos: -58.5,1.5
       parent: 1
+- proto: PosterContrabandBorgFancyv2
+  entities:
+  - uid: 4771
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 76.5,9.5
+      parent: 1
 - proto: PosterContrabandBountyHunters
   entities:
   - uid: 20105
@@ -142697,10 +143003,10 @@ entities:
       parent: 1
 - proto: PottedPlant8
   entities:
-  - uid: 4711
+  - uid: 30116
     components:
     - type: Transform
-      pos: 59.516224,16.589823
+      pos: 60.265957,22.364315
       parent: 1
 - proto: PottedPlantBioluminscent
   entities:
@@ -145974,6 +146280,12 @@ entities:
       parent: 1
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 5107
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 76.5,8.5
+      parent: 1
   - uid: 5259
     components:
     - type: Transform
@@ -146522,11 +146834,6 @@ entities:
     components:
     - type: Transform
       pos: -17.5,-41.5
-      parent: 1
-  - uid: 25186
-    components:
-    - type: Transform
-      pos: 77.5,8.5
       parent: 1
   - uid: 25227
     components:
@@ -154203,11 +154510,6 @@ entities:
     - type: Transform
       pos: 64.5,-1.5
       parent: 1
-  - uid: 5589
-    components:
-    - type: Transform
-      pos: 70.5,-1.5
-      parent: 1
   - uid: 5592
     components:
     - type: Transform
@@ -155903,11 +156205,6 @@ entities:
     - type: Transform
       pos: 75.5,0.5
       parent: 1
-  - uid: 25179
-    components:
-    - type: Transform
-      pos: 76.5,6.5
-      parent: 1
   - uid: 25468
     components:
     - type: Transform
@@ -157005,6 +157302,13 @@ entities:
     - type: Transform
       pos: 71.5,37.5
       parent: 1
+- proto: SentientSmileCore
+  entities:
+  - uid: 23774
+    components:
+    - type: Transform
+      pos: 25.5,42.5
+      parent: 1
 - proto: ShardGlass
   entities:
   - uid: 5401
@@ -157670,23 +157974,6 @@ entities:
     - type: Transform
       pos: 59.5,-19.5
       parent: 1
-  - uid: 28472
-    components:
-    - type: Transform
-      pos: 77.5,9.5
-      parent: 1
-    - type: Storage
-      storedItems:
-        28473:
-          position: 0,0
-          _rotation: East
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 28473
 - proto: ShelfRGlass
   entities:
   - uid: 22094
@@ -158273,6 +158560,16 @@ entities:
       linkedPorts:
         25833:
         - Pressed: Toggle
+  - uid: 25183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 78.5,8.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        5107:
+        - Pressed: Toggle
   - uid: 25800
     components:
     - type: MetaData
@@ -158351,22 +158648,15 @@ entities:
       linkedPorts:
         22428:
         - Pressed: Toggle
-  - uid: 29142
+  - uid: 29071
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 156.5,-0.5
+      pos: 64.5,-1.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        29138:
-        - Pressed: Toggle
-        29139:
-        - Pressed: Toggle
-        29140:
-        - Pressed: Toggle
-        29141:
-        - Pressed: Toggle
+        5594:
+        - Pressed: Open
 - proto: SignalControlledValve
   entities:
   - uid: 28991
@@ -158484,15 +158774,6 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         5798:
-        - Status: Toggle
-  - uid: 2677
-    components:
-    - type: Transform
-      pos: 76.5,9.5
-      parent: 1
-    - type: DeviceLinkSource
-      linkedPorts:
-        25186:
         - Status: Toggle
   - uid: 2907
     components:
@@ -160788,12 +161069,6 @@ entities:
     - type: Transform
       pos: 35.5,24.5
       parent: 1
-  - uid: 5127
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -20.5,-5.5
-      parent: 1
   - uid: 7067
     components:
     - type: Transform
@@ -161886,13 +162161,6 @@ entities:
     - type: Transform
       pos: -0.5,24.5
       parent: 1
-- proto: SpawnMobSmile
-  entities:
-  - uid: 23774
-    components:
-    - type: Transform
-      pos: 25.5,42.5
-      parent: 1
 - proto: SpawnMobWalter
   entities:
   - uid: 22755
@@ -162028,10 +162296,22 @@ entities:
       parent: 1
 - proto: SpawnPointBrigmedic
   entities:
-  - uid: 25185
+  - uid: 30118
     components:
     - type: Transform
-      pos: 76.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-5.5
+      parent: 1
+  - uid: 30119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,-6.5
+      parent: 1
+  - uid: 30134
+    components:
+    - type: Transform
+      pos: 5.5,-46.5
       parent: 1
 - proto: SpawnPointCaptain
   entities:
@@ -162771,6 +163051,11 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-46.5
+      parent: 1
+  - uid: 30135
+    components:
+    - type: Transform
+      pos: 26.5,-43.5
       parent: 1
 - proto: SpawnPointProsecutor
   entities:
@@ -163562,6 +163847,16 @@ entities:
     components:
     - type: Transform
       pos: 80.5,34.5
+      parent: 1
+  - uid: 26621
+    components:
+    - type: Transform
+      pos: -23.5,-6.5
+      parent: 1
+  - uid: 30114
+    components:
+    - type: Transform
+      pos: -24.5,-6.5
       parent: 1
 - proto: Stool
   entities:
@@ -166930,6 +167225,12 @@ entities:
     - type: Transform
       pos: 102.5,-19.5
       parent: 1
+  - uid: 28472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-6.5
+      parent: 1
   - uid: 28857
     components:
     - type: Transform
@@ -169469,6 +169770,16 @@ entities:
     - type: Transform
       pos: 61.5,-18.5
       parent: 1
+  - uid: 25186
+    components:
+    - type: Transform
+      pos: 70.5,-1.5
+      parent: 1
+  - uid: 25188
+    components:
+    - type: Transform
+      pos: 76.5,6.5
+      parent: 1
 - proto: ToiletDirtyWater
   entities:
   - uid: 4366
@@ -170391,6 +170702,13 @@ entities:
     components:
     - type: Transform
       pos: 4.5,25.5
+      parent: 1
+- proto: VendingMachineDetDrobe
+  entities:
+  - uid: 25184
+    components:
+    - type: Transform
+      pos: 59.5,16.5
       parent: 1
 - proto: VendingMachineDinnerware
   entities:
@@ -176292,16 +176610,6 @@ entities:
     - type: Transform
       pos: 75.5,9.5
       parent: 1
-  - uid: 4771
-    components:
-    - type: Transform
-      pos: 76.5,9.5
-      parent: 1
-  - uid: 4772
-    components:
-    - type: Transform
-      pos: 77.5,9.5
-      parent: 1
   - uid: 4773
     components:
     - type: Transform
@@ -177096,6 +177404,11 @@ entities:
     components:
     - type: Transform
       pos: 47.5,-21.5
+      parent: 1
+  - uid: 5127
+    components:
+    - type: Transform
+      pos: 75.5,8.5
       parent: 1
   - uid: 5271
     components:
@@ -190979,6 +191292,11 @@ entities:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
+  - uid: 25195
+    components:
+    - type: Transform
+      pos: 76.5,9.5
+      parent: 1
   - uid: 25308
     components:
     - type: Transform
@@ -192497,6 +192815,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 108.5,8.5
       parent: 1
+- proto: WindoorSecureCorpsmanLocked
+  entities:
+  - uid: 30121
+    components:
+    - type: Transform
+      pos: -21.5,-3.5
+      parent: 1
 - proto: WindoorSecureEngineeringLocked
   entities:
   - uid: 2519
@@ -192674,17 +192999,12 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -179934.36
+      secondsUntilStateChange: -186176.19
       state: Opening
   - uid: 5096
     components:
     - type: Transform
       pos: -21.5,1.5
-      parent: 1
-  - uid: 5106
-    components:
-    - type: Transform
-      pos: -22.5,-4.5
       parent: 1
   - uid: 5315
     components:
@@ -192696,7 +193016,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -179934.36
+      secondsUntilStateChange: -186176.19
       state: Opening
   - uid: 5498
     components:
@@ -192712,7 +193032,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -179657.98
+      secondsUntilStateChange: -185899.81
       state: Opening
   - uid: 8696
     components:
@@ -192745,7 +193065,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -179656.1
+      secondsUntilStateChange: -185897.92
       state: Opening
   - uid: 18835
     components:
@@ -192757,13 +193077,18 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -179653.1
+      secondsUntilStateChange: -185894.92
       state: Opening
   - uid: 23917
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 71.5,24.5
+      parent: 1
+  - uid: 29045
+    components:
+    - type: Transform
+      pos: -23.5,-4.5
       parent: 1
 - proto: WindoorServiceLocked
   entities:
@@ -194039,11 +194364,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 113.5,0.5
       parent: 1
-  - uid: 1767
-    components:
-    - type: Transform
-      pos: -21.5,-4.5
-      parent: 1
   - uid: 2040
     components:
     - type: Transform
@@ -194138,16 +194458,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 113.5,6.5
-      parent: 1
-  - uid: 5105
-    components:
-    - type: Transform
-      pos: -20.5,-4.5
-      parent: 1
-  - uid: 5107
-    components:
-    - type: Transform
-      pos: -23.5,-4.5
       parent: 1
   - uid: 5108
     components:
@@ -194391,6 +194701,34 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 64.5,-4.5
+      parent: 1
+  - uid: 30113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-6.5
+      parent: 1
+  - uid: 30117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-5.5
+      parent: 1
+  - uid: 30122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.5,-4.5
+      parent: 1
+  - uid: 30123
+    components:
+    - type: Transform
+      pos: -20.5,-3.5
+      parent: 1
+  - uid: 30124
+    components:
+    - type: Transform
+      pos: -22.5,-3.5
       parent: 1
 - proto: WindowTintedDirectional
   entities:

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -2,7 +2,7 @@
   id: Tortuga
   mapName: 'Tortuga'
   mapPath: /Maps/tortuga.yml
-  minPlayers: 50
+  minPlayers: 40
   stations:
     Tortuga:
       stationProto: StandardNanotrasenStation

--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Windoors/windoor.yml
@@ -88,6 +88,15 @@
     containers:
       board: [ DoorElectronicsRobotics ]
 
+- type: entity
+  parent: WindoorSecure
+  id: WindoorSecureSurgeryLocked
+  suffix: Surgery, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsSurgery ]
+
 #Add windoors from upstream roles
 - type: entity
   parent: WindoorSecure


### PR DESCRIPTION
## About the PR
Arena
- Swaps med breakroom and tool room 
- Makes surgery enclosed
- Adds some missing holopads
- Makes all gun safes in armory armory locked
- Adds a surgery windoor

Hive
- Fixes AI turret links
- Connects AI distro
- Adds some missing holopads
- Moves corpsman to engineering wing sec-point(warden gets a bedroom)

Tortuga
- Drops minpop -> 40


## Why / Balance
🐝🥊🐢

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
n/a
