### PR TITLE
fix objectives tab not working

### DIFF
--- a/Content.Server/_DV/Store/Conditions/ObjectiveUnlockCondition.cs
+++ b/Content.Server/_DV/Store/Conditions/ObjectiveUnlockCondition.cs
@@ -11,11 +11,11 @@ public sealed partial class ObjectiveUnlockCondition : ListingCondition
 {
     public override bool Condition(ListingConditionArgs args)
     {
-        var minds = args.EntityManager.System<SharedMindSystem>();
-        if (!minds.TryGetMind(args.Buyer, out _, out var mind))
+        var ent = args.EntityManager;
+        if (!ent.TryGetComponent<MindComponent>(args.Buyer, out var mind))
             return false;
 
-        var unlocker = args.EntityManager.System<StoreUnlockerSystem>();
+        var unlocker = ent.System<StoreUnlockerSystem>();
         return unlocker.IsUnlocked(mind, args.Listing.ID);
     }
 }


### PR DESCRIPTION
## About the PR
gamer couldnt rename it to BuyerMind or something so it doesnt compile but no

## Why / Balance
fixes #2988

## Technical details
args.Buyer is the mind now

## Media
![06:41:21](https://github.com/user-attachments/assets/02b04f34-1097-4d6e-ad16-c3036e2c89a6)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed uplink's objectives tab not existing.