### PR TITLE
Decrease survival, increase traitors, give survival a thieves chance.

### DIFF
--- a/Resources/Prototypes/_DV/secret_weights.yml
+++ b/Resources/Prototypes/_DV/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom
   id: SecretDeltaV
   weights:
-    Survival: 0.30
+    Survival: 0.35
     Nukeops: 0.15
     Zombie: 0.07
-    Traitor: 0.48
+    Traitor: 0.43
     #Pirates: 0.15 #ahoy me bucko

--- a/Resources/Prototypes/_DV/secret_weights.yml
+++ b/Resources/Prototypes/_DV/secret_weights.yml
@@ -1,8 +1,8 @@
 - type: weightedRandom
   id: SecretDeltaV
   weights:
-    Survival: 0.35
+    Survival: 0.30
     Nukeops: 0.15
     Zombie: 0.07
-    Traitor: 0.43
+    Traitor: 0.48
     #Pirates: 0.15 #ahoy me bucko

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -13,6 +13,7 @@
     #- SpaceTrafficControlFriendlyEventScheduler # DeltaV: spam of garbage roles nobody takes every 10-20 minutes
     - BasicRoundstartVariation
     - GlimmerEventScheduler # DeltaV
+    - SubGamemodesRule
 
 - type: gamePreset
   id: KesslerSyndrome

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -13,7 +13,7 @@
     #- SpaceTrafficControlFriendlyEventScheduler # DeltaV: spam of garbage roles nobody takes every 10-20 minutes
     - BasicRoundstartVariation
     - GlimmerEventScheduler # DeltaV
-    - SubGamemodesRule
+    - SubGamemodesRule # DeltaV
 
 - type: gamePreset
   id: KesslerSyndrome


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Title! 5% is taken away from survival and is given to traitors. Survival now also has thieves.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Right now, traitors is the most developed and mature gamemode while also having a high level of RP involved. Certain departments really struggle (Law especially) in survival leading to those jobs almost never being picked. Hopefully making traitors slightly more likely will make playing those jobs more enjoyable! Adding thieves to survival is also very useful for justice so they could have stuff to do on survival.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Thieves can now roll in survival.
- add: Survival gamemode weight -5%, traitor gamemode weight +5%
