### PR TITLE
Add more folders to the Bureaucracy crate

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/service.yml
@@ -124,18 +124,29 @@
   - type: StorageFill
     contents:
     - id: Paper
-      amount: 15
+      amount: 10 # DeltaV - make room for more folders in the bureaucracy crate
     - id: Pen
       amount: 2
     - id: BoxFolderClipboard
       amount: 2
     - id: HandLabeler
     - id: BoxFolderBlue
+      amount: 2 # DeltaV - more folders in the bureacracy crate
     - id: BoxFolderRed
+      amount: 2 # DeltaV - more folders in the bureacracy crate
     - id: BoxFolderYellow
+      amount: 2 # DeltaV - more folders in the bureacracy crate
     - id: NewtonCradle
     - id: BoxEnvelope
     - id: BrbSign
+    # Start DeltaV - More folders in the bureaucracy crate
+    - id: BoxFolderBlack
+      amount: 2
+    - id: BoxFolderGrey
+      amount: 2
+    - id: BoxFolderGreen
+      amount: 2
+    # End DeltaV - More folders in the bureaucracy crate
 
 - type: entity
   id: CrateServiceFaxMachine


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The bureaucracy crate now has more types of folders, and 2 of each type of folder

## Why / Balance
3 folders is a disappointing amount of them to have, and the available colours are commonly already mapped for the paperwork roles that have them.
This increases both the variety of folders, and how many folders you can get.

## Technical details
- add more folders to the cargo crate fill

## Media
![grafik](https://github.com/user-attachments/assets/ab009cd8-8eb7-4a77-a9d9-e5d6ee11c116)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Bureaucracy crate has more and more varied folders
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
