### PR TITLE
Allow autodoc to proceed with just anesthesia instead of requiring sleep

### DIFF
--- a/Content.Shared/_Shitmed/Autodoc/Systems/SharedAutodocSystem.cs
+++ b/Content.Shared/_Shitmed/Autodoc/Systems/SharedAutodocSystem.cs
@@ -317,7 +317,7 @@ public abstract class SharedAutodocSystem : EntitySystem
 
     public bool IsAwake(EntityUid uid)
     {
-        return _mobState.IsAlive(uid) && !HasComp<SleepingComponent>(uid);
+        return _mobState.IsAlive(uid) && !(HasComp<SleepingComponent>(uid) || HasComp<Content.Shared._DV.Surgery.AnesthesiaComponent>(uid)); // DeltaV: allow autodoc to proceed with only anesthesia
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The autodoc can now proceed with just anesthesia instead of requiring the patient to be asleep.

## Why / Balance
We have anesthesia as a separate thing from forced sleep, and I forgot to update the Autodoc in the PR for that.
This is a `sleeping OR anesthesia` situation to continue to allow the autodoc to be used for strange maints surgeries.

## Technical details
- `SharedAutodocSystem#IsAwake` now also checks for the `Anesthesia` component

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Autodoc can now operate on patients only under the effect of chloral hydrate
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
