### PR TITLE
always end the round when nuke explodes

### DIFF
--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -159,6 +159,8 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
 
             _roundEndSystem.EndRound();
         }
+
+        _roundEndSystem.EndRound(); // DeltaV - end the round regardless of game rules
     }
 
     // DeltaV - Kidnap heads nukie objective


### PR DESCRIPTION
## About the PR
if there are no nukeops rules it will still end the round
for admin abuse or loneop bugs or whatever

## Why / Balance
i died pls restart
fixes #3099 as i cant reproduce baby nuke so it will need reproduction steps or server logs for a specific round it happened in

**Changelog**
:cl:
DELTAVADMIN:
- tweak: The nuke exploding will now end the round even without a nukeops gamerule.