### PR TITLE
add missing ipc survival boxes

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -539,6 +539,7 @@
   - EmergencyNitrogenClown
   - EmergencyOxygenClown
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyIPCBox # DeltaV
 
 - type: loadoutGroup
   id: MimeHead
@@ -596,6 +597,7 @@
   - EmergencyNitrogenMime
   - EmergencyOxygenMime
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyIPCBox # DeltaV
 
 - type: loadoutGroup
   id: MusicianJumpsuit
@@ -901,6 +903,7 @@
   - EmergencyNitrogenExtended
   - EmergencyOxygenExtended
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyIPCBox # DeltaV
 
 # Science
 - type: loadoutGroup
@@ -1232,6 +1235,7 @@
   - EmergencyNitrogenSecurity
   - EmergencyOxygenSecurity
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyIPCBox # DeltaV
 
 - type: loadoutGroup
   id: SecurityStar
@@ -1430,6 +1434,7 @@
   - EmergencyNitrogenMedical
   - EmergencyOxygenMedical
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyIPCBox # DeltaV
 
 # Wildcards
 - type: loadoutGroup
@@ -1474,6 +1479,7 @@
   - EmergencyNitrogenSyndicate
   - EmergencyOxygenSyndicate
   - LoadoutSpeciesVoxNitrogen
+  - EmergencyIPCBox # DeltaV
 
 - type: loadoutGroup
   id: GroupSpeciesBreathTool


### PR DESCRIPTION
## About the PR
fixes #3061

**Changelog**
:cl:
- fix: Fixed med, sec, engi and nukie ipcs not getting survival boxes.