### PR TITLE
disable observer respawn metatrolling

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -381,6 +381,7 @@ namespace Content.Server.GameTicking
             _adminLogger.Add(LogType.LateJoin,
                 LogImpact.Low,
                 $"{player.Name} late joined the round as an Observer with {ToPrettyString(ghost):entity}.");
+            _respawn.SetDeathRespawnTime(player.UserId); // DeltaV - no seeing all the valids then respawning immediately
         }
 
         #region Spawn Points

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -1,3 +1,4 @@
+using Content.Server._Corvax.Respawn; // DeltaV
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.Chat.Managers;
@@ -62,6 +63,7 @@ namespace Content.Server.GameTicking
         [Dependency] private readonly MetaDataSystem _metaData = default!;
         [Dependency] private readonly SharedRoleSystem _roles = default!;
         [Dependency] private readonly ServerDbEntryManager _dbEntryManager = default!;
+        [Dependency] private readonly RespawnSystem _respawn = default!; // DeltaV
 
         [ViewVariables] private bool _initialized;
         [ViewVariables] private bool _postInitialized;

--- a/Content.Server/_Corvax/Respawn/RespawnSystem.cs
+++ b/Content.Server/_Corvax/Respawn/RespawnSystem.cs
@@ -66,6 +66,15 @@ public sealed class RespawnSystem : EntitySystem
         SetRespawnTime(session.UserId, ref respawnData, _timing.CurTime + TimeSpan.FromSeconds(_respawnTime));
     }
 
+    /// <summary>
+    /// DeltaV: Sets the respawn time for a player to the full death cooldown.
+    /// </summary>
+    public void SetDeathRespawnTime(NetUserId player)
+    {
+        var respawnData = GetRespawnData(player);
+        SetRespawnTime(player, ref respawnData, _timing.CurTime + TimeSpan.FromSeconds(_respawnTime));
+    }
+
     private void OnMindRemoved(EntityUid entity, MindContainerComponent _, MindRemovedMessage e)
     {
         if (e.Mind.Comp.UserId is null)


### PR DESCRIPTION
## About the PR
if you observe you get 20 minute cooldown on respawning same as dying

## Why / Balance
fixes #3041

## Technical details
:trollface:

## Media
ui was already fucked but it says that it fails in console

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed being able to immediately respawn after observing, it now has a cooldown like dying.