### PR TITLE
Grabbag of fixes for sanitation

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -200,7 +200,7 @@ public sealed class SurgerySystem : SharedSurgerySystem
         var exceedsAmount = (dirtiness - ent.Comp.DirtinessThreshold).Float();
         var additionalDamage = (1f / ent.Comp.InverseDamageCoefficient.Float()) * (exceedsAmount * exceedsAmount);
 
-        return FixedPoint2.New(additionalDamage) + ent.Comp.BaseDamage;
+        return FixedPoint2.Min(FixedPoint2.New(additionalDamage) + ent.Comp.BaseDamage, ent.Comp.ToxinStepLimit);
     }
 
     private void AddDirt(EntityUid ent, FixedPoint2 amount)

--- a/Content.Shared/_DV/Surgery/SurgeryContaminableComponent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryContaminableComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class SurgeryContaminableComponent : Component
     ///     How much cross contamination should increase dirtiness per incompatible DNA
     /// </summary>
     [DataField]
-    public FixedPoint2 CrossContaminationDirtinessLevel = 40.0;
+    public FixedPoint2 CrossContaminationDirtinessLevel = 60.0;
 
     /// <summary>
     ///     The level of dirtiness above which toxin damage will be dealt
@@ -26,7 +26,7 @@ public sealed partial class SurgeryContaminableComponent : Component
     ///     The base amount of toxin damage to deal above the threshold
     /// </summary>
     [DataField]
-    public FixedPoint2 BaseDamage = 2.0;
+    public FixedPoint2 BaseDamage = 1.0;
 
     /// <summary>
     ///     The inverse of the coefficient to scale the toxin damage by

--- a/Content.Shared/_DV/Surgery/SurgeryStepDirtinessComponent.cs
+++ b/Content.Shared/_DV/Surgery/SurgeryStepDirtinessComponent.cs
@@ -13,11 +13,11 @@ public sealed partial class SurgeryStepDirtinessComponent : Component
     ///     The amount of dirtiness this step should add to tools on completion
     /// </summary>
     [DataField]
-    public FixedPoint2 ToolDirtiness = 2.0;
+    public FixedPoint2 ToolDirtiness = 0.5;
 
     /// <summary>
     ///     The amount of dirtiness this step should add to gloves on completion
     /// </summary>
     [DataField]
-    public FixedPoint2 GloveDirtiness = 2.0;
+    public FixedPoint2 GloveDirtiness = 0.5;
 }

--- a/Resources/Prototypes/_Shitmed/Damage/containers.yml
+++ b/Resources/Prototypes/_Shitmed/Damage/containers.yml
@@ -3,5 +3,5 @@
   supportedGroups:
   - Brute
   - Burn
-  supportedTypes: # DeltaV: limbs can take poison
+  supportedTypes: # DeltaV - limbs can take poison
   - Poison

--- a/Resources/Prototypes/_Shitmed/Damage/containers.yml
+++ b/Resources/Prototypes/_Shitmed/Damage/containers.yml
@@ -3,3 +3,5 @@
   supportedGroups:
   - Brute
   - Burn
+  supportedTypes: # DeltaV: limbs can take poison
+  - Poison


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- poison is now bounded
- parts can now take poison damage to indicate something going wrong on that part
- steps overall dirty the tools slower
- steps deal 1 poison as a base, not 2
- cross contamination is now more of a concern

## Why / Balance
- player feedback on sanitation being too much and having poor feedback because medical scanner is usually focused on a part

## Technical details
- add poison to the part damage container
- adjust default values in the contaminable component
- surgery system now bounds checks poison

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Surgical tools get less dirtier than before from normal procedures and dirtier from cross contamination, and have a lower base poison damage once they become too dirty
- add: Poor sanitation now deals poison damage on the specific part
- fix: Poison damage from surgery is no longer unbounded
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
