### PR TITLE
return airlock blacklist for emag

### DIFF
--- a/Content.Shared/Emag/Components/EmagComponent.cs
+++ b/Content.Shared/Emag/Components/EmagComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Emag.Systems;
 using Content.Shared.Tag;
+using Content.Shared.Whitelist; // DeltaV
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -19,6 +20,12 @@ public sealed partial class EmagComponent : Component
     [DataField]
     [AutoNetworkedField]
     public ProtoId<TagPrototype> EmagImmuneTag = "EmagImmune";
+
+    /// <summary>
+    /// DeltaV: Blacklist for entities that cannot be emagged with this.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist;
 
     /// <summary>
     /// What type of emag effect this device will do

--- a/Content.Shared/Emag/Systems/EmagSystem.cs
+++ b/Content.Shared/Emag/Systems/EmagSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
+using Content.Shared.Whitelist; // DeltaV
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Serialization;
 
@@ -20,6 +21,7 @@ namespace Content.Shared.Emag.Systems;
 /// 5. Optionally, set Repeatable on the event to true if you don't want the emagged component to be added
 public sealed class EmagSystem : EntitySystem
 {
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!; // DeltaV
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedChargesSystem _charges = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -60,6 +62,11 @@ public sealed class EmagSystem : EntitySystem
 
         if (_tag.HasTag(target, ent.Comp.EmagImmuneTag))
             return false;
+
+        // Begin DeltaV Additions
+        if (_whitelist.IsBlacklistPass(ent.Comp.Blacklist, target))
+            return false;
+        // End DeltaV Additions
 
         TryComp<LimitedChargesComponent>(ent, out var charges);
         if (_charges.IsEmpty(ent, charges))

--- a/Resources/Prototypes/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/emag.yml
@@ -6,6 +6,9 @@
   description: The all-in-one hacking solution. Friend of any syndicate. The iconic EMAG.
   components:
   - type: Emag
+    blacklist: # DeltaV - prevent emag removing access from doors
+      components:
+      - Airlock
   - type: Sprite
     sprite: Objects/Tools/emag.rsi
     state: icon

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/emag.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/emag.yml
@@ -6,6 +6,7 @@
   components:
   - type: Emag
     emagType: Access # LockSystem has its type changed so this only affects airlocks
+    blacklist: null # allow airlocks
   - type: Sprite
     sprite: _DV/Objects/Tools/doorjack.rsi
   - type: Item


### PR DESCRIPTION
## About the PR
it was handled by the access reader component though not airlock
so blacklist was brought back to not let it

## Media
![11:32:18](https://github.com/user-attachments/assets/5df2cd2f-b85f-484d-a482-84e28a988508)


**Changelog**
:cl:
- fix: Fixed emags removing access from airlocks.