### PR TITLE
add departmental access to borgs

### DIFF
--- a/Resources/Prototypes/_DV/borg_types.yml
+++ b/Resources/Prototypes/_DV/borg_types.yml
@@ -39,6 +39,8 @@
   - type: Fiber # red plasteel fibers
     fiberMaterial: fibers-plasteel
     fiberColor: fibers-red
+  - type: AccessReader
+    access: [["Command"], ["Robotics"], ["Security"]]
 
   radioChannels:
   - Science

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -248,7 +248,7 @@
   - Service
 
   job: Bartender # DeltaV - borg job requirements
-  addedComponents: # DeltaV - departmental access
+  addComponents: # DeltaV - departmental access
   - type: AccessReader
     access: [["Command"], ["Robotics"], ["Service"]]
 

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -51,7 +51,9 @@
 
   lawset: Engineer # DeltaV - Custom lawset
   job: StationEngineer # DeltaV - borg job requirements
-  addComponents: # DeltaV - orange plasteel fibers
+  addComponents: # DeltaV - fibers, departmental access
+  - type: AccessReader
+    access: [["Command"], ["Robotics"], ["Engineering"]]
   - type: Fiber
     fiberMaterial: fibers-plasteel
     fiberColor: fibers-orange
@@ -92,10 +94,12 @@
   - BorgModuleAppraisal
 
   job: SalvageSpecialist # DeltaV - borg job requirements
-  addComponents: # DeltaV - brown plasteel fibers
+  addComponents: # DeltaV - fibers, departmental access
   - type: Fiber
     fiberMaterial: fibers-plasteel
     fiberColor: fibers-brown
+  - type: AccessReader
+    access: [["Command"], ["Robotics"], ["Salvage"]]
 
   radioChannels:
   - Supply
@@ -134,10 +138,12 @@
 
   lawset: Janitor # DeltaV - Custom lawset
   job: Janitor # DeltaV - borg job requirements
-  addComponents: # DeltaV - purple plasteel fibers
+  addComponents: # DeltaV - fibers, departmental access
   - type: Fiber
     fiberMaterial: fibers-plasteel
     fiberColor: fibers-purple
+  - type: AccessReader
+    access: [["Command"], ["Robotics"], ["Janitor"]]
 
   radioChannels:
   - Science
@@ -196,6 +202,8 @@
   - type: Fiber # DeltaV - white plasteel fibers
     fiberMaterial: fibers-plasteel
     fiberColor: fibers-white
+  - type: AccessReader # DeltaV - departmental access
+    access: [["Command"], ["Robotics"], ["Medical"]]
   - type: SurgeryTarget # Shitmed
   - type: Sanitized # Shitmed
 
@@ -240,6 +248,9 @@
   - Service
 
   job: Bartender # DeltaV - borg job requirements
+  addedComponents: # DeltaV - departmental access
+  - type: AccessReader
+    access: [["Command"], ["Robotics"], ["Service"]]
 
   # Visual
   inventoryTemplateId: borgTall


### PR DESCRIPTION
## About the PR
all of epi can no longer unlock borgs (except generic because its basically sciborg)

now its split between command, robotics (or they cant do their job) and the relevant department:
- sec is sec
- engi is engi
- salv is salv
- med is med
- jani is jani
- service is service

## Why / Balance
shadow factory isnt automatically epi valid KOS since non epi can now unlock them, also lets them get upgraded at their department

part of #3060

renaming your department borg to something better is much easier

## Technical details
:trollface:

## Media
scientist id can no longer unlock every borg
![11:56:36](https://github.com/user-attachments/assets/adf015d3-1434-4e3c-857a-dd07c98614a2)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Cyborg's lock access is now command robotics and the relevant department, scientists can no longer unlock every borg.