### PR TITLE
Revert "Remove Security Cyborg"

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -40,6 +40,7 @@
 
 - type: latheRecipePack
   parent:
+  - BorgModulesDeltaV # DeltaV
   - BorgModulesShitmed # Shitmed change
   id: BorgModules
   recipes:

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -147,6 +147,7 @@
   roles:
   - Borg
   - MedicalBorg # DeltaV - roundstart mediborg job
+  - SecurityBorg # Delta-V : Security Borg
   - StationAi
   primary: false # DeltaV - removed from primary dept
 

--- a/Resources/Prototypes/_DV/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -1,59 +1,7 @@
 - type: entity
   id: BorgChassisSecurity
-  parent: BaseBorgChassisNT
+  parent: BorgChassisSelectable
   name: security cyborg
   components:
-  - type: Sprite
-    sprite: _DV/Mobs/Silicon/chassis.rsi
-    layers:
-    - state: security
-      map: ["enum.BorgVisualLayers.Body", "movement"]
-    - state: security_e_r
-      map: ["enum.BorgVisualLayers.Light"]
-      shader: unshaded
-      visible: false
-    - state: security_l
-      shader: unshaded
-      map: ["light","enum.BorgVisualLayers.LightStatus"]
-      visible: false
-  - type: BorgChassis
-    maxModules: 4
-    moduleWhitelist:
-      tags:
-      - BorgModuleGeneric
-      - BorgModuleSecurity
-    hasMindState: security_e
-    noMindState: security_e_r
-  - type: IntrinsicRadioReceiver
-  - type: IntrinsicRadioTransmitter
-    channels:
-    - Binary
-    - Common
-    - Science
-    - Security
-  - type: ActiveRadio
-    channels:
-    - Binary
-    - Common
-    - Science
-    - Security
-  - type: AccessReader
-    access: [["Security"], ["Command"], ["Research"]]
-  - type: ShowJobIcons
-  - type: ShowMindShieldIcons
-  - type: ShowCriminalRecordIcons
-  - type: SiliconLawProvider
-    laws: SiliconPolice
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      80: Critical # -20 to Crit Threshold
-      200: Dead
-  - type: FlashImmunity
-  - type: Speech
-    speechVerb: Robotic
-  - type: BorgTransponder
-    sprite:
-      sprite: Mobs/Silicon/chassis.rsi
-      state: peace
-    name: Security Cyborg
+  - type: BorgSwitchableType
+    selectedBorgType: security

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/robotics.yml
@@ -6,6 +6,12 @@
   - ClothingEyesHudDiagnostic
 
 - type: latheRecipePack
+  id: BorgModulesDeltaV
+  recipes:
+  - BorgModuleSecurityChase
+  - BorgModuleSecurityEscalate
+
+- type: latheRecipePack
   id: RoboticsStaticDeltaV
   recipes:
   - Oilpack

--- a/Resources/Prototypes/_DV/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/robotics.yml
@@ -1,4 +1,24 @@
 - type: latheRecipe
+  parent: BaseGoldBorgModuleRecipe
+  id: BorgModuleSecurityEscalate
+  result: BorgModuleSecurityEscalate
+
+- type: latheRecipe
+  parent: BaseGoldBorgModuleRecipe
+  id: BorgModuleSecurityChase
+  result: BorgModuleSecurityChase
+
+- type: latheRecipe
+  parent: BaseBorgModuleRecipe
+  id: BorgModuleSecurityPatrol
+  result: BorgModuleSecurityPatrol
+
+- type: latheRecipe
+  parent: BaseBorgModuleRecipe
+  id: BorgModuleSecurityBastion
+  result: BorgModuleSecurityBastion
+
+- type: latheRecipe
   id: BorgModuleSyndicateWeapon
   result: BorgModuleSyndicateWeapon
   category: Robotics

--- a/Resources/Prototypes/_DV/Research/arsenal.yml
+++ b/Resources/Prototypes/_DV/Research/arsenal.yml
@@ -67,6 +67,7 @@
   recipeUnlocks:
   - WeaponEnergyGun
   - WeaponEnergyGunMini
+  - BorgModuleSecurityChase
 
 - type: technology
   id: ExperimentalSalvageWeaponry
@@ -109,6 +110,7 @@
   recipeUnlocks:
   - AdvancedTruncheon
   - TelescopicShield
+  - BorgModuleSecurityEscalate
 
 # Tier 3
 

--- a/Resources/Prototypes/_DV/borg_types.yml
+++ b/Resources/Prototypes/_DV/borg_types.yml
@@ -1,0 +1,65 @@
+# Security borg
+- type: borgType
+  id: security
+
+  # Description
+  dummyPrototype: BorgChassisSecurity
+
+  # Functional
+  extraModuleCount: 3
+  moduleWhitelist:
+    tags:
+    - BorgModuleGeneric
+    - BorgModuleSecurity
+
+  # TODO: change these when reworking secborg modules to have the equivalent of roundstart gear
+  defaultModules:
+  - BorgModuleSecurityDeescalate
+  - BorgModuleSecurityPatrol
+  - BorgModuleSecurityBastion
+
+  lawset: SiliconPolice
+
+  addComponents:
+  - type: FlashImmunity
+  - type: ShowMindShieldIcons
+  - type: ShowCriminalRecordIcons
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      80: Critical # -20 to Crit Threshold
+      200: Dead
+  - type: Fiber # red plasteel fibers
+    fiberMaterial: fibers-plasteel
+    fiberColor: fibers-red
+
+  radioChannels:
+  - Science
+  - Security
+
+  # Visual
+  clientComponents:
+  - type: Sprite
+    noRot: true
+    drawdepth: Mobs
+    sprite: _DV/Mobs/Silicon/chassis.rsi
+    layers:
+    - state: security
+      map: ["enum.BorgVisualLayers.Body", "movement"]
+    - state: security_e_r
+      map: ["enum.BorgVisualLayers.Light"]
+      shader: unshaded
+      visible: false
+    - state: security_l
+      shader: unshaded
+      map: ["light","enum.BorgVisualLayers.LightStatus"]
+      visible: false
+  inventoryTemplateId: borgShort
+  spriteBodyState: security
+  spriteHasMindState: security_e
+  spriteNoMindState: security_e_r
+  spriteToggleLightState: security_l
+
+  # Pet
+  petSuccessString: petting-success-security-cyborg
+  petFailureString: petting-failure-security-cyborg


### PR DESCRIPTION
Reverts DeltaV-Station/Delta-v#3038

We didn't actually discuss it to our normal standards, I went to bed before the discussion happened and woke up to it being direction approved. 

I'd like to retool it, relaw it, I think it has good utility and purpose, but needs work rather than 1984

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Security Borg is back! Direction is working to compile a list of outstanding issues with the egg robot. Thanks for your patience!