### PR TITLE
Laika/Vulpkanin comfortable temperature range shifts slightly down

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -55,6 +55,9 @@
     - DoorBumpOpener
   - type: StealTarget
     stealGroup: AnimalSecurity # DeltaV - Adjusts because we have multiple possible sec animals
+  - type: Temperature
+    heatDamageThreshold: 315 # 10 lower than base
+    coldDamageThreshold: 240 # 20 lower than base
 
 - type: entity
   parent: MobCarp
@@ -225,3 +228,5 @@
       - FootstepSound
     - type: StealTarget
       stealGroup: AnimalSilvia
+    - type: ShowHealthBars
+    - type: ShowHealthIcons

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -228,5 +228,3 @@
       - FootstepSound
     - type: StealTarget
       stealGroup: AnimalSilvia
-    - type: ShowHealthBars
-    - type: ShowHealthIcons

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -100,6 +100,9 @@
       Female: FemaleVulpkanin
       Unsexed: MaleVulpkanin
   - type: DogVision
+  - type: Temperature
+    heatDamageThreshold: 315 # 10 lower than base
+    coldDamageThreshold: 240 # 20 lower than base
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
vulpkanin guidebook says they get cold temp resist but that is troll. also gives this to laika. they can stand -10 less heat, but +20 more cold variance. 

## Why / Balance
fur gaming

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Vulpkanin and Laika are more comfortable at colder temperatures, and less comfortable when it gets hot
