### PR TITLE
Fix damage state displays in the Crew Monitoring UI

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -221,7 +221,7 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
 
             else if (sensor.DamagePercentage != null)
             {
-                var index = MathF.Round(4f * sensor.DamagePercentage.Value);
+                var index = (int)(sensor.DamagePercentage.Value * 5f); // DeltaV - Ensure damage states are calculated properly
 
                 if (index >= 5)
                     specifier = new SpriteSpecifier.Rsi(new ResPath("Interface/Alerts/human_crew_monitoring.rsi"), "critical");


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Changed the damage state calculation in the crew monitoring UI to more accurately reflect reality.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I noticed that the damage states (Good, okay, poor, bad, bad!, and crit) displayed on the crew monitor did not always match the actual state displayed on the client damage state display (the one in the alert menu above the thirsty / hungry icons and stuff)

## Technical details
<!-- Summary of code changes for easier review. -->
### The previous calculation
`var index = MathF.Round(4f * sensor.DamagePercentage.Value);`
Based on this calculation, the damage percentage thresholds for each state were:
Good (health0): 0% - 12.5%
Okay (health1): 12.5% - 37.5%
Poor (health2): 37.5% - 62.5%
Bad (health3): 62.5% - 87.5%
Bad! (health4): 87.5% **- 112.5%**
Critical: 112.5% and above

I was not able to track down an exact source of truth for damage states (did not find the client system responsible for the damage status display), and I still suspect there is some weirdness going on somewhere (see second video), but the new system is a huge improvement from before and at this point I think this is good enough.
### New calculation:
`var index = (int)(sensor.DamagePercentage.Value * 5f);`
Resulting in: 
Good: 0-20%
Okay: 20-40%
Poor: 40-60%
Bad: 60-80%
Bad!: 80-100%
Critical: 100%+

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Attached videos of the new calculation in effect. Did not add videos of the before state, but it was obvious that for critical entities the damage state displays bad! for some time.

https://github.com/user-attachments/assets/96f35c86-5d00-402a-8e3f-6d25c496b735

https://github.com/user-attachments/assets/f10ffde4-860b-4d35-8617-4082e024e7bd

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
don't need one.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
