### PR TITLE
fix teaching a lesson to nuggets

### DIFF
--- a/Content.Server/Mind/MindSystem.cs
+++ b/Content.Server/Mind/MindSystem.cs
@@ -264,6 +264,7 @@ public sealed class MindSystem : SharedMindSystem
         if (entity != null)
         {
             component!.Mind = mindId;
+            component.OriginalMind ??= mindId; // DeltaV
             mind.OwnedEntity = entity;
             mind.OriginalOwnedEntity ??= GetNetEntity(mind.OwnedEntity);
             Entity<MindComponent> mindEnt = (mindId, mind);

--- a/Content.Server/_DV/Objectives/Systems/TeachLessonConditionSystem.cs
+++ b/Content.Server/_DV/Objectives/Systems/TeachLessonConditionSystem.cs
@@ -1,7 +1,7 @@
 ﻿using Content.Server._DV.Objectives.Components;
 using Content.Server.Objectives.Components;
 using Content.Server.Objectives.Systems;
-using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;
 
 namespace Content.Server._DV.Objectives.Systems;
@@ -12,7 +12,6 @@ namespace Content.Server._DV.Objectives.Systems;
 public sealed class TeachLessonConditionSystem : EntitySystem
 {
     [Dependency] private readonly CodeConditionSystem _codeCondition = default!;
-    [Dependency] private readonly SharedMindSystem _mind = default!;
 
     public override void Initialize()
     {
@@ -27,8 +26,9 @@ public sealed class TeachLessonConditionSystem : EntitySystem
         if (args.NewMobState != MobState.Dead)
             return;
 
-        // Get the mind of the entity that just died (if it has one)
-        if (!_mind.TryGetMind(args.Target, out var mindId, out _))
+        // Get the mind of the entity that just died (if it had one)
+        // Uses OriginalMind so if someone ghosts or otherwise loses control of a mob, you can still greentext
+        if (!TryComp<MindContainerComponent>(args.Target, out var mc) || mc.OriginalMind is not {} mindId)
             return;
 
         // Get all TeachLessonConditionComponent entities

--- a/Content.Shared/Mind/Components/MindContainerComponent.cs
+++ b/Content.Shared/Mind/Components/MindContainerComponent.cs
@@ -17,6 +17,12 @@ public sealed partial class MindContainerComponent : Component
     public EntityUid? Mind { get; set; }
 
     /// <summary>
+    /// DeltaV: The first mind to control this mob. Will only be null if the mob never had a mind at all.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? OriginalMind;
+
+    /// <summary>
     ///     True if we have a mind, false otherwise.
     /// </summary>
     [MemberNotNullWhen(true, nameof(Mind))]


### PR DESCRIPTION
## About the PR
if you removed someones brain or head (or they used /ghost) it wouldn't greentext when they died

## Why / Balance
fixes #2747

## Technical details
added OriginalMind to MindContainerComponent, similar to OriginalOwnedEntity

## Media
brain is removed from the target
![01:21:40](https://github.com/user-attachments/assets/b92f87d7-1836-4ea9-a484-2a57b2d7ffa4)
and greentext when they die
![01:21:58](https://github.com/user-attachments/assets/ea0f11f9-48c4-4bbd-bb91-7e24561a5342)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed not being able to teach a lesson to someone by beheading them.
