### PR TITLE
upstream event weight tweaks

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -137,7 +137,7 @@
   - type: StationEvent
     startAnnouncement: station-event-bureaucratic-error-announcement
     startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
-      path: /Audio/Announcements/bureaucratic_error.ogg 
+      path: /Audio/Announcements/bureaucratic_error.ogg
     minimumPlayers: 25
     weight: 5
     duration: 1
@@ -178,7 +178,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 1 # DeltaV - was 6.5
+    weight: 2 # DeltaV - was 6.5
     earliestStart: 60 # DeltaV - was 40
     reoccurrenceDelay: 20
     minimumPlayers: 45 # DeltaV - was 20
@@ -308,7 +308,7 @@
   - type: StationEvent
     earliestStart: 15
     minimumPlayers: 10 # DeltaV - Was 15
-    weight: 5 # DeltaV - was 7
+    weight: 7
     duration: 240
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-kudzu-growth-result-message
@@ -497,7 +497,7 @@
   id: LoneOpsSpawn
   components:
   - type: StationEvent
-    earliestStart: 60 # DeltaV - was 45
+    earliestStart: 45
     weight: 3.5 # DeltaV - was 5
     minimumPlayers: 30 # DeltaV - was 20
     reoccurrenceDelay: 30

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -137,7 +137,7 @@
   - type: StationEvent
     startAnnouncement: station-event-bureaucratic-error-announcement
     startAudio: #Delta-V: Previously unheard announcer line for DeltaV's custom announcer
-      path: /Audio/Announcements/bureaucratic_error.ogg
+      path: /Audio/Announcements/bureaucratic_error.ogg 
     minimumPlayers: 25
     weight: 5
     duration: 1

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -48,7 +48,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming
     startAudio:
       path: /Audio/Announcements/attention.ogg
-    weight: 10 # 10 default
+    weight: 5 # DeltaV - was 10, all of these kinda suck
     reoccurrenceDelay: 30
     duration: 1
     maxOccurrences: 1 # should be the same as [copies] in shuttle_incoming_event.yml


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
nukeops can spawn at 45
dragon double chance wowa
halved unknown shuttles because they suck
more kudzu. kudzu buff incoming fr

## Why / Balance
more gaming per game

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Increased dragon spawn rate
- tweak: Decreased spawn of Traveling Chef, Syndie Escape Pod, and all those friendly shuttles
- tweak: LoneOps can now spawn at 45 mins, down from 60
- tweak: Kudzu is more frequent