### PR TITLE
Justice lockable buttons

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Wallmounts/switch.yml
@@ -5,3 +5,35 @@
   components:
   - type: AccessReader
     access: [["Robotics"]]
+
+- type: entity
+  parent: LockableButton
+  suffix: Justice
+  id: LockableButtonJustice
+  components:
+  - type: AccessReader
+    access: [["Justice"]]
+
+- type: entity
+  parent: LockableButton
+  suffix: Prosecutor
+  id: LockableButtonProsecutor
+  components:
+  - type: AccessReader
+    access: [["Prosecutor"]]
+
+- type: entity
+  parent: LockableButton
+  suffix: Clerk
+  id: LockableButtonClerk
+  components:
+  - type: AccessReader
+    access: [["Clerk"]]
+
+- type: entity
+  parent: LockableButton
+  suffix: Chief Justice
+  id: LockableButtonRCJ
+  components:
+  - type: AccessReader
+    access: [["ChiefJustice"]]

--- a/Resources/Prototypes/_DV/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Wallmounts/switch.yml
@@ -33,7 +33,7 @@
 - type: entity
   parent: LockableButton
   suffix: Chief Justice
-  id: LockableButtonRCJ
+  id: LockableButtonCJ
   components:
   - type: AccessReader
     access: [["ChiefJustice"]]

--- a/Resources/Prototypes/_DV/Entities/Structures/Wallmounts/switch.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Wallmounts/switch.yml
@@ -1,39 +1,39 @@
 - type: entity
   parent: LockableButton
-  suffix: Robotics
   id: LockableButtonRobotics
+  suffix: Robotics
   components:
   - type: AccessReader
     access: [["Robotics"]]
 
 - type: entity
   parent: LockableButton
-  suffix: Justice
   id: LockableButtonJustice
+  suffix: Justice
   components:
   - type: AccessReader
     access: [["Justice"]]
 
 - type: entity
   parent: LockableButton
-  suffix: Prosecutor
   id: LockableButtonProsecutor
+  suffix: Prosecutor
   components:
   - type: AccessReader
     access: [["Prosecutor"]]
 
 - type: entity
   parent: LockableButton
-  suffix: Clerk
   id: LockableButtonClerk
+  suffix: Clerk
   components:
   - type: AccessReader
     access: [["Clerk"]]
 
 - type: entity
   parent: LockableButton
-  suffix: Chief Justice
   id: LockableButtonCJ
+  suffix: Chief Justice
   components:
   - type: AccessReader
     access: [["ChiefJustice"]]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Added lockable buttons to the rest of Justice. So the prosecutor, clerk, chief justice, and the department as a whole have buttons that can be locked, respectively. So the attorney is not the only one in the department that has one anymore.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As stated above

## Technical details
<!-- Summary of code changes for easier review. -->
4 new buttons that can be mapped in Justice as needed for mappers: Justice, Prosecutor, Clerk, Chief Justice.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Field Command
- tweak: Some more lockable buttons for the justice department specifically.