### PR TITLE
change air alarm defaults

### DIFF
--- a/Resources/Prototypes/Atmospherics/thresholds.yml
+++ b/Resources/Prototypes/Atmospherics/thresholds.yml
@@ -15,11 +15,11 @@
     threshold: 550 # HazardHighPressure from Atmospherics.cs
   lowerBound: !type:AlarmThresholdSetting
     # Actual low pressure damage threshold is at 20 kPa, but below ~85 kPa you can't breathe due to lack of oxygen.
-    threshold: 85
+    threshold: 40 # DeltaV - was 80
   upperWarnAround: !type:AlarmThresholdSetting
     threshold: 0.7 # 385 kPa, WarningHighPressure from Atmospherics.cs
   lowerWarnAround: !type:AlarmThresholdSetting
-    threshold: 1.05 # ~90 kPa
+    threshold: 2 # DeltaV - 80kpa, was 1.05 (90kpa)
 
 # a reminder that all of these are percentages (where 1 is 100%),
 # so 0.01 is 1%,
@@ -31,7 +31,7 @@
   lowerBound: !type:AlarmThresholdSetting
     threshold: 0.10
   upperBound: !type:AlarmThresholdSetting
-    threshold: 0.3
+    threshold: 0.8 # DeltaV - was 0.3, ridiculous
   lowerWarnAround: !type:AlarmThresholdSetting
     threshold: 1.5
   upperWarnAround: !type:AlarmThresholdSetting


### PR DESCRIPTION
## About the PR
change oxygen upper limit from 30% and 24% to 80% and like 50%

## Why / Balance
instakilling from inhaling gas was removed years ago so the upstream justification is a meme
and even if it was still a thing, just fix that instead of having meme air alarm settings that mean nothing

current pressure setting constantly dilutes air alarms as you take next to no airloss damage at 80kpa

i have to change these every single atmos round on every air alarm

for actual spacings firelocks close on their own regardless of air alarm settings so it just serves to annoy people

## Technical details
number

## Media


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Made air alarms less sensitive to higher oxygen and slightly lower pressure. Opening random firelocks is more likely to actually be dangerous!