### PR TITLE
Let Carpy speak & write

### DIFF
--- a/Resources/Locale/en-US/_DV/paper/stamp-component.ftl
+++ b/Resources/Locale/en-US/_DV/paper/stamp-component.ftl
@@ -1,4 +1,5 @@
 stamp-component-stamped-name-notary = NOTARY
+stamp-component-stamped-name-carpy = Legal Carp
 stamp-component-stamped-name-chiefjustice = Chief Justice
 stamp-component-stamped-name-prosec = Prosecutor
 stamp-component-stamped-name-admin-assistant = Administrative Assistant

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -87,6 +87,20 @@
         Base: dead
         BaseUnshaded: dead_mouth
         BaseUnshadedAccessory: suit_dead
+  - type: Accentless
+    removes:
+    - type: ReplacementAccent
+      accent: genericAggressive
+  - type: Body
+    prototype: Human # For two hands.
+  - type: InnateTool
+    tools:
+      - id: LuxuryPen
+      - id: RubberStampCarpy
+  - type: Inventory
+    speciesId: carp
+    templateId: carpy
+  - type: Hands
   - type: GhostRole
     makeSentient: true
     allowSpeech: true
@@ -98,6 +112,39 @@
       department: Justice
       time: 3600 # 1 hours
   - type: GhostTakeoverAvailable
+  - type: UserInterface
+    interfaces:
+      enum.SurgeryUIKey.Key:
+        type: SurgeryBui
+      enum.StrippingUiKey.Key:
+        type: StrippableBoundUserInterface
+
+- type: entity
+  name: legal carp stamp
+  parent: RubberStampBase
+  id: RubberStampCarpy
+  suffix: DO NOT MAP
+  description: A stamp specially designed for legal carps, to mark documents that aren't fishy.
+  components:
+  - type: Stamp
+    stampedName: stamp-component-stamped-name-carpy
+    stampedColor: "#a81f3d"
+    stampState: "paper_stamp-notary"
+  - type: Sprite
+    sprite: _DV/Objects/Misc/stamps.rsi
+    state: stamp-notary
+
+- type: inventoryTemplate
+  id: carpy
+  slots:
+  - name: id
+    slotTexture: id
+    slotFlags: IDCARD
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 2,1
+    strippingWindowPos: 2,4
+    displayName: ID
 
 - type: entity
   name: Silvia


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR gives Carpy an innate luxury pen and legal carp stamp, which it can use to write and stamp documents, as well as the ability to speak, to argue about aforementioned legal documents. An ID card slot has been added to allow someone in-round to decide that Carpy should be able to annoy Security or Justice by arguing about aforementioned legal documents.

## Why / Balance
Given that the justice department is all about words, and that the Mystagogue has a speaking familiar, I think it's only fair for Carpy to be able to write and speak because legal nerds, and to give it a stamp because more stamps are always fun. Pets being able to help out with departments in a minor way is already precedented, see the security pets' fighting or Silvia being able to inject omnizine into people.

## Technical details
- Accentless, to make Carpy able to speak
- `Body`, `InnateTool`, `Hands` to give Carpy a luxury pen and a legal carp stamp
- new legal carp stamp prototype
- new carpy inventory template that only has an ID card

## Media
![grafik](https://github.com/user-attachments/assets/bfac1541-c641-4586-a5e0-345f2ad70986)
![grafik](https://github.com/user-attachments/assets/7764a392-728d-45ca-b6df-56a05ff0074c)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Carpy now has an unremovable pen and stamp, and can talk & be given an ID card for crew that wishes to let it annoy Security with more efficiency.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
