### PR TITLE
make the knife not kill you anymore

### DIFF
--- a/Content.Server/Nyanotrasen/Psionics/AntiPsychicWeaponComponent.cs
+++ b/Content.Server/Nyanotrasen/Psionics/AntiPsychicWeaponComponent.cs
@@ -19,6 +19,6 @@ namespace Content.Server.Psionics
         ///     Punish when used against a non-psychic.
         /// </summary
         [DataField("punish")]
-        public bool Punish = true;
+        public bool Punish = false;
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
all this does is change a single thing to make the anti-psychic knife not kill you when using it against a non-psychic anymore

## Why / Balance
it doesn't even do that much extra damage if any, and holy damage literally doesn't work against psionics because Holy isn't even in their damage container. There's basically no reason to punish you for using it.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: the anti-psychic knife isn't strictly anti-psychic anymore

