### PR TITLE
tweak shuttle time on peri and horizon again

### DIFF
--- a/Resources/ConfigPresets/DeltaV/horizon.toml
+++ b/Resources/ConfigPresets/DeltaV/horizon.toml
@@ -8,8 +8,8 @@ preset_enabled = true
 map_enabled = true
 
 [shuttle]
-auto_call_time = 180 # 3 hours
-auto_call_extension_time = 60 # next auto call at 4h00, gamers gotta game
+auto_call_time = 150 # 2.5 hours
+auto_call_extension_time = 30 # next auto call at 3h00, gamers gotta game
 
 [ooc]
 enable_during_round = true

--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -12,8 +12,8 @@ map_enabled = true
 enabled     = false
 
 [shuttle]
-auto_call_time = 180 # 3 hours
-auto_call_extension_time = 60 # next auto call at 4h00, gamers gotta game
+auto_call_time = 150 # 2.5 hours
+auto_call_extension_time = 30 # next auto call at 3h00, gamers gotta game
 
 [ooc]
 enable_during_round = true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
shuttle time 2:30 and extension time 30

## Why / Balance
3 hours is killing people

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Periapsis & Horizon now have an autoshuttle at 2:30 hours, not 3:00. 
