### PR TITLE
Fix mail teleporter graphically being powered on at round start

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/mailTeleporter.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Machines/mailTeleporter.yml
@@ -28,6 +28,7 @@
     - state: unlit
       shader: unshaded
       map: ["enum.PowerDeviceVisualLayers.Powered"]
+      visible: false
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic


### PR DESCRIPTION
## About the PR
Make the powered layer of the mail teleporter invisible by default

## Why / Balance
Mail teleporter currently looks turned on at round start, causing confusion for couriers.

## Technical details
see above

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
n/A

**Changelog**
:cl:
- fix: Fixed mail teleporter having wrong sprite at round start
