### PR TITLE
Hostage implants are now free for hostage ops

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
@@ -265,3 +265,24 @@
     whitelist:
       tags:
       - NukeOpsUplink
+
+- type: listing
+  id: UplinkHostageImplanterNukieFree
+  name: uplink-syndicate-hostage-implanter-bundle-name
+  description: uplink-syndicate-hostage-implanter-bundle-desc
+  icon: { sprite: Objects/Misc/handcuffs.rsi, state: handcuff }
+  productEntity: BoxSyndicateHostageImplanter
+  categories:
+  - UplinkObjectives
+  conditions:
+  - !type:ObjectiveUnlockCondition
+  - !type:ListingLimitedStockCondition
+    stock: 1
+  - !type:BuyerWhitelistCondition
+    blacklist:
+      components:
+      - SurplusBundle
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink

--- a/Resources/Prototypes/_DV/Objectives/nukies.yml
+++ b/Resources/Prototypes/_DV/Objectives/nukies.yml
@@ -53,6 +53,7 @@
     listings:
     - UplinkBodyBagBox
     - UplinkStunBundleNukie
+    - UplinkHostageImplanterNukieFree
 
 - type: entity
   parent: BaseStealObjective


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
No reason not to do this! Nukies were basically just ignoring them so giving them for free is fine.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Hostage implants are now free for hostage ops nukies