### PR TITLE
bring back ai overlay for diagnostic hud

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -131,6 +131,10 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
     private void OnAiAccessible(Entity<StationAiOverlayComponent> ent, ref AccessibleOverrideEvent args)
     {
+        // Begin DeltaV Additions
+        if (ent.Comp.Cosmetic)
+            return;
+        // End DeltaV Additions
         args.Handled = true;
 
         // Hopefully AI never needs storage
@@ -149,6 +153,10 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
     private void OnAiMenu(Entity<StationAiOverlayComponent> ent, ref MenuVisibilityEvent args)
     {
+        // Begin DeltaV Additions
+        if (ent.Comp.Cosmetic)
+            return;
+        // End DeltaV Additions
         args.Visibility &= ~MenuVisibility.NoFov;
     }
 
@@ -186,6 +194,10 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
     private void OnAiInRange(Entity<StationAiOverlayComponent> ent, ref InRangeOverrideEvent args)
     {
+        // Begin DeltaV Additions
+        if (ent.Comp.Cosmetic)
+            return;
+        // End DeltaV Additions
         args.Handled = true;
         var targetXform = Transform(args.Target);
 

--- a/Content.Shared/Silicons/StationAi/StationAiOverlayComponent.cs
+++ b/Content.Shared/Silicons/StationAi/StationAiOverlayComponent.cs
@@ -6,4 +6,13 @@ namespace Content.Shared.Silicons.StationAi;
 /// Handles the static overlay for station AI.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class StationAiOverlayComponent : Component;
+[AutoGenerateComponentState] // DeltaV
+public sealed partial class StationAiOverlayComponent : Component
+{
+    /// <summary>
+    /// DeltaV: Makes this purely an overlay and not functional.
+    /// Exists because this component also controls interaction ranges for some reason.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Cosmetic;
+}

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -16,15 +16,27 @@
   - type: ShowHealthIcons
 
 - type: entity
-  parent: ClothingEyesBase
+  parent: [ ClothingEyesBase, BaseToggleClothing ] # DeltaV - Added BaseToggleClothing
   id: ClothingEyesHudDiagnostic
   name: diagnostic hud
-  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium.
+  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium. Has a camera mod to work with Station AI. # DeltaV - Add last sentence
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/diag.rsi
   - type: Clothing
     sprite: Clothing/Eyes/Hud/diag.rsi
+  # Begin DeltaV Additions
+  - type: ToggleClothing
+    action: ActionToggleHudDiagnosticCamera
+    disableOnUnequip: true
+  - type: ItemToggle
+    onActivate: false # remove verb so you can't press E on it to add StationAiOverlay to a grid or something
+  - type: ComponentToggler
+    parent: true
+    components:
+    - type: StationAiOverlay
+      cosmetic: true # don't give roboticists reach hacks
+  # End DeltaV Additions
   - type: ShowHealthBars
     damageContainers:
     - Inorganic

--- a/Resources/Prototypes/_DV/Actions/clothing.yml
+++ b/Resources/Prototypes/_DV/Actions/clothing.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: ActionToggleHudDiagnosticCamera
+  name: Toggle camera mod
+  description: Toggles the AI vision camera mod on and off.
+  components:
+  - type: InstantAction
+    event: !type:ToggleActionEvent


### PR DESCRIPTION
## About the PR
soft revert of #2627
ai overlay from the hud no longer gives you reach hacks

## Why / Balance
we have the technology

## Technical details
added Cosmetic field to StationAiOverlay

## Media
no infinite interaction range...
![01:12:37](https://github.com/user-attachments/assets/78316c84-eb7d-40f9-ba7e-ec58392fbc78)

cant use verbs outside of regular interaction range
![01:12:46](https://github.com/user-attachments/assets/08fc5d43-f741-435b-b7da-6214ba489a52)

can still use verbs inside interaction range
![01:12:51](https://github.com/user-attachments/assets/0602edd5-904b-4556-9589-665d0f4aa5af)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: Added back the station AI overlay to the diagnostic HUD as it no longer gives you infinite reach.