### PR TITLE
add pride cloaks back to pride vend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
@@ -17,7 +17,7 @@
     PlushieSharkBlue: 2
     PlushieSharkPink: 2
     PlushieSharkGrey: 2
-    ClothingNeckCloakAce: 2
+    ClothingNeckCloakAce: 2 # begin DeltaV
     ClothingNeckCloakAro: 2
     ClothingNeckCloakBi: 2
     ClothingNeckCloakEnby: 2
@@ -25,7 +25,7 @@
     ClothingNeckCloakLesbian: 2
     ClothingNeckCloakPan: 2
     ClothingNeckCloakIntersex: 2
-    ClothingNeckCloakTrans: 2
+    ClothingNeckCloakTrans: 2 # end DeltaV
     ClothingNeckScarfStripedAce: 2
     ClothingNeckScarfStripedAro: 2
     ClothingNeckScarfStripedBiSexual: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
@@ -17,6 +17,15 @@
     PlushieSharkBlue: 2
     PlushieSharkPink: 2
     PlushieSharkGrey: 2
+    ClothingNeckCloakAce: 2
+    ClothingNeckCloakAro: 2
+    ClothingNeckCloakBi: 2
+    ClothingNeckCloakEnby: 2
+    ClothingNeckCloakGay: 2
+    ClothingNeckCloakLesbian: 2
+    ClothingNeckCloakPan: 2
+    ClothingNeckCloakIntersex: 2
+    ClothingNeckCloakTrans: 2
     ClothingNeckScarfStripedAce: 2
     ClothingNeckScarfStripedAro: 2
     ClothingNeckScarfStripedBiSexual: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/pride.yml
@@ -17,7 +17,7 @@
     PlushieSharkBlue: 2
     PlushieSharkPink: 2
     PlushieSharkGrey: 2
-    ClothingNeckCloakAce: 2 # begin DeltaV
+    ClothingNeckCloakAce: 2 # Begin DeltaV Additions
     ClothingNeckCloakAro: 2
     ClothingNeckCloakBi: 2
     ClothingNeckCloakEnby: 2
@@ -25,7 +25,7 @@
     ClothingNeckCloakLesbian: 2
     ClothingNeckCloakPan: 2
     ClothingNeckCloakIntersex: 2
-    ClothingNeckCloakTrans: 2 # end DeltaV
+    ClothingNeckCloakTrans: 2 # End DeltaV Additions
     ClothingNeckScarfStripedAce: 2
     ClothingNeckScarfStripedAro: 2
     ClothingNeckScarfStripedBiSexual: 2

--- a/Resources/Prototypes/_DV/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/_DV/Catalog/Cargo/cargo_vending.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockPrideFilled
-  cost: 1100
+  cost: 1300
   category: Service
   group: market
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
yaml, add pride cloak back to pride vend

## Why / Balance
representation doesnt have to be gamer loot 

## Technical details
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- add: Re-added pride cloaks to the PrideVend