### PR TITLE
New keybind to switch hands in reverse for borgs/other multihand entities

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -57,6 +57,7 @@ namespace Content.Client.Input
             human.AddFunction(EngineKeyFunctions.MoveRight);
             human.AddFunction(EngineKeyFunctions.Walk);
             human.AddFunction(ContentKeyFunctions.SwapHands);
+            human.AddFunction(ContentKeyFunctions.SwapHandsReversed);
             human.AddFunction(ContentKeyFunctions.Drop);
             human.AddFunction(ContentKeyFunctions.UseItemInHand);
             human.AddFunction(ContentKeyFunctions.AltUseItemInHand);
@@ -113,6 +114,7 @@ namespace Content.Client.Input
             aghost.AddFunction(EngineKeyFunctions.MoveRight);
             aghost.AddFunction(EngineKeyFunctions.Walk);
             aghost.AddFunction(ContentKeyFunctions.SwapHands);
+            aghost.AddFunction(ContentKeyFunctions.SwapHandsReversed);
             aghost.AddFunction(ContentKeyFunctions.Drop);
             aghost.AddFunction(ContentKeyFunctions.UseItemInHand);
             aghost.AddFunction(ContentKeyFunctions.AltUseItemInHand);

--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -57,7 +57,6 @@ namespace Content.Client.Input
             human.AddFunction(EngineKeyFunctions.MoveRight);
             human.AddFunction(EngineKeyFunctions.Walk);
             human.AddFunction(ContentKeyFunctions.SwapHands);
-            human.AddFunction(ContentKeyFunctions.SwapHandsReversed);
             human.AddFunction(ContentKeyFunctions.Drop);
             human.AddFunction(ContentKeyFunctions.UseItemInHand);
             human.AddFunction(ContentKeyFunctions.AltUseItemInHand);
@@ -114,7 +113,6 @@ namespace Content.Client.Input
             aghost.AddFunction(EngineKeyFunctions.MoveRight);
             aghost.AddFunction(EngineKeyFunctions.Walk);
             aghost.AddFunction(ContentKeyFunctions.SwapHands);
-            aghost.AddFunction(ContentKeyFunctions.SwapHandsReversed);
             aghost.AddFunction(ContentKeyFunctions.Drop);
             aghost.AddFunction(ContentKeyFunctions.UseItemInHand);
             aghost.AddFunction(ContentKeyFunctions.AltUseItemInHand);
@@ -138,6 +136,11 @@ namespace Content.Client.Input
             common.AddFunction(ContentKeyFunctions.OpenDecalSpawnWindow);
             common.AddFunction(ContentKeyFunctions.OpenAdminMenu);
             common.AddFunction(ContentKeyFunctions.OpenGuidebook);
+
+            // DeltaV - Swap Hands Reversed Start
+            human.AddFunction(ContentKeyFunctions.SwapHandsReversed);
+            aghost.AddFunction(ContentKeyFunctions.SwapHandsReversed);
+            // DeltaV - Swap Hands Reversed End
         }
     }
 }

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -190,7 +190,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.Drop);
             AddButton(ContentKeyFunctions.ExamineEntity);
             AddButton(ContentKeyFunctions.SwapHands);
-            AddButton(ContentKeyFunctions.SwapHandsReversed);
+            AddButton(ContentKeyFunctions.SwapHandsReversed); // DeltaV - Swap Hands Reversed
             AddButton(ContentKeyFunctions.MoveStoredItem);
             AddButton(ContentKeyFunctions.RotateStoredItem);
             AddButton(ContentKeyFunctions.SaveItemLocation);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -190,6 +190,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.Drop);
             AddButton(ContentKeyFunctions.ExamineEntity);
             AddButton(ContentKeyFunctions.SwapHands);
+            AddButton(ContentKeyFunctions.SwapHandsReversed);
             AddButton(ContentKeyFunctions.MoveStoredItem);
             AddButton(ContentKeyFunctions.RotateStoredItem);
             AddButton(ContentKeyFunctions.SaveItemLocation);

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -31,6 +31,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
             .Bind(ContentKeyFunctions.UseItemInHand, InputCmdHandler.FromDelegate(HandleUseItem, handle: false, outsidePrediction: false))
             .Bind(ContentKeyFunctions.AltUseItemInHand, InputCmdHandler.FromDelegate(HandleAltUseInHand, handle: false, outsidePrediction: false))
             .Bind(ContentKeyFunctions.SwapHands, InputCmdHandler.FromDelegate(SwapHandsPressed, handle: false, outsidePrediction: false))
+            .Bind(ContentKeyFunctions.SwapHandsReversed, InputCmdHandler.FromDelegate(SwapHandsReversedPressed, handle: false, outsidePrediction: false))
             .Bind(ContentKeyFunctions.Drop, new PointerInputCmdHandler(DropPressed))
             .Register<SharedHandsSystem>();
     }
@@ -78,21 +79,34 @@ public abstract partial class SharedHandsSystem : EntitySystem
             TryUseItemInHand(args.SenderSession.AttachedEntity.Value, true, handName: msg.HandName);
     }
 
-    private void SwapHandsPressed(ICommonSession? session)
+    private void ChangeHandIndex(ICommonSession? session, int modifier)
     {
         if (!TryComp(session?.AttachedEntity, out HandsComponent? component))
             return;
-
         if (!_actionBlocker.CanInteract(session.AttachedEntity.Value, null))
             return;
-
         if (component.ActiveHand == null || component.Hands.Count < 2)
             return;
 
-        var newActiveIndex = component.SortedHands.IndexOf(component.ActiveHand.Name) + 1;
+        var newActiveIndex = component.SortedHands.IndexOf(component.ActiveHand.Name) + modifier;
+        if (newActiveIndex < 0)
+        {
+            newActiveIndex += component.SortedHands.Count;
+        }
+        
         var nextHand = component.SortedHands[newActiveIndex % component.Hands.Count];
 
         TrySetActiveHand(session.AttachedEntity.Value, nextHand, component);
+    }
+
+    private void SwapHandsPressed(ICommonSession? session)
+    {
+        ChangeHandIndex(session, 1);
+    }
+
+    private void SwapHandsReversedPressed(ICommonSession? session)
+    {
+        ChangeHandIndex(session, -1);
     }
 
     private bool DropPressed(ICommonSession? session, EntityCoordinates coords, EntityUid netEntity)

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -31,7 +31,7 @@ public abstract partial class SharedHandsSystem : EntitySystem
             .Bind(ContentKeyFunctions.UseItemInHand, InputCmdHandler.FromDelegate(HandleUseItem, handle: false, outsidePrediction: false))
             .Bind(ContentKeyFunctions.AltUseItemInHand, InputCmdHandler.FromDelegate(HandleAltUseInHand, handle: false, outsidePrediction: false))
             .Bind(ContentKeyFunctions.SwapHands, InputCmdHandler.FromDelegate(SwapHandsPressed, handle: false, outsidePrediction: false))
-            .Bind(ContentKeyFunctions.SwapHandsReversed, InputCmdHandler.FromDelegate(SwapHandsReversedPressed, handle: false, outsidePrediction: false))
+            .Bind(ContentKeyFunctions.SwapHandsReversed, InputCmdHandler.FromDelegate(SwapHandsReversedPressed, handle: false, outsidePrediction: false)) // DeltaV - Swap Hands Reversed
             .Bind(ContentKeyFunctions.Drop, new PointerInputCmdHandler(DropPressed))
             .Register<SharedHandsSystem>();
     }
@@ -77,36 +77,6 @@ public abstract partial class SharedHandsSystem : EntitySystem
     {
         if (args.SenderSession.AttachedEntity != null)
             TryUseItemInHand(args.SenderSession.AttachedEntity.Value, true, handName: msg.HandName);
-    }
-
-    private void ChangeHandIndex(ICommonSession? session, int modifier)
-    {
-        if (!TryComp(session?.AttachedEntity, out HandsComponent? component))
-            return;
-        if (!_actionBlocker.CanInteract(session.AttachedEntity.Value, null))
-            return;
-        if (component.ActiveHand == null || component.Hands.Count < 2)
-            return;
-
-        var newActiveIndex = component.SortedHands.IndexOf(component.ActiveHand.Name) + modifier;
-        if (newActiveIndex < 0)
-        {
-            newActiveIndex += component.SortedHands.Count;
-        }
-        
-        var nextHand = component.SortedHands[newActiveIndex % component.Hands.Count];
-
-        TrySetActiveHand(session.AttachedEntity.Value, nextHand, component);
-    }
-
-    private void SwapHandsPressed(ICommonSession? session)
-    {
-        ChangeHandIndex(session, 1);
-    }
-
-    private void SwapHandsReversedPressed(ICommonSession? session)
-    {
-        ChangeHandIndex(session, -1);
     }
 
     private bool DropPressed(ICommonSession? session, EntityCoordinates coords, EntityUid netEntity)

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -35,7 +35,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";
         public static readonly BoundKeyFunction SwapHands = "SwapHands";
-        public static readonly BoundKeyFunction SwapHandsReversed = "SwapHandsReversed";
+        public static readonly BoundKeyFunction SwapHandsReversed = "SwapHandsReversed"; // DeltaV - Swap Hands Reversed
         public static readonly BoundKeyFunction MoveStoredItem = "MoveStoredItem";
         public static readonly BoundKeyFunction RotateStoredItem = "RotateStoredItem";
         public static readonly BoundKeyFunction SaveItemLocation = "SaveItemLocation";

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -35,6 +35,7 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";
         public static readonly BoundKeyFunction SwapHands = "SwapHands";
+        public static readonly BoundKeyFunction SwapHandsReversed = "SwapHandsReversed";
         public static readonly BoundKeyFunction MoveStoredItem = "MoveStoredItem";
         public static readonly BoundKeyFunction RotateStoredItem = "RotateStoredItem";
         public static readonly BoundKeyFunction SaveItemLocation = "SaveItemLocation";

--- a/Content.Shared/_DV/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
+++ b/Content.Shared/_DV/Hands/EntitySystems/SharedHandsSystem.Interactions.cs
@@ -1,0 +1,50 @@
+using Content.Shared.Hands.Components;
+using Robust.Shared.Player;
+
+namespace Content.Shared.Hands.EntitySystems;
+
+public partial class SharedHandsSystem
+{
+    /// <summary>
+    /// Swap hands in the right direction
+    /// </summary>
+    /// <param name="session">Session data</param>
+    private void SwapHandsPressed(ICommonSession? session)
+    {
+        ChangeHandIndex(session, 1);
+    }
+
+    /// <summary>
+    /// Will swap hands in the left direction
+    /// </summary>
+    /// <param name="session">Session data</param>
+    private void SwapHandsReversedPressed(ICommonSession? session)
+    {
+        ChangeHandIndex(session, -1);
+    }
+
+    /// <summary>
+    /// Will swap hands relative to the current hand position using the given modifier.
+    /// </summary>
+    /// <param name="session">Session data</param>
+    /// <param name="modifier">positive or negative value</param>
+    private void ChangeHandIndex(ICommonSession? session, int modifier)
+    {
+        if (!TryComp(session?.AttachedEntity, out HandsComponent? component))
+            return;
+        if (!_actionBlocker.CanInteract(session.AttachedEntity.Value, null))
+            return;
+        if (component.ActiveHand == null || component.Hands.Count < 2)
+            return;
+
+        var newActiveIndex = component.SortedHands.IndexOf(component.ActiveHand.Name) + modifier;
+        while (newActiveIndex < 0)
+        {
+            newActiveIndex += component.SortedHands.Count;
+        }
+
+        var nextHand = component.SortedHands[newActiveIndex % component.Hands.Count];
+
+        TrySetActiveHand(session.AttachedEntity.Value, nextHand, component);
+    }
+}

--- a/Resources/Locale/en-US/_DV/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_DV/escape-menu/options-menu.ftl
@@ -2,3 +2,4 @@
 ui-options-general-forknotice = Note: These settings are fork-specific and might not apply on other servers.
 
 ui-options-no-filters = Disable species vision filters
+ui-options-function-swap-hands-reversed = Swap Hands Reverse

--- a/Resources/Locale/en-US/_DV/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_DV/escape-menu/options-menu.ftl
@@ -2,4 +2,4 @@
 ui-options-general-forknotice = Note: These settings are fork-specific and might not apply on other servers.
 
 ui-options-no-filters = Disable species vision filters
-ui-options-function-swap-hands-reversed = Swap Hands Reverse
+ui-options-function-swap-hands-reversed = Swap hands (reversed)

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -165,6 +165,8 @@ binds:
 - function: SwapHands
   type: State
   key: X
+- function: SwapHandsReversed
+  type: State
 - function: MoveStoredItem
   type: State
   key: MouseLeft

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -165,8 +165,6 @@ binds:
 - function: SwapHands
   type: State
   key: X
-- function: SwapHandsReversed
-  type: State
 - function: MoveStoredItem
   type: State
   key: MouseLeft


### PR DESCRIPTION
This is my first PR and I've attempted to make it fully compliant, the changes are spread over a few commits which I hope isnt a pain. Please let me know If I've done anything incorrect.

## About the PR
Added a new keybind that can be found under controls section.
Its "Swap hands (reversed)"
Upon pressing the keybind:
- As a human, you hands will swap as normal.
- As a borg, it will rotate your tools or 'hands' in reverse order allowing you to go backwards within the module.

## Why / Balance
As a borg you have tasks requiring you to switch between multiple tools resulting in you having to rotate through all your tools multiple times which is very time consuming and it feels unnecessary. I wouldnt think this could cause any balance issues.

## Technical details
New keybind and associated methods (Everywhere that the swap hands appeared previously now has a reversed variant)
The previous handling method for swapping hands has been rewritten to avoid code duplication and has been moved to a partial class.

## Media

https://github.com/user-attachments/assets/f0d0fe24-c826-4473-8ce5-683d410ce6f7

Heres an mp4 as a demonstration as its hard to provide an image for tools swapping. I did some random interactions to kind of demonstrate I didnt break it or theres some kind of desync
![image](https://github.com/user-attachments/assets/38626454-6bb5-49d8-a845-c5f5b48dbe9a)
Heres the config. There is no default binding to avoid any potential issues.
I didn't put it on the DeltaV tab as it would take a considerable rework to the way the keybinds are registered which the 'shitmed' merge also did not attempt to do. I would happily move it to that tab if that work was done.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None... I dont think?

**Changelog**
:cl: 
- add: New keybind to swap hands in reverse, this is not bound by default. Should only matter if you play borg.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
