### PR TITLE
Reduced Destructible threshold from 300 and 150 to 100 and 50

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -70,13 +70,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 100 # DeltaV - was 300
       behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 50 # DeltaV was 150
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -70,13 +70,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 100
       behaviors:
         - !type:DoActsBehavior
           acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 150
+        damage: 50
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
For ClosetBase, its Destructible threshold was 300 and 150. I reduced this to 100 and 50 respectively.

## Why / Balance
Every other locker/closet except for the maintenance lockers and anything else directly relying on ClosetBase required a lot less damage to destroy. For example, a gun safe would require 3 wielded fireaxe swings while the maintenance locker was able to withstand 5. After discussing in the discord's general, the people I spoke to agreed that this was likely an oversight and that it was unreasonable for a closet in maints to be so much stronger than a gun safe. 

This change should only really affect the gameplay of salvagers as their PKA may require less shots to destroy a locker (something that normally gets in the way of shooting space carp on wrecks). Apart from that, I don't know many people trying to destroy a maints locker when they can just.. open it.

## Technical details
<!-- Summary of code changes for easier review. -->
Changed the Destructible threshold for ClosetBase
```yml
    - trigger:
        !type:DamageTrigger
        damage: 100 # used to be 300
      behaviors:
        - !type:DoActsBehavior
          acts: [ "Destruction" ]
    - trigger:
        !type:DamageTrigger
        damage: 50 # used to be 150
      behaviors:
      - !type:DoActsBehavior
        acts: ["Destruction"]
```

I changed two numbers. I dunno how to better summarize..

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Nerfed the health of maintenance and emergency closets so they aren't double the health of basically every other locker/safe in the game.
