### PR TITLE
Proof of concept for woundmed/ailmentmed

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Content.Client.Message;
+using Content.Shared._DV.Ailments; // DeltaV
 using Content.Shared._DV.Traits.Assorted; // DeltaV
 using Content.Shared.Atmos;
 using Content.Client.UserInterface.Controls;
@@ -38,6 +39,7 @@ namespace Content.Client.HealthAnalyzer.UI
         private readonly IPrototypeManager _prototypes;
         private readonly IResourceCache _cache;
         private readonly UnborgableSystem _unborgable; // DeltaV
+        private readonly SharedAilmentSystem _ailments; // DeltaV
 
         // Shitmed Change Start
         public event Action<TargetBodyPart?, EntityUid>? OnBodyPartSelected;
@@ -60,6 +62,7 @@ namespace Content.Client.HealthAnalyzer.UI
             _prototypes = dependencies.Resolve<IPrototypeManager>();
             _cache = dependencies.Resolve<IResourceCache>();
             _unborgable = _entityManager.System<UnborgableSystem>(); // DeltaV
+            _ailments = _entityManager.System<SharedAilmentSystem>(); // DeltaV
             // Shitmed Change Start
             _bodyPartControls = new Dictionary<TargetBodyPart, TextureButton>
             {
@@ -187,8 +190,9 @@ namespace Content.Client.HealthAnalyzer.UI
 
             // Alerts
 
+            var ailments = _ailments.HealthAnalyzerMessages(part is {} partId ? partId : _target.Value); // DeltaV: ailments
             var unborgable = _unborgable.IsUnborgable(_target.Value); // DeltaV
-            var showAlerts = msg.Unrevivable == true || msg.Bleeding == true || unborgable;
+            var showAlerts = msg.Unrevivable == true || msg.Bleeding == true || unborgable || ailments.Count > 0;
 
             AlertsDivider.Visible = showAlerts;
             AlertsContainer.Visible = showAlerts;
@@ -219,6 +223,18 @@ namespace Content.Client.HealthAnalyzer.UI
                     Margin = new Thickness(0, 4),
                     MaxWidth = 300
                 });
+
+            // Begin DeltaV: ailments
+            foreach (var ailment in ailments)
+            {
+                AlertsContainer.AddChild(new RichTextLabel
+                {
+                    Text = ailment,
+                    Margin = new Thickness(0, 4),
+                    MaxWidth = 300
+                });
+            }
+            // End DeltaV: ailments
 
             // Damage Groups
 

--- a/Content.Client/_DV/Ailments/AilmentSurgerySystem.cs
+++ b/Content.Client/_DV/Ailments/AilmentSurgerySystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._DV.Ailments;
+
+namespace Content.Client._DV.Ailments;
+
+public partial class AilmentSurgerySystem : SharedAilmentSurgerySystem;

--- a/Content.Client/_DV/Ailments/AilmentSystem.cs
+++ b/Content.Client/_DV/Ailments/AilmentSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._DV.Ailments;
+
+namespace Content.Client._DV.Ailments;
+
+public partial class AilmentSystem : SharedAilmentSystem;

--- a/Content.Server/_DV/Ailments/AilmentSurgerySystem.cs
+++ b/Content.Server/_DV/Ailments/AilmentSurgerySystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._DV.Ailments;
+
+namespace Content.Server._DV.Ailments;
+
+public partial class AilmentSurgerySystem : SharedAilmentSurgerySystem;

--- a/Content.Server/_DV/Ailments/AilmentSystem.cs
+++ b/Content.Server/_DV/Ailments/AilmentSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._DV.Ailments;
+
+namespace Content.Server._DV.Ailments;
+
+public partial class AilmentSystem : SharedAilmentSystem;

--- a/Content.Server/_DV/EntityEffects/Conditions/TypeDamage.cs
+++ b/Content.Server/_DV/EntityEffects/Conditions/TypeDamage.cs
@@ -1,0 +1,67 @@
+using Content.Shared.EntityEffects;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.EntityEffects.EffectConditions;
+
+public sealed partial class TypeDamage : EntityEffectCondition
+{
+    [DataField]
+    public FixedPoint2 Max = FixedPoint2.MaxValue;
+
+    [DataField]
+    public FixedPoint2 Min = FixedPoint2.Zero;
+
+    [DataField]
+    public ProtoId<DamageGroupPrototype>? DamageGroup;
+
+    [DataField]
+    public ProtoId<DamageTypePrototype>? DamageType;
+
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        if (args.EntityManager.TryGetComponent(args.TargetEntity, out DamageableComponent? damage))
+        {
+            FixedPoint2 total;
+            if (DamageGroup is { } group)
+                total = damage.DamagePerGroup.GetValueOrDefault(group, FixedPoint2.Zero);
+            else if (DamageType is { } kind)
+                total = damage.Damage.DamageDict.GetValueOrDefault(kind, FixedPoint2.Zero);
+            else
+                total = damage.TotalDamage;
+
+            if (total >= Min && total <= Max)
+                return true;
+        }
+
+        return false;
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        if (DamageGroup is { } group)
+        {
+            var name = prototype.Index(group).LocalizedName;
+            return Loc.GetString("reagent-effect-condition-guidebook-group-damage",
+                ("max", Max == FixedPoint2.MaxValue ? (float) int.MaxValue : Max.Float()),
+                ("min", Min.Float()),
+                ("group", name));
+        }
+        else if (DamageType is { } kind)
+        {
+            var name = prototype.Index(kind).LocalizedName;
+            return Loc.GetString("reagent-effect-condition-guidebook-type-damage",
+                ("max", Max == FixedPoint2.MaxValue ? (float) int.MaxValue : Max.Float()),
+                ("min", Min.Float()),
+                ("type", name));
+        }
+        else
+        {
+            return Loc.GetString("reagent-effect-condition-guidebook-total-damage",
+                ("max", Max == FixedPoint2.MaxValue ? (float) int.MaxValue : Max.Float()),
+                ("min", Min.Float()));
+        }
+    }
+}

--- a/Content.Shared/_DV/Ailments/AilmentComponent.cs
+++ b/Content.Shared/_DV/Ailments/AilmentComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared._DV.Ailments;
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Ailments;
+
+/// <summary>
+///     Contains the set of possible ailment packs & the currently active ailments in those packs, similar to a damage container
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AilmentComponent : Component
+{
+    [DataField, ViewVariables, AutoNetworkedField]
+    public List<ProtoId<AilmentPackPrototype>> Packs = default!;
+
+    [DataField, ViewVariables, AutoNetworkedField]
+    public Dictionary<ProtoId<AilmentPackPrototype>, ProtoId<AilmentPrototype>?> ActiveAilments = new();
+}

--- a/Content.Shared/_DV/Ailments/AilmentPrototype.cs
+++ b/Content.Shared/_DV/Ailments/AilmentPrototype.cs
@@ -1,0 +1,140 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Array;
+using Content.Shared.EntityEffects;
+
+namespace Content.Shared._DV.Ailments;
+
+/// <summary>
+///     Represents some condition on the body that isn't numerical damage
+/// </summary>
+[Prototype]
+public sealed partial class AilmentPrototype : IPrototype, IInheritingPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    [ViewVariables]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    ///     What this ailment shows up as on the health scanner, if anything
+    /// </summary>
+    [DataField]
+    public LocId? HealthAnalyzerDescription { get; set; } = default!;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    public string? LocalizedHealthAnalyzerDescription => HealthAnalyzerDescription is null ? null : Loc.GetString(HealthAnalyzerDescription);
+
+    /// <inheritdoc/>
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<AilmentPrototype>))]
+    [ViewVariables]
+    public string[]? Parents { get; private set; } = default!;
+
+    [NeverPushInheritance]
+    [AbstractDataField]
+    [ViewVariables]
+    public bool Abstract { get; private set; } = default!;
+
+    /// <summary>
+    ///     Entity effects to run when this ailment becomes active
+    /// </summary>
+    [DataField(serverOnly: true)]
+    [ViewVariables]
+    public EntityEffect[] Mount { get; private set; } = default!;
+
+    /// <summary>
+    ///     Entity effects to run when this ailment becomes inactive
+    /// </summary>
+    [DataField(serverOnly: true)]
+    [ViewVariables]
+    public EntityEffect[] Unmount { get; private set; } = default!;
+
+    /// <summary>
+    ///     Entity effects to run twice per second when this ailment is active
+    /// </summary>
+    [DataField(serverOnly: true)]
+    [ViewVariables]
+    public EntityEffect[] Periodic { get; private set; } = default!;
+}
+
+/// <summary>
+///     Represents a transition from one ailment to another, e.g. from being fine to having a minor bone fracture
+/// </summary>
+[Prototype]
+public sealed partial class AilmentTransitionPrototype : IPrototype, IInheritingPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    [ViewVariables]
+    public string ID { get; private set; } = default!;
+
+    /// <inheritdoc/>
+    [ParentDataField(typeof(AbstractPrototypeIdArraySerializer<AilmentTransitionPrototype>))]
+    [ViewVariables]
+    public string[]? Parents { get; private set; } = default!;
+
+    [NeverPushInheritance]
+    [AbstractDataField]
+    [ViewVariables]
+    public bool Abstract { get; private set; } = default!;
+
+    /// <summary>
+    ///     The chance for the transition to trigger if the trigger conditions are met
+    /// </summary>
+    [ViewVariables]
+    public float TriggerChance { get; private set; } = 1f;
+
+    /// <summary>
+    ///     Conditions for the transition, that when met, will cause the transition to fire without outside intervention
+    /// </summary>
+    [DataField(serverOnly: true)]
+    [ViewVariables]
+    public EntityEffectCondition[]? Triggers { get; private set; } = default!;
+
+    /// <summary>
+    ///     Conditions for the transition, that are required but don't cause a transition without outside intervention
+    /// </summary>
+    [DataField(serverOnly: true)]
+    [ViewVariables]
+    public EntityEffectCondition[] Conditions { get; private set; } = new EntityEffectCondition[] {};
+
+    /// <summary>
+    ///     Effects that run when this transition is taken
+    /// </summary>
+    [DataField(serverOnly: true)]
+    [ViewVariables]
+    public EntityEffect[]? Effects { get; private set; } = default!;
+
+    /// <summary>
+    ///     Which ailment we're transitioning from
+    /// </summary>
+    [DataField(required: true)]
+    [ViewVariables]
+    public ProtoId<AilmentPrototype>? Start { get; private set; } = default!;
+
+    /// <summary>
+    ///     Which ailment we're transitioning to
+    /// </summary>
+    [DataField(required: true)]
+    [ViewVariables]
+    public ProtoId<AilmentPrototype>? End { get; private set; } = default!;
+}
+
+/// <summary>
+///     A collection of ailments and transitions between them. Only one ailment in a pack can be active at a time.
+/// </summary>
+[Prototype]
+public sealed partial class AilmentPackPrototype : IPrototype
+{
+    /// <inheritdoc/>
+    [IdDataField]
+    [ViewVariables]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    [ViewVariables]
+    public ProtoId<AilmentPrototype>[] Ailments { get; private set; } = default!;
+
+    [DataField]
+    [ViewVariables]
+    public ProtoId<AilmentTransitionPrototype>[] Transitions { get; private set; } = default!;
+}

--- a/Content.Shared/_DV/Ailments/SharedAilmentSurgerySystem.cs
+++ b/Content.Shared/_DV/Ailments/SharedAilmentSurgerySystem.cs
@@ -1,0 +1,52 @@
+using Content.Shared._Shitmed.Medical.Surgery.Conditions;
+using Content.Shared._Shitmed.Medical.Surgery.Steps;
+using Content.Shared._Shitmed.Medical.Surgery;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Ailments;
+
+public abstract partial class SharedAilmentSurgerySystem : EntitySystem
+{
+    [Dependency] private readonly SharedAilmentSystem _ailments = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<SurgeryHasAilmentConditionComponent, SurgeryValidEvent>(OnAilmentConditionValid);
+        SubscribeLocalEvent<SurgeryStepAilmentTransitionComponent, SurgeryStepCompleteCheckEvent>(OnCheckTransitionComplete);
+        SubscribeLocalEvent<SurgeryStepAilmentTransitionComponent, SurgeryStepEvent>(OnAilmentTransition);
+    }
+
+    private void OnAilmentConditionValid(Entity<SurgeryHasAilmentConditionComponent> ent, ref SurgeryValidEvent args)
+    {
+        if (!TryComp<AilmentComponent>(args.Part, out var comp))
+        {
+            args.Cancelled = true;
+            return;
+        }
+
+        var hasAilment = comp.ActiveAilments.GetValueOrDefault(ent.Comp.Pack) == ent.Comp.Ailment;
+        args.Cancelled = !hasAilment;
+    }
+
+    private void OnCheckTransitionComplete(Entity<SurgeryStepAilmentTransitionComponent> ent, ref SurgeryStepCompleteCheckEvent args)
+    {
+        if (!TryComp<AilmentComponent>(args.Part, out var ailments))
+            return;
+
+        var eeba = new EntityEffectBaseArgs(args.Body, EntityManager);
+        var canTakeTransition = _ailments.ValidateTransition(new Entity<AilmentComponent>(args.Part, ailments), ent.Comp.Pack, ent.Comp.Transition, eeba);
+        args.Cancelled = canTakeTransition;
+    }
+
+    private void OnAilmentTransition(Entity<SurgeryStepAilmentTransitionComponent> ent, ref SurgeryStepEvent args)
+    {
+        if (!TryComp<AilmentComponent>(args.Part, out var ailments))
+            return;
+
+        var eeba = new EntityEffectBaseArgs(args.Body, EntityManager);
+        _ailments.TryTransition(new Entity<AilmentComponent>(args.Part, ailments), ent.Comp.Pack, ent.Comp.Transition, eeba);
+    }
+}

--- a/Content.Shared/_DV/Ailments/SharedAilmentSystem.cs
+++ b/Content.Shared/_DV/Ailments/SharedAilmentSystem.cs
@@ -1,0 +1,131 @@
+using Content.Shared._DV.Ailments;
+using Content.Shared.Damage;
+using Content.Shared.EntityEffects;
+using Content.Shared.Popups;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using System.Linq;
+
+namespace Content.Shared._DV.Ailments;
+
+public abstract class SharedAilmentSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<AilmentComponent, DamageChangedEvent>(OnDamageChanged);
+    }
+
+    private void OnDamageChanged(Entity<AilmentComponent> ent, ref DamageChangedEvent args)
+    {
+        EvaluateAilments(ent);
+    }
+
+    private void EvaluateAilments(Entity<AilmentComponent> ent)
+    {
+        var args = new EntityEffectBaseArgs(ent.Owner, EntityManager);
+        foreach (var packId in ent.Comp.Packs)
+        {
+            var pack = _protoMan.Index(packId);
+            foreach (var transitionId in pack.Transitions)
+            {
+                EvaluatePotentialTransition(ent, packId, transitionId, args);
+            }
+        }
+    }
+
+    public List<string> HealthAnalyzerMessages(EntityUid uid)
+    {
+        var items = new List<string>();
+        if (!TryComp<AilmentComponent>(uid, out var ailments))
+            return items;
+
+        foreach (var (_, ailment) in ailments.ActiveAilments)
+        {
+            if (ailment is null)
+                continue;
+
+            if (_protoMan.Index(ailment.Value).LocalizedHealthAnalyzerDescription is {} desc)
+                items.Add(desc);
+        }
+        return items;
+    }
+
+    public bool ValidateTransition(Entity<AilmentComponent> ent, ProtoId<AilmentPackPrototype> pack, ProtoId<AilmentTransitionPrototype> transitionId, EntityEffectBaseArgs args)
+    {
+        if (!_protoMan.TryIndex(transitionId, out var transition))
+            return false;
+
+        var activeAilment = ent.Comp.ActiveAilments.GetValueOrDefault(pack);
+        var startMatches = transition.Start == activeAilment;
+        var endMatches = transition.End != activeAilment;
+        var conditionsMatch = transition.Conditions.All(condition => condition.Condition(args));
+
+        return startMatches && endMatches && conditionsMatch;
+    }
+
+    public bool TryTransition(Entity<AilmentComponent> ent, ProtoId<AilmentPackPrototype> pack, ProtoId<AilmentTransitionPrototype> transitionId, EntityEffectBaseArgs args)
+    {
+        if (!_protoMan.TryIndex(transitionId, out var transition))
+            return false;
+
+        if (!ValidateTransition(ent, pack, transitionId, args))
+            return false;
+
+        if (transition.Start is ProtoId<AilmentPrototype> startAilment)
+        {
+            RemoveAilment(ent, startAilment, args);
+        }
+        if (transition.End is ProtoId<AilmentPrototype> endAilment)
+        {
+            AddAilment(ent, endAilment, args);
+        }
+
+        ent.Comp.ActiveAilments[pack] = transition.End;
+
+        if (transition.Effects is not null) foreach (var effect in transition.Effects)
+        {
+            effect.Effect(args);
+        }
+
+        Dirty(ent);
+        return true;
+    }
+
+    private void EvaluatePotentialTransition(Entity<AilmentComponent> ent, ProtoId<AilmentPackPrototype> pack, ProtoId<AilmentTransitionPrototype> transitionId, EntityEffectBaseArgs args)
+    {
+        if (!_protoMan.TryIndex(transitionId, out var transition))
+            return;
+
+        if (transition.Triggers is null)
+            return;
+
+        var triggersMatch = transition.Triggers.All(condition => condition.Condition(args));
+
+        if (triggersMatch && _random.NextFloat() <= transition.TriggerChance)
+        {
+            TryTransition(ent, pack, transitionId, args);
+        }
+    }
+
+    private void RemoveAilment(Entity<AilmentComponent> ent, ProtoId<AilmentPrototype> ailmentId, EntityEffectBaseArgs args)
+    {
+        var ailment = _protoMan.Index(ailmentId);
+        if (ailment.Unmount is not null) foreach (var effect in ailment.Unmount)
+        {
+            effect.Effect(args);
+        }
+    }
+
+    private void AddAilment(Entity<AilmentComponent> ent, ProtoId<AilmentPrototype> ailmentId, EntityEffectBaseArgs args)
+    {
+        var ailment = _protoMan.Index(ailmentId);
+        if (ailment.Mount is not null) foreach (var effect in ailment.Mount)
+        {
+            effect.Effect(args);
+        }
+    }
+}

--- a/Content.Shared/_DV/Ailments/SurgeryHasAilmentConditionComponent.cs
+++ b/Content.Shared/_DV/Ailments/SurgeryHasAilmentConditionComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Ailments;
+
+/// <summary>
+/// Requires that this part has an ailment for the surgery to be done
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class SurgeryHasAilmentConditionComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<AilmentPackPrototype> Pack;
+
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<AilmentPrototype> Ailment;
+}

--- a/Content.Shared/_DV/Ailments/SurgeryStepAilmentTransitionComponent.cs
+++ b/Content.Shared/_DV/Ailments/SurgeryStepAilmentTransitionComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.Analyzers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Ailments;
+
+/// <summary>
+/// A surgery step that attempts to cause the given transition in the given ailment pack
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class SurgeryStepAilmentTransitionComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<AilmentPackPrototype> Pack;
+
+    [DataField(required: true), AutoNetworkedField]
+    public ProtoId<AilmentTransitionPrototype> Transition;
+}

--- a/Resources/Locale/en-US/_DV/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/en-US/_DV/guidebook/chemistry/conditions.ftl
@@ -1,1 +1,18 @@
 reagent-explanation-netinadone-ribcage = the target's ribcage is open
+reagent-effect-condition-guidebook-type-damage =
+    { $max ->
+        [2147483648] it has at least {NATURALFIXED($min, 2)} {$type} damage
+        *[other] { $min ->
+                    [0] it has at most {NATURALFIXED($max, 2)} {$type} damage
+                    *[other] it has between {NATURALFIXED($min, 2)} and {NATURALFIXED($max, 2)} {$type} damage
+                 }
+    }
+
+reagent-effect-condition-guidebook-group-damage =
+    { $max ->
+        [2147483648] it has at least {NATURALFIXED($min, 2)} total {$group} damage
+        *[other] { $min ->
+                    [0] it has at most {NATURALFIXED($max, 2)} total {$group} damage
+                    *[other] it has between {NATURALFIXED($min, 2)} and {NATURALFIXED($max, 2)} total {$group} damage
+                 }
+    }

--- a/Resources/Locale/en-US/_DV/surgery/surgery-popup.ftl
+++ b/Resources/Locale/en-US/_DV/surgery/surgery-popup.ftl
@@ -1,0 +1,3 @@
+surgery-popup-step-SurgeryStepResetDislocatedJoint = {$user} is resetting a dislocated joint on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepMendHairlineFractures = {$user} is mending hairline fractures on {$target}'s {$part}.
+surgery-popup-step-SurgeryStepMendCompoundFractures = {$user} is mending compound fractures {$target}'s {$part}.

--- a/Resources/Prototypes/Body/Parts/base.yml
+++ b/Resources/Prototypes/Body/Parts/base.yml
@@ -117,6 +117,9 @@
       left hand:
         id: left hand
         type: Hand
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments
 
 - type: entity
   abstract: true
@@ -135,6 +138,9 @@
       right hand:
         id: right hand
         type: Hand
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments
 
 - type: entity
   abstract: true
@@ -149,6 +155,9 @@
     partType: Hand
     symmetry: Left
     toolName: "a left hand" # Shitmed Change
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments
 
 - type: entity
   abstract: true
@@ -163,6 +172,9 @@
     partType: Hand
     symmetry: Right
     toolName: "a right hand" # Shitmed Change
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments
 
 - type: entity
   abstract: true
@@ -182,6 +194,9 @@
         id: left foot
         type: Foot
   - type: MovementBodyPart
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments
 
 - type: entity
   abstract: true
@@ -201,6 +216,9 @@
         id: right foot
         type: Foot
   - type: MovementBodyPart
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments
 
 - type: entity
   abstract: true
@@ -215,6 +233,9 @@
     partType: Foot
     symmetry: Left
     toolName: "a left foot" # Shitmed Change
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments
 
 - type: entity
   abstract: true
@@ -229,3 +250,6 @@
     partType: Foot
     symmetry: Right
     toolName: "a right foot" # Shitmed Change
+  - type: Ailment # DeltaV: ailments
+    packs:
+    - BoneAilments

--- a/Resources/Prototypes/_DV/Ailments/ailments.yml
+++ b/Resources/Prototypes/_DV/Ailments/ailments.yml
@@ -1,0 +1,155 @@
+- type: ailmentPack
+  id: BoneAilments
+  ailments:
+  - JointDislocation
+  - HairlineFracture
+  - CompoundFracture
+  transitions:
+  # damages
+  - NullToCompound
+  - NullToHairline
+  - NullToJointDislocation
+  # worsening fractures
+  - DislocationToCompound
+  - DislocationToHairline
+  - HairlineToCompound
+  # tending to them
+  - HealDislocation
+  - HealHairline
+  - HealCompound
+
+- type: ailmentTransition
+  id: NullToJointDislocation
+  triggerChance: 0.1
+  triggers:
+  - !type:TypeDamage
+    min: 15
+    damageType: Blunt
+  effects:
+  - !type:HealthChange
+    damage:
+      types:
+        Blunt: -15
+  start: null
+  end: JointDislocation
+
+- type: ailmentTransition
+  id: NullToHairline
+  triggerChance: 0.3
+  triggers:
+  - !type:TypeDamage
+    min: 30
+    damageType: Blunt
+  effects:
+  - !type:HealthChange
+    damage:
+      types:
+        Blunt: -30
+  start: null
+  end: HairlineFracture
+
+- type: ailmentTransition
+  id: NullToCompound
+  triggerChance: 0.6
+  triggers:
+  - !type:TypeDamage
+    min: 45
+    damageType: Blunt
+  effects:
+  - !type:HealthChange
+    damage:
+      types:
+        Blunt: -45
+  start: null
+  end: CompoundFracture
+
+- type: ailmentTransition
+  id: DislocationToCompound
+  triggerChance: 0.6
+  triggers:
+  - !type:TypeDamage
+    min: 30
+    damageType: Blunt
+  effects:
+  - !type:HealthChange
+    damage:
+      types:
+        Blunt: -30
+  start: JointDislocation
+  end: CompoundFracture
+
+- type: ailmentTransition
+  id: DislocationToHairline
+  triggerChance: 0.3
+  triggers:
+  - !type:TypeDamage
+    min: 15
+    damageType: Blunt
+  effects:
+  - !type:HealthChange
+    damage:
+      types:
+        Blunt: -15
+  start: JointDislocation
+  end: HairlineFracture
+
+- type: ailmentTransition
+  id: HairlineToCompound
+  triggerChance: 0.5
+  triggers:
+  - !type:TypeDamage
+    min: 15
+    damageType: Blunt
+  effects:
+  - !type:HealthChange
+    damage:
+      types:
+        Blunt: -15
+  start: HairlineFracture
+  end: CompoundFracture
+
+- type: ailmentTransition
+  id: HealCompound
+  conditions:
+  - !type:TypeDamage
+    max: 10
+    damageType: Blunt
+  start: CompoundFracture
+  end: null
+
+- type: ailmentTransition
+  id: HealHairline
+  conditions:
+  - !type:TypeDamage
+    max: 30
+    damageType: Blunt
+  start: HairlineFracture
+  end: null
+
+- type: ailmentTransition
+  id: HealDislocation
+  conditions:
+  - !type:TypeDamage
+    max: 50
+    damageType: Blunt
+  start: JointDislocation
+  end: null
+
+- type: ailment
+  id: BaseFracture
+  abstract: true
+
+- type: ailment
+  parent: BaseFracture
+  id: JointDislocation
+  healthAnalyzerDescription: The joint is dislocated
+
+- type: ailment
+  parent: BaseFracture
+  id: HairlineFracture
+  healthAnalyzerDescription: The bones have a thin fracture
+
+- type: ailment
+  parent: BaseFracture
+  id: CompoundFracture
+  healthAnalyzerDescription: The bones have a large fracture

--- a/Resources/Prototypes/_DV/Ailments/surgeries.yml
+++ b/Resources/Prototypes/_DV/Ailments/surgeries.yml
@@ -1,0 +1,46 @@
+- type: entity
+  parent: SurgeryBase
+  id: SurgeryResetDislocatedJoint
+  name: Reset Dislocated Joint
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Surgery
+    steps:
+    - SurgeryStepResetDislocatedJoint
+  - type: SurgeryPartPresentCondition
+  - type: SurgeryHasAilmentCondition
+    pack: BoneAilments
+    ailment: JointDislocation
+
+- type: entity
+  parent: SurgeryBase
+  id: SurgeryMendHairlineFractures
+  name: Mend Hairline Fractures
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Surgery
+    requirement: SurgeryOpenIncision
+    steps:
+    - SurgeryStepMendHairlineFractures
+    - SurgeryStepSealWounds
+  - type: SurgeryPartPresentCondition
+  - type: SurgeryHasAilmentCondition
+    pack: BoneAilments
+    ailment: HairlineFracture
+
+- type: entity
+  parent: SurgeryBase
+  id: SurgeryMendCompoundFractures
+  name: Mend Compound Fractures
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Surgery
+    requirement: SurgeryOpenIncision
+    steps:
+    - SurgeryStepSawBones
+    - SurgeryStepPriseOpenBones
+    - SurgeryStepMendCompoundFractures
+  - type: SurgeryPartPresentCondition
+  - type: SurgeryHasAilmentCondition
+    pack: BoneAilments
+    ailment: CompoundFracture

--- a/Resources/Prototypes/_DV/Ailments/surgery_steps.yml
+++ b/Resources/Prototypes/_DV/Ailments/surgery_steps.yml
@@ -1,0 +1,61 @@
+- type: entity
+  parent: SurgeryStepBase
+  id: SurgeryStepResetDislocatedJoint
+  name: Reset dislocated joint
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryStep
+    tool:
+    - type: Bonesetter
+    duration: 8
+  - type: Sprite
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/bonesetter.rsi
+    state: bonesetter
+  - type: SurgeryStepAilmentTransition
+    pack: BoneAilments
+    transition: HealDislocation
+
+- type: entity
+  parent: SurgeryStepBase
+  id: SurgeryStepMendHairlineFractures
+  name: Mend hairline fractures
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryStep
+    tool:
+    - type: BoneGel
+    duration: 8
+  - type: Sprite
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/bone-gel.rsi
+    state: bone-gel
+  - type: SurgeryStepAilmentTransition
+    pack: BoneAilments
+    transition: HealHairline
+  - type: SurgeryDamageChangeEffect
+    sleepModifier: 0.2
+    damage:
+      types:
+        Slash: 30
+
+- type: entity
+  parent: SurgeryStepBase
+  id: SurgeryStepMendCompoundFractures
+  name: Mend compound fractures
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryStep
+    tool:
+    - type: BoneGel
+    duration: 16
+  - type: Sprite
+    sprite: _Shitmed/Objects/Specific/Medical/Surgery/bone-gel.rsi
+    state: bone-gel
+  - type: SurgeryStepAilmentTransition
+    pack: BoneAilments
+    transition: HealCompound
+  - type: SurgeryDamageChangeEffect # DeltaV
+    sleepModifier: 0.1
+    damage:
+      types:
+        Slash: 60
+


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR primarily serves as a proof of concept for ailmentmed, and does not represent a finished gameplay proposal.

The fundamental basis of ailmentmed is the ailment, which are arranged into ailment packs with defined ailment transitions, and all of these are contained within an ailment component on something that can take ailments. The system is intentionally open-ended as to not require custom C# for every ailment that can exist.

## Where to go from here

- relying less on `EntityEffect`/`EntityEffectCondition` for things, such as triggers
- carrying extra data for ailments, such as a lodged bullet
- actually building out the content side of things

## Why / Balance

- vary medical gameplay more than just trekmed/surgical part swapping
- lasting consequences for running headlong into someone with a gun (get stuck with a cast for 20 minutes)

## Technical details
- `AilmentComponent`: similar to a damage container, contains a set of ailment packs and a dictionary of which ailments are active in each pack
- `AilmentPrototype`: defines an ailment, such as "joint dislocation" or "severe fracture" & its effects
- `AilmentTransitionPrototype`: defines how you move between ailments in a pack, such as a minor fracture worsening into a severe fracture or a severe fracture being tended to
- `AilmentPackPrototype`: set of ailments and transitions
- `SharedAilmentSystem`: responsible for managing transitions and effects of ailments
- `SharedAilmentSurgerySystem`: responsible for ailment interactions with shitmed

## Media
![grafik](https://github.com/user-attachments/assets/c9d5803d-c49c-4b5b-9fbe-1846b057b4de)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Someone merged something that wasn't ready to merge

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
