### PR TITLE
Mindshield Rework

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -114,7 +114,7 @@
     sprite: Objects/Specific/Medical/implanter.rsi
     state: implanter0
   product: CrateMindShieldImplants
-  cost: 3000
+  cost: 5000 # DeltaV increased cost from 3000 to 5000
   category: cargoproduct-category-name-medical
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -46,12 +46,12 @@
   id: CrateMindShieldImplants
   parent: CrateMedical
   name: MindShield implant crate
-  description: Crate filled with 3 MindShield implants.
+  description: Crate holding a MindShield implant. # DeltaV - lowered MindShield count from 3 to 1
   components:
   - type: StorageFill
     contents:
       - id: MindShieldImplanter
-        amount: 3
+        amount: 1 # DeltaV - lowered MindShield count from 3 to 1
 
 - type: entity
   id: CrateMedicalSurgery

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -335,7 +335,7 @@
     - id: CigarGoldCase
       prob: 0.50
     - id: ClothingBeltSecurityFilled
-    - id: ClothingEyesGlassesSecurity
+    #- id: ClothingEyesGlassesSecurity # DeltaV - replaced with Investigator glasses
     - id: ClothingHeadsetAltSecurity
     - id: ClothingMaskNeckGaiter
 #    - id: ClothingOuterCoatHoSTrench # DeltaV - removed for incongruence

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -187,7 +187,8 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingEyesGlassesSecurity
+#      - id: ClothingEyesGlassesSecurity # DeltaV - Replaced with Investigator glasses
+      - id: ClothingEyesGlassesInvestigator # DeltaV - Replacing sec glasses
 #        prob: 0.3 # DeltaV - standardise until HUD balance worked out
 #      - id: ClothingHeadHatFedoraBrown # DeltaV - removed for incongruence
 #      - id: ClothingNeckTieDet # DeltaV - removed for incongruence

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -191,10 +191,10 @@
     coverage: EYES
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: [ClothingEyesBase, ShowAdministrationIcons, BaseCommandContraband] # DeltaV - Add MindShield to admin glasses.
   id: ClothingEyesGlassesCommand
   name: administration glasses
-  description: Upgraded sunglasses that provide flash immunity and show ID card status. 
+  description: Upgraded sunglasses that provide flash immunity and show ID card status.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/commandglasses.rsi
@@ -209,7 +209,7 @@
     - WhitelistChameleon
   - type: IdentityBlocker
     coverage: EYES
-  - type: ShowJobIcons
+  #- type: ShowJobIcons # DeltaV - Parent ShowAdministrationIcons instead
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -4,7 +4,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: ShowJobIcons
-  - type: ShowMindShieldIcons
+  #- type: ShowMindShieldIcons # DeltaV - Remove MindShield icons from sechuds
   - type: ShowCriminalRecordIcons
 
 - type: entity
@@ -59,16 +59,16 @@
     - HudSecurity
 
 - type: entity
-  parent: [ClothingEyesBase, BaseCommandContraband]
+  parent: [ClothingEyesBase, ShowAdministrationIcons, BaseCommandContraband] # DeltaV - Add MindShield to admin huds.
   id: ClothingEyesHudCommand
   name: administration hud
-  description: A heads-up display that scans the humanoids in view and provides accurate data about their ID status.
+  description: A heads-up display that scans the humanoids in view and provides accurate data about their ID and MindShield status. # DeltaV - Add MindShield to admin huds.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/command.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/command.rsi
-  - type: ShowJobIcons
+  #- type: ShowJobIcons # DeltaV - Using parent ShowAdministrationIcons
 
 - type: entity
   parent: ClothingEyesBase
@@ -165,7 +165,7 @@
     - HudMedicalSecurity
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
+  parent: [ClothingEyesBase, ShowAdministrationIcons, ShowSecurityIcons, ShowMedicalIcons] # DeltaV - Seperated Admin from Sec icons
   id: ClothingEyesHudMultiversal
   name: multiversal hud
   description: Filler
@@ -181,7 +181,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons]
+  parent: [ClothingEyesBase, ShowAdministrationIcons, ShowSecurityIcons, ShowMedicalIcons] # DeltaV - Seperated Admin from Sec icons
   id: ClothingEyesHudOmni
   name: omni hud
   description: Filler
@@ -199,7 +199,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseSyndicateContraband]
+  parent: [ClothingEyesBase, ShowAdministrationIcons, ShowSecurityIcons, BaseSyndicateContraband] # DeltaV - Seperated Admin from Sec icons
   id: ClothingEyesHudSyndicate
   name: syndicate visor
   description: The syndicate's professional head-up display, designed for better detection of humanoids and their subsequent elimination.
@@ -211,7 +211,7 @@
   - type: ShowSyndicateIcons
 
 - type: entity
-  parent: [ClothingEyesBase, ShowSecurityIcons, BaseSyndicateContraband]
+  parent: [ClothingEyesBase, ShowAdministrationIcons, ShowSecurityIcons, BaseSyndicateContraband] # DeltaV - Seperated Admin from Sec icons
   id: ClothingEyesHudSyndicateAgent
   name: syndicate agent visor
   description: The Syndicate Agent's professional heads-up display, designed for quick diagnosis of their team's status.
@@ -224,7 +224,7 @@
   - type: ShowHealthBars
 
 - type: entity
-  parent: [ClothingEyesGlassesSunglasses, ShowSecurityIcons]
+  parent: [ClothingEyesGlassesSunglasses, ShowAdministrationIcons, ShowSecurityIcons] # DeltaV - Seperated Admin from Sec icons
   id: ClothingEyesGlassesHiddenSecurity
   suffix: Syndicate
 

--- a/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/visitors_startinggear.yml
@@ -132,7 +132,7 @@
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSatchelSecurity
     ears: ClothingHeadsetAltSecurity
-    eyes: ClothingEyesGlassesSecurity
+    eyes: ClothingEyesGlassesInvestigator # DeltaV - Move MindShield glasses to Investigator
     outerClothing: ClothingOuterCoatHoSTrench
     pocket1: WeaponDisabler
     pocket2: MagazinePistolSubMachineGunTopMounted
@@ -151,7 +151,7 @@
     belt: ClothingBeltSecurityFilled
     back: ClothingBackpackSatchelLeather
     ears: ClothingHeadsetAltSecurity
-    eyes: ClothingEyesGlassesSecurity
+    eyes: ClothingEyesGlassesInvestigator # DeltaV - Move MindShield glasses to Investigator
     pocket1: WeaponDisabler
     pocket2: MagazinePistolSubMachineGunTopMounted
   inhand:
@@ -282,7 +282,7 @@
     outerClothing: ClothingOuterArmorBasicSlim
     pocket1: WeaponPistolMk58
     pocket2: MagazinePistol
-  inhand: 
+  inhand:
   - FlashlightSeclite
 
 - type: startingGear
@@ -859,7 +859,7 @@
     eyes: ClothingEyesHudMedical
     pocket1: RegenerativeMesh
     pocket2: PillCanisterBicaridine
-  inhand: 
+  inhand:
   - ScalpelAdvanced
   - MedicatedSuture
 

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -26,7 +26,7 @@
 - type: startingGear
   id: DetectiveGear
   equipment:
-    eyes: ClothingEyesGlassesSecurity
+    eyes: ClothingEyesGlassesInvestigator # DeltaV - Move MindShield glasses to Investigator
     id: DetectivePDA
     gloves: ClothingHandsGlovesForensic # DeltaV - roundstart detective forensic gloves
     ears: ClothingHeadsetSecurity

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -48,7 +48,7 @@
 - type: startingGear
   id: HoSGear
   equipment:
-    eyes: ClothingEyesGlassesSecurity
+    eyes: ClothingEyesGlassesInvestigator # DeltaV - Move MindShield glasses to Investigator
     id: HoSPDA
     gloves: ClothingHandsGlovesCombat
     ears: ClothingHeadsetAltSecurity

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
@@ -84,6 +84,7 @@
   id: LockerFillHeadOfSecurityDeltaV
   table: !type:AllSelector
     children:
+    - id: ClothingEyesGlassesInvestigator # DeltaV - Replaces sec glasses
     - id: BoxPDASecurity
     - id: WeaponEnergyGunMultiphase
     - id: HoSIDCard

--- a/Resources/Prototypes/_DV/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_DV/Clothing/Eyes/hud.yml
@@ -1,0 +1,13 @@
+- type: entity
+  id: ShowAdministrationIcons
+  abstract: true
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ShowJobIcons
+  - type: ShowMindShieldIcons
+
+- type: entity
+  parent: [ClothingEyesGlassesSecurity, ShowAdministrationIcons]
+  id: ClothingEyesGlassesInvestigator
+  name: investigator glasses
+  description: Improved security glasses that allows the user to see MindShield status.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
I moved MindShield visibility from sec hud/glasses to Admin hud/glasses. HoS and detective get Investigator glasses which still can see MindShield status. Coming along with SOP changes to specify MindShields are only to be used voluntarily, and MindShielding is recommended during the process of promoting new sec/command. MindShields will not apply when injected into a traitor as they are not loyal to Nanotrasen in the first place.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
relevant discussion https://discordapp.com/channels/968983104247185448/1332949868041470044
My design goal for MindShields is for them to act as a stamp of approval for already loyal crew, and to protect those crew from outside influences (ie. sleepers and revs if they existed).

Getting promoted into command is incredibly easy compared to the amount of power it can bring and the influence an antag command can have. It is trivial to simply not be evil for a few minutes until they get promoted. This gives very little interaction on the part of CO's/HoS's as there are simply no tools provided that would let them ensure they are promoting people with good intentions. Players have gravitated to MindShields as standard NT protocol to ensure good actors are promoted into sensitive positions. This is understandable given that Security and Command round start all have MindShields. I have moved us towards that by protecting MindShielded people from sleeper events.

These changes are to make MindShields a tool to validate and protect loyal crewmembers who need extra validation for these sensitive positions. MindShields are now largely a part of the hiring process into command and security. As such MindShield Visibility will be moved away from security and to the huds of people dealing with that Administrative duty. Detectives also get MindShield capable huds as it can help them with investigative measures.

To continue with MindShields being a tool to validate loyal crew, they will fail on traitorous syndicates. Syndicates will have tools to get around this though. Primarily the fake MindShield which if used well can trick people into believing they were successfully mindshielded. The TC cost of the fake MindShield in this case acts similarly to antag advantage. MindShields have also been made much more expensive as to give Syndicates room to negotiate their way out of getting one as well.

## Technical details
<!-- Summary of code changes for easier review. -->
Moved ShowMindShieldIcons and ShowJobIcons to
ShowAdministrationIcons to parent off of easier.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![Screenshot_1](https://github.com/user-attachments/assets/2a1465a0-d3da-42f5-88ed-a64a03009c9b)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: MindShields no longer apply when used on Syndicates.
- remove: MindShield status no longer visible on standard Security hud/glasses.
- add: HoS and Detective receive Investigator glasses which retain the ability to see MindShield status.
- add: Administration hud/glasses now are able to see MindShield status.
- tweak: MindShields no longer apply when used on Syndicates.
- tweak: Increased cost of MindShields to 5000 per implanter
