### PR TITLE
Glass can repair IPCs and Bleed doesnt infinitly become evil

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/glass.yml
@@ -52,6 +52,7 @@
   - type: BlindHealing
     damageContainers:
       - Silicon
+      - HumanoidSilicon # DeltaV - IPCs need to see
   - type: StackPrice
     price: 2
 

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -45,7 +45,7 @@
 - type: damageModifierSet
   id: BloodlossIPC
   coefficients:
-    Blunt: 0.08
+    Blunt: 0.00 # no evil doublestack damage
     Slash: 0.25
     Piercing: 0.2
     Shock: 0.0


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
ipcs dont bleed from blunt, glass can fix eye damage

## Why / Balance
its good 

## Technical details
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: IPC bloodloss no longer causes more bleeding
- fix: IPCs eyes may be repaired with glass again