### PR TITLE
added soap to surgeon's lockers so they don't have to tide

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
@@ -101,6 +101,7 @@
     - id: ClothingBackpackDuffelSurgeryFilled
     - id: ClothingOuterVestTank
     - id: NitrousOxideTankFilled
+    - id: SoapNT
     - id: LunchboxMedicalFilledRandom
       prob: 0.3
     - id: BoxSyringe


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
With the new sanitization changes, it's become mandatory to clean your surgeon's tools with soap. This requires one to go out and hunt for soap, usually scouring maints or asking a janitor if you happen to find them. Since soap is basically required by the job, it makes sense to add it to the locker.

## Why / Balance
If you get two patients and don't have soap, you're basically screwed and have to go and hunt some down.

## Technical details
Added NT-branded soap to surgeon's locker (since that's their employer)

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or **it does not require an ingame showcase.**
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: Added NT-branded soap to surgeon lockers.