### PR TITLE
Nuke time raised

### DIFF
--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Nuke
         /// </summary>
         [DataField("timer")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public int Timer = 300;
+        public int Timer = 450;
 
         /// <summary>
         ///     If the nuke is disarmed, this sets the minimum amount of time the timer can have.

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Nuke
         /// </summary>
         [DataField("timer")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public int Timer = 450; // DeltaV - raised to 450 from 300 (7.5 minutes)
+        public int Timer = 300;
 
         /// <summary>
         ///     If the nuke is disarmed, this sets the minimum amount of time the timer can have.

--- a/Content.Server/Nuke/NukeComponent.cs
+++ b/Content.Server/Nuke/NukeComponent.cs
@@ -23,7 +23,7 @@ namespace Content.Server.Nuke
         /// </summary>
         [DataField("timer")]
         [ViewVariables(VVAccess.ReadWrite)]
-        public int Timer = 450;
+        public int Timer = 450; // DeltaV - raised to 450 from 300 (7.5 minutes)
 
         /// <summary>
         ///     If the nuke is disarmed, this sets the minimum amount of time the timer can have.

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -93,6 +93,7 @@
     enabled: false
   - type: NukeLabel
   - type: Nuke
+    timer: 450
     explosionType: Default
     maxIntensity: 100
     intensitySlope: 5


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
nuke time from 300 to 450 seconds (7.5 minutes)

## Why / Balance
gives sec and nukies more time to hash it out, 5 minutes is NOTHING

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- tweak: nuke time raised to 450 seconds (7.5 minutes)

