### PR TITLE
fix ipc encryption key mispredict

### DIFF
--- a/Content.Server/_EE/Silicon/EncryptionHolderRequiresLock/EncryptionHolderRequiresLockSystem.cs
+++ b/Content.Server/_EE/Silicon/EncryptionHolderRequiresLock/EncryptionHolderRequiresLockSystem.cs
@@ -23,6 +23,7 @@ public sealed class EncryptionHolderRequiresLockSystem : EntitySystem
             return;
 
         keyHolder.KeysUnlocked = !lockComp.Locked;
+        Dirty(uid, keyHolder); // DeltaV
         _encryptionKeySystem.UpdateChannels(uid, keyHolder);
     }
 }

--- a/Content.Shared/Radio/Components/EncryptionKeyHolderComponent.cs
+++ b/Content.Shared/Radio/Components/EncryptionKeyHolderComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Chat;
 using Content.Shared.Tools;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
+using Robust.Shared.GameStates; // DeltaV
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Shared.Radio.Components;
@@ -9,7 +10,7 @@ namespace Content.Shared.Radio.Components;
 /// <summary>
 ///     This component is by entities that can contain encryption keys
 /// </summary>
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState] // DeltaV: Network it
 public sealed partial class EncryptionKeyHolderComponent : Component
 {
     /// <summary>
@@ -17,6 +18,7 @@ public sealed partial class EncryptionKeyHolderComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("keysUnlocked")]
+    [AutoNetworkedField] // DeltaV
     public bool KeysUnlocked = true;
 
     /// <summary>


### PR DESCRIPTION
## About the PR
it was setting a field in server so client
networked it so it works at least

## Why / Balance
:)

## Media

client and server ipc are the same after unlocking instead of client thinking its still locked
![04:10:05](https://github.com/user-attachments/assets/8783364d-c19f-4a9b-bb01-9df1a3710d9e)
