### PR TITLE
Add departamental lathes

### DIFF
--- a/Resources/Locale/en-US/_DV/objectives/conditions/steal-target-groups.ftl
+++ b/Resources/Locale/en-US/_DV/objectives/conditions/steal-target-groups.ftl
@@ -8,3 +8,7 @@ steal-target-groups-box-folder-rd-clipboard = research digi-board
 steal-target-groups-bible-mystagogue = book of mysteries
 steal-target-groups-recruiter-pen = recruiter's pen
 steal-target-groups-captains-cloak = captain's cloak
+steal-target-groups-engineering-techfab-circuitboard = engineering techfab's circuitboard
+steal-target-groups-logistics-techfab-circuitboard = logistics techfab's circuitboard
+steal-target-groups-service-techfab-circuitboard = service techfab's circuitboard
+steal-target-groups-epistemics-techfab-circuitboard = epistemics techfab's circuitboard

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/techboard.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/techboard.yml
@@ -32,8 +32,8 @@
     - CommsComputerCircuitboard
     #- ShuttleConsoleCircuitboard # Delta V - Remove shuttle boards
     - ComputerMassMediaCircuitboard
-    - AutolatheMachineCircuitboard
-    - ProtolatheMachineCircuitboard
+    # - AutolatheMachineCircuitboard # DeltaV - departamental lathes
+    # - ProtolatheMachineCircuitboard # DeltaV - departamental lathes
     - SalvageMagnetMachineCircuitboard
     - PortableGeneratorSuperPacmanMachineCircuitboard # Delta V - Add additional boards
     - PortableGeneratorJrPacmanMachineCircuitboard # Delta V - Add additional boards

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -3,6 +3,7 @@
   parent: BaseMachineCircuitboard
   name: autolathe machine board
   description: A machine printed circuit board for an autolathe.
+  suffix: DO NOT MAP # DeltaV - departamental lathes
   components:
     - type: MachineBoard
       prototype: Autolathe
@@ -36,6 +37,7 @@
   parent: BaseMachineCircuitboard
   name: protolathe machine board
   description: A machine printed circuit board for a protolathe.
+  suffix: DO NOT MAP # DeltaV - departamental lathes
   components:
     - type: MachineBoard
       prototype: Protolathe

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -90,6 +90,7 @@
   parent: BaseLatheLube
   name: autolathe
   description: It produces basic items using metal and glass. Has the ability to process blueprints to print new recipes.
+  suffix: DO NOT MAP # DeltaV - departamental lathes
   components:
   - type: Sprite
     sprite: Structures/Machines/autolathe.rsi
@@ -167,6 +168,7 @@
   parent: BaseLatheLube
   name: protolathe
   description: Converts raw materials into advanced items.
+  suffix: DO NOT MAP # DeltaV - departamental lathes
   components:
   - type: Sprite
     sprite: Structures/Machines/protolathe.rsi

--- a/Resources/Prototypes/Procedural/salvage_loot.yml
+++ b/Resources/Prototypes/Procedural/salvage_loot.yml
@@ -9,8 +9,8 @@
           prob: 0.5
         - proto: AmmoTechFabCircuitboard
           cost: 2
-        - proto: AutolatheMachineCircuitboard
-          cost: 2
+        # - proto: AutolatheMachineCircuitboard # DeltaV - departamental lathes
+        #   cost: 2
         - proto: BiomassReclaimerMachineCircuitboard
           cost: 2
         - proto: BluespaceBeaker
@@ -54,7 +54,7 @@
         - proto: PowerCellAntiqueProto
           cost: 5
           prob: 0.5
-        - proto: ProtolatheMachineCircuitboard
+        # - proto: ProtolatheMachineCircuitboard # DeltaV - departamental lathes
         - proto: RandomArtifactSpawner
           cost: 2
         - proto: RandomCargoCorpseSpawner

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/CircuitBoards/Machine/production.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/CircuitBoards/Machine/production.yml
@@ -21,3 +21,70 @@
       Capacitor: 2
       Glass: 4
       Cable: 5
+
+- type: entity
+  parent: BaseMachineCircuitboard
+  id: BaseTechFabCircuitboardDV
+  abstract: true
+  components:
+  - type: MachineBoard
+    prototype: EngineeringTechFab
+    stackRequirements:
+      MatterBin: 2
+      Manipulator: 2
+    tagRequirements:
+      GlassBeaker:
+        amount: 2
+        defaultPrototype: Beaker
+
+- type: entity
+  parent: BaseTechFabCircuitboardDV
+  id: EngineeringTechFabCircuitboard
+  name: engineering techfab machine board
+  description: A machine printed circuit board for an engineering techfab.
+  components:
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: EngineeringTechFab
+  - type: StealTarget
+    stealGroup: EngineeringTechFabCircuitboard
+
+- type: entity
+  parent: BaseTechFabCircuitboardDV
+  id: LogisticsTechFabCircuitboard
+  name: logistics techfab machine board
+  description: A machine printed circuit board for a logistics techfab.
+  components:
+  - type: Sprite
+    state: supply
+  - type: MachineBoard
+    prototype: LogisticsTechFab
+  - type: StealTarget
+    stealGroup: LogisticsTechFabCircuitboard
+
+- type: entity
+  parent: BaseTechFabCircuitboardDV
+  id: ServiceTechFabCircuitboard
+  name: service techfab machine board
+  description: A machine printed circuit board for a service techfab.
+  components:
+  - type: Sprite
+    state: service
+  - type: MachineBoard
+    prototype: ServiceTechFab
+  - type: StealTarget
+    stealGroup: ServiceTechFabCircuitboard
+
+- type: entity
+  parent: BaseTechFabCircuitboardDV
+  id: EpistemicsTechFabCircuitboard
+  name: epistemics techfab machine board
+  description: A machine printed circuit board for a epistemics techfab.
+  components:
+  - type: Sprite
+    state: science
+  - type: MachineBoard
+    prototype: ServiceTechFab
+  - type: StealTarget
+    stealGroup: EpistemicsTechFabCircuitboard

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/CircuitBoards/Machine/production.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/CircuitBoards/Machine/production.yml
@@ -23,12 +23,11 @@
       Cable: 5
 
 - type: entity
+  abstract: true
   parent: BaseMachineCircuitboard
   id: BaseTechFabCircuitboardDV
-  abstract: true
   components:
   - type: MachineBoard
-    prototype: EngineeringTechFab
     stackRequirements:
       MatterBin: 2
       Manipulator: 2
@@ -85,6 +84,6 @@
   - type: Sprite
     state: science
   - type: MachineBoard
-    prototype: ServiceTechFab
+    prototype: EpistemicsTechFab
   - type: StealTarget
     stealGroup: EpistemicsTechFabCircuitboard

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -11,3 +11,160 @@
     - BorgModulesSyndicateStatic
   - type: Machine
     board: SyndieExosuitFabricatorMachineCircuitboard
+
+- type: entity
+  parent: BaseLatheLube
+  id: EngineeringTechFab
+  name: engineering techfab
+  description: Prints equipment for engineers.
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/techfab.rsi
+    layers:
+    - state: icon
+      map: ["enum.LatheVisualLayers.IsRunning"]
+    - state: engi
+    - state: unlit
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    - state: inserting
+      map: ["enum.MaterialStorageVisualLayers.Inserting"]
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Lathe
+    idleState: icon
+    runningState: icon
+    staticPacks:
+    - ToolsStatic
+    - PartsStatic
+    - AtmosStatic
+    - CablesStatic
+    - PowerCellsStatic
+    - ElectronicsStatic
+    - LightsStatic
+    - MaterialsStatic
+    dynamicPacks:
+    - AdvancedTools
+    - PowerCells
+    - AtmosTools
+    - EngineeringWeapons
+    - FauxTiles
+    - Equipment
+  - type: Machine
+    board: EngineeringTechFabCircuitboard
+  - type: StealTarget
+    stealGroup: EngineeringTechFabCircuitboard
+
+- type: entity
+  parent: BaseLatheLube
+  id: LogisticsTechFab
+  name: logistics techfab
+  description: Prints equipment for the logistics department.
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/techfab.rsi
+    layers:
+    - state: icon
+      map: ["enum.LatheVisualLayers.IsRunning"]
+    - state: cargo
+    - state: unlit
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    - state: inserting
+      map: ["enum.MaterialStorageVisualLayers.Inserting"]
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Lathe
+    idleState: icon
+    runningState: icon
+    staticPacks:
+    - ToolsStatic
+    - PartsStatic
+    - LVCablesStatic
+    - CargoStatic
+    dynamicPacks:
+    - Equipment
+    - Mining
+    - SalvageWeapons
+  - type: Machine
+    board: ServiceTechFabCircuitboard
+  - type: StealTarget
+    stealGroup: ServiceTechFabCircuitboard
+
+- type: entity
+  parent: BaseLatheLube
+  id: ServiceTechFab
+  name: service techfab
+  description: Prints equipment for the service department.
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/techfab.rsi
+    layers:
+    - state: icon
+      map: ["enum.LatheVisualLayers.IsRunning"]
+    - state: service
+    - state: unlit
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    - state: inserting
+      map: ["enum.MaterialStorageVisualLayers.Inserting"]
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Lathe
+    idleState: icon
+    runningState: icon
+    staticPacks:
+    - RingsStatic
+    - ReportingStatic
+    - LVCablesStatic
+    - LightsStatic
+    - ServiceStatic
+    dynamicPacks:
+    - Janitor
+    - Instruments
+    - Botany
+  - type: Machine
+    board: ServiceTechFabCircuitboard
+  - type: StealTarget
+    stealGroup: ServiceTechFabCircuitboard
+
+- type: entity
+  parent: BaseLatheLube
+  id: EpistemicsTechFab
+  name: epistemics techfab
+  description: Prints equipment for the epistemics department.
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/techfab.rsi
+    layers:
+    - state: icon
+      map: ["enum.LatheVisualLayers.IsRunning"]
+    - state: sci
+    - state: unlit
+      shader: unshaded
+      map: ["enum.PowerDeviceVisualLayers.Powered"]
+    - state: inserting
+      map: ["enum.MaterialStorageVisualLayers.Inserting"]
+    - state: panel
+      map: ["enum.WiresVisualLayers.MaintenancePanel"]
+  - type: Lathe
+    idleState: icon
+    runningState: icon
+    staticPacks:
+    - ToolsStatic
+    - PartsStatic
+    - LVCablesStatic
+    - MaterialsStatic
+    - BasicChemistryStatic
+    - ChemistryStatic
+    dynamicPacks:
+    - ScienceEquipment
+    - ScienceClothing
+    - ScienceWeapons
+    - Chemistry
+  - type: Machine
+    board: EpistemicsTechFabCircuitboard
+  - type: StealTarget
+    stealGroup: EpistemicsTechFabCircuitboard
+
+

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -92,9 +92,9 @@
     - Mining
     - SalvageWeapons
   - type: Machine
-    board: ServiceTechFabCircuitboard
+    board: LogisticsTechFabCircuitboard
   - type: StealTarget
-    stealGroup: ServiceTechFabCircuitboard
+    stealGroup: LogisticsTechFabCircuitboard
 
 - type: entity
   parent: BaseTechFabDepartamental

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -14,12 +14,22 @@
 
 - type: entity
   parent: BaseLatheLube
+  id: BaseTechFabDepartamental
+  abstract: true
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/techfab.rsi
+  - type: Lathe
+    idleState: icon
+    runningState: icon
+
+- type: entity
+  parent: BaseTechFabDepartamental
   id: EngineeringTechFab
   name: engineering techfab
   description: Prints equipment for engineers.
   components:
   - type: Sprite
-    sprite: Structures/Machines/techfab.rsi
     layers:
     - state: icon
       map: ["enum.LatheVisualLayers.IsRunning"]
@@ -32,8 +42,6 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: Lathe
-    idleState: icon
-    runningState: icon
     staticPacks:
     - ToolsStatic
     - PartsStatic
@@ -56,13 +64,12 @@
     stealGroup: EngineeringTechFabCircuitboard
 
 - type: entity
-  parent: BaseLatheLube
+  parent: BaseTechFabDepartamental
   id: LogisticsTechFab
   name: logistics techfab
   description: Prints equipment for the logistics department.
   components:
   - type: Sprite
-    sprite: Structures/Machines/techfab.rsi
     layers:
     - state: icon
       map: ["enum.LatheVisualLayers.IsRunning"]
@@ -75,8 +82,6 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: Lathe
-    idleState: icon
-    runningState: icon
     staticPacks:
     - ToolsStatic
     - PartsStatic
@@ -92,13 +97,12 @@
     stealGroup: ServiceTechFabCircuitboard
 
 - type: entity
-  parent: BaseLatheLube
+  parent: BaseTechFabDepartamental
   id: ServiceTechFab
   name: service techfab
   description: Prints equipment for the service department.
   components:
   - type: Sprite
-    sprite: Structures/Machines/techfab.rsi
     layers:
     - state: icon
       map: ["enum.LatheVisualLayers.IsRunning"]
@@ -111,8 +115,6 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: Lathe
-    idleState: icon
-    runningState: icon
     staticPacks:
     - RingsStatic
     - ReportingStatic
@@ -129,13 +131,10 @@
     stealGroup: ServiceTechFabCircuitboard
 
 - type: entity
-  parent: BaseLatheLube
+  parent: BaseTechFabDepartamental
   id: EpistemicsTechFab
-  name: epistemics techfab
-  description: Prints equipment for the epistemics department.
   components:
   - type: Sprite
-    sprite: Structures/Machines/techfab.rsi
     layers:
     - state: icon
       map: ["enum.LatheVisualLayers.IsRunning"]
@@ -148,8 +147,6 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: Lathe
-    idleState: icon
-    runningState: icon
     staticPacks:
     - ToolsStatic
     - PartsStatic
@@ -166,5 +163,3 @@
     board: EpistemicsTechFabCircuitboard
   - type: StealTarget
     stealGroup: EpistemicsTechFabCircuitboard
-
-

--- a/Resources/Prototypes/_DV/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/stealTargetGroups.yml
@@ -54,6 +54,34 @@
     sprite: _DV/Objects/Misc/plutonium_core.rsi
     state: icon
 
+- type: stealTargetGroup
+  id: EngineeringTechFabCircuitboard
+  name: steal-target-groups-engineering-techfab-circuitboard
+  sprite:
+    sprite: Objects/Misc/module.rsi
+    state: engineering
+
+- type: stealTargetGroup
+  id: LogisticsTechFabCircuitboard
+  name: steal-target-groups-logistics-techfab-circuitboard
+  sprite:
+    sprite: Objects/Misc/module.rsi
+    state: supply
+
+- type: stealTargetGroup
+  id: ServiceTechFabCircuitboard
+  name: steal-target-groups-service-techfab-circuitboard
+  sprite:
+    sprite: Objects/Misc/module.rsi
+    state: service
+
+- type: stealTargetGroup
+  id: EpistemicsTechFabCircuitboard
+  name: steal-target-groups-epistemics-techfab-circuitboard
+  sprite:
+    sprite: Objects/Misc/module.rsi
+    state: science
+
 # Ninja
 
 - type: stealTargetGroup

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
@@ -5,3 +5,10 @@
   recipes:
   - SignallerDeadMans
   - JetpackVoid # RE
+
+## Static
+
+- type: latheRecipePack
+  id: LVCablesStatic
+  recipes:
+  - CableStack


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This adds four new techfabs: engineering, service, logistics, and science.

## Why / Balance
As it is, All Crafting being centralised in two techfabs (but not really when you consider medical and security) is suboptimal:
- epistemics and logistics get treated as item crafters rather than scientists and logistics
- resource gameplay essentially becomes an exercise in two main stockpiles (logistics and epistemics), instead of "do departments have the materials they need to function" being something logistics actually cares about
- epistemics having access to all equipment they research causes epistemics players to take first dibs for fancy tools that aren't necessarily required for their jobs
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
- new circuitboards
- new machines for the circuitboards
- make sure they have steal targets

## Media
![grafik](https://github.com/user-attachments/assets/e6ed10ca-6bc0-45b1-8d23-dfe890af05f9)
service techfab:
![service techfab](https://github.com/user-attachments/assets/5819071f-0993-49e7-a06d-6d3a0493159d)
epistemics techfab:
![epistemics techfab](https://github.com/user-attachments/assets/8749e1b8-c242-434f-854b-3beb8a22f3ee)
logistics techfab:
![logistics techfab](https://github.com/user-attachments/assets/43003dc9-f320-4d99-adcd-0c275c15cd6c)
engineering techfab:
![engineering techfab](https://github.com/user-attachments/assets/41f647c8-667d-462b-90dc-bc0649158baf)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The engineering, service, logistics, and epistemics techfabs now exist
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
