### PR TITLE
Derotate Hammurabi Station

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -9,7 +9,7 @@
   - Edge
   - Elegance
   - Glacier
-  - Hammurabi
+#  - Hammurabi - undergoing extensive maintenance
   - Lighthouse
 #  - Micro - to be revisited later ~Colin
   - Pebble


### PR DESCRIPTION
## About the PR
Derotates Hammurabi for overhaul

## Why / Balance
It needs it

## Technical details
n/a

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl: Velcroboy
- remove: Removed Hammurabi Prison Station. Map is undergoing a significant overhaul. It will be back...eventually.  
