### PR TITLE
IPC typo fix

### DIFF
--- a/Resources/Locale/en-US/_EE/power/batteryDrinker.ftl
+++ b/Resources/Locale/en-US/_EE/power/batteryDrinker.ftl
@@ -1,2 +1,2 @@
 battery-drinker-verb-drink = Drain
-battery-drinker-empty = {CAPATALIZE(THE($target))} is already empty!
+battery-drinker-empty = {CAPITALIZE(THE($target))} is already empty!


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Typo fix

## Why / Balance
CAPATALIZE

## Technical details
A->I

## Media
![image](https://github.com/user-attachments/assets/8b539665-f25a-4779-bb6c-f52db0c35cd5)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
:cl:
- fix: Wrong text when trying to drain an empty APC as IPC
