### PR TITLE
Fix silicon law UI not populating

### DIFF
--- a/Content.Client/Silicons/Laws/Ui/SiliconLawBoundUserInterface.cs
+++ b/Content.Client/Silicons/Laws/Ui/SiliconLawBoundUserInterface.cs
@@ -30,7 +30,7 @@ public sealed class SiliconLawBoundUserInterface : BoundUserInterface
     {
         base.UpdateState(state);
 
-        if (state is not SiliconLawBuiState msg)
+        if (_menu is null || state is not SiliconLawBuiState msg)
             return;
 
         if (_laws != null && _laws.Count == msg.Laws.Count)

--- a/Content.Client/Silicons/Laws/Ui/SiliconLawBoundUserInterface.cs
+++ b/Content.Client/Silicons/Laws/Ui/SiliconLawBoundUserInterface.cs
@@ -30,6 +30,7 @@ public sealed class SiliconLawBoundUserInterface : BoundUserInterface
     {
         base.UpdateState(state);
 
+        // DeltaV: add _menu is null check because apparently state gets sent before UI opens
         if (_menu is null || state is not SiliconLawBuiState msg)
             return;
 


### PR DESCRIPTION
## About the PR
make Silicon UI show laws on open again

## Why / Balance
bugfix

## Technical details
Early exit in Silicon Law UI if the window is not opened yet

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
n/A

**Changelog**
:cl:
- fix: Fixed Silicon Law UI being blank
