### PR TITLE
Allow hand-written mail to go into mail bags

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/tools.yml
@@ -21,4 +21,4 @@
     whitelist:
       components:
         - Mail
-        - Envelope # DeltaV - Allow handwritten mail
+        - Envelope

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/tools.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/tools.yml
@@ -21,3 +21,4 @@
     whitelist:
       components:
         - Mail
+        - Envelope # DeltaV - Allow handwritten mail


### PR DESCRIPTION
## About the PR
Allow envelopes to go into mail bags

## Why / Balance
Envelopes is mail
Mail bag is for mail
Mail goes in mail bag
Envelopes should go in mail bag
:)

## Technical details
Allow entities with EnvelopeComponent into the Mail Bag's content filter

## Media
none

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
:cl:
- add: Envelopes go in mail bags