### PR TITLE
make borgs use ipc repairing

### DIFF
--- a/Content.Server/Medical/HealingSystem.cs
+++ b/Content.Server/Medical/HealingSystem.cs
@@ -138,7 +138,7 @@ public sealed class HealingSystem : EntitySystem
         var healingDict = healing.Damage.DamageDict;
         foreach (var type in healingDict)
         {
-            if (damageableDict[type.Key].Value > 0)
+            if (damageableDict.GetValueOrDefault(type.Key) > 0) // DeltaV - 0 instead of throwing
             {
                 return true;
             }

--- a/Content.Server/_EE/Silicon/WeldingHealable/WeldingHealableComponent.cs
+++ b/Content.Server/_EE/Silicon/WeldingHealable/WeldingHealableComponent.cs
@@ -5,5 +5,12 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototy
 namespace Content.Server._EE.Silicon.WeldingHealable
 {
     [RegisterComponent]
-    public sealed partial class WeldingHealableComponent : Component { }
+    public sealed partial class WeldingHealableComponent : Component
+    {
+        /// <summary>
+        /// DeltaV: Disables self-healing with any type of WeldingHealing item.
+        /// </summary>
+        [DataField]
+        public bool AllowSelfHealing = true;
+    }
 }

--- a/Content.Server/_EE/Silicon/WeldingHealable/WeldingHealableComponent.cs
+++ b/Content.Server/_EE/Silicon/WeldingHealable/WeldingHealableComponent.cs
@@ -11,6 +11,6 @@ namespace Content.Server._EE.Silicon.WeldingHealable
         /// DeltaV: Disables self-healing with any type of WeldingHealing item.
         /// </summary>
         [DataField]
-        public bool AllowSelfHealing = true;
+        public bool AllowSelfHeal = true;
     }
 }

--- a/Content.Server/_EE/Silicon/WeldingHealable/WeldingHealableSystem.cs
+++ b/Content.Server/_EE/Silicon/WeldingHealable/WeldingHealableSystem.cs
@@ -81,7 +81,7 @@ public sealed class WeldingHealableSystem : SharedWeldingHealableSystem
             || !component.DamageContainers.Contains(damageable.DamageContainerID)
             || !HasDamage((args.Target, damageable), component, args.User)
             || !_toolSystem.HasQuality(args.Used, component.QualityNeeded)
-            || args.User == args.Target && !component.AllowSelfHeal)
+            || args.User == args.Target && !(component.AllowSelfHeal && healableComponent.AllowSelfHeal)) // DeltaV - self heal disabled by WeldingHealable
             return;
 
         float delay = args.User == args.Target

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -104,9 +104,13 @@
     - Common
     - Science
   - type: ZombieImmune
-  - type: Repairable
-    doAfterDelay: 10
-    allowSelfRepair: false
+  # Begin DeltaV Changes - use IPC healing instead of 1 weld to heal everything
+  #- type: Repairable
+  #  doAfterDelay: 10
+  #  allowSelfRepair: false
+  - type: WeldingHealable
+    allowSelfHeal: false
+  # End DeltaV Changes
   - type: BorgChassis
   - type: SurgerySelfDirty # DeltaV: borgs get dirty from doing surgery
   - type: Fiber # DeltaV - borgs leave metal fibers


### PR DESCRIPTION
## About the PR
welding for brute and cable for burn, same as ipcs

still no radiation so plasma does nothing

## Why / Balance
part of #3060

cable module more useful for the shadow factory...

## Technical details
shitcode threw if a Healing had a type not in the damage container so fixed it

## Media

cant use cable with no burn damage
![07:50:59](https://github.com/user-attachments/assets/ce416b86-f723-41a3-ad57-8b87f4b22398)

using cable after shooting with a laser
![07:51:12](https://github.com/user-attachments/assets/6d2c1bf1-8723-4ea7-b071-90018a5cc512)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Borgs now get healed like IPCs, repeated welding for brute and cables for burn damage.
