### PR TITLE
Add Anodynafil as a more effective anesthetic

### DIFF
--- a/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
+++ b/Content.Shared/Chemistry/Reaction/ChemicalReactionSystem.cs
@@ -165,6 +165,13 @@ namespace Content.Shared.Chemistry.Reaction
             var solution = comp.Solution;
 
             var energy = reaction.ConserveEnergy ? solution.GetThermalEnergy(_prototypeManager) : 0;
+            // DeltaV: allow reactions to preserve data
+            var datas = reaction.Reactants.SelectMany(reactant =>
+                solution.Contents
+                    .Where(reagent => reagent.Reagent.Prototype == reactant.Key)
+                    .Where(reagent => reagent.Reagent.Data is not null)
+                    .SelectMany(reagent => reagent.Reagent.Data!)).ToList();
+            // End DeltaV
 
             //Remove reactants
             foreach (var reactant in reaction.Reactants)
@@ -181,7 +188,7 @@ namespace Content.Shared.Chemistry.Reaction
             foreach (var product in reaction.Products)
             {
                 products.Add(product.Key);
-                solution.AddReagent(product.Key, product.Value * unitReactions);
+                solution.AddReagent(new ReagentId(product.Key, reaction.ConserveData ? datas : null), product.Value * unitReactions); // DeltaV: allow reactions to preserve data
             }
 
             if (reaction.ConserveEnergy)

--- a/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
+++ b/Content.Shared/Chemistry/Reaction/ReactionPrototype.cs
@@ -39,6 +39,13 @@ namespace Content.Shared.Chemistry.Reaction
         [DataField("conserveEnergy")]
         public bool ConserveEnergy = true;
 
+        // Delta-V: Reactions can preserve DNA
+        /// <summary>
+        ///     If true, this reaction will attempt to conserve data such as DNA.
+        /// </summary>
+        [DataField]
+        public bool ConserveData;
+
         /// <summary>
         ///     The maximum temperature the reaction can occur at.
         /// </summary>

--- a/Content.Shared/_DV/EntityEffects/EffectConditions/SameDNA.cs
+++ b/Content.Shared/_DV/EntityEffects/EffectConditions/SameDNA.cs
@@ -1,0 +1,35 @@
+using Content.Shared.Forensics.Components;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Chemistry;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+using System.Linq;
+
+namespace Content.Shared._DV.EntityEffects.EffectConditions;
+
+/// <summary>
+///     Condition that ensures the reagent being metabolised has the same DNA as the metaboliser
+/// </summary>
+public sealed partial class SameDNA : EntityEffectCondition
+{
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        if (!args.EntityManager.TryGetComponent<DnaComponent>(args.TargetEntity, out var dnaComponent))
+            return false;
+        if (args is not EntityEffectReagentArgs reagentArgs)
+            return false;
+
+        var expectedData = new DnaData { DNA = dnaComponent.DNA };
+
+        return
+            reagentArgs.Source is Solution solution &&
+                solution.Contents
+                    .Any(reagent => reagent.Reagent.Data is not null && reagent.Reagent.Data.Any(data => data == expectedData));
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        return Loc.GetString("reagent-effect-condition-guidebook-same-dna-condition");
+    }
+}

--- a/Resources/Locale/en-US/_DV/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/en-US/_DV/guidebook/chemistry/conditions.ftl
@@ -1,1 +1,3 @@
 reagent-explanation-netinadone-ribcage = the target's ribcage is open
+reagent-effect-condition-guidebook-same-dna-condition =
+    the target's body has the same DNA as the reagent

--- a/Resources/Locale/en-US/_DV/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_DV/reagents/meta/medicine.ftl
@@ -4,7 +4,31 @@ reagent-desc-hemoxadone = A cryogenics chemical. Used to treat severe blood loss
 reagent-name-cyanoxadone = cyanoxadone
 reagent-desc-cyanoxadone = A cryogenics chemical. Used to treat severe blood loss in blue-blooded creatures by regenerating hemocyanin and promoting reperfusion. Works regardless of the patient being alive or dead.
 
-reagent-desc-doxarubixadone-deltav = A cryogenics chemical. Heals certain types of cellular damage caused by dangerous gases and chemicals. Works regardless of the patient being alive or dead.
-
 reagent-name-netinadone = netinadone
 reagent-desc-netinadone = A cryogenic drug that slowly encourages rotting matter and brain tissue to regenerate.
+
+reagent-name-anodynafil = anodynafil
+reagent-desc-anodynafil = An effective short-lasting anesthetic that doesn't interfere with consciousness. It needs to be mixed with the patient's blood in order to work.
+
+reagent-name-anodynafil-blood = anodynafil (blood)
+reagent-desc-anodynafil-blood = Anodynafil mixed with blood to anesthetize a red-blooded individual.
+
+reagent-name-anodynafil-insect-blood = anodynafil (insect blood)
+reagent-desc-anodynafil-insect-blood = Anodynafil mixed with blood to anesthetize an insect-blooded individual.
+
+reagent-name-anodynafil-slime = anodynafil (slime)
+reagent-desc-anodynafil-slime = Anodynafil mixed with blood to anesthetize a slimy individual.
+
+reagent-name-anodynafil-sap = anodynafil (sap)
+reagent-desc-anodynafil-sap = Anodynafil mixed with blood to anesthetize a plant gestalt.
+
+reagent-name-anodynafil-copper-blood = anodynafil (copper blood)
+reagent-desc-anodynafil-copper-blood = Anodynafil mixed with blood to anesthetize a copper-blooded individual.
+
+reagent-name-anodynafil-ammonia-blood = anodynafil (ammonia blood)
+reagent-desc-anodynafil-ammonia-blood = Anodynafil mixed with blood to anesthetize an ammonia-blooded individual.
+
+reagent-name-anodynafil-ammonia-blood = anodynafil (synth blood)
+reagent-desc-anodynafil-ammonia-blood = Anodynafil mixed with blood to anesthetize a synthetic-blooded individual.
+
+reagent-desc-doxarubixadone-deltav = A cryogenics chemical. Heals certain types of cellular damage caused by dangerous gases and chemicals. Works regardless of the patient being alive or dead.

--- a/Resources/Prototypes/_DV/Reagents/anesthetics.yml
+++ b/Resources/Prototypes/_DV/Reagents/anesthetics.yml
@@ -1,0 +1,79 @@
+- type: reagent
+  id: Anodynafil
+  name: reagent-name-anodynafil
+  desc: reagent-desc-anodynafil
+  flavor: tingly
+  color: "#8FABA3"
+  physicalDesc: reagent-physical-desc-sticky
+  group: Medicine
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:GenericStatusEffect
+        conditions:
+        - !type:SameDNA
+        key: Anesthesia
+        component: Anesthesia
+        refresh: false
+        time: 4.0
+        type: Add
+      - !type:Emote
+        emote: Yawn
+        showInChat: true
+        probability: 0.1
+        conditions:
+        - !type:SameDNA
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.5
+        sprintSpeedModifier: 0.5
+        conditions:
+        - !type:SameDNA
+
+- type: reagent
+  id: AnodynafilBlood
+  parent: Anodynafil
+  name: reagent-name-anodynafil-blood
+  desc: reagent-desc-anodynafil-blood
+  color: "#b9b6ce"
+
+- type: reagent
+  id: AnodynafilInsectBlood
+  parent: Anodynafil
+  name: reagent-name-anodynafil-insect-blood
+  desc: reagent-desc-anodynafil-insect-blood
+  color: "#88c5b0"
+
+- type: reagent
+  id: AnodynafilSlime
+  parent: Anodynafil
+  name: reagent-name-anodynafil-slime
+  desc: reagent-desc-anodynafil-slime
+  color: "#5ecd94"
+
+- type: reagent
+  id: AnodynafilSap
+  parent: Anodynafil
+  name: reagent-name-anodynafil-sap
+  desc: reagent-desc-anodynafil-sap
+  color: "#c9b5a1"
+
+- type: reagent
+  id: AnodynafilCopperBlood
+  parent: Anodynafil
+  name: reagent-name-anodynafil-copper-blood
+  desc: reagent-desc-anodynafil-copper-blood
+  color: "#7cbdff"
+
+- type: reagent
+  id: AnodynafilAmmoniaBlood
+  parent: Anodynafil
+  name: reagent-name-anodynafil-ammonia-blood
+  desc: reagent-desc-anodynafil-ammonia-blood
+  color: "#a9b7e4"
+
+- type: reagent
+  id: AnodynafilSynthBlood
+  parent: Anodynafil
+  name: reagent-name-anodynafil-synth-blood
+  desc: reagent-desc-anodynafil-synth-blood
+  color: "#4ab5af"

--- a/Resources/Prototypes/_DV/Recipes/Reactions/anesthetics.yml
+++ b/Resources/Prototypes/_DV/Recipes/Reactions/anesthetics.yml
@@ -1,0 +1,82 @@
+- type: reaction
+  id: Anodynafil
+  minTemp: 400
+  reactants:
+    ChloralHydrate:
+      amount: 1
+    SulfuricAcid:
+      amount: 1
+    SodiumCarbonate:
+      amount: 1
+    Iodine:
+      amount: 1
+  products:
+    Anodynafil: 3
+    Oxygen: 1
+    Water: 1
+
+- type: reaction
+  id: AnodynafilBlood
+  conserveData: true
+  reactants:
+    Anodynafil:
+      amount: 1
+    Blood:
+      amount: 1
+  products:
+    AnodynafilBlood: 1
+
+- type: reaction
+  id: AnodynafilInsectBlood
+  conserveData: true
+  reactants:
+    Anodynafil:
+      amount: 1
+    InsectBlood:
+      amount: 1
+  products:
+    AnodynafilInsectBlood: 1
+
+- type: reaction
+  id: AnodynafilSlime
+  conserveData: true
+  reactants:
+    Anodynafil:
+      amount: 1
+    Slime:
+      amount: 1
+  products:
+    AnodynafilSlime: 1
+
+- type: reaction
+  id: AnodynafilSap
+  conserveData: true
+  reactants:
+    Anodynafil:
+      amount: 1
+    Sap:
+      amount: 1
+  products:
+    AnodynafilSap: 1
+
+- type: reaction
+  id: AnodynafilCopperBlood
+  conserveData: true
+  reactants:
+    Anodynafil:
+      amount: 1
+    CopperBlood:
+      amount: 1
+  products:
+    AnodynafilCopperBlood: 1
+
+- type: reaction
+  id: AnodynafilAmmoniaBlood
+  conserveData: true
+  reactants:
+    Anodynafil:
+      amount: 1
+    AmmoniaBlood:
+      amount: 1
+  products:
+    AnodynafilAmmoniaBlood: 1


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR adds Anodynafil, an effective short-term anesthetic that requires mixing with a sample of the patient's blood in order to become effective.
<!-- What did you change? -->

## Why / Balance
As it is, legitimate surgeons only have access to NO2 or chloral hydrate. NO2 doesn't cover everybody and causes unconsciousness, and chloral hydrate is long-lasting and causes drowsiness. This adds a somewhat complicated but pretty potent anesthetic option that gives chemists and surgeons a nice "mid-late-game" option to stock surgery, or something nice to splurge on people that would be bad to have unconscious (like the Captain).
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
- add ability for reactions to conserve data
- add new condition that compares reagent DNA to target DNA
- add reagents and reactions for anodynafil

## Media
![grafik](https://github.com/user-attachments/assets/c890ef19-4cff-437a-8978-80b8c19564bf)

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added Anodynafil, a specialised anesthetic that leaves the patient conscious but requires a sample of the patient's blood to work
