### PR TITLE
Revert "[Port]Game presets can now have cooldowns to prevent back-to-back modes"

### DIFF
--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -33,15 +33,6 @@ namespace Content.Server.GameTicking.Presets
         [DataField("maxPlayers")]
         public int? MaxPlayers;
 
-        // Begin Imp
-        /// <summary>
-        /// Ensures that this gamemode does not get selected for a number of rounds
-        /// by something like Secret. This is not considered when the preset is forced.
-        /// </summary>
-        [DataField]
-        public int Cooldown = 0;
-        // End Imp
-
         [DataField("rules", customTypeSerializer: typeof(PrototypeIdListSerializer<EntityPrototype>))]
         public IReadOnlyList<string> Rules { get; private set; } = Array.Empty<string>();
 

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -4,7 +4,6 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking.Presets;
 using Content.Server.GameTicking.Rules.Components;
-using Content.Shared._DV.CCVars; // DeltaV
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
@@ -23,11 +22,6 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IComponentFactory _compFact = default!;
-    [Dependency] private readonly GameTicker _ticker = default!; // begin Imp
-
-    // Dictionary that contains the minimum round number for certain preset
-    // prototypes to be allowed to roll again
-    private static Dictionary<ProtoId<GamePresetPrototype>, int> _nextRoundAllowed = new(); // end Imp
 
     private string _ruleCompName = default!;
 
@@ -51,15 +45,6 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
 
         Log.Info($"Selected {preset.ID} as the secret preset.");
         _adminLogger.Add(LogType.EventStarted, $"Selected {preset.ID} as the secret preset.");
-
-        if (_configurationManager.GetCVar(DCCVars.EnableBacktoBack) == true) // DeltaV
-        {
-            if (preset.Cooldown > 0) // Begin Imp
-            {
-                _nextRoundAllowed[preset.ID] = _ticker.RoundId + preset.Cooldown + 1;
-                Log.Info($"{preset.ID} is now on cooldown until {_nextRoundAllowed[preset.ID]}");
-            } // End Imp
-        } // DeltaV
 
         foreach (var rule in preset.Rules)
         {
@@ -181,15 +166,6 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
             if (ruleComp.MinPlayers > players && ruleComp.CancelPresetOnTooFewPlayers)
                 return false;
         }
-
-        if (_configurationManager.GetCVar(DCCVars.EnableBacktoBack) == true) // DeltaV
-        {
-            if (_nextRoundAllowed.ContainsKey(selected.ID) && _nextRoundAllowed[selected.ID] > _ticker.RoundId) // Begin Imp
-            {
-                Log.Info($"Skipping preset {selected.ID} (Not available until round {_nextRoundAllowed[selected.ID]}");
-                return false;
-            } // End Imp
-        } // DeltaV
 
         return true;
     }

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -155,10 +155,4 @@ public sealed class DCCVars
     /// </summary>
     public static readonly CVarDef<string> DiscordReplyColor =
         CVarDef.Create("admin.discord_reply_color", string.Empty, CVar.SERVERONLY);
-
-    /// <summary>
-    ///    Whether or not to disable the preset selecting test rule from running. Should be disabled in production. DeltaV specific, attached to Impstation Secret concurrent feature.
-    /// </summary>
-    public static readonly CVarDef<bool> EnableBacktoBack =
-        CVarDef.Create("game.disable_preset_test", false, CVar.SERVERONLY);
 }

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -5,7 +5,6 @@
   name: survival-title
   showInVote: true # secret # DeltaV - Me when the survival. Used for periapsis.
   description: survival-description
-  cooldown: 2 # Imp - Can't occur thrice
   rules:
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
@@ -156,7 +155,6 @@
     - tator
   name: traitor-title
   description: traitor-description
-  cooldown: 2 # Imp - Can't occur thrice
   showInVote: false
   rules:
     - Traitor
@@ -187,7 +185,6 @@
   name: nukeops-title
   description: nukeops-description
   showInVote: false
-  cooldown: 2 # Imp - Can't occur thrice
   rules:
     - Nukeops
     - SubGamemodesRule
@@ -225,7 +222,6 @@
   - zomber
   name: zombie-title
   description: zombie-description
-  cooldown: 2 # Imp - Can't occur thrice
   showInVote: false
   rules:
   - Zombie


### PR DESCRIPTION
Reverts DeltaV-Station/Delta-v#2744

Shit is broken and somehow it's forcing nukeops back to back.