### PR TITLE
Set panic bunker to 240 minutes instead of default 600

### DIFF
--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -9,6 +9,7 @@ secret_weight_prototype = "SecretDeltaV"
 # New players can't join a server without admins
 [game.panic_bunker]
 enabled = true
+min_overall_minutes = 240
 disable_with_admins = true
 enable_without_admins = true
 show_reason = true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR

Panic bunker currently requires 10 hours playtime by default, meaning that, when the server restarts, admins have to reset it to 4 hours. This just makes the change in cvars
<!-- What did you change? -->

## Why / Balance

10 hours is too restrictive for new players.
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details

Change in CVar
<!-- Summary of code changes for easier review. -->

## Media

N/A
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

N/A
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Lowered panic bunker hours requirement.
