### PR TITLE
Don't double apply modifiers when Oni punch people

### DIFF
--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -222,10 +222,12 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         // Begin DeltaV additions
         // Allow users of melee weapons to have bonuses applied
-        var userEv = new GetMeleeDamageEvent(uid, new(component.Damage), new(), user, component.ResistanceBypass);
-        RaiseLocalEvent(user, ref userEv);
+        if (user != uid)
+        {
+            RaiseLocalEvent(user, ref ev);
+        }
 
-        return DamageSpecifier.ApplyModifierSets(ev.Damage, ev.Modifiers.Concat(userEv.Modifiers));
+        return DamageSpecifier.ApplyModifierSets(ev.Damage, ev.Modifiers);
         // End DeltaV additions
     }
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixed Oni punch modifiers applying twice.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Reported in the oni refactor PR: https://github.com/DeltaV-Station/Delta-v/pull/2805#issuecomment-2676891513 by [@forzii](https://github.com/Forzii).

## Media
![415997054-13aadc66-80cd-4082-a36b-4c8da192e150](https://github.com/user-attachments/assets/e64fd21a-09ac-413e-96d5-4b3b081ef35f)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X ] I have tested all added content and changes.
- [X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- fix: Fixed Oni punches having modifiers apply twice