### PR TITLE
seismic 1984

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -10,8 +10,6 @@
     cost: 150
   - id: Soap
     cost: 200
-  - id: SeismicCharge
-    cost: 250
   - id: WeaponGrapplingGun
     cost: 300
   # TODO: laser pointer 300, toy facehugger 300

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/salvage_points.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/salvage_points.yml
@@ -37,6 +37,8 @@
   - id: Fulton
     cost: 1000
   # TODO: lazarus injector for 1k
+  - id: SeismicCharge
+    cost: 1250
   - id: ClothingBackpackDuffelSalvageConscription
     cost: 1500
   - id: SpaceCash1000


### PR DESCRIPTION
## About the PR
made seismics 5x as expensive. they can still be found on debris

## Why / Balance
salv having 20 bombs roundstart was bad and raider bait
salv being able to buy 100 bombs after mining for an hour isnt good either (unlucky elijah, now its only 20)
they are useless for mining anyway its solely for being evil

## Technical details
:trollface:

## Media
:trollface:

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Increased seismic charge cost to 1250 mining points.