### PR TITLE
give ipcs and borgs fibers

### DIFF
--- a/Content.Server/Forensics/Systems/ForensicsSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicsSystem.cs
@@ -32,6 +32,7 @@ namespace Content.Server.Forensics
         public override void Initialize()
         {
             SubscribeLocalEvent<FingerprintComponent, ContactInteractionEvent>(OnInteract);
+            SubscribeLocalEvent<FiberComponent, ContactInteractionEvent>(OnFiberInteract); // DeltaV
             SubscribeLocalEvent<FiberComponent, MapInitEvent>(OnFiberInit); // DeltaV #1455 - unique glove fibers
             SubscribeLocalEvent<FingerprintComponent, MapInitEvent>(OnFingerprintInit);
             SubscribeLocalEvent<DnaComponent, MapInitEvent>(OnDNAInit);
@@ -64,12 +65,19 @@ namespace Content.Server.Forensics
             ApplyEvidence(uid, args.Other);
         }
 
-        // DeltaV #1455 - unique glove fibers
-        private void OnFiberInit(EntityUid uid, FiberComponent component, MapInitEvent args)
+        // Begin DeltaV Additions
+        // ipcs and borgs leave metal fibers
+        private void OnFiberInteract(Entity<FiberComponent> ent, ref ContactInteractionEvent args)
         {
-            component.Fiberprint = GenerateFingerprint(length: 7);
+            ApplyEvidence(ent, args.Other);
         }
-        // End of DeltaV code
+
+        // #1455 - unique glove fibers
+        private void OnFiberInit(Entity<FiberComponent> ent, ref MapInitEvent args)
+        {
+            ent.Comp.Fiberprint = GenerateFingerprint(length: 7);
+        }
+        // End DeltaV Additions
 
         private void OnFingerprintInit(EntityUid uid, FingerprintComponent component, MapInitEvent args)
         {
@@ -294,10 +302,19 @@ namespace Content.Server.Forensics
                 return;
 
             var component = EnsureComp<ForensicsComponent>(target);
+            // Begin DeltaV Additions - IPCs and borgs leave fibers
+            if (TryComp<FiberComponent>(user, out var fiber) && CanAccessFingerprint(user, out _))
+            {
+                var fiberLocale = string.IsNullOrEmpty(fiber.FiberColor)
+                    ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial))
+                    : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial));
+                component.Fibers.Add(fiberLocale + " ; " + fiber.Fiberprint);
+            }
+            // End DeltaV Additions
             if (_inventory.TryGetSlotEntity(user, "gloves", out var gloves))
             {
                 // DeltaV #1455 - unique glove fibers
-                if (TryComp<FiberComponent>(gloves, out var fiber) && !string.IsNullOrEmpty(fiber.FiberMaterial))
+                if (TryComp<FiberComponent>(gloves, out fiber) && !string.IsNullOrEmpty(fiber.FiberMaterial))
                 {
                     var fiberLocale = string.IsNullOrEmpty(fiber.FiberColor)
                         ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial))

--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -95,7 +95,8 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
         TryComp<FingerprintComponent>(player, out var fingerprintComponent);
         TryComp<DnaComponent>(player, out var dnaComponent);
 
-        CreateGeneralRecord(station, idUid.Value, profile.Name, profile.Age, profile.Species, profile.Gender, jobId, fingerprintComponent?.Fingerprint, dnaComponent?.DNA, profile, records);
+        var prints = fingerprintComponent?.Fingerprint ?? CompOrNull<FiberComponent>(player)?.Fiberprint; // DeltaV - IPCs use fibers
+        CreateGeneralRecord(station, idUid.Value, profile.Name, profile.Age, profile.Species, profile.Gender, jobId, prints, dnaComponent?.DNA, profile, records); // DeltaV - use prints var
     }
 
 

--- a/Resources/Locale/en-US/_DV/forensics/fibers.ftl
+++ b/Resources/Locale/en-US/_DV/forensics/fibers.ftl
@@ -1,0 +1,5 @@
+# IPC
+fibers-steel = steel
+# Borg, coloured with the chassis colour for non-generic borgs
+fibers-plasteel = plasteel
+fibers-degraded-plasteel = degraded plasteel

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -109,6 +109,8 @@
     allowSelfRepair: false
   - type: BorgChassis
   - type: SurgerySelfDirty # DeltaV: borgs get dirty from doing surgery
+  - type: Fiber # DeltaV - borgs leave metal fibers
+    fiberMaterial: fibers-plasteel
   - type: LockingWhitelist
     blacklist:
       components:
@@ -338,6 +340,8 @@
       Unsexed: UnisexSiliconSyndicate
   - type: PointLight
     color: "#dd200b"
+  - type: Fiber # DeltaV - syndiborgs have black plasteel fibers
+    fiberColor: fibers-black
 
 - type: entity
   id: BaseBorgChassisDerelict
@@ -358,3 +362,5 @@
   - type: IonStormTarget
     chance: 1
   - type: ShowJobIcons
+  - type: Fiber # DeltaV - derelict borgs have degraded plasteel fibers
+    fiberMaterial: fibers-degraded-plasteel

--- a/Resources/Prototypes/_DV/borg_types.yml
+++ b/Resources/Prototypes/_DV/borg_types.yml
@@ -29,6 +29,9 @@
       0: Alive
       80: Critical # -20 to Crit Threshold
       200: Dead
+  - type: Fiber # red plasteel fibers
+    fiberMaterial: fibers-plasteel
+    fiberColor: fibers-red
 
   radioChannels:
   - Science

--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
@@ -315,3 +315,5 @@
     - type: Targeting
     - type: SurgeryTarget
     - type: LayingDown
+    - type: Fiber # DeltaV - IPCs leave fibers instead of prints
+      fiberMaterial: fibers-steel

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -50,6 +50,10 @@
   - BorgModuleCable
 
   lawset: Engineer # DeltaV: Custom lawset
+  addComponents: # DeltaV - orange plasteel fibers
+  - type: Fiber
+    fiberMaterial: fibers-plasteel
+    fiberColor: fibers-orange
 
   radioChannels:
   - Engineering
@@ -85,6 +89,11 @@
   - BorgModuleGrapplingGun
   - BorgModuleMining
   - BorgModuleAppraisal
+
+  addComponents: # DeltaV - brown plasteel fibers
+  - type: Fiber
+    fiberMaterial: fibers-plasteel
+    fiberColor: fibers-brown
 
   radioChannels:
   - Supply
@@ -122,6 +131,10 @@
   - BorgModuleCleaning
 
   lawset: Janitor # DeltaV: Custom lawset
+  addComponents: # DeltaV - purple plasteel fibers
+  - type: Fiber
+    fiberMaterial: fibers-plasteel
+    fiberColor: fibers-purple
 
   radioChannels:
   - Science
@@ -176,6 +189,9 @@
     actions:
     - ActionFabricateLollipop
     - ActionFabricateGumball
+  - type: Fiber # DeltaV - white plasteel fibers
+    fiberMaterial: fibers-plasteel
+    fiberColor: fibers-white
   - type: SurgeryTarget # Shitmed
   - type: Sanitized # Shitmed
 


### PR DESCRIPTION
## About the PR
ipcs get steel fibers, borgs get coloured plasteel fibers
also fixes ipcs not leaving glove fibers

every borg has a unique fiber colour except:
- service has same fiber as generic because it has nothing else going for it :trollface:
- syndiborgs are all black plasteel
- derelict borg has decayed plasteel

## Why / Balance
fixes #2980

## Technical details
ctrl c ctrl v :trollface:

## Media
fiberprints are listed in records
![07:57:18](https://github.com/user-attachments/assets/6fcf8edf-5f06-492b-99e0-0311e4eae864)

touching thing with no gloves leaves steel fibers
![07:57:08](https://github.com/user-attachments/assets/fcbc7d31-6f41-4ed0-b47a-8920dc19f37b)

fingerless gloves work as expected
![07:57:40](https://github.com/user-attachments/assets/6f83012f-dc43-4444-9f6d-a74acc4b9da7)

ipc with gloves hides metal fibers
![07:57:56](https://github.com/user-attachments/assets/71f207e7-5965-4717-b66a-c41599e4e47c)

avengers assemble
![08:09:06](https://github.com/user-attachments/assets/7f455ac5-5cc5-4b03-ac3e-a0994afd88c2)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: Borgs and IPCs now leave metal fibers when touching things.
- fix: Fixed IPCs not leaving fibers when using gloves.
