### PR TITLE
Add more prereqs to tech tree (WIP)

### DIFF
--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -36,6 +36,8 @@
   - HamtrPeripheralsElectronics
   - MechEquipmentGrabberSmall
   - VimHarness
+  technologyPrerequisites:
+  - BasicRobotics
 
 - type: technology
   id: AudioVisualCommunication
@@ -83,6 +85,8 @@
   cost: 5000
   recipeUnlocks:
   - BorgModuleAdvancedCleaning
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - BasicRobotics
 
 - type: technology
   id: MeatManipulation
@@ -164,7 +168,9 @@
   - HonkerPeripheralsElectronics
   - HonkerTargetingElectronics
   - MechEquipmentHorn
-
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - RipleyAPLU
+- 
 - type: technology
   id: AdvancedSpray
   name: research-technology-advanced-spray
@@ -177,6 +183,8 @@
   recipeUnlocks:
   - WeaponSprayNozzle
   - ClothingBackpackWaterTank
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - AdvancedCleaning
 
 - type: technology
   id: BluespaceCargoTransport
@@ -203,6 +211,8 @@
   cost: 10000
   recipeUnlocks:
   - ClothingShoesBootsSpeed
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - MagentsTech
 
 - type: technology
   id: BluespaceChemistry

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -43,7 +43,9 @@
   - PowerCellHigh
   - TurboItemRechargerCircuitboard
   - SMESAdvancedMachineCircuitboard
-
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - PowerGeneration
+- 
 - type: technology
   id: MechanicalCompression
   name: research-technology-mechanical-compression
@@ -120,7 +122,9 @@
   - RipleyCentralElectronics
   - RipleyPeripheralsElectronics
   - MechEquipmentGrabber
-
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - CritterMechs
+- 
 # Tier 2
 
 - type: technology
@@ -183,6 +187,9 @@
     - OreBagOfHolding
     - MiningDrillDiamond
     - AdvancedMineralScannerEmpty
+    technologyPrerequisites: # DeltaV: added prerequesite
+    - SalvageEquipment
+    - Hydroponics
 
 # Tier 3
 
@@ -199,6 +206,8 @@
   - ClothingBackpackHolding
   - ClothingBackpackSatchelHolding
   - ClothingBackpackDuffelHolding
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - BluespaceChemistry
 
 - type: technology
   id: PortableFission

--- a/Resources/Prototypes/_DV/Research/arsenal.yml
+++ b/Resources/Prototypes/_DV/Research/arsenal.yml
@@ -59,6 +59,8 @@
   recipeUnlocks:
   - WeaponEnergyGunPistol
   - WeaponGunLaserCarbineAutomatic
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - EnergyGuns
 
 - type: technology
   id: RobustMelee
@@ -83,3 +85,5 @@
   cost: 10000
   recipeUnlocks:
   - WeaponColdCannon
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - AdvancedAtmospherics

--- a/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
@@ -48,7 +48,9 @@
   cost: 10000
   recipeUnlocks:
   - AutodocCircuitboard
-
+  technologyPrerequisites: # DeltaV: added prerequesite
+  - CyberneticEnhancements
+- 
 # Tier 3
 
 # Start DeltaV changes - Removed the medical multitool.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Make techs require other techs. puts loose restrictions on epi research path

## Why / Balance
New mystagogues firing their for not wanting to waste 70k points getting all of industrial tree just to use ~6 of the recipes they unlock.
Putting loose restrictions and niche requirements will prevent powergaming.
Makes sense that you cant have bags of holding without plant bag of holding, cant have Cryo emission equipment without studying atmospherics

## Technical details
This is a draft and none of the changes ive made so far are final, making this for proof of concept and so i can have something to make commits to as direction decides.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [TBD] I have tested all added content and changes.
- [TBD] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
