### PR TITLE
Return of warops, death of non-hostage stealthops

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server._DV.Antag; // DeltaV
 using Content.Server.RoundEnd;
 using Content.Shared.Dataset;
 using Content.Shared.NPC.Prototypes;
@@ -8,7 +9,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.GameTicking.Rules.Components;
 
-[RegisterComponent, Access(typeof(NukeopsRuleSystem))]
+[RegisterComponent, Access(typeof(NukeopsRuleSystem),typeof(NukieOperationSystem))] // Delta V - Auto war declare
 public sealed partial class NukeopsRuleComponent : Component
 {
     /// <summary>

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -402,7 +402,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         return WarConditionStatus.YesWar;
     }
 
-    private void DistributeExtraTc(Entity<NukeopsRuleComponent> nukieRule)
+    public void DistributeExtraTc(Entity<NukeopsRuleComponent> nukieRule) // Delta V - Public so our war can work
     {
         var enumerator = EntityQueryEnumerator<StoreComponent>();
         while (enumerator.MoveNext(out var uid, out var component))

--- a/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
@@ -103,7 +103,7 @@ internal sealed class NoosphericFryRule : StationEventSystem<NoosphericFryRuleCo
         while (queryReactive.MoveNext(out var reactive, out _, out var xform, out var physics))
         {
             // shoot out three bolts of lighting...
-            _glimmerReactiveSystem.BeamRandomNearProber(reactive, 1, 12);
+            _glimmerReactiveSystem.BeamRandomNearProber(reactive, 3, 12);
 
             // try to anchor if we can
             if (!xform.Anchored)

--- a/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
@@ -103,7 +103,7 @@ internal sealed class NoosphericFryRule : StationEventSystem<NoosphericFryRuleCo
         while (queryReactive.MoveNext(out var reactive, out _, out var xform, out var physics))
         {
             // shoot out three bolts of lighting...
-            _glimmerReactiveSystem.BeamRandomNearProber(reactive, 3, 12);
+            _glimmerReactiveSystem.BeamRandomNearProber(reactive, 1, 12);
 
             // try to anchor if we can
             if (!xform.Anchored)

--- a/Content.Server/_DV/Antag/NukieOperationComponent.cs
+++ b/Content.Server/_DV/Antag/NukieOperationComponent.cs
@@ -22,8 +22,6 @@ public sealed partial class NukieOperationComponent : Component
     [DataField]
     public ProtoId<NukieOperationPrototype>? ChosenOperation;
 
-    [DataField]
-    public bool HasWarBeenDeclared;
 
     /// <summary>
     ///     Automatically calls war after set time.

--- a/Content.Server/_DV/Antag/NukieOperationComponent.cs
+++ b/Content.Server/_DV/Antag/NukieOperationComponent.cs
@@ -21,6 +21,15 @@ public sealed partial class NukieOperationComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<NukieOperationPrototype>? ChosenOperation;
+
+    [DataField]
+    public bool HasWarBeenDeclared;
+
+    /// <summary>
+    ///     Automatically calls war after set time.
+    /// </summary>
+    [DataField]
+    public TimeSpan AutoWarCallTime = TimeSpan.FromMinutes(2);
 }
 
 /// <summary>

--- a/Content.Server/_DV/Antag/NukieOperationSystem.cs
+++ b/Content.Server/_DV/Antag/NukieOperationSystem.cs
@@ -1,10 +1,12 @@
 ﻿using Content.Server.Antag;
+using Content.Server.GameTicking;
 using Content.Server.Objectives;
 using Content.Shared._DV.FeedbackOverwatch;
 using Content.Shared.Mind;
 using Content.Shared.Random.Helpers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Toolshed.Commands.Math;
 
 namespace Content.Server._DV.Antag;
 
@@ -15,6 +17,8 @@ public sealed class NukieOperationSystem : EntitySystem
     [Dependency] private readonly ObjectivesSystem _objectives = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly SharedFeedbackOverwatchSystem _feedback = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -23,7 +27,25 @@ public sealed class NukieOperationSystem : EntitySystem
         SubscribeLocalEvent<GetNukeCodePaperWriting>(OnNukeCodePaperWritingEvent);
     }
 
-    private void OnAntagSelected(Entity<NukieOperationComponent> ent, ref AfterAntagEntitySelectedEvent args)
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        var currentTime = _ticker.RoundDuration();
+        var query = EntityQueryEnumerator<NukieOperationComponent>();
+        // query.MoveNext(out var nukieOperationComp);
+        // nukieOperationComp.AutoWarCallTime
+        if (query.MoveNext(out var nukieOperationComp)
+            && nukieOperationComp.ChosenOperation == "NukieOperationDestroyStation"
+            && currentTime >= nukieOperationComp.AutoWarCallTime
+            && !nukieOperationComp.HasWarBeenDeclared)
+        {
+
+
+
+        }
+    }
+
+private void OnAntagSelected(Entity<NukieOperationComponent> ent, ref AfterAntagEntitySelectedEvent args)
     {
         // Yes this is bad, but I couldn't easily find an event that would work.
         if (ent.Comp.ChosenOperation == null)

--- a/Content.Server/_DV/Antag/NukieOperationSystem.cs
+++ b/Content.Server/_DV/Antag/NukieOperationSystem.cs
@@ -34,7 +34,9 @@ public sealed class NukieOperationSystem : EntitySystem
         SubscribeLocalEvent<NukieOperationComponent, AfterAntagEntitySelectedEvent>(OnAntagSelected);
         SubscribeLocalEvent<GetNukeCodePaperWriting>(OnNukeCodePaperWritingEvent);
     }
-
+    /// <summary>
+    /// This runs the automatic war declaration, distributes tc,and makes sure it only happens when its not hostage ops.
+    /// </summary>
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -42,7 +44,6 @@ public sealed class NukieOperationSystem : EntitySystem
         var nukieOperationQuery = EntityQueryEnumerator<NukieOperationComponent>();
         var nukieRuleQuery = EntityQueryEnumerator<NukeopsRuleComponent>();
 
-        // This code is bad, but its because upstream code smells ;)
         if (nukieOperationQuery.MoveNext(out var nukieOperationComp) && nukieRuleQuery.MoveNext(out var nukeopsUid, out var nukeopsRuleComp)
             && nukieOperationComp.ChosenOperation == "NukieOperationDestroyStation"
             && currentTime >= nukieOperationComp.AutoWarCallTime
@@ -51,7 +52,9 @@ public sealed class NukieOperationSystem : EntitySystem
         {
             nukeopsRuleComp.WarDeclaredTime = _time.CurTime;
             _nukeops.DistributeExtraTc((nukeopsUid, nukeopsRuleComp));
-            _chat.DispatchGlobalAnnouncement(Loc.GetString("nuke-ops-auto-war-message"), Loc.GetString("nuke-ops-auto-war-title"), true, new SoundPathSpecifier("/Audio/Announcements/war.ogg"), Color.DarkRed);
+            _chat.DispatchGlobalAnnouncement(Loc.GetString("nuke-ops-auto-war-message"),
+                Loc.GetString("nuke-ops-auto-war-title"),
+                true, new SoundPathSpecifier("/Audio/Announcements/war.ogg"), Color.DarkRed);
         }
     }
 

--- a/Resources/Locale/en-US/_DV/nukie-operations/autowar.ftl
+++ b/Resources/Locale/en-US/_DV/nukie-operations/autowar.ftl
@@ -1,5 +1,5 @@
 ﻿# Played when war is automatically called
 
-nuke-ops-auto-war-message = Central Command
+nuke-ops-auto-war-message = Our intelligence indicates that a hostile boarding party is enroute to your location.
 nuke-ops-auto-war-title = Central Command
 

--- a/Resources/Locale/en-US/_DV/nukie-operations/autowar.ftl
+++ b/Resources/Locale/en-US/_DV/nukie-operations/autowar.ftl
@@ -1,0 +1,5 @@
+﻿# Played when war is automatically called
+
+nuke-ops-auto-war-message = Central Command
+nuke-ops-auto-war-title = Central Command
+


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
WOWZA ITS WAR TIME!!!!

If a nukie mode is not hostage ops it will AUTOMATICALLY call war after 2 minutes of the round starting. War still includes everything it did, as a reminder ill put what it does here

all nukies get 80TC (yes, still 80 without hardsuits)
nukies cannot depart until a certain period of time has passed to give station time to prepare
crew cannot call evac until 25 minutes

TO BE DONE AT A LATER DATE:
once ERT gamerules get added I will add those to automatically spawn, as well as force the shuttle to come with a timer that cannot be recalled.

## Why / Balance
Id love to do my nukie rant here, but ill try to keep it concise. Current nukies is 30 minutes of RP, and then instant round over with little involvement for crew. Warops is ~25 minutes of the station coming together to defend themselves and become victorious. so +RP, +comradery, +not having 30 minutes wasted.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
I will add if requested but its literally just a funny announcement

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The announcement that happens is pending direction discussion and will be added later

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Non-hostage ops nukies will always be warops.

