### PR TITLE
Add surgical cleanliness and sanitation

### DIFF
--- a/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
+++ b/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
@@ -1,0 +1,15 @@
+using Content.Shared._DV.Surgery;
+
+namespace Content.Client._DV.Surgery;
+
+/// <summary>
+///     This gets the examine tooltip and sanitize verb predicted on the client so there's no pop-in after latency
+/// </summary>
+public sealed class SurgeryCleanSystem : SharedSurgeryCleanSystem
+{
+    public override bool RequiresCleaning(EntityUid target)
+    {
+        // Predict that it can be cleaned if it has dirt on it
+        return TryComp<SurgeryDirtinessComponent>(target, out var dirtiness) && dirtiness.Dirtiness > 0;
+    }
+}

--- a/Content.Server/_DV/Surgery/SurgeryCleanSystem.cs
+++ b/Content.Server/_DV/Surgery/SurgeryCleanSystem.cs
@@ -1,0 +1,43 @@
+using Content.Shared._DV.Surgery;
+using Content.Shared.Forensics;
+using Content.Shared.FixedPoint;
+using System.Linq;
+
+namespace Content.Server._DV.Surgery;
+
+/// <summary>
+///     Responsible for handling the visual appearance of and sanitzation of items that can get dirty from surgery
+/// </summary>
+public sealed class SurgeryCleanSystem : SharedSurgeryCleanSystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SurgeryCrossContaminationComponent, SurgeryCleanedEvent>(OnCleanDNA);
+    }
+
+    public override bool RequiresCleaning(EntityUid target)
+    {
+        var isDirty = (TryComp<SurgeryDirtinessComponent>(target, out var dirtiness) && dirtiness.Dirtiness > 0);
+        var isContaminated = (TryComp<SurgeryCrossContaminationComponent>(target, out var contamination) && contamination.DNAs.Count > 0);
+
+        return isDirty || isContaminated;
+    }
+
+    private void OnCleanDNA(Entity<SurgeryCrossContaminationComponent> ent, ref SurgeryCleanedEvent args)
+    {
+        var i = 0;
+        var count = args.DnaAmount;
+        ent.Comp.DNAs.RemoveWhere(item => i++ < count);
+    }
+
+    protected override void FinishCleaning(Entity<SurgeryCleansDirtComponent> ent, ref SurgeryCleanDirtDoAfterEvent args)
+    {
+        base.FinishCleaning(ent, ref args);
+
+        // daisychain to forensics because if you sterilise something youve almost definitely scrubbed all dna and fibers off of it
+        var daisyChainEvent = new CleanForensicsDoAfterEvent() { DoAfter = args.DoAfter };
+        RaiseLocalEvent(ent.Owner, daisyChainEvent);
+    }
+}

--- a/Content.Server/_DV/Surgery/SurgeryCrossContaminationComponent.cs
+++ b/Content.Server/_DV/Surgery/SurgeryCrossContaminationComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server._DV.Surgery;
+
+/// <summary>
+///     Component that allows an entity to be cross contamined from being used in surgery
+/// </summary>
+[RegisterComponent]
+public sealed partial class SurgeryCrossContaminationComponent : Component
+{
+    /// <summary>
+    ///     Patient DNAs that are present on this dirtied tool
+    /// </summary>
+    [DataField]
+    public HashSet<string> DNAs = new();
+}

--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -12,6 +12,10 @@ using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Interaction;
 using Content.Shared.Inventory;
 using Content.Shared._DV.Surgery; // DeltaV: expanded anesthesia
+using Content.Server.Forensics; // DeltaV: surgery cross contamination
+using Content.Server._DV.Surgery; // DeltaV: surgery cross contamination
+using Content.Shared.FixedPoint; // DeltaV: surgery cross contamination
+using Content.Shared.Damage.Prototypes; // DeltaV: surgery cross contamination
 using Content.Shared._Shitmed.Medical.Surgery;
 using Content.Shared._Shitmed.Medical.Surgery.Conditions;
 using Content.Shared._Shitmed.Medical.Surgery.Effects.Step;
@@ -40,6 +44,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
     [Dependency] private readonly UserInterfaceSystem _ui = default!;
     [Dependency] private readonly RottingSystem _rot = default!;
     [Dependency] private readonly BlindableSystem _blindableSystem = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!; // DeltaV: surgery cross contamination
 
     public override void Initialize()
     {
@@ -47,6 +52,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
 
         SubscribeLocalEvent<SurgeryToolComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
         SubscribeLocalEvent<SurgeryTargetComponent, SurgeryStepDamageEvent>(OnSurgeryStepDamage);
+        SubscribeLocalEvent<SurgeryTargetComponent, SurgeryDirtinessEvent>(OnSurgerySanitation); // DeltaV: surgery cross contamination
         // You might be wondering "why aren't we using StepEvent for these two?" reason being that StepEvent fires off regardless of success on the previous functions
         // so this would heal entities even if you had a used or incorrect organ.
         SubscribeLocalEvent<SurgerySpecialDamageChangeEffectComponent, SurgeryStepDamageChangeEvent>(OnSurgerySpecialDamageChange);
@@ -140,6 +146,116 @@ public sealed class SurgerySystem : SharedSurgerySystem
 
     private void OnSurgeryStepDamage(Entity<SurgeryTargetComponent> ent, ref SurgeryStepDamageEvent args) =>
         SetDamage(args.Body, args.Damage, args.PartMultiplier, args.User, args.Part);
+
+    // Begin DeltaV: surgery cross contamination
+    private FixedPoint2 Dirtiness(EntityUid entity)
+    {
+        var comp = EnsureComp<SurgeryDirtinessComponent>(entity);
+        return comp.Dirtiness;
+    }
+
+    private HashSet<string> CrossContaminants(EntityUid entity)
+    {
+        var comp = EnsureComp<SurgeryCrossContaminationComponent>(entity);
+        return comp.DNAs;
+    }
+
+    public FixedPoint2 TotalDirtiness(EntityUid user, List<EntityUid> tools, Entity<DnaComponent, SurgeryContaminableComponent> target)
+    {
+        var total = FixedPoint2.Zero;
+        var dnas = new HashSet<string>();
+
+        if (HasComp<SurgerySelfDirtyComponent>(user))
+        {
+            total += Dirtiness(user);
+            dnas.UnionWith(CrossContaminants(user));
+        }
+        else
+        {
+            if (_inventory.TryGetSlotEntity(user, "gloves", out var glovesEntity))
+            {
+                total += Dirtiness(glovesEntity.Value);
+                dnas.UnionWith(CrossContaminants(glovesEntity.Value));
+            }
+
+            foreach (var tool in tools)
+            {
+                total += Dirtiness(tool);
+                dnas.UnionWith(CrossContaminants(tool));
+            }
+        }
+
+        dnas.Remove(target.Comp1.DNA);
+
+        return total + dnas.Count * target.Comp2.CrossContaminationDirtinessLevel;
+    }
+
+    public FixedPoint2 DamageToBeDealt(Entity<SurgeryContaminableComponent> ent, FixedPoint2 dirtiness)
+    {
+        if (ent.Comp.DirtinessThreshold > dirtiness)
+        {
+            return 0;
+        }
+
+        var exceedsAmount = (dirtiness - ent.Comp.DirtinessThreshold).Float();
+        var additionalDamage = (1f / ent.Comp.InverseDamageCoefficient.Float()) * (exceedsAmount * exceedsAmount);
+
+        return FixedPoint2.New(additionalDamage) + ent.Comp.BaseDamage;
+    }
+
+    private void AddDirt(EntityUid ent, FixedPoint2 amount)
+    {
+        var dirtiness = EnsureComp<SurgeryDirtinessComponent>(ent);
+        dirtiness.Dirtiness += amount;
+        Dirty(ent, dirtiness);
+    }
+
+    private void AddDNA(EntityUid ent, string dna)
+    {
+        var contamination = EnsureComp<SurgeryCrossContaminationComponent>(ent);
+        contamination.DNAs.Add(dna);
+    }
+
+    private void OnSurgerySanitation(Entity<SurgeryTargetComponent> target, ref Content.Shared._DV.Surgery.SurgeryDirtinessEvent args)
+    {
+        if (!TryComp<SurgeryContaminableComponent>(target.Owner, out var contaminableComp))
+            return;
+
+        if (!TryComp<DnaComponent>(target.Owner, out var dnaComp))
+            return;
+
+        var dirtiness = TotalDirtiness(args.User, args.Tools, new(target.Owner, dnaComp, contaminableComp));
+        var damage = DamageToBeDealt(new(target.Owner, contaminableComp), dirtiness);
+
+        if (damage > 0)
+        {
+            var sepsis = new DamageSpecifier(_prototypes.Index<DamageTypePrototype>("Poison"), damage);
+            SetDamage(target.Owner, sepsis, 0.5f, args.User, args.Part);
+        }
+
+        if (!TryComp<SurgeryStepDirtinessComponent>(args.Step, out var surgicalStepDirtiness))
+            return;
+
+        if (HasComp<SurgerySelfDirtyComponent>(args.User))
+        {
+            AddDirt(args.User, surgicalStepDirtiness.ToolDirtiness);
+            AddDNA(args.User, dnaComp.DNA);
+            return;
+        }
+
+        if (_inventory.TryGetSlotEntity(args.User, "gloves", out var glovesEntity))
+        {
+            AddDirt(glovesEntity.Value, surgicalStepDirtiness.GloveDirtiness);
+            AddDNA(glovesEntity.Value, dnaComp.DNA);
+        }
+        foreach (var tool in args.Tools)
+        {
+            AddDirt(tool, surgicalStepDirtiness.ToolDirtiness);
+            AddDNA(tool, dnaComp.DNA);
+        }
+    }
+
+    // End DeltaV: surgery cross contamination
 
     private void OnSurgeryDamageChange(Entity<SurgeryDamageChangeEffectComponent> ent, ref SurgeryStepEvent args) // DeltaV
     {

--- a/Content.Shared/_DV/Surgery/SharedSurgeryCleanSystem.cs
+++ b/Content.Shared/_DV/Surgery/SharedSurgeryCleanSystem.cs
@@ -1,0 +1,116 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Examine;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._DV.Surgery;
+
+public abstract class SharedSurgeryCleanSystem : EntitySystem
+{
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SurgeryCleansDirtComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<SurgeryCleansDirtComponent, SurgeryCleanDirtDoAfterEvent>(FinishCleaning);
+
+        SubscribeLocalEvent<SurgeryDirtinessComponent, ExaminedEvent>(OnDirtyExamined);
+        SubscribeLocalEvent<SurgeryCleansDirtComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
+
+        SubscribeLocalEvent<SurgeryDirtinessComponent, SurgeryCleanedEvent>(OnCleanDirt);
+    }
+
+    private void OnUtilityVerb(Entity<SurgeryCleansDirtComponent> ent, ref GetVerbsEvent<UtilityVerb> args)
+    {
+        if (!args.CanInteract || !args.CanAccess)
+            return;
+
+        var user = args.User;
+        var target = args.Target;
+
+        var verb = new UtilityVerb()
+        {
+            Act = () => TryStartCleaning(ent, user, target),
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/bubbles.svg.192dpi.png")),
+            Text = Loc.GetString(Loc.GetString("sanitization-verb-text")),
+            Message = Loc.GetString(Loc.GetString("sanitization-verb-message")),
+            // we daisychain to forensics here so we shouldn't leave forensic traces of our own
+            DoContactInteraction = false
+        };
+
+        args.Verbs.Add(verb);
+    }
+
+    private void OnDirtyExamined(Entity<SurgeryDirtinessComponent> ent, ref ExaminedEvent args)
+    {
+        var stage = (int)Math.Ceiling(ent.Comp.Dirtiness.Double() / 20.0);
+
+        var description = stage switch {
+            0 => "surgery-cleanliness-0",
+            1 => "surgery-cleanliness-1",
+            2 => "surgery-cleanliness-2",
+            3 => "surgery-cleanliness-3",
+            4 => "surgery-cleanliness-4",
+            _ => "surgery-cleanliness-5",
+        };
+
+        args.PushMarkup(Loc.GetString(description));
+    }
+
+    public abstract bool RequiresCleaning(EntityUid target);
+
+    private void OnAfterInteract(Entity<SurgeryCleansDirtComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || !args.CanReach || args.Target == null)
+            return;
+
+        args.Handled = TryStartCleaning(ent, args.User, args.Target.Value);
+    }
+
+    public bool TryStartCleaning(Entity<SurgeryCleansDirtComponent> ent, EntityUid user, EntityUid target)
+    {
+        if (!RequiresCleaning(target))
+        {
+            _popup.PopupPredicted(Loc.GetString("sanitization-cannot-clean", ("target", target)), user, user, PopupType.MediumCaution);
+            return false;
+        }
+
+        var cleanDelay = ent.Comp.CleanDelay;
+        var doAfterArgs = new DoAfterArgs(EntityManager, user, cleanDelay, new SurgeryCleanDirtDoAfterEvent(), ent, target: target, used: ent)
+        {
+            NeedHand = true,
+            BreakOnDamage = true,
+            BreakOnMove = true,
+            MovementThreshold = 0.01f,
+            DistanceThreshold = 1f,
+        };
+
+        _doAfter.TryStartDoAfter(doAfterArgs);
+        _popup.PopupClient(Loc.GetString("sanitization-cleaning", ("target", target)), user, user);
+
+        return true;
+    }
+
+    protected virtual void FinishCleaning(Entity<SurgeryCleansDirtComponent> ent, ref SurgeryCleanDirtDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.Args.Target == null)
+            return;
+
+        var ev = new SurgeryCleanedEvent(ent.Comp.DirtAmount, ent.Comp.DnaAmount);
+        RaiseLocalEvent(args.Args.Target.Value, ref ev);
+
+        args.Repeat = RequiresCleaning(args.Args.Target.Value);
+    }
+
+    private void OnCleanDirt(Entity<SurgeryDirtinessComponent> ent, ref SurgeryCleanedEvent args)
+    {
+        ent.Comp.Dirtiness = FixedPoint2.Max(FixedPoint2.Zero, ent.Comp.Dirtiness - args.DirtAmount);
+        Dirty(ent);
+    }
+}

--- a/Content.Shared/_DV/Surgery/SurgeryCleanDirtDoAfterEvent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryCleanDirtDoAfterEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._DV.Surgery;
+
+[Serializable, NetSerializable]
+public sealed partial class SurgeryCleanDirtDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_DV/Surgery/SurgeryCleanedEvent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryCleanedEvent.cs
@@ -1,0 +1,9 @@
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+/// 	Event fired when an object is sterilised for surgery
+/// </summary>
+[ByRefEvent]
+public record struct SurgeryCleanedEvent(FixedPoint2 DirtAmount, int DnaAmount);

--- a/Content.Shared/_DV/Surgery/SurgeryCleansDirt.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryCleansDirt.cs
@@ -1,0 +1,29 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+///     For items that can clean up surgical dirtiness
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryCleansDirtComponent : Component
+{
+    /// <summary>
+    /// How long it takes to wipe prints/blood/etc. off of things using this entity
+    /// </summary>
+    [DataField]
+    public float CleanDelay = 4.0f;
+
+    /// <summary>
+    /// How much dirt is removed per clean
+    /// </summary>
+    [DataField]
+    public FixedPoint2 DirtAmount = 5.0;
+
+    /// <summary>
+    /// How many DNAs are removed per clean
+    /// </summary>
+    [DataField]
+    public int DnaAmount = 1;
+}

--- a/Content.Shared/_DV/Surgery/SurgeryContaminableComponent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryContaminableComponent.cs
@@ -1,0 +1,42 @@
+using Content.Shared._Shitmed.Medical.Surgery;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+///     Component that indicates how an entity should respond to unsanitary surgery conditions
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedSurgerySystem))]
+public sealed partial class SurgeryContaminableComponent : Component
+{
+    /// <summary>
+    ///     How much cross contamination should increase dirtiness per incompatible DNA
+    /// </summary>
+    [DataField]
+    public FixedPoint2 CrossContaminationDirtinessLevel = 40.0;
+
+    /// <summary>
+    ///     The level of dirtiness above which toxin damage will be dealt
+    /// </summary>
+    [DataField]
+    public FixedPoint2 DirtinessThreshold = 50.0;
+
+    /// <summary>
+    ///     The base amount of toxin damage to deal above the threshold
+    /// </summary>
+    [DataField]
+    public FixedPoint2 BaseDamage = 2.0;
+
+    /// <summary>
+    ///     The inverse of the coefficient to scale the toxin damage by
+    /// </summary>
+    [DataField]
+    public FixedPoint2 InverseDamageCoefficient = 250.0;
+
+    /// <summary>
+    ///     The upper limit on how much toxin damage can be dealt in a single step
+    /// </summary>
+    [DataField]
+    public FixedPoint2 ToxinStepLimit = 15.0;
+}

--- a/Content.Shared/_DV/Surgery/SurgeryDirtinessComponent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryDirtinessComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared._Shitmed.Medical.Surgery;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+///     Component that allows an entity to take on dirtiness from being used in surgery
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(SharedSurgeryCleanSystem), typeof(SharedSurgerySystem))]
+public sealed partial class SurgeryDirtinessComponent : Component
+{
+    /// <summary>
+    ///     The level of dirtiness this component represents; above 50 is usually where consequences start to happen
+    /// </summary>
+    [DataField]
+    [AutoNetworkedField]
+    public FixedPoint2 Dirtiness = 0.0;
+}

--- a/Content.Shared/_DV/Surgery/SurgeryDirtinessEvent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryDirtinessEvent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+/// 	Handled by the server when a surgery step is completed in order to deal with sanitization concerns
+/// </summary>
+[ByRefEvent]
+public record struct SurgeryDirtinessEvent(EntityUid User, EntityUid Part, List<EntityUid> Tools, EntityUid Step);

--- a/Content.Shared/_DV/Surgery/SurgerySelfDirtyComponent.cs
+++ b/Content.Shared/_DV/Surgery/SurgerySelfDirtyComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+///     Marker component that indicates that the entity should become dirtied instead of its tools doing surgery
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgerySelfDirtyComponent : Component;

--- a/Content.Shared/_DV/Surgery/SurgeryStepDirtinessComponent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryStepDirtinessComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Surgery;
+
+/// <summary>
+///     Component that allows a step to increase tools and gloves' dirtiness
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class SurgeryStepDirtinessComponent : Component
+{
+    /// <summary>
+    ///     The amount of dirtiness this step should add to tools on completion
+    /// </summary>
+    [DataField]
+    public FixedPoint2 ToolDirtiness = 2.0;
+
+    /// <summary>
+    ///     The amount of dirtiness this step should add to gloves on completion
+    /// </summary>
+    [DataField]
+    public FixedPoint2 GloveDirtiness = 2.0;
+}

--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -178,6 +178,9 @@ public abstract partial class SharedSurgerySystem
                 RaiseLocalEvent(args.Body, ref ev);
             }
         }
+
+        var dirtinessEv = new Content.Shared._DV.Surgery.SurgeryDirtinessEvent(args.User, args.Part, args.Tools, args.Step); // DeltaV: surgery cross contamination
+        RaiseLocalEvent(args.Body, ref dirtinessEv); // DeltaV: surgery cross contamination
     }
 
     private void OnToolCheck(Entity<SurgeryStepComponent> ent, ref SurgeryStepCompleteCheckEvent args)

--- a/Resources/Locale/en-US/_DV/surgery/cleanliness.ftl
+++ b/Resources/Locale/en-US/_DV/surgery/cleanliness.ftl
@@ -1,0 +1,11 @@
+surgery-cleanliness-0 = It's pristine
+surgery-cleanliness-1 = It's a little dirty
+surgery-cleanliness-2 = It's somewhat dirty
+surgery-cleanliness-3 = It's very dirty
+surgery-cleanliness-4 = It's frighteningly dirty
+surgery-cleanliness-5 = You're afraid to touch the dirt
+
+sanitization-verb-text = Sanitize
+sanitization-verb-message = Remove all cross contaminants and grime from the object
+sanitization-cannot-clean = There's nothing to sanitize on {THE($target)}!
+sanitization-cleaning = You begin to sanitize {THE($target)}...

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -108,6 +108,7 @@
     doAfterDelay: 10
     allowSelfRepair: false
   - type: BorgChassis
+  - type: SurgerySelfDirty # DeltaV: borgs get dirty from doing surgery
   - type: LockingWhitelist
     blacklist:
       components:

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -229,6 +229,7 @@
   - type: LayingDown # WD EDIT
   - type: Targeting # Shitmed Change
   - type: SurgeryTarget # Shitmed Change
+  - type: SurgeryContaminable # DeltaV - surgery cross contamination
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -67,6 +67,7 @@
     solution: soap
   - type: BadFood
   - type: CleansForensics
+  - type: SurgeryCleansDirt # DeltaV - surgery cross contamination
   - type: Residue
     residueAdjective: residue-slippery
     residueColor: residue-green

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -3,6 +3,7 @@
   abstract: true
   components:
   - type: SurgeryStep
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
 
 - type: entity
   parent: SurgeryStepBase
@@ -232,6 +233,9 @@
     sprite: _Shitmed/Objects/Specific/Medical/Surgery/manipulation.rsi
     state: insertion
   - type: SurgeryAddPartStep
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
+    toolDirtiness: 7.5
+    gloveDirtiness: 7.5
 
 - type: entity
   parent: SurgeryStepBase
@@ -329,6 +333,9 @@
     damage:
       types:
         Slash: 30
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
+    toolDirtiness: 7.5
+    gloveDirtiness: 7.5
 
 # Tend Wounds
 
@@ -371,6 +378,9 @@
       groups:
         Brute: -3 # DeltaV: was -5
   - type: SurgeryRepeatableStep
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
+    toolDirtiness: 0.5
+    gloveDirtiness: 0.5
 
 - type: entity
   parent: SurgeryStepBase
@@ -395,6 +405,9 @@
       types:
         Slash: 2
   - type: SurgeryRepeatableStep
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
+    toolDirtiness: 0.5
+    gloveDirtiness: 0.5
 
 - type: entity
   parent: SurgeryStepBase
@@ -477,6 +490,9 @@
     damage:
       types:
         Slash: 50
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
+    toolDirtiness: 7.5
+    gloveDirtiness: 7.5
 
 - type: entity
   parent: SurgeryStepBase
@@ -498,6 +514,9 @@
     damage:
       types:
         Blunt: 5
+  - type: SurgeryStepDirtiness # DeltaV - surgery cross contamination
+    toolDirtiness: 7.5
+    gloveDirtiness: 7.5
 
 - type: entity
   parent: SurgeryStepInsertOrgan


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- surgical tools and gloves can now get dirty and require sanitization
- soap can be used to sanitize surgical tools slowly
<!-- What did you change? -->

## Why / Balance
- surgery is very low-committal and LRP-feeling as it is, requiring tools to be sanitized makes more of a commitment required to do surgery well and adds a mechanical basis for surgeons to care about sanitation
- this was balanced around the assumption that you'd probably want to change your gloves and tools after a part transplant, so all of the steps involved in a heart surgery add up to ~50 dirtiness, after which point poison damage will start to happen if all of that dirtiness went to a single pair of gloves and a tool
- surgical steps have a maximum cap on how much poison damage they can do at once, in order to prevent a 5000 dirtiness scalpel from instantly round removing someone after an incision
- cross-contamination between patients is a big no-no, and adds a ton of dirtiness to the calculations

## Technical details
- components
  - `SurgeryCleansDirtComponent`: add it to items to allow them to sanitize tools and gloves manually
  - `SurgeryCrossContaminationComponent`: keeps track of other patients' DNA that has been on this tool
  - `SurgeryContaminableComponent`: add it to mobs that need to react to having (un)sanitary surgery equipment used on them
  - `SurgeryDirtinessComponent`: keeps track of how dirty a component is after surgery
  - `SurgeryStepDirtinessComponent`: add it to surgery steps to adjust how much dirtiness they cause after a step is done
- systems
  - `SurgeryCleanSystem`: new system that handles the examination of dirtied items and of scrubbing them with soap
  - `SurgerySystem`: augmented with sanitization checks after a step is completed in order to dirty involved tools and to deal damage if they're too dirty	
- base mob now has `SurgeryContaminableComponent`
- base soap now has `SurgeryCleansDirt`
- surgery steps now have `SurgeryStepDirtiness`
<!-- Summary of code changes for easier review. -->

## Media
![grafik](https://github.com/user-attachments/assets/c81dc014-2d14-4b75-ac8e-5b65bf95bb05)
![grafik](https://github.com/user-attachments/assets/692a5a1d-dd8c-45a3-815d-8046c3f26f5f)

https://github.com/user-attachments/assets/8a29f6ca-58d6-4fd5-9ed2-6f356f46205d

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## After This PR

This PR has follow-up opportunities, such as adding an autoclave or other methods for sanitizing tools and gloves faster than soaps do

**Changelog**
:cl:
- add: Surgical gloves and equipment can now get dirty and require sanitation with soap.