### PR TITLE
Ensure the Horizontal state is set when buckling/unbuckling

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -362,7 +362,6 @@ public abstract partial class SharedBuckleSystem
 
         _audio.PlayPredicted(strap.Comp.BuckleSound, strap, user);
 
-        SetBuckledTo(buckle, strap!);
         Appearance.SetData(strap, StrapVisuals.State, true);
         Appearance.SetData(buckle, BuckleVisuals.Buckled, true);
 
@@ -383,6 +382,8 @@ public abstract partial class SharedBuckleSystem
                 _standing.Down(buckle, false, false);
                 break;
         }
+
+        SetBuckledTo(buckle, strap!); // DeltaV - Allow standing system to handle Down/Stand before buckling
 
         var ev = new StrappedEvent(strap, buckle);
         RaiseLocalEvent(strap, ref ev);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixes https://github.com/DeltaV-Station/Delta-v/issues/2740
Allows the standing system to fully handle state changes before attaching the buckled entity properly.

I found that the best way to cause the bug is to give asphyx damage to the entity on the table, that seemed to work well.

## Why / Balance
It's annoying for the up/down thing when you're buckled in.

## Technical details
Standing system's `Down` and `Stand` functions short circuit if the user is buckled, which means that the standing system never gets a chance to properly set state for if the entity is standing or not. This is a bit of an annoying cyclical dependency between buckling and standing.

To fix this, we simply move the buckling state change to _after_ the standing call is done so we're able to make sure the standing state is properly updated. This doesn't need to be done on the `Unbuckle` call since we're unbuckled by the time the standing call is done anyway.

## Media
Before 
https://github.com/user-attachments/assets/64c1d5c9-5e88-4cae-ab35-4bdc8f7eb1e4

After 
https://github.com/user-attachments/assets/64d9be5a-40e1-48a1-8883-8eb94bceee74

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fix the up/down when entities are buckled.
