### PR TITLE
IPC bugfixes

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -108,6 +108,7 @@
   name: Urist McPositronic
   parent: MobHumanDummy
   id: MobIPCDummy
+  categories: [ HideSpawnMenu ] # Goobstation
   description: A dummy IPC meant to be used in character setup.
   components:
   - type: HumanoidAppearance

--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
@@ -150,6 +150,9 @@
           sprite: "Effects/creampie.rsi"
           state: "creampie_human"
           visible: false
+    - type: CanEnterCryostorage # Goobstation
+    - type: StatusIcon # Goobstation
+      bounds: -0.5,-0.5,0.5,0.5
     #- type: Bloodstream This is left commented out because it's not necessary for a robot, but you may want it.
     #  damageBleedModifiers: BloodlossIPC
     #  bloodReagent: Oil
@@ -299,6 +302,7 @@
         - Pacified
         # - PsionicsDisabled
         # - PsionicallyInsulated
+        - Flashed # Goobstation
     - type: Blindable
     - type: FireVisuals
       alternateState: Standing


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

- Fixed IPCs being unable to enter crypods and allows them to be flashed.
- Hides the Dummy mob from showing up in the spawn menu.
- Fixes job icons not showing up
Code is ported from https://github.com/Goob-Station/Goob-Station/pull/1123

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: IPCs can now enter cryosleep.
- fix: IPCs can be flashed.
- fix: IPC job icons now show up on sec huds.
