### PR TITLE
Make MindShielded players immune to becoming Sleeper Agents.

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -137,7 +137,7 @@
   - type: StationEvent
     startAnnouncement: station-event-bureaucratic-error-announcement
     startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
-      path: /Audio/Announcements/bureaucratic_error.ogg
+      path: /Audio/Announcements/bureaucratic_error.ogg 
     minimumPlayers: 25
     weight: 5
     duration: 1

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -557,7 +557,7 @@
       playerRatio: 10
       blacklist:
         components:
-        - MindShield
+        - MindShield # DeltaV - Mind Shielded people are immune to becoming syndicate
         - AntagImmune
       mindRoles:
       - MindRoleTraitorSleeper

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -137,7 +137,7 @@
   - type: StationEvent
     startAnnouncement: station-event-bureaucratic-error-announcement
     startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
-      path: /Audio/Announcements/bureaucratic_error.ogg 
+      path: /Audio/Announcements/bureaucratic_error.ogg
     minimumPlayers: 25
     weight: 5
     duration: 1
@@ -557,6 +557,7 @@
       playerRatio: 10
       blacklist:
         components:
+        - MindShield
         - AntagImmune
       mindRoles:
       - MindRoleTraitorSleeper


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Made MindShielded players ineligible to be Sleeper Agents.

## Why / Balance
Currently mindshields are useless as there are no revs. Command members are antag immune due to the damage that can be caused by an antag command member. People promoted into command and mindshielded should be immune for the same reasons. This also allows for Captains to point acting heads more comfortably, knowing that they will not become a sleeper agents.

## Technical details

## Media
https://github.com/user-attachments/assets/a52ffc98-d982-4fb8-8fb8-cbbcbe797400

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: SolStar
- tweak: Mindshield implants will now make people immune to becoming sleeper agents.
