### PR TITLE
Add DeltaV-specific HE and shrapnel mines

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
@@ -19,6 +19,9 @@
   id: LandMineShrapnel
   components:
   - type: DeleteOnTrigger
+  - type: ContainerContainer
+    containers:
+      cluster-payload: !type:Container
   - type: ProjectileGrenade
     fillPrototype: PelletClusterLethal
     capacity: 30

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: explosive mine
-  suffix: DeltaV
   parent: BaseLandMine
   id: LandMineHE
+  name: explosive mine
+  suffix: DeltaV, High Explosive
   components:
   - type: ExplodeOnTrigger
   - type: Explosive
@@ -13,10 +13,9 @@
     canCreateVacuum: false
 
 - type: entity
-  name: shrapnel mine
-  suffix: DeltaV
   parent: BaseLandMine
   id: LandMineShrapnel
+  name: shrapnel mine
   components:
   - type: DeleteOnTrigger
   - type: ContainerContainer

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
@@ -7,9 +7,9 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    maxIntensity: 21 # DeltaV - 10 > 20
-    intensitySlope: 10 # DeltaV - 3 > 10
-    totalIntensity: 120 # about a ~4 tile radius
+    maxIntensity: 21
+    intensitySlope: 10
+    totalIntensity: 120
     canCreateVacuum: false
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/land_mine.yml
@@ -1,0 +1,24 @@
+- type: entity
+  name: explosive mine
+  suffix: DeltaV
+  parent: BaseLandMine
+  id: LandMineHE
+  components:
+  - type: ExplodeOnTrigger
+  - type: Explosive
+    explosionType: Default
+    maxIntensity: 21 # DeltaV - 10 > 20
+    intensitySlope: 10 # DeltaV - 3 > 10
+    totalIntensity: 120 # about a ~4 tile radius
+    canCreateVacuum: false
+
+- type: entity
+  name: shrapnel mine
+  suffix: DeltaV
+  parent: BaseLandMine
+  id: LandMineShrapnel
+  components:
+  - type: DeleteOnTrigger
+  - type: ProjectileGrenade
+    fillPrototype: PelletClusterLethal
+    capacity: 30


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Adds DeltaV HE mines (with a reduced explosive radius of 3x3, making them more effective for protecting secure areas) and shrapnel mines (which do far less damage to walls - but be careful putting them next to windows).
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
May prove useful for mappers so that the land mines around armoury are more of a help than a hindrance.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added Delta-V specific HE and shrapnel mines for mappers to use.
