### PR TITLE
cybernetic limb adjustment

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -108,7 +108,7 @@
   - type: BodyPart
     onAdd:
     - type: Prying
-      speedModifier: 1.5
+      speedModifier: 1.2 # DeltaV change from 1.5
       pryPowered: true
 
 - type: entity
@@ -120,7 +120,7 @@
   - type: BodyPart
     onAdd:
     - type: Prying
-      speedModifier: 1.5
+      speedModifier: 1.2 # DeltaV change from 1.5
       pryPowered: true
 
 - type: entity
@@ -134,7 +134,7 @@
     sprintSpeed: 5.625
   - type: BodyPart
     onAdd:
-    - type: NoSlip
+  #  - type: NoSlip # DeltaV no noslip
     - type: ProtectedFromStepTriggers
 
 - type: entity
@@ -148,5 +148,5 @@
     sprintSpeed: 5.625
   - type: BodyPart
     onAdd:
-    - type: NoSlip
+    #  - type: NoSlip # DeltaV no noslip
     - type: ProtectedFromStepTriggers

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -108,7 +108,7 @@
   - type: BodyPart
     onAdd:
     - type: Prying
-      speedModifier: 1.2 # DeltaV change from 1.5
+      speedModifier: 1.2 # DeltaV - change from 1.5
       pryPowered: true
 
 - type: entity
@@ -120,7 +120,7 @@
   - type: BodyPart
     onAdd:
     - type: Prying
-      speedModifier: 1.2 # DeltaV change from 1.5
+      speedModifier: 1.2 # DeltaV - change from 1.5
       pryPowered: true
 
 - type: entity
@@ -134,7 +134,7 @@
     sprintSpeed: 5.625
   - type: BodyPart
     onAdd:
-  #  - type: NoSlip # DeltaV no noslip
+  #  - type: NoSlip # DeltaV - no noslip
     - type: ProtectedFromStepTriggers
 
 - type: entity
@@ -148,5 +148,5 @@
     sprintSpeed: 5.625
   - type: BodyPart
     onAdd:
-    #  - type: NoSlip # DeltaV no noslip
+    #  - type: NoSlip # DeltaV - no noslip
     - type: ProtectedFromStepTriggers


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
removes no slips from speed legs
slows down JOL on the cyber arms

## Why / Balance
speed legs with noslips is dumb. super fast JOL is dumb. both tuned down

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: SPEED Legs can slip
