### PR TITLE
Food/Produce chemmaster dump fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/food_base.yml
@@ -36,8 +36,12 @@
   components:
   - type: InjectableSolution
     solution: food
-  - type: RefillableSolution
-    solution: food
+  # Begin Delta-V FoodBase Changes
+  # This is inteded to add the ability to draw from food/produce however current gamestate doesnt allow it
+  # Has side-effect of allowing food/produce to be draged into machines such as chemmaster
+  #- type: RefillableSolution
+  #  solution: food
+  # End Delta-V FoodBase Changes
 
 # usable by any food that can be opened
 # handles appearance with states "icon" and "icon-open"


### PR DESCRIPTION
## About the PR
The InjectableSolution entity had an extra component "RefillableSolution" which made food/produce of this entity able to be dragged (dumped) into the chem master. This affected items such as pizza, ambrosia deus, and other food/produce items. Without having the game implementation to allow for drawing out of food/produce. However upstream seems to maybe intend this in the future -- so it is commented out for the time being rather than removed outright. Food is still able to be injected into and instead goes directly into the user's hand when interacted with -- instead of being able to drag the sprite around.

Located within food_base.yml

## Why / Balance
As mentioned this component is intended to allow for drawing out of food items however there is no game implementation for such a thing. This also had the side effect (bug) of allowing food/produce to be dragged into the chemmaster.

The balance this brings is two major points alongside removing this bug:
- Food and produce items can no longer be emptied out and injected with unknown reagents. (No more donk-pocket roulette / 17u lexorin pizza)
- The grinding process can not be subverted and just dragged into chem masters. (Sorry that 100 potency deus needs to be ground -- even though it doesn't fit in a 100u beaker)

## Technical details
Within the food_base.yml the id: FoodInjectableBase entity has had the type: RefillableSolution component commented out. As previous comments seem to be that upstream might intend for produce/food items to be drawn from with syringes. 

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] it does not require an ingame showcase.

## Breaking changes
If upstream ever intends to add the ability to draw from produce/food with syringes then these comment lines should be removed. However, this will reintroduce the issue of being able to drag food/produce into the chem master. Which is an issue with the FoodInjectableBase component itself.

**Changelog**
:cl:
- tweak: Food/Produce can no longer be dragged into machines such as the chem master.
