### PR TITLE
remove thief ghost role steal objectives

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -117,14 +117,13 @@
   id: ThiefObjectiveGroupAnimal
   weights:
     IanStealObjective: 1
-    BingusStealObjective: 1
+    #BingusStealObjective: 1 # DeltaV - no stealing ghost roles
     McGriffStealObjective: 1
     WalterStealObjective: 1
     MortyStealObjective: 1
     RenaultStealObjective: 1
-    ShivaStealObjective: 1
+    #ShivaStealObjective: 1 # DeltaV - no stealing ghost roles
     TropicoStealObjective: 1
-    SilviaStealObjective: 1 # DeltaV - CMO steal objective, see Resources/Prototypes/_DV/Objectives/traitor.yml
 
 - type: weightedRandom
   id: ThiefObjectiveGroupEscape

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -40,17 +40,6 @@
     stealGroup: RubberStampNotary
     owner: job-name-clerk
 
-- type: entity
-  abstract: true
-  parent: BaseTraitorStealObjective
-  id: SilviaStealObjective
-  components:
-  - type: NotJobRequirement
-    job: ChiefMedicalOfficer
-  - type: StealCondition
-    stealGroup: AnimalSilvia
-    owner: job-name-cmo
-
 # Mystagogue steal objective
 - type: entity
   parent: BaseTraitorStealObjective


### PR DESCRIPTION
## About the PR
- removed shiva/laika objective
- removed bingus objective

silvia objective didnt work anyway as it required traitor so you could never get it as thief since traitor could only possibly roll after thief

## Why / Balance
the only way to do this is to build a indestructible oxygenated scrubbed room specifically to hold this animal and prevent it dying randomly. begging logi for a pet carrier is already valid and takes 30m to arrive anyway, and if you do get it you drop it when evac docks so you fail it anyway unless you are a diona

regardless of how you contain the animal you get completely cucked if someone takes the ghost role, at which point you have to keep them sedated 24/7 to prevent them attacking you or just running away and snitching when they get cogni

**Changelog**
:cl:
- remove: Shiva and Bingus are no longer thief objectives.