### PR TITLE
remove crew monitor objective

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -13,7 +13,7 @@
   weights:
     CaptainIDStealObjective: 1
     CMOHyposprayStealObjective: 1
-    CMOCrewMonitorStealObjective: 1
+    #CMOCrewMonitorStealObjective: 1 # DeltaV - You can buy this + paramedics all have them
     RDHardsuitStealObjective: 1
     MagbootsStealObjective: 1
     # CorgiMeatStealObjective: 1 # DeltaV - Disable the horrible murder of Ian as an objective


### PR DESCRIPTION
## About the PR
traitors no longer get funny crew monitor "objective"

## Why / Balance
you can literally fucking buy it
![11:14:36](https://github.com/user-attachments/assets/0a25f3bc-edae-4b9e-890e-95c605a9a81e)

and all parameds spawn with them, so its not stealing from the cmo anyway
you can also RE it to mass produce it

the alternative is:
- removing them from parameds
- removing REing it
- removing it from the observation kit (making it entirely useless)

## Technical details
removed from the steal objective weights

## Media
:trollface:

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- remove: Removed the crew monitor steal objective as there were too many loopholes.
