### PR TITLE
Add HasComponent condition for reagents

### DIFF
--- a/Content.Shared/_DV/EntityEffects/EffectConditions/HasComponent.cs
+++ b/Content.Shared/_DV/EntityEffects/EffectConditions/HasComponent.cs
@@ -1,0 +1,78 @@
+using System.Linq;
+using Content.Shared.EntityEffects;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Localization;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
+
+namespace Content.Shared._DV.EntityEffects.EffectConditions;
+
+/// <summary>
+///     Reagent effect condition that depends on if the entity has a given component(s), potentially on a body part
+/// </summary>
+public sealed partial class HasComponent : EntityEffectCondition
+{
+    /// <summary>
+    ///     The set of components that this condition cares about
+    /// </summary>
+    [DataField(required: true)]
+    public ComponentRegistry Components;
+
+    /// <summary>
+    ///     Whether or not the given components should be present
+    /// </summary>
+    [DataField]
+    public bool ShouldHave = true;
+
+    /// <summary>
+    ///     Whether the check is an existential or universal check
+    /// </summary>
+    [DataField]
+    public bool ConsiderAll;
+
+    /// <summary>
+    ///     The explanation displayed in the guidebook for this condition
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Explanation;
+
+    /// <summary>
+    ///     The body part of the entity to test for the components
+    /// </summary>
+    [DataField]
+    public BodyPartType? BodyPart;
+
+    /// <summary>
+    ///     The side of the entity's body to test for the components
+    /// </summary>
+    [DataField]
+    public BodyPartSymmetry? BodyPartSymmetry;
+
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        var _body = args.EntityManager.System<SharedBodySystem>();
+        var entity =
+            BodyPart is {} bodyPart
+                ? _body.GetBodyChildrenOfType(args.TargetEntity, bodyPart, symmetry: BodyPartSymmetry).Select(it => it.Id).FirstOrDefault()
+                : args.TargetEntity;
+
+        if (!entity.IsValid())
+        {
+            return !ShouldHave;
+        }
+
+        var tested =
+            ConsiderAll
+                ? Components.Values.All(c => args.EntityManager.HasComponent(entity, c.Component.GetType()))
+                : Components.Values.Any(c => args.EntityManager.HasComponent(entity, c.Component.GetType()));
+
+        return tested ^ !ShouldHave;
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        return Loc.GetString(Explanation);
+    }
+}


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
There is now a `HasComponent` entity effect condition that allows an effect to be predicated on whether a component is/isn't present, possibly on a given body part

## Why / Balance
This allows reagents to interact with shitmed, by e.g. requiring that a body part has an incision or that it's closed up in order to do a certain effect.

## Technical details
Adds a new `HasComponent` EntityEffectCondition.

## Media

Here is an example of having a reagent ignite people if their head has an open incision:

https://github.com/user-attachments/assets/3a5394ea-e342-4d25-baa1-59e48ece7cfe

```yml
- type: reagent
  id : Mannitol # currently this is just a way to create psicodine
  name: reagent-name-mannitol
  group: Medicine
  desc: reagent-desc-mannitol
  physicalDesc: reagent-physical-desc-opaque
  flavor: sweet
  color: "#A0A0A0"
  metabolisms:
    Medicine:
      effects:
      - !type:PopupMessage
        conditions:
        - !type:ReagentThreshold
          min: 15
        type: Local
        visualType: Medium
        messages: [ "mannitol-effect-enlightened" ]
        probability: 0.2
      - !type:FlammableReaction
        multiplier: 2.0
        conditions:
        - !type:HasComponent
          bodyPart: Head
          components:
          - type: IncisionOpen
      - !type:AdjustTemperature
        amount: 10000
        conditions:
        - !type:HasComponent
          bodyPart: Head
          components:
          - type: IncisionOpen
      - !type:Ignite
        conditions:
        - !type:HasComponent
          bodyPart: Head
          components:
          - type: IncisionOpen
```
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
