### PR TITLE
rename ammonia back to miasma

### DIFF
--- a/Resources/Locale/en-US/_DV/gases/gases.ftl
+++ b/Resources/Locale/en-US/_DV/gases/gases.ftl
@@ -1,0 +1,1 @@
+gases-miasma = Miasma

--- a/Resources/Locale/en-US/_DV/prototypes/entities/structures/piping/atmospherics/miners.ftl
+++ b/Resources/Locale/en-US/_DV/prototypes/entities/structures/piping/atmospherics/miners.ftl
@@ -1,0 +1,1 @@
+ent-GasMinerAmmonia = miasma gas miner

--- a/Resources/Locale/en-US/_DV/prototypes/entities/structures/storage/canisters/gas_canisters.ftl
+++ b/Resources/Locale/en-US/_DV/prototypes/entities/structures/storage/canisters/gas_canisters.ftl
@@ -1,0 +1,2 @@
+ent-AmmoniaCanister = miasma canister
+    .desc = A canister that can contain any type of gas. This one is supposed to contain miasma. It can be attached to connector ports using a wrench.

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -61,7 +61,7 @@
 
 - type: gas
   id: 6
-  name: gases-ammonia
+  name: gases-miasma # DeltaV
   specificHeat: 20
   heatCapacityRatio: 1.4
   molarMass: 44
@@ -69,7 +69,7 @@
   gasOverlayState: miasma
   gasMolesVisible: 2
   gasVisbilityFactor: 3.5
-  color: 56941E
+  color: 1E092A # DeltaV - purple instead of green, matches the sprite
   reagent: Ammonia
   pricePerMole: 0.15
 


### PR DESCRIPTION
## About the PR
change its name to miasma (reagent is still ammonia because its used in chem)
new gas analyzer colour is some pixel i picked from the overlay sprite

## Why / Balance
ammonia noob miasma pro

## Technical details
entity localization gameplay

## Media
![09:57:28](https://github.com/user-attachments/assets/37d4e9c4-de8f-4f75-8ee3-5a2b27191c55)

![09:58:03](https://github.com/user-attachments/assets/4b1de37e-fa85-4cd5-a155-9cd5d91f7800)

![09:58:43](https://github.com/user-attachments/assets/af06bc5b-0d5f-4f6f-97ab-886b9051f637)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Renamed ammonia back to miasma.