### PR TITLE
fix borgs not preserving emag laws when switching type

### DIFF
--- a/Content.Server/_DV/Silicons/Borgs/BorgSwitchableTypeSystem.Lawset.cs
+++ b/Content.Server/_DV/Silicons/Borgs/BorgSwitchableTypeSystem.Lawset.cs
@@ -30,8 +30,7 @@ public sealed partial class BorgSwitchableTypeSystem
         // re-add law 0 and final law based on new lawset
         if (CompOrNull<EmagSiliconLawComponent>(uid)?.OwnerName != null)
         {
-            // raising the event manually to bypass re-emagging checks
-            var ev = new GotEmaggedEvent(uid, EmagType.Interaction); // user wont be used since OwnerName isnt null, safe to pass itself
+            var ev = new SiliconEmaggedEvent(uid);
             RaiseLocalEvent(uid, ref ev);
         }
 


### PR DESCRIPTION
## About the PR
it uses the new emag event for silicons directly, old way was broken after emag rework my beloved

## Media
![12:28:11](https://github.com/user-attachments/assets/74bd125d-5c9d-4405-8dbf-3b3b3c871a56)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed emagged generic borgs losing their laws when switching type.