### PR TITLE
dont play weather sounds in lobby

### DIFF
--- a/Content.Client/Weather/WeatherSystem.cs
+++ b/Content.Client/Weather/WeatherSystem.cs
@@ -128,6 +128,20 @@ public sealed class WeatherSystem : SharedWeatherSystem
         if (!Timing.IsFirstTimePredicted)
             return true;
 
+        // Begin DeltaV Additions: Prevent hearing weather in the lobby
+        if (_playerManager.LocalEntity is not {} ent)
+            return false;
+
+        var map = Transform(uid).MapUid;
+        var entMap = Transform(ent).MapUid;
+
+        if (map == null || entMap != map)
+        {
+            weather.Stream = _audio.Stop(weather.Stream);
+            return false;
+        }
+        // End DeltaV Additions
+
         // TODO: Fades (properly)
         weather.Stream = _audio.Stop(weather.Stream);
         weather.Stream = _audio.PlayGlobal(weatherProto.Sound, Filter.Local(), true)?.Entity;


### PR DESCRIPTION
## About the PR
when i was looking at this ages ago i didnt notice there was a second place playing the sound, and it just happened to have no map checks

## Why / Balance
fixes #2509

## Technical details
ctrl c ctrl v :trollface:

**Changelog**
:cl:
- fix: Fixed being able to hear ash storms in the lobby.
