### PR TITLE
add nitrous tank to surgeon locker

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
@@ -100,6 +100,7 @@
     - id: ClothingEyesHudMedical
     - id: ClothingBackpackDuffelSurgeryFilled
     - id: ClothingOuterVestTank
+    - id: NitrousOxideTankFilled
     - id: LunchboxMedicalFilledRandom
       prob: 0.3
     - id: BoxSyringe


### PR DESCRIPTION
## About the PR
i thought it had it already but it didnt, only the tank harness

## Why / Balance
more roundstart anesthetic for surgeons

**Changelog**
:cl:
- add: Added a nitrous oxide tank to surgeon lockers.
