### PR TITLE
fix spy monitor not fitting in storage implant

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -59,6 +59,8 @@
     useRate: 10
   - type: StaticPrice
     price: 750
+  - type: Tag # DeltaV - Let it be put in storage implants by removing HighRiskItem
+    tags: []
 
 - type: entity
   id: SpyCrewMonitorEmpty


### PR DESCRIPTION
## About the PR
title

## Why / Balance
something you buy != steal objective getting sent to the shadow realm

## Technical details
removed HighRiskItem tag from spy monitor

## Media
![11:24:58](https://github.com/user-attachments/assets/25a1ce5c-c1c4-40c6-8e79-a4a5f4953a26)


## Requirements
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed not being able to put spy monitors in your storage implant.
