### PR TITLE
give secborgs cuffs and zipties

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -54,7 +54,19 @@
     items:
     - StunbatonSelfCharging
     - FlashRecharging
-    - BorgHypoPax
+    - FlashlightSecliteRecharging
+    - SecurityWhistle
+  - type: DroppableBorgModule
+    moduleId: Deescalate
+    items:
+    - id: Handcuffs
+      whitelist:
+        components:
+        - Handcuff
+    - id: Zipties
+      whitelist:
+        components:
+        - Handcuff
 
 - type: entity
   id: BorgModuleSecurityEscalate


### PR DESCRIPTION
## About the PR
gives secborgs cuffs and zipties which can be replaced by picking them up
1 of each, but you can replace them with any kind of cuff including makeshift cuffs :trollface: 

## Why / Balance
for #3060, lets secborgs actually arrest noncompliant people instead of having to kill them or be a glorified intercom

## Technical details
seclite and whistle included so maybe conflicts with full module rework wont be too bad :trollface:

## Media

cuffs real
![12:25:23](https://github.com/user-attachments/assets/42e4713a-ec64-4fa2-95e9-e3f3a2eb3949)

cuffing people real
![12:25:56](https://github.com/user-attachments/assets/5b26baae-8b5a-400e-97b3-a4133c4de78c)

able to pick up handcuffs into old ziptie slot
![12:26:06](https://github.com/user-attachments/assets/e78de7ef-6bd8-482d-93ba-f25841238edc)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: Security cyborgs now get cuffs to arrest criminals. Follow Rules of Engagement, stop beating people to death!
