### PR TITLE
Fix glimmer events being queued

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -17,7 +17,6 @@
   parent: BaseGameRule
   id: GlimmerEventScheduler
   components:
-  - type: NextEvent
   - type: BasicStationEventScheduler
     minMaxEventTiming:
       min: 300


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
I explained why I shouldn't queue glimmer events. I didn't plan on queueing glimmer events. I queued glimmer events.

## Why / Balance
Never was supposed to happen. Fixes bug where it tries to read glimmer event results but they were never implemented thus sending no message.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl: SolStar
- fix: Fixed bug causing precognition power to sometimes fail to display a message.
