### PR TITLE
Add more useful items for hostage ops and stun bundle for syndicates to boot.

### DIFF
--- a/Resources/Locale/en-US/_DV/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/_DV/store/uplink-catalog.ftl
@@ -46,3 +46,9 @@ uplink-dead-mans-signaller-desc = A device that if armed, will send a signal to 
 # Objectives
 uplink-syndicate-handcuff-bundle-name = Handcuff implant bundle
 uplink-syndicate-handcuff-bundle-desc = Includes 10 metal handcuffs. We recommended you share with your friends!
+
+uplink-syndicate-bodybag-name = Box of body bags
+uplink-syndicate-bodybag-desc = For when stuff goes wrong.
+
+uplink-syndicate-stun-bundle-name = Stun bundle
+uplink-syndicate-stun-bundle-desc = Includes a stun baton and a disabler.

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
@@ -104,6 +104,4 @@
   - type: StorageFill
     contents:
     - id: Stunbaton
-      amount: 1
     - id: WeaponDisabler
-      amount: 1

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
@@ -88,9 +88,9 @@
       amount: 10
 
 - type: entity
-  name: syndicate stun box
   parent: BoxCardboard
   id: BoxSyndicateStunBundle
+  name: syndicate stun box
   description: A box of two basic stun weapons.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
@@ -86,3 +86,24 @@
     contents:
     - id: Handcuffs
       amount: 10
+
+- type: entity
+  name: syndicate stun box
+  parent: BoxCardboard
+  id: BoxSyndicateStunBundle
+  description: A box of two basic stun weapons.
+  components:
+  - type: Sprite
+    layers:
+    - state: box_of_doom
+    - state: writing_of_doom
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,3,1
+  - type: StorageFill
+    contents:
+    - id: Stunbaton
+      amount: 1
+    - id: WeaponDisabler
+      amount: 1

--- a/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
@@ -222,3 +222,65 @@
     whitelist:
       tags:
       - NukeOpsUplink
+
+- type: listing
+  id: UplinkBodyBagBox
+  name: uplink-syndicate-bodybag-name
+  description: uplink-syndicate-bodybag-desc
+  icon: { sprite: Objects/Specific/Medical/Morgue/bodybags.rsi, state: bag }
+  productEntity: BoxBodyBag
+  cost:
+    Telecrystal: 0
+  categories:
+  - UplinkObjectives
+  conditions:
+  - !type:ObjectiveUnlockCondition
+  - !type:ListingLimitedStockCondition
+    stock: 1
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+
+# Free bundle for hostage ops
+- type: listing
+  id: UplinkStunBundleNukie
+  name: uplink-syndicate-stun-bundle-name
+  description: uplink-syndicate-stun-bundle-desc
+  icon: { sprite: Objects/Storage/boxes.rsi, state: box_of_doom }
+  productEntity: BoxSyndicateStunBundle
+  cost:
+    Telecrystal: 0
+  categories:
+  - UplinkObjectives
+  conditions:
+  - !type:ObjectiveUnlockCondition
+  - !type:ListingLimitedStockCondition
+    stock: 1
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+
+# Stun bundle for everyone
+- type: listing
+  id: UplinkStunBundle
+  name: uplink-syndicate-stun-bundle-name
+  description: uplink-syndicate-stun-bundle-desc
+  icon: { sprite: Objects/Storage/boxes.rsi, state: box_of_doom }
+  productEntity: BoxSyndicateStunBundle
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 2
+  cost:
+    Telecrystal: 4
+  categories:
+  - UplinkWeaponry

--- a/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
@@ -229,8 +229,6 @@
   description: uplink-syndicate-bodybag-desc
   icon: { sprite: Objects/Specific/Medical/Morgue/bodybags.rsi, state: bag }
   productEntity: BoxBodyBag
-  cost:
-    Telecrystal: 0
   categories:
   - UplinkObjectives
   conditions:
@@ -253,8 +251,6 @@
   description: uplink-syndicate-stun-bundle-desc
   icon: { sprite: Objects/Storage/boxes.rsi, state: box_of_doom }
   productEntity: BoxSyndicateStunBundle
-  cost:
-    Telecrystal: 0
   categories:
   - UplinkObjectives
   conditions:
@@ -269,18 +265,3 @@
     whitelist:
       tags:
       - NukeOpsUplink
-
-# Stun bundle for everyone
-- type: listing
-  id: UplinkStunBundle
-  name: uplink-syndicate-stun-bundle-name
-  description: uplink-syndicate-stun-bundle-desc
-  icon: { sprite: Objects/Storage/boxes.rsi, state: box_of_doom }
-  productEntity: BoxSyndicateStunBundle
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 2
-  cost:
-    Telecrystal: 4
-  categories:
-  - UplinkWeaponry

--- a/Resources/Prototypes/_DV/Objectives/nukies.yml
+++ b/Resources/Prototypes/_DV/Objectives/nukies.yml
@@ -3,7 +3,7 @@
 - type: weightedRandom
   id: NukieOperations
   weights:
-    NukieOperationDestroyStation: 1
+    NukieOperationDestroyStation: 100
     NukieOperationKidnapHeads: 1
 
 - type: nukieOperation
@@ -49,6 +49,10 @@
     max: 4
     title: nukie-operations-kidnap-heads-objective-title
     description: nukie-operations-kidnap-heads-objective-descript
+  - type: StoreUnlocker
+    listings:
+    - UplinkBodyBagBox
+    - UplinkStunBundleNukie
 
 - type: entity
   parent: BaseStealObjective

--- a/Resources/Prototypes/_DV/Objectives/nukies.yml
+++ b/Resources/Prototypes/_DV/Objectives/nukies.yml
@@ -3,7 +3,7 @@
 - type: weightedRandom
   id: NukieOperations
   weights:
-    NukieOperationDestroyStation: 100
+    NukieOperationDestroyStation: 1
     NukieOperationKidnapHeads: 1
 
 - type: nukieOperation


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Title

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hostage ops really needed some way of getting hostages without just killing them. Before the only option was really noct but that sucks. This is more fun!

In the discussion it sounded like normal traitors should have some stun equipment as well so they got the same bundle but not for free.

## Technical details
<!-- Summary of code changes for easier review. -->
copy paste central :sob:

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Stun bundle: 4 tc for a stun baton and disabler!
- add: Hostage ops now receive free body bags and stun bundle in their uplink!

