### PR TITLE
replace thief radio jammer with doorjack

### DIFF
--- a/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
+++ b/Resources/Prototypes/Catalog/thief_toolbox_sets.yml
@@ -61,7 +61,7 @@
     sprite: Objects/Specific/Syndicate/telecrystal.rsi
     state: telecrystal
   content:
-  - RadioJammer
+  - Doorjack # DeltaV - replaced RadioJammer with doorjack
   - TraitorCodePaper
   - Emag
   - Lighter


### PR DESCRIPTION
## About the PR
title

## Why / Balance
jammer was useless besides proving to nukies you are valid
doorjack lets you rush free AA easier now

**Changelog**
:cl:
- tweak: Replaced thief's radio jammer with a doorjack.
