### PR TITLE
Give heads of staff spare departamental lathe boards

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
@@ -11,6 +11,7 @@
     - id: ClothingShoesBootsWinterLogisticsOfficer
     - id: MiningShuttleConsoleCircuitboard
     - id: StockTradingCartridge
+    - id: LogisticsTechFabCircuitboard
     - id: LunchboxCommandFilledRandom
       prob: 0.3
 
@@ -42,6 +43,7 @@
     - id: ClothingShoesBootsLaceup
     - id: ClothingShoesMiscWhite
     - id: ClothingShoesBootsWinterHeadOfPersonel
+    - id: ServiceTechFabCircuitboard
     - id: LunchboxCommandFilledRandom
       prob: 0.3
 
@@ -52,6 +54,7 @@
     - id: BoxPDAEngineering
     - id: CEIDCard
     - id: ClothingShoesBootsWinterChiefEngineer
+    - id: EngineeringTechFabCircuitboard
     - id: LunchboxCommandFilledRandom
       prob: 0.3
 
@@ -78,6 +81,7 @@
     - id: RDIDCard
     - id: BoxFolderRdClipboard
     - id: ClothingShoesBootsWinterMystagogue
+    - id: EpistemicsTechFabCircuitboard
     - id: LunchboxCommandFilledRandom
       prob: 0.3
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Give the heads of staff departamental lathe boards

## Why / Balance
They should have spare lathe boards, like how they already have spare departamental boards and like how medical and security have spare boards for their machines.

## Technical details
- change locker fills

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The HoP, LO, MG, and CE now have spare boards for their departments' techfabs
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
