### PR TITLE
make skeletons take holy damage

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -223,7 +223,7 @@
     Asphyxiation: 0.0
     Bloodloss: 0.0
     Cellular: 0.0
-    Holy: 1.5
+    Holy: 1.5 # Delta-V
   flatReductions:
     Blunt: 5
 

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -223,7 +223,7 @@
     Asphyxiation: 0.0
     Bloodloss: 0.0
     Cellular: 0.0
-    Holy: 1.5 # Delta-V
+    Holy: 1.5 # DeltaV
   flatReductions:
     Blunt: 5
 

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -223,6 +223,7 @@
     Asphyxiation: 0.0
     Bloodloss: 0.0
     Cellular: 0.0
+    Holy: 1.5
   flatReductions:
     Blunt: 5
 

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -9,7 +9,7 @@
   components:
   - type: HumanoidAppearance
     species: Skeleton
-  - type: Carriable # Carrying system from nyanotrasen.
+  - type: Carriable # Carrying system from nyanotrasen.  
   - type: Icon
     sprite: Mobs/Species/Skeleton/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -9,7 +9,7 @@
   components:
   - type: HumanoidAppearance
     species: Skeleton
-  - type: Carriable # Carrying system from nyanotrasen.
+  - type: Carriable # Carrying system from nyanotrasen. 
   - type: Icon
     sprite: Mobs/Species/Skeleton/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -18,7 +18,7 @@
     requiredLegs: 2
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
-    damageContainer: BiologicalMetaphysical # Delta-V
+    damageContainer: BiologicalMetaphysical # DeltaV
     damageModifierSet: Skeleton
   - type: DamageVisuals
     damageOverlayGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -9,7 +9,7 @@
   components:
   - type: HumanoidAppearance
     species: Skeleton
-  - type: Carriable # Carrying system from nyanotrasen. 
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Skeleton/parts.rsi
     state: full

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -9,7 +9,7 @@
   components:
   - type: HumanoidAppearance
     species: Skeleton
-  - type: Carriable # Carrying system from nyanotrasen.  
+  - type: Carriable # Carrying system from nyanotrasen.
   - type: Icon
     sprite: Mobs/Species/Skeleton/parts.rsi
     state: full
@@ -18,7 +18,7 @@
     requiredLegs: 2
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: BiologicalMetaphysical
     damageModifierSet: Skeleton
   - type: DamageVisuals
     damageOverlayGroups:

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -18,7 +18,7 @@
     requiredLegs: 2
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
-    damageContainer: BiologicalMetaphysical
+    damageContainer: BiologicalMetaphysical # Delta-V
     damageModifierSet: Skeleton
   - type: DamageVisuals
     damageOverlayGroups:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
simple enough change, makes skeletons take holy damage like the undead they are

## Why / Balance
it's more of a flavor thing than anything, skeletons are rarely used as is but there's been talk of some skeletal shenanigans, so this is a thing. perhaps one day, holy damage will actually be relevant. 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![3f02e0adb72389fde901c5ebfcedd695](https://github.com/user-attachments/assets/c229c82d-4afc-4bee-8657-e7710a3030c5)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Skeletons now take Holy damage as they are undead.
