### PR TITLE
Add hotbar indicator to surgery cleanliness

### DIFF
--- a/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
+++ b/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
@@ -11,8 +11,10 @@ public sealed class SurgeryCleanSystem : SharedSurgeryCleanSystem
     public override void Initialize()
     {
         base.Initialize();
+
         Subs.ItemStatus<SurgeryDirtinessComponent>(ent => new SurgeryDirtinessItemStatus(ent, EntityManager));
     }
+
     public override bool RequiresCleaning(EntityUid target)
     {
         // Predict that it can be cleaned if it has dirt on it

--- a/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
+++ b/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
@@ -1,3 +1,4 @@
+using Content.Client.Items;
 using Content.Shared._DV.Surgery;
 
 namespace Content.Client._DV.Surgery;
@@ -7,6 +8,11 @@ namespace Content.Client._DV.Surgery;
 /// </summary>
 public sealed class SurgeryCleanSystem : SharedSurgeryCleanSystem
 {
+    public override void Initialize()
+    {
+        base.Initialize();
+        Subs.ItemStatus<SurgeryDirtinessComponent>(ent => new SurgeryDirtinessItemStatus(ent, EntityManager));
+    }
     public override bool RequiresCleaning(EntityUid target)
     {
         // Predict that it can be cleaned if it has dirt on it

--- a/Content.Client/_DV/Surgery/SurgeryDirtinessItemStatus.cs
+++ b/Content.Client/_DV/Surgery/SurgeryDirtinessItemStatus.cs
@@ -1,0 +1,44 @@
+using Content.Client.UserInterface.Controls;
+using Content.Shared._DV.Surgery;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Timing;
+
+namespace Content.Client._DV.Surgery;
+
+public sealed class SurgeryDirtinessItemStatus : SplitBar
+{
+    private readonly IEntityManager _entMan;
+    private readonly EntityUid _uid;
+    private FixedPoint2? _dirtiness = null;
+
+    public SurgeryDirtinessItemStatus(EntityUid uid, IEntityManager entManager)
+    {
+        _uid = uid;
+        _entMan = entManager;
+        Margin = new Thickness(4);
+        MinHeight = 16;
+        MaxHeight = 16;
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+        if (!_entMan.TryGetComponent<SurgeryDirtinessComponent>(_uid, out var dirtiness))
+            return;
+
+        if (_dirtiness == dirtiness.Dirtiness)
+            return;
+        _dirtiness = dirtiness.Dirtiness;
+
+        Clear();
+
+        var amount = FixedPoint2.Min(_dirtiness.Value / 100, 1);
+        var remaining = 1 - amount;
+
+        if (amount != FixedPoint2.Zero)
+            AddEntry(amount.Float(), amount < 0.5 ? Color.RosyBrown : Color.Red);
+
+        if (remaining != FixedPoint2.Zero)
+            AddEntry(remaining.Float(), Color.SlateGray);
+    }
+}

--- a/Content.Client/_DV/Surgery/SurgeryDirtinessItemStatus.cs
+++ b/Content.Client/_DV/Surgery/SurgeryDirtinessItemStatus.cs
@@ -11,10 +11,10 @@ public sealed class SurgeryDirtinessItemStatus : SplitBar
     private readonly EntityUid _uid;
     private FixedPoint2? _dirtiness = null;
 
-    public SurgeryDirtinessItemStatus(EntityUid uid, IEntityManager entManager)
+    public SurgeryDirtinessItemStatus(EntityUid uid, IEntityManager entMan)
     {
         _uid = uid;
-        _entMan = entManager;
+        _entMan = entMan;
         Margin = new Thickness(4);
         MinHeight = 16;
         MaxHeight = 16;
@@ -23,12 +23,13 @@ public sealed class SurgeryDirtinessItemStatus : SplitBar
     protected override void FrameUpdate(FrameEventArgs args)
     {
         base.FrameUpdate(args);
-        if (!_entMan.TryGetComponent<SurgeryDirtinessComponent>(_uid, out var dirtiness))
+
+        if (!_entMan.TryGetComponent<SurgeryDirtinessComponent>(_uid, out var comp))
             return;
 
-        if (_dirtiness == dirtiness.Dirtiness)
+        if (_dirtiness == comp.Dirtiness)
             return;
-        _dirtiness = dirtiness.Dirtiness;
+        _dirtiness = comp.Dirtiness;
 
         Clear();
 

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -142,6 +142,7 @@
   - type: Fiber
     fiberMaterial: fibers-latex
   - type: FingerprintMask
+  - type: SurgeryDirtiness # DeltaV - gloves that are likely to be used for surgery should have their bar visible from the getgo
 
 - type: entity
   parent: ClothingHandsButcherable
@@ -156,6 +157,7 @@
   - type: Fiber
     fiberMaterial: fibers-nitrile
   - type: FingerprintMask
+  - type: SurgeryDirtiness # DeltaV - gloves that are likely to be used for surgery should have their bar visible from the getgo
 ####
 - type: entity
   parent: ClothingHandsButcherable

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -14,6 +14,7 @@
     tags:
     - SurgeryTool
   - type: SurgeryTool
+  - type: SurgeryDirtiness # DeltaV - make sure surgery tools start with surgery dirtiness component
 
 # Cautery
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This adds a UI element to the hotbar to see how dirty an item is surgically

## Why / Balance
It's not otherwise visible without checking the tooltip

## Technical details
- `SurgeryDirtinessItemStatus` -> displays the hotbar status
- adds `SurgeryDirtiness` to a few prototypes so they have an empty hotbar from the getgo instead of requiring the item to be held and unheld after using for the first time to display the bar

## Media
![grafik](https://github.com/user-attachments/assets/410e463b-bec7-4669-b5ab-f3505cee984f)



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added an indicator to the hotbar of how dirty a tool or glove is for surgery
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
