### PR TITLE
Fix big sprite in health analyzer

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -29,7 +29,6 @@
                               Margin="0 0 0 5">
                     <PanelContainer>
                         <SpriteView OverrideDirection="South"
-                                    Scale="2.5 2.5"
                                     Name="SpriteView"
                                     Access="Public"
                                     SetSize="96 96"/>


### PR DESCRIPTION
It was either removing scale here, or in the code-behind. The code-behind's value is correct (3 instead of 2.5) so I opted to keep that one

## About the PR
Removed superfluous icon scale in health analyzer UI

## Why / Balance
:bug:

## Technical details
Scale was being applied twice on opening UI for the first time. I don't know why or how but this fixed it :trollface:

## Media
Before:
![body dummy sprite is too big](https://github.com/user-attachments/assets/5e521e11-3584-442c-a1be-6b32661abb6d)
After:
![body dummy sprite is not too big](https://github.com/user-attachments/assets/7614c6b5-b145-4673-bd67-280e7277259f)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
:cl:
- fix: Fixed health analyzer dummy sprite being too big when you first open it