### PR TITLE
Use required number of legs to determine if standing fails

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -462,7 +462,7 @@ public partial class SharedBodySystem
 
     private void OnStandAttempt(Entity<BodyComponent> ent, ref StandAttemptEvent args)
     {
-        if (ent.Comp.LegEntities.Count == 0)
+        if (ent.Comp.LegEntities.Count < ent.Comp.RequiredLegs) // DeltaV
             args.Cancel();
     }
 

--- a/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
+++ b/Content.Shared/_White/Standing/SharedLayingDownSystem.cs
@@ -126,6 +126,14 @@ public abstract class SharedLayingDownSystem : EntitySystem
             HasComp<DebrainedComponent>(uid))
             return false;
 
+        // Begin DeltaV Addition
+        // Don't allow users to start trying to stand if they couldn't stand anyway
+        var msg = new StandAttemptEvent();
+        RaiseLocalEvent(uid, msg, false);
+        if (msg.Cancelled)
+            return false;
+        // End DeltaV Addition
+
         var args = new DoAfterArgs(EntityManager, uid, layingDown.StandingUpTime, new StandingUpDoAfterEvent(), uid)
         {
             BreakOnHandChange = false,


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Uses the components `RequiredLegs` field to determine if an entity can stand or not, rather than checking for 0. As it turns out, borgs don't have any legs so they will always cancel the stand attempt. Thus they always stay fallen over once they've been repaired.
Fixes https://github.com/DeltaV-Station/Delta-v/issues/2738

## Why / Balance
Needs to be fixed because borgs that are prone can only be hit with direct shots to their sprite, not collisions via normal bullets.
This also means that currently users with one a single leg and still stand and move around like normal, which is not ideal.

## Technical details
There's a slight weirdness in that the attempt to stand doesn't check whether users can actually do so. So when a user with 1 leg is prone (from the surgery to amputate) presses the default button standing/prone toggle, a DoAfter appears and then nothing occurs. If they press it again then the sound of falling to the floor plays as well.

To fix that I've added a local event to check whether the user would even pass that test to begin with so we don't bother allowing them to even try and stand up.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- fix: Fixed borgs being permanently prone even after repairs are done.
- fix: Entities without the correct number of legs cannot stand up anymore.
