### PR TITLE
make uranium 10% as radioactive

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -235,7 +235,7 @@
           Quantity: 2
         canReact: false
   - type: RadiationSource
-    intensity: 0.1
+    intensity: 0.01 # DeltaV - was 0.1, now 0.3 rads from a full stack
     slope: 3
   - type: PointLight
     radius: 1.2


### PR DESCRIPTION
## About the PR
10% of 3 is 0.3 rads/s, the new radiation for a stack of uranium

damage from eating it is unaffected

## Why / Balance
3 rads/s from a single stack is insane, leading to death lockers making 30 rads easily from a bit of mining

uranium 238 (99.2% of unenriched uranium) is fertile and barely decays

## Technical details
no

## Media
![05:31:41](https://github.com/user-attachments/assets/8dba91aa-5cb5-470c-a7d4-27e2e9ee29da)

glorious alpha decay (stopped by a sheet of paper) with a half life of 4.5B years, surely the effects of this arent exaggerated... right? 

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Made uranium far less radioactive.
