### PR TITLE
Make omnipatch stacks include 10 patches

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
@@ -334,6 +334,7 @@
     bloodlossModifier: -20 # DeltaV - IPCs bleed
   - type: Stack
     stackType: OmniPatch
+    count: 10
 
 - type: entity
   id: Omnipatch1


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
title 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Omnipatch spawns (including the uplink purchase) only include five patches, which seems like a mistake. They're set to have a max of 10.

## Technical details
<!-- Summary of code changes for easier review. -->
yaml

<!--## Media-->
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!--## Breaking changes-->
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: omnipatch stacks now correctly include 10 patches