### PR TITLE
Fix Thaven guidebook entry not showing up

### DIFF
--- a/Resources/Prototypes/Guidebook/species.yml
+++ b/Resources/Prototypes/Guidebook/species.yml
@@ -19,6 +19,8 @@
     - Rodentia
     - Chitinid
     - IPC
+    # ImpStation additions
+    - Thaven
 
 - type: guideEntry
   id: Arachnid


### PR DESCRIPTION
## About the PR
Fix Thaven guidebook entry not showing up

## Why / Balance
Nobody will understand what a Thaven is :pensive:

## Technical details
Make Thaven guidebook entry not show up

## Media
No

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No

**Changelog**
:cl:
- fix: Thaven guidebook entry is now accessible