### PR TITLE
make pizza crates not invalidate chef

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,19 +4,19 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 450
+  cost: 1000
   category: cargoproduct-category-name-food
   group: market
 
-- type: cargoProduct
-  id: FoodPizzaLarge
-  icon:
-    sprite: Objects/Consumable/Food/Baked/pizza.rsi
-    state: margherita
-  product: CrateFoodPizzaLarge
-  cost: 1800
-  category: cargoproduct-category-name-food
-  group: market
+#- type: cargoProduct
+#  id: FoodPizzaLarge
+#  icon:
+#    sprite: Objects/Consumable/Food/Baked/pizza.rsi
+#    state: margherita
+#  product: CrateFoodPizzaLarge
+#  cost: 1800
+#  category: cargoproduct-category-name-food
+#  group: market
 
 - type: cargoProduct
   id: FoodMRE

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 1000 # DrltaV - raised from 450
+  cost: 1000 # DeltaV - raised from 450
   category: cargoproduct-category-name-food
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,11 +4,11 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 1000
+  cost: 1000 # DrltaV - raised from 450
   category: cargoproduct-category-name-food
   group: market
 
-#- type: cargoProduct
+#- type: cargoProduct # DeltaV - Removed to not invalidate chef
 #  id: FoodPizzaLarge
 #  icon:
 #    sprite: Objects/Consumable/Food/Baked/pizza.rsi

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -65,7 +65,7 @@
     description: cargo-gift-pizza-large
     dest: cargo-gift-dest-bar
     gifts:
-      FoodPizzaLarge: 1              # 16 pizzas
+      FoodPizza: 2 # DeltaV - Changed to 2 small pizza crates, 8 pizzas total
       FoodBarSupply: 1
       FoodSoftdrinksLarge: 1
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
removed the large pizza crate, bumped the price of the small pizza crate from 450 to 1000

changed the large pizza party gamerule to include 8 pizzas instead of 16

## Why / Balance
Cargo shouldn't be able to invalidate chef for the low low price of 1.5k, or any price really. MRE crates are still available as is the small pizza crate with 4 pizza's

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Disaster pizza crate is no longer orderable
- tweak: Emergency pizza crate now costs more
