### PR TITLE
Book of Mysteries becomes useful + steal objective

### DIFF
--- a/Resources/Locale/en-US/_DV/objectives/conditions/steal-target-groups.ftl
+++ b/Resources/Locale/en-US/_DV/objectives/conditions/steal-target-groups.ftl
@@ -5,6 +5,6 @@ steal-target-groups-x01 = x-01 multiphase energy gun
 steal-target-groups-notary-stamp = notary stamp
 steal-target-groups-silvia = silvia
 steal-target-groups-box-folder-rd-clipboard = research digi-board
-
+steal-target-groups-bible-mystagogue = book of mysteries
 steal-target-groups-recruiter-pen = recruiter's pen
 steal-target-groups-captains-cloak = captain's cloak

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -285,6 +285,7 @@
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
     - id: RubberStampRd
+    - id: BibleMystagogue  # DeltaV - steal objective and source of abilities
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
@@ -12,3 +12,14 @@
   - type: Item
     size: Small
     sprite: Nyanotrasen/Objects/Specific/Chapel/holylight.rsi
+  - type: Spellbook
+    spellActions:
+      ActionFlashRune: -1
+      ActionStunRune: -1
+      ActionForceWall: -1
+  - type: Tag
+    tags:
+    - HighRiskItem
+    - Spellbook
+  - type: StealTarget
+    stealGroup: BibleMystagogue

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
@@ -4,8 +4,6 @@
   name: book of mysteries
   description: The mystagogue's holy book.
   components:
-  - type: Summonable
-    specialItem: SpawnPointGhostIfrit
   - type: Sprite
     sprite: Nyanotrasen/Objects/Specific/Chapel/holylight.rsi
     state: icon

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
@@ -14,8 +14,6 @@
     sprite: Nyanotrasen/Objects/Specific/Chapel/holylight.rsi
   - type: Spellbook
     spellActions:
-      ActionFlashRune: -1
-      ActionStunRune: -1
       ActionForceWall: -1
   - type: Tag
     tags:

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -30,6 +30,7 @@
     LOLuckyBillStealObjective: 0.5 # DeltaV - LO steal objective, see Resources/Prototypes/_DV/Objectives/traitor.yml
     HoPBookIanDossierStealObjective: 1 # DeltaV - HoP steal objective, see Resources/Prototypes/_DV/Objectives/traitor.yml
     HoSGunStealObjective: 0.5 # DeltaV
+    BibleMystagogueStealObjective: 0.5 # DeltaV - Mysta steal objective see Resources/Prototypes/_DV/Objectives/traitor.yml
 
 - type: weightedRandom
   id: TraitorObjectiveGroupKill

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -46,7 +46,6 @@
   equipment:
     id: RnDPDA
     ears: ClothingHeadsetRD
-    belt: BibleMystagogue # Nyanotrasen - Mystagogue book for their Ifrit
   storage:
     back:
     - Flash

--- a/Resources/Prototypes/_DV/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/stealTargetGroups.yml
@@ -27,11 +27,11 @@
     state: rd_clipboard
 
 - type: stealTargetGroup
-  id: BoxFolderRdClipboard
-  name: steal-target-groups-box-folder-rd-clipboard
+  id: BibleMystagogue
+  name: steal-target-groups-bible-mystagogue
   sprite:
-    sprite: _DV/Objects/Misc/rd_clipboard.rsi
-    state: rd_clipboard
+    sprite: Nyanotrasen/Objects/Specific/Chapel/holylight.rsi
+    state: icon
 
 - type: stealTargetGroup
   id: RubberStampNotary

--- a/Resources/Prototypes/_DV/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/stealTargetGroups.yml
@@ -27,6 +27,13 @@
     state: rd_clipboard
 
 - type: stealTargetGroup
+  id: BoxFolderRdClipboard
+  name: steal-target-groups-box-folder-rd-clipboard
+  sprite:
+    sprite: _DV/Objects/Misc/rd_clipboard.rsi
+    state: rd_clipboard
+
+- type: stealTargetGroup
   id: RubberStampNotary
   name: steal-target-groups-notary-stamp
   sprite:

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -72,7 +72,6 @@
     stealGroup: BibleMystagogue
     owner: job-name-rd
 
-
 # teach lesson
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -62,6 +62,17 @@
     stealGroup: BoxFolderRdClipboard
     owner: job-name-rd
 
+- type: entity
+  parent: BaseTraitorStealObjective
+  id: BibleMystagogueStealObjective
+  components:
+  - type: NotJobRequirement
+    job: ResearchDirector
+  - type: StealCondition
+    stealGroup: BibleMystagogue
+    owner: job-name-rd
+
+
 # teach lesson
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
book of mysteries can now grant whoever holds it the power to make forcewalls, which block bullets, lasers, objects, and all other projectiles from passing through them. They can however still be passed through by people. The MG can no longer summon ifrit with their book, and it will no longer spawn in their loadout, instead appearing in their locker. the book of mysteries is also now a steal objective.

## Why / Balance
ifrit was outdated and it really showed. the role was almost exclusively used for raiders or validhunters, and the occasional newbie would take it and roleplay as an advanced welder. In the future i hope to add more spells to this and a shop similar to the grimoire, but this is the first step.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
![image](https://github.com/user-attachments/assets/f6467bbd-191f-4c3a-a524-88060c017005)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: The book of mysteries is now a steal objective, spawning in the locker instead of on the mystagogue.
- tweak: The book of mysteries can no longer summon ifrits, instead granting the secret of forcewall!

