### PR TITLE
Change default value of game.secret_weight

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -348,7 +348,7 @@ public sealed partial class CCVars
         ///     The prototype to use for secret weights.
         /// </summary>
         public static readonly CVarDef<string> SecretWeightPrototype =
-            CVarDef.Create("game.secret_weight_prototype", "Secret", CVar.SERVERONLY);
+            CVarDef.Create("game.secret_weight_prototype", "SecretDeltaV", CVar.SERVERONLY); // DeltaV (duh) - Change default secret weight prototype for easier testing
 
         /// <summary>
         ///     The id of the sound collection to randomly choose a sound from and play when the round ends.


### PR DESCRIPTION
## About the PR
Set the default value of the `game.secret_weight` CVar to "SecretDeltaV" from "Secret", since "Secret" causes errors unless overridden.

## Why / Balance
Creates semi-frequent confusion in contributor-help channel on discord, so might as well change it.

## Technical details
see above

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
none, internal change
