### PR TITLE
Map Edits: Arena/Tortuga

### DIFF
--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -142,7 +142,7 @@ entities:
           version: 6
         3,1:
           ind: 3,1
-          tiles: XgAAAAAAfwAAAAAAXgAAAAAAXgAAAAADXgAAAAACXgAAAAADXgAAAAAAXgAAAAABXgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAACJQAAAAACXgAAAAADfwAAAAAAXgAAAAABXgAAAAADXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAADfwAAAAAAJQAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAACJQAAAAAAXgAAAAABfwAAAAAAXgAAAAAAXgAAAAADXgAAAAADXgAAAAAAXgAAAAABXgAAAAABfwAAAAAAJQAAAAAAfwAAAAAAJQAAAAADJQAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAABfwAAAAAAJQAAAAADJQAAAAADfwAAAAAAJQAAAAABJQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAJQAAAAACJQAAAAADfwAAAAAAJQAAAAAAJQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAQwAAAAAAfwAAAAAAJQAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAABJQAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAaQAAAAABfwAAAAAAfwAAAAAAJQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAAAJQAAAAADfwAAAAAAaQAAAAADaQAAAAADaQAAAAABaQAAAAACaQAAAAADaQAAAAAAaQAAAAABfwAAAAAAJQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAADfwAAAAAAaQAAAAABaQAAAAADaQAAAAADaQAAAAAAaQAAAAACaQAAAAADaQAAAAADfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAJQAAAAABfwAAAAAAfwAAAAAAaQAAAAABaQAAAAABaQAAAAAAaQAAAAADaQAAAAACaQAAAAADfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAaQAAAAAAaQAAAAAAaQAAAAABaQAAAAAAaQAAAAABaQAAAAABaQAAAAABbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAaQAAAAAAaQAAAAABaQAAAAABaQAAAAABaQAAAAADaQAAAAABaQAAAAABfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAaQAAAAABaQAAAAADaQAAAAADaQAAAAADaQAAAAACaQAAAAABfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAA
+          tiles: XgAAAAAAfwAAAAAAXgAAAAAAXgAAAAADXgAAAAACXgAAAAADXgAAAAAAXgAAAAABXgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAACJQAAAAACXgAAAAADfwAAAAAAXgAAAAABXgAAAAADXgAAAAAAXgAAAAAAXgAAAAAAXgAAAAADfwAAAAAAJQAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAACJQAAAAAAXgAAAAABfwAAAAAAXgAAAAAAXgAAAAADXgAAAAADXgAAAAAAXgAAAAABXgAAAAABfwAAAAAAJQAAAAAAfwAAAAAAJQAAAAADJQAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAABfwAAAAAAJQAAAAADJQAAAAADfwAAAAAAJQAAAAABJQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAJQAAAAACJQAAAAADfwAAAAAAJQAAAAAAJQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAQwAAAAAAfwAAAAAAJQAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAABJQAAAAADfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAaQAAAAABfwAAAAAAfwAAAAAAJQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAAAJQAAAAADfwAAAAAAaQAAAAADaQAAAAADaQAAAAABaQAAAAACaQAAAAADaQAAAAAAaQAAAAABfwAAAAAAJQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAJQAAAAADfwAAAAAAaQAAAAABaQAAAAADaQAAAAADaQAAAAAAaQAAAAACaQAAAAADaQAAAAADfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAJQAAAAABfwAAAAAAfwAAAAAAaQAAAAABaQAAAAABaQAAAAAAaQAAAAADaQAAAAACaQAAAAADfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAaQAAAAAAaQAAAAAAaQAAAAABaQAAAAAAaQAAAAABaQAAAAABaQAAAAABbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAaQAAAAAAaQAAAAABaQAAAAABaQAAAAABaQAAAAADaQAAAAABaQAAAAABfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAaQAAAAABaQAAAAADaQAAAAADaQAAAAADaQAAAAACaQAAAAABfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAA
           version: 6
         3,0:
           ind: 3,0
@@ -354,7 +354,7 @@ entities:
           version: 6
         3,2:
           ind: 3,2
-          tiles: fwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: fwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAbQAAAAAAUAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         3,3:
           ind: 3,3
@@ -462,11 +462,11 @@ entities:
           version: 6
         4,1:
           ind: 4,1
-          tiles: QwAAAAAAQwAAAAAAQwAAAAAAQwAAAAAAQwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAACIAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAABIAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: QwAAAAAAQwAAAAAAQwAAAAAAQwAAAAAAQwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAACIAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAACfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAIAAAAAABIAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         4,2:
           ind: 4,2
-          tiles: fwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          tiles: bQAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAbQAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAfwAAAAAAUAAAAAAAUAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfgAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfwAAAAAAfwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
           version: 6
         2,4:
           ind: 2,4
@@ -11980,6 +11980,15 @@ entities:
       - 3737
       - 29764
       - 29763
+  - uid: 13375
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 65.5,31.5
+      parent: 6747
+    - type: DeviceList
+      devices:
+      - 13296
   - uid: 13485
     components:
     - type: Transform
@@ -13155,15 +13164,6 @@ entities:
       - 25258
       - 13955
       - 1148
-  - uid: 26597
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 64.5,31.5
-      parent: 6747
-    - type: DeviceList
-      devices:
-      - 27051
   - uid: 26945
     components:
     - type: Transform
@@ -13891,6 +13891,32 @@ entities:
     - type: Transform
       pos: 47.5,14.5
       parent: 6747
+  - uid: 7258
+    components:
+    - type: Transform
+      pos: 65.5,25.5
+      parent: 6747
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        13401:
+        - DoorStatus: DoorBolt
+        29400:
+        - DoorStatus: DoorBolt
+  - uid: 7260
+    components:
+    - type: Transform
+      pos: 65.5,26.5
+      parent: 6747
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        13401:
+        - DoorStatus: DoorBolt
+        29400:
+        - DoorStatus: DoorBolt
   - uid: 13267
     components:
     - type: Transform
@@ -13901,32 +13927,6 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         13301:
-        - DoorStatus: DoorBolt
-  - uid: 13415
-    components:
-    - type: Transform
-      pos: 64.5,26.5
-      parent: 6747
-    - type: DeviceLinkSink
-      invokeCounter: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        13411:
-        - DoorStatus: DoorBolt
-        13412:
-        - DoorStatus: DoorBolt
-  - uid: 13416
-    components:
-    - type: Transform
-      pos: 64.5,25.5
-      parent: 6747
-    - type: DeviceLinkSink
-      invokeCounter: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        13411:
-        - DoorStatus: DoorBolt
-        13412:
         - DoorStatus: DoorBolt
   - uid: 16822
     components:
@@ -14287,31 +14287,18 @@ entities:
       linkedPorts:
         13267:
         - DoorStatus: DoorBolt
-  - uid: 13411
+  - uid: 13401
     components:
     - type: Transform
-      pos: 69.5,26.5
+      pos: 70.5,26.5
       parent: 6747
     - type: DeviceLinkSink
       invokeCounter: 2
     - type: DeviceLinkSource
       linkedPorts:
-        13415:
+        7260:
         - DoorStatus: DoorBolt
-        13416:
-        - DoorStatus: DoorBolt
-  - uid: 13412
-    components:
-    - type: Transform
-      pos: 69.5,25.5
-      parent: 6747
-    - type: DeviceLinkSink
-      invokeCounter: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        13415:
-        - DoorStatus: DoorBolt
-        13416:
+        7258:
         - DoorStatus: DoorBolt
   - uid: 23995
     components:
@@ -14323,6 +14310,19 @@ entities:
     - type: DeviceLinkSource
       linkedPorts:
         23989:
+        - DoorStatus: DoorBolt
+  - uid: 29400
+    components:
+    - type: Transform
+      pos: 70.5,25.5
+      parent: 6747
+    - type: DeviceLinkSink
+      invokeCounter: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        7258:
+        - DoorStatus: DoorBolt
+        7260:
         - DoorStatus: DoorBolt
 - proto: AirlockExternalGlassLocked
   entities:
@@ -16303,6 +16303,14 @@ entities:
       deviceLists:
       - 22089
       - 22090
+  - uid: 13296
+    components:
+    - type: Transform
+      pos: 69.5,28.5
+      parent: 6747
+    - type: DeviceNetwork
+      deviceLists:
+      - 13375
   - uid: 17073
     components:
     - type: Transform
@@ -16942,12 +16950,6 @@ entities:
       deviceLists:
       - 13176
       - 304
-  - uid: 27051
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,32.5
-      parent: 6747
   - uid: 29423
     components:
     - type: Transform
@@ -20620,21 +20622,25 @@ entities:
     - type: Transform
       pos: 71.5,23.5
       parent: 6747
-  - uid: 13403
-    components:
-    - type: Transform
-      pos: 66.5,36.5
-      parent: 6747
   - uid: 13404
     components:
     - type: Transform
       pos: 67.5,36.5
       parent: 6747
+    - type: DeviceLinkSink
+      invokeCounter: 1
   - uid: 22929
     components:
     - type: Transform
       pos: -0.5,-71.5
       parent: 6747
+  - uid: 27049
+    components:
+    - type: Transform
+      pos: 68.5,36.5
+      parent: 6747
+    - type: DeviceLinkSink
+      invokeCounter: 1
   - uid: 29737
     components:
     - type: Transform
@@ -21457,6 +21463,17 @@ entities:
       parent: 6747
 - proto: ButtonFrameCaution
   entities:
+  - uid: 7544
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 65.5,32.5
+      parent: 6747
+  - uid: 7547
+    components:
+    - type: Transform
+      pos: 66.5,27.5
+      parent: 6747
   - uid: 27589
     components:
     - type: Transform
@@ -21473,17 +21490,6 @@ entities:
     components:
     - type: Transform
       pos: 70.5,23.5
-      parent: 6747
-  - uid: 27595
-    components:
-    - type: Transform
-      pos: 65.5,27.5
-      parent: 6747
-  - uid: 27596
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 64.5,32.5
       parent: 6747
 - proto: ButtonFrameCautionSecurity
   entities:
@@ -21986,6 +21992,21 @@ entities:
     - type: Transform
       pos: 26.5,-68.5
       parent: 6747
+  - uid: 7541
+    components:
+    - type: Transform
+      pos: 59.5,32.5
+      parent: 6747
+  - uid: 7542
+    components:
+    - type: Transform
+      pos: 59.5,33.5
+      parent: 6747
+  - uid: 7543
+    components:
+    - type: Transform
+      pos: 58.5,33.5
+      parent: 6747
   - uid: 8323
     components:
     - type: Transform
@@ -22176,6 +22197,11 @@ entities:
     - type: Transform
       pos: 47.5,50.5
       parent: 6747
+  - uid: 13294
+    components:
+    - type: Transform
+      pos: 59.5,31.5
+      parent: 6747
   - uid: 13363
     components:
     - type: Transform
@@ -22190,6 +22216,11 @@ entities:
     components:
     - type: Transform
       pos: 47.5,53.5
+      parent: 6747
+  - uid: 13411
+    components:
+    - type: Transform
+      pos: 59.5,30.5
       parent: 6747
   - uid: 14193
     components:
@@ -35791,21 +35822,6 @@ entities:
     - type: Transform
       pos: 57.5,33.5
       parent: 6747
-  - uid: 26537
-    components:
-    - type: Transform
-      pos: 57.5,32.5
-      parent: 6747
-  - uid: 26538
-    components:
-    - type: Transform
-      pos: 57.5,31.5
-      parent: 6747
-  - uid: 26539
-    components:
-    - type: Transform
-      pos: 57.5,30.5
-      parent: 6747
   - uid: 26540
     components:
     - type: Transform
@@ -38055,6 +38071,16 @@ entities:
     components:
     - type: Transform
       pos: 12.5,-30.5
+      parent: 6747
+  - uid: 29794
+    components:
+    - type: Transform
+      pos: 59.5,29.5
+      parent: 6747
+  - uid: 29795
+    components:
+    - type: Transform
+      pos: 58.5,29.5
       parent: 6747
 - proto: CableApcStack
   entities:
@@ -59504,6 +59530,11 @@ entities:
     - type: Transform
       pos: 20.5,-52.5
       parent: 6747
+  - uid: 29785
+    components:
+    - type: Transform
+      pos: 55.5,17.5
+      parent: 6747
 - proto: Claymore
   entities:
   - uid: 2957
@@ -77295,11 +77326,6 @@ entities:
     - type: Transform
       pos: 49.5,14.5
       parent: 6747
-  - uid: 7851
-    components:
-    - type: Transform
-      pos: 64.5,27.5
-      parent: 6747
   - uid: 8317
     components:
     - type: Transform
@@ -77309,6 +77335,11 @@ entities:
     components:
     - type: Transform
       pos: 14.5,36.5
+      parent: 6747
+  - uid: 27999
+    components:
+    - type: Transform
+      pos: 65.5,27.5
       parent: 6747
 - proto: FancyTableSpawner
   entities:
@@ -79413,6 +79444,12 @@ entities:
       - 29427
 - proto: FirelockEdge
   entities:
+  - uid: 2161
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 64.5,26.5
+      parent: 6747
   - uid: 3031
     components:
     - type: Transform
@@ -79422,6 +79459,12 @@ entities:
     components:
     - type: Transform
       pos: -3.5,-88.5
+      parent: 6747
+  - uid: 6593
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 64.5,25.5
       parent: 6747
   - uid: 8054
     components:
@@ -79467,18 +79510,6 @@ entities:
     components:
     - type: Transform
       pos: 0.5,-87.5
-      parent: 6747
-  - uid: 19087
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 63.5,25.5
-      parent: 6747
-  - uid: 19088
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 63.5,26.5
       parent: 6747
   - uid: 19089
     components:
@@ -82340,6 +82371,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-85.5
       parent: 6747
+  - uid: 13290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 64.5,28.5
+      parent: 6747
 - proto: GasOutletInjector
   entities:
   - uid: 250
@@ -82419,11 +82456,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 1.5,-90.5
       parent: 6747
-  - uid: 13284
+  - uid: 13412
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 65.5,28.5
+      pos: 66.5,35.5
       parent: 6747
   - uid: 15078
     components:
@@ -82474,6 +82511,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -25.5,-73.5
       parent: 6747
+  - uid: 29793
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 66.5,28.5
+      parent: 6747
 - proto: GasPassiveGate
   entities:
   - uid: 7933
@@ -82506,8 +82549,8 @@ entities:
     - type: Transform
       pos: 55.5,48.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
+    missingComponents:
+    - AtmosPipeColor
   - uid: 7945
     components:
     - type: Transform
@@ -82720,22 +82763,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 7547
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 54.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 7548
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 51.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 7860
     components:
     - type: Transform
@@ -82838,22 +82865,27 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#CC6600FF'
-  - uid: 8132
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 55.5,43.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8133
+  - uid: 8131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 54.5,43.5
       parent: 6747
+  - uid: 8134
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,29.5
+      parent: 6747
     - type: AtmosPipeColor
-      color: '#CC6600FF'
+      color: '#FF5500FF'
+  - uid: 8135
+    components:
+    - type: Transform
+      pos: 69.5,34.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 8148
     components:
     - type: Transform
@@ -82878,13 +82910,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 8802
-    components:
-    - type: Transform
-      pos: 55.5,35.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 8816
     components:
     - type: Transform
@@ -82968,14 +82993,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 11943
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 55.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 12866
     components:
     - type: Transform
@@ -82984,60 +83001,17 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF5500FF'
-  - uid: 13051
+  - uid: 13040
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 68.5,29.5
+      pos: 55.5,43.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13052
-    components:
-    - type: Transform
-      pos: 68.5,30.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13053
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 65.5,30.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13054
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 65.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13055
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,31.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13056
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
   - uid: 13057
     components:
     - type: Transform
-      pos: 68.5,34.5
+      pos: 57.5,32.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
   - uid: 13058
     components:
     - type: Transform
@@ -83077,29 +83051,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 13085
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 65.5,31.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13086
-    components:
-    - type: Transform
-      pos: 68.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13087
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 65.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
   - uid: 13098
     components:
     - type: Transform
@@ -83123,13 +83074,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 13146
-    components:
-    - type: Transform
-      pos: 57.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 13188
     components:
     - type: Transform
@@ -83177,6 +83121,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 13289
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 53.5,35.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#CC6600FF'
   - uid: 13297
     components:
     - type: Transform
@@ -83289,6 +83241,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 13386
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 66.5,30.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 13489
     components:
     - type: Transform
@@ -85203,13 +85163,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 7928
-    components:
-    - type: Transform
-      pos: 51.5,35.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 10078
     components:
     - type: Transform
@@ -85231,6 +85184,13 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#66FF66FF'
+  - uid: 13092
+    components:
+    - type: Transform
+      pos: 51.5,35.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#CC6600FF'
   - uid: 13245
     components:
     - type: Transform
@@ -85959,42 +85919,13 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 7485
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 64.5,28.5
-      parent: 6747
-  - uid: 7541
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 52.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 7543
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 53.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 7544
-    components:
-    - type: Transform
-      pos: 55.5,46.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 7545
     components:
     - type: Transform
       pos: 55.5,47.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
+    missingComponents:
+    - AtmosPipeColor
   - uid: 7681
     components:
     - type: Transform
@@ -86698,11 +86629,8 @@ entities:
   - uid: 8061
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 52.5,35.5
+      pos: 54.5,42.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 8075
     components:
     - type: Transform
@@ -86782,62 +86710,18 @@ entities:
     - type: Transform
       pos: 54.5,46.5
       parent: 6747
-  - uid: 8131
+  - uid: 8132
     components:
     - type: Transform
-      pos: 55.5,44.5
+      rot: -1.5707963267948966 rad
+      pos: 56.5,32.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8134
+  - uid: 8133
     components:
     - type: Transform
-      pos: 54.5,42.5
+      rot: -1.5707963267948966 rad
+      pos: 55.5,32.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8135
-    components:
-    - type: Transform
-      pos: 54.5,41.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8136
-    components:
-    - type: Transform
-      pos: 54.5,40.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8137
-    components:
-    - type: Transform
-      pos: 54.5,39.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8138
-    components:
-    - type: Transform
-      pos: 54.5,38.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8139
-    components:
-    - type: Transform
-      pos: 54.5,37.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8140
-    components:
-    - type: Transform
-      pos: 54.5,36.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 8726
     components:
     - type: Transform
@@ -86846,14 +86730,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 8803
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 54.5,35.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 9338
     components:
     - type: Transform
@@ -87141,13 +87017,11 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 12998
+  - uid: 13004
     components:
     - type: Transform
-      pos: 57.5,32.5
+      pos: 54.5,41.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 13005
     components:
     - type: Transform
@@ -87395,6 +87269,42 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 13041
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 55.5,44.5
+      parent: 6747
+  - uid: 13051
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 54.5,37.5
+      parent: 6747
+  - uid: 13052
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 54.5,40.5
+      parent: 6747
+  - uid: 13053
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 54.5,39.5
+      parent: 6747
+  - uid: 13054
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 54.5,38.5
+      parent: 6747
+  - uid: 13055
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 54.5,36.5
+      parent: 6747
   - uid: 13067
     components:
     - type: Transform
@@ -87505,14 +87415,11 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 13092
+  - uid: 13091
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 67.5,33.5
+      pos: 57.5,31.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
   - uid: 13093
     components:
     - type: Transform
@@ -87553,46 +87460,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 13101
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 66.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13102
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 66.5,31.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13103
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 67.5,30.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13104
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 67.5,34.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13106
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 66.5,34.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
   - uid: 13108
     components:
     - type: Transform
@@ -87766,13 +87633,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 13143
-    components:
-    - type: Transform
-      pos: 57.5,31.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 13147
     components:
     - type: Transform
@@ -87787,14 +87647,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 13149
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 56.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 13155
     components:
     - type: Transform
@@ -88331,10 +88183,34 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 13282
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 54.5,35.5
+      parent: 6747
+  - uid: 13285
+    components:
+    - type: Transform
+      pos: 55.5,45.5
+      parent: 6747
+  - uid: 13287
+    components:
+    - type: Transform
+      pos: 53.5,37.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#CC6600FF'
   - uid: 13291
     components:
     - type: Transform
       pos: 57.5,40.5
+      parent: 6747
+  - uid: 13292
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 64.5,29.5
       parent: 6747
   - uid: 13316
     components:
@@ -88581,6 +88457,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 13383
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 67.5,34.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 13389
     components:
     - type: Transform
@@ -88656,6 +88540,20 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
+  - uid: 13413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 65.5,28.5
+      parent: 6747
+  - uid: 13429
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 68.5,29.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 13488
     components:
     - type: Transform
@@ -111149,6 +111047,12 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 29792
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 65.5,35.5
+      parent: 6747
 - proto: GasPipeTJunction
   entities:
   - uid: 293
@@ -111166,6 +111070,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 963
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 66.5,33.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 1597
     components:
     - type: Transform
@@ -111290,22 +111202,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF1212FF'
-  - uid: 7264
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 51.5,34.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 7265
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 51.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 7754
     components:
     - type: Transform
@@ -111407,14 +111303,6 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#66FF66FF'
-  - uid: 8056
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 53.5,35.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 8118
     components:
     - type: Transform
@@ -111423,22 +111311,38 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#CC6600FF'
+  - uid: 8140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,31.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 8142
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,33.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
+    missingComponents:
+    - AtmosPipeColor
   - uid: 8143
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 54.5,34.5
       parent: 6747
+    missingComponents:
+    - AtmosPipeColor
+  - uid: 8144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,33.5
+      parent: 6747
     - type: AtmosPipeColor
-      color: '#CC6600FF'
+      color: '#FF5500FF'
   - uid: 8150
     components:
     - type: Transform
@@ -111447,6 +111351,12 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#CC6600FF'
+  - uid: 8210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 54.5,32.5
+      parent: 6747
   - uid: 8428
     components:
     - type: Transform
@@ -111638,6 +111548,21 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 58.5,29.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
+  - uid: 13086
+    components:
+    - type: Transform
+      pos: 66.5,34.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
+  - uid: 13089
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,30.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF5500FF'
@@ -111834,6 +111759,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 13385
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,32.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 13453
     components:
     - type: Transform
@@ -113276,6 +113209,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#66FF66FF'
+  - uid: 22428
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 66.5,31.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 22743
     components:
     - type: Transform
@@ -114455,6 +114396,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
+  - uid: 27596
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 66.5,32.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 28449
     components:
     - type: Transform
@@ -114550,22 +114499,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 10.5,-25.5
       parent: 6747
-  - uid: 7258
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 52.5,34.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 7260
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 52.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 7753
     components:
     - type: Transform
@@ -114642,27 +114575,24 @@ entities:
       rot: 3.141592653589793 rad
       pos: 54.5,44.5
       parent: 6747
-  - uid: 8144
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 53.5,33.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
-  - uid: 8145
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 53.5,34.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 8190
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 60.5,27.5
+      parent: 6747
+  - uid: 8802
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 51.5,33.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#CC6600FF'
+  - uid: 8803
+    components:
+    - type: Transform
+      pos: 64.5,31.5
       parent: 6747
   - uid: 11226
     components:
@@ -114718,22 +114648,46 @@ entities:
     - type: Transform
       pos: -8.5,-84.5
       parent: 6747
+  - uid: 13101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 52.5,32.5
+      parent: 6747
+  - uid: 13102
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 52.5,34.5
+      parent: 6747
+  - uid: 13106
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 52.5,33.5
+      parent: 6747
   - uid: 13145
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 61.5,27.5
       parent: 6747
-  - uid: 13151
+  - uid: 13149
     components:
     - type: Transform
       pos: 62.5,30.5
       parent: 6747
-  - uid: 13282
+  - uid: 13283
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 62.5,28.5
+      parent: 6747
+  - uid: 13416
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 63.5,35.5
       parent: 6747
   - uid: 14914
     components:
@@ -114868,6 +114822,12 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#CC6600FF'
+  - uid: 8056
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 53.5,32.5
+      parent: 6747
   - uid: 8121
     components:
     - type: Transform
@@ -114882,13 +114842,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: 54.5,45.5
       parent: 6747
-  - uid: 8141
-    components:
-    - type: Transform
-      pos: 54.5,35.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 11245
     components:
     - type: Transform
@@ -114928,19 +114881,48 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#0335FCFF'
-  - uid: 13283
+  - uid: 11944
+    components:
+    - type: Transform
+      pos: 55.5,46.5
+      parent: 6747
+  - uid: 13104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 51.5,34.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#CC6600FF'
+  - uid: 13143
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 53.5,33.5
+      parent: 6747
+  - uid: 13146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 53.5,34.5
+      parent: 6747
+  - uid: 13151
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 64.5,35.5
+      parent: 6747
+  - uid: 13295
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 63.5,28.5
       parent: 6747
-  - uid: 13429
+  - uid: 13415
     components:
     - type: Transform
-      pos: 57.5,30.5
+      pos: 64.5,30.5
       parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
   - uid: 13430
     components:
     - type: Transform
@@ -115136,15 +115118,6 @@ entities:
       color: '#0335FCFF'
 - proto: GasValve
   entities:
-  - uid: 7542
-    components:
-    - type: Transform
-      pos: 55.5,45.5
-      parent: 6747
-    - type: GasValve
-      open: False
-    - type: AtmosPipeColor
-      color: '#CC6600FF'
   - uid: 7862
     components:
     - type: Transform
@@ -115177,25 +115150,35 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#CC6600FF'
-  - uid: 8210
+  - uid: 12998
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 53.5,37.5
+      rot: 1.5707963267948966 rad
+      pos: 52.5,35.5
       parent: 6747
     - type: GasValve
       open: False
     - type: AtmosPipeColor
       color: '#CC6600FF'
-  - uid: 11944
+  - uid: 13087
     components:
     - type: Transform
-      pos: 55.5,34.5
+      rot: -1.5707963267948966 rad
+      pos: 68.5,34.5
       parent: 6747
     - type: GasValve
       open: False
     - type: AtmosPipeColor
-      color: '#CC6600FF'
+      color: '#FF5500FF'
+  - uid: 13284
+    components:
+    - type: Transform
+      pos: 57.5,30.5
+      parent: 6747
+    - type: GasValve
+      open: False
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 13340
     components:
     - type: Transform
@@ -119398,6 +119381,14 @@ entities:
       color: '#FF1212FF'
 - proto: GasVolumePump
   entities:
+  - uid: 7264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 68.5,32.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 7633
     components:
     - type: Transform
@@ -119413,6 +119404,22 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 8139
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 68.5,31.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
+  - uid: 13090
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 68.5,30.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 13116
     components:
     - type: Transform
@@ -119426,6 +119433,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 62.5,31.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
+  - uid: 13384
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 68.5,33.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF5500FF'
@@ -119913,11 +119928,6 @@ entities:
     components:
     - type: Transform
       pos: 49.5,7.5
-      parent: 6747
-  - uid: 963
-    components:
-    - type: Transform
-      pos: 64.5,34.5
       parent: 6747
   - uid: 965
     components:
@@ -120798,11 +120808,6 @@ entities:
     components:
     - type: Transform
       pos: 30.5,-30.5
-      parent: 6747
-  - uid: 2161
-    components:
-    - type: Transform
-      pos: 64.5,33.5
       parent: 6747
   - uid: 2227
     components:
@@ -122454,6 +122459,11 @@ entities:
     - type: Transform
       pos: -50.5,-8.5
       parent: 6747
+  - uid: 7485
+    components:
+    - type: Transform
+      pos: 65.5,30.5
+      parent: 6747
   - uid: 7647
     components:
     - type: Transform
@@ -122609,6 +122619,11 @@ entities:
     - type: Transform
       pos: 48.5,39.5
       parent: 6747
+  - uid: 7851
+    components:
+    - type: Transform
+      pos: 65.5,35.5
+      parent: 6747
   - uid: 7906
     components:
     - type: Transform
@@ -122688,6 +122703,16 @@ entities:
     components:
     - type: Transform
       pos: 56.5,48.5
+      parent: 6747
+  - uid: 8136
+    components:
+    - type: Transform
+      pos: 65.5,34.5
+      parent: 6747
+  - uid: 8141
+    components:
+    - type: Transform
+      pos: 65.5,33.5
       parent: 6747
   - uid: 8152
     components:
@@ -123274,11 +123299,6 @@ entities:
     - type: Transform
       pos: 20.5,-12.5
       parent: 6747
-  - uid: 11129
-    components:
-    - type: Transform
-      pos: 64.5,35.5
-      parent: 6747
   - uid: 11139
     components:
     - type: Transform
@@ -123564,21 +123584,6 @@ entities:
     - type: Transform
       pos: 56.5,34.5
       parent: 6747
-  - uid: 13004
-    components:
-    - type: Transform
-      pos: 64.5,30.5
-      parent: 6747
-  - uid: 13040
-    components:
-    - type: Transform
-      pos: 64.5,29.5
-      parent: 6747
-  - uid: 13041
-    components:
-    - type: Transform
-      pos: 64.5,28.5
-      parent: 6747
   - uid: 13043
     components:
     - type: Transform
@@ -123624,25 +123629,15 @@ entities:
     - type: Transform
       pos: 69.5,20.5
       parent: 6747
-  - uid: 13387
+  - uid: 13381
     components:
     - type: Transform
-      pos: 69.5,30.5
-      parent: 6747
-  - uid: 13388
-    components:
-    - type: Transform
-      pos: 69.5,31.5
-      parent: 6747
-  - uid: 13401
-    components:
-    - type: Transform
-      pos: 69.5,32.5
+      pos: 65.5,28.5
       parent: 6747
   - uid: 13402
     components:
     - type: Transform
-      pos: 69.5,33.5
+      pos: 70.5,32.5
       parent: 6747
   - uid: 13436
     components:
@@ -125284,6 +125279,21 @@ entities:
     - type: Transform
       pos: -7.5,55.5
       parent: 6747
+  - uid: 26537
+    components:
+    - type: Transform
+      pos: 65.5,29.5
+      parent: 6747
+  - uid: 26597
+    components:
+    - type: Transform
+      pos: 70.5,31.5
+      parent: 6747
+  - uid: 26598
+    components:
+    - type: Transform
+      pos: 70.5,30.5
+      parent: 6747
   - uid: 26895
     components:
     - type: Transform
@@ -125964,6 +125974,11 @@ entities:
     - type: Transform
       pos: 17.5,-37.5
       parent: 6747
+  - uid: 29787
+    components:
+    - type: Transform
+      pos: 70.5,33.5
+      parent: 6747
 - proto: GrilleBroken
   entities:
   - uid: 9970
@@ -126641,35 +126656,27 @@ entities:
       parent: 6747
 - proto: HeatExchanger
   entities:
+  - uid: 8138
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 67.5,30.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
+  - uid: 13085
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 67.5,33.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
   - uid: 13088
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 66.5,30.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13089
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
+      rot: -1.5707963267948966 rad
       pos: 67.5,31.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13090
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 67.5,32.5
-      parent: 6747
-    - type: AtmosPipeColor
-      color: '#FF5500FF'
-  - uid: 13091
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 66.5,33.5
       parent: 6747
     - type: AtmosPipeColor
       color: '#FF5500FF'
@@ -126697,6 +126704,14 @@ entities:
       parent: 6747
     - type: AtmosPipeColor
       color: '#00FFFFFF'
+  - uid: 13382
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 67.5,32.5
+      parent: 6747
+    - type: AtmosPipeColor
+      color: '#FF5500FF'
 - proto: HelicopterInstrument
   entities:
   - uid: 11800
@@ -142531,31 +142546,11 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 22391
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,34.5
-      parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 22420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 57.5,19.5
-      parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 22428
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,29.5
       parent: 6747
     - type: PointLight
       enabled: False
@@ -142681,33 +142676,18 @@ entities:
   - uid: 22627
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,7.5
+      pos: -24.5,2.5
       parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 22628
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,1.5
+      pos: -24.5,8.5
       parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 22629
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,4.5
+      pos: -24.5,5.5
       parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
   - uid: 22630
     components:
     - type: Transform
@@ -142782,6 +142762,12 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 27051
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,29.5
+      parent: 6747
   - uid: 27052
     components:
     - type: Transform
@@ -142801,6 +142787,12 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 27595
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 69.5,34.5
+      parent: 6747
   - uid: 27822
     components:
     - type: Transform
@@ -143130,6 +143122,12 @@ entities:
       enabled: False
     - type: ApcPowerReceiver
       powerLoad: 0
+  - uid: 13388
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 73.5,24.5
+      parent: 6747
   - uid: 15622
     components:
     - type: Transform
@@ -143328,16 +143326,6 @@ entities:
     components:
     - type: Transform
       pos: 5.5,-93.5
-      parent: 6747
-    - type: PointLight
-      enabled: False
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 22422
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 70.5,24.5
       parent: 6747
     - type: PointLight
       enabled: False
@@ -146128,12 +146116,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 38.5,0.5
-      parent: 6747
-  - uid: 6593
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 70.5,27.5
       parent: 6747
   - uid: 6613
     components:
@@ -153531,55 +153513,55 @@ entities:
     - type: Transform
       pos: 4.5,-92.5
       parent: 6747
-  - uid: 13296
-    components:
-    - type: Transform
-      pos: 69.5,30.5
-      parent: 6747
-  - uid: 13375
-    components:
-    - type: Transform
-      pos: 64.5,35.5
-      parent: 6747
   - uid: 13377
     components:
     - type: Transform
-      pos: 64.5,34.5
+      pos: 65.5,34.5
       parent: 6747
   - uid: 13378
     components:
     - type: Transform
-      pos: 64.5,33.5
+      pos: 65.5,30.5
       parent: 6747
-  - uid: 13381
+  - uid: 13403
     components:
     - type: Transform
-      pos: 64.5,30.5
+      pos: 65.5,35.5
       parent: 6747
-  - uid: 13382
+  - uid: 19087
     components:
     - type: Transform
-      pos: 64.5,29.5
+      pos: 65.5,33.5
       parent: 6747
-  - uid: 13383
+  - uid: 19088
     components:
     - type: Transform
-      pos: 64.5,28.5
+      pos: 65.5,29.5
       parent: 6747
-  - uid: 13384
+  - uid: 22391
     components:
     - type: Transform
-      pos: 69.5,31.5
+      pos: 65.5,28.5
       parent: 6747
-  - uid: 13385
+  - uid: 29788
     components:
     - type: Transform
-      pos: 69.5,32.5
+      pos: 70.5,30.5
       parent: 6747
-  - uid: 13386
+  - uid: 29789
     components:
     - type: Transform
-      pos: 69.5,33.5
+      pos: 70.5,31.5
+      parent: 6747
+  - uid: 29790
+    components:
+    - type: Transform
+      pos: 70.5,32.5
+      parent: 6747
+  - uid: 29791
+    components:
+    - type: Transform
+      pos: 70.5,33.5
       parent: 6747
 - proto: ReinforcedWindow
   entities:
@@ -158303,16 +158285,20 @@ entities:
     - type: Transform
       pos: 18.5,12.5
       parent: 6747
-  - uid: 13413
-    components:
-    - type: Transform
-      pos: 66.5,27.5
-      parent: 6747
   - uid: 13414
     components:
     - type: Transform
       pos: 67.5,27.5
       parent: 6747
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 22422
+    components:
+    - type: Transform
+      pos: 68.5,27.5
+      parent: 6747
+    - type: DeviceLinkSink
+      invokeCounter: 1
 - proto: ShuttersWindowOpen
   entities:
   - uid: 5090
@@ -159350,37 +159336,37 @@ entities:
         - Status: Toggle
         - On: Toggle
         - Off: Toggle
+  - uid: 26538
+    components:
+    - type: Transform
+      pos: 66.5,27.5
+      parent: 6747
+    - type: DeviceLinkSource
+      linkedPorts:
+        13414:
+        - On: Toggle
+        - Off: Toggle
+        - Status: Toggle
+        22422:
+        - On: Toggle
+        - Off: Toggle
+        - Status: Toggle
   - uid: 26595
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 64.5,32.5
+      pos: 65.5,32.5
       parent: 6747
     - type: DeviceLinkSource
       linkedPorts:
-        13403:
-        - Status: Toggle
-        - On: Toggle
-        - Off: Toggle
         13404:
-        - Status: Toggle
         - On: Toggle
         - Off: Toggle
-  - uid: 27049
-    components:
-    - type: Transform
-      pos: 65.5,27.5
-      parent: 6747
-    - type: DeviceLinkSource
-      linkedPorts:
-        13413:
         - Status: Toggle
+        27049:
         - On: Toggle
         - Off: Toggle
-        13414:
         - Status: Toggle
-        - On: Toggle
-        - Off: Toggle
   - uid: 27053
     components:
     - type: Transform
@@ -160692,6 +160678,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -4.5,37.5
       parent: 6747
+  - uid: 7548
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 69.5,27.5
+      parent: 6747
   - uid: 27990
     components:
     - type: Transform
@@ -160739,12 +160731,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 59.5,39.5
-      parent: 6747
-  - uid: 27999
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 68.5,27.5
       parent: 6747
   - uid: 28000
     components:
@@ -164115,6 +164101,16 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Engineering Break Room
+  - uid: 26596
+    components:
+    - type: Transform
+      pos: 69.5,28.5
+      parent: 6747
+    - type: SurveillanceCamera
+      setupAvailableNetworks:
+      - SurveillanceCameraEngineering
+      nameSet: True
+      id: TEG Burn Chamber
   - uid: 28628
     components:
     - type: Transform
@@ -164155,16 +164151,6 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Atmospherics Burn Chamber
-  - uid: 29400
-    components:
-    - type: Transform
-      pos: 68.5,28.5
-      parent: 6747
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraEngineering
-      nameSet: True
-      id: TEG Burn Chamber
   - uid: 29401
     components:
     - type: Transform
@@ -176025,6 +176011,11 @@ entities:
     - type: Transform
       pos: -52.5,13.5
       parent: 6747
+  - uid: 7265
+    components:
+    - type: Transform
+      pos: 66.5,36.5
+      parent: 6747
   - uid: 7372
     components:
     - type: Transform
@@ -176660,6 +176651,11 @@ entities:
     - type: Transform
       pos: 50.5,36.5
       parent: 6747
+  - uid: 7928
+    components:
+    - type: Transform
+      pos: 70.5,34.5
+      parent: 6747
   - uid: 8043
     components:
     - type: Transform
@@ -176714,6 +176710,16 @@ entities:
     components:
     - type: Transform
       pos: 56.5,51.5
+      parent: 6747
+  - uid: 8137
+    components:
+    - type: Transform
+      pos: 65.5,32.5
+      parent: 6747
+  - uid: 8145
+    components:
+    - type: Transform
+      pos: 65.5,31.5
       parent: 6747
   - uid: 8214
     components:
@@ -177910,6 +177916,11 @@ entities:
     - type: Transform
       pos: -18.5,-57.5
       parent: 6747
+  - uid: 11129
+    components:
+    - type: Transform
+      pos: 70.5,28.5
+      parent: 6747
   - uid: 11163
     components:
     - type: Transform
@@ -178220,6 +178231,11 @@ entities:
     - type: Transform
       pos: 49.5,10.5
       parent: 6747
+  - uid: 11943
+    components:
+    - type: Transform
+      pos: 70.5,29.5
+      parent: 6747
   - uid: 11946
     components:
     - type: Transform
@@ -178275,6 +178291,16 @@ entities:
     - type: Transform
       pos: 70.5,5.5
       parent: 6747
+  - uid: 13056
+    components:
+    - type: Transform
+      pos: 70.5,36.5
+      parent: 6747
+  - uid: 13103
+    components:
+    - type: Transform
+      pos: 70.5,35.5
+      parent: 6747
   - uid: 13234
     components:
     - type: Transform
@@ -178290,60 +178316,30 @@ entities:
     - type: Transform
       pos: 64.5,36.5
       parent: 6747
-  - uid: 13285
-    components:
-    - type: Transform
-      pos: 64.5,27.5
-      parent: 6747
   - uid: 13286
     components:
     - type: Transform
       pos: 65.5,27.5
-      parent: 6747
-  - uid: 13287
-    components:
-    - type: Transform
-      pos: 68.5,27.5
       parent: 6747
   - uid: 13288
     components:
     - type: Transform
       pos: 69.5,27.5
       parent: 6747
-  - uid: 13289
-    components:
-    - type: Transform
-      pos: 69.5,28.5
-      parent: 6747
-  - uid: 13290
-    components:
-    - type: Transform
-      pos: 69.5,29.5
-      parent: 6747
-  - uid: 13292
-    components:
-    - type: Transform
-      pos: 68.5,36.5
-      parent: 6747
   - uid: 13293
     components:
     - type: Transform
       pos: 69.5,36.5
       parent: 6747
-  - uid: 13294
-    components:
-    - type: Transform
-      pos: 69.5,35.5
-      parent: 6747
-  - uid: 13295
-    components:
-    - type: Transform
-      pos: 69.5,34.5
-      parent: 6747
   - uid: 13299
     components:
     - type: Transform
       pos: 59.5,39.5
+      parent: 6747
+  - uid: 13387
+    components:
+    - type: Transform
+      pos: 70.5,24.5
       parent: 6747
   - uid: 13417
     components:
@@ -179595,15 +179591,10 @@ entities:
     - type: Transform
       pos: 59.5,36.5
       parent: 6747
-  - uid: 26596
+  - uid: 26539
     components:
     - type: Transform
-      pos: 64.5,31.5
-      parent: 6747
-  - uid: 26598
-    components:
-    - type: Transform
-      pos: 64.5,32.5
+      pos: 66.5,27.5
       parent: 6747
   - uid: 26885
     components:
@@ -180729,6 +180720,11 @@ entities:
     components:
     - type: Transform
       pos: -0.5,-67.5
+      parent: 6747
+  - uid: 29786
+    components:
+    - type: Transform
+      pos: 70.5,27.5
       parent: 6747
 - proto: WallRiveted
   entities:


### PR DESCRIPTION
## About the PR
Arena
- Fixes lights blocking doors in jail cells
- Expands TEG area 1 tile and gives them proper mixing ports
- Disconnects waste line from TEG hot loop
- Adds circuit imprinter to engineering

Tortuga:
- Fixes light blocking blast door on AI sat
- Gives Justice access to evidence room
- Adds door between jail cells and main sec area
- Gives prosecutor a criminal records comp
- Fixes disposal in chef's break room
- Adds circuit imprinter to engineering

## Why / Balance
🥊🐢
