### PR TITLE
Remove Contra and EMAG Inv from YouTool

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -13,8 +13,10 @@
     FlashlightLantern: 5
     ClothingHandsGlovesColorYellowBudget: 3
     SprayPainter: 3
+# DeltaV - begin changes
   # Some engineer forgot to take the multitool out the youtool when working on it, happens.
-#  contrabandInventory: # DeltaV - remove contrabandInventory and emaggedInventory
+#  contrabandInventory:
 #    Multitool: 1
 #  emaggedInventory:
 #    ClothingHandsGlovesColorYellow: 1
+# DeltaV - end changes

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -14,7 +14,7 @@
     ClothingHandsGlovesColorYellowBudget: 3
     SprayPainter: 3
   # Some engineer forgot to take the multitool out the youtool when working on it, happens.
-  contrabandInventory:
-    Multitool: 1
-  emaggedInventory:
-    ClothingHandsGlovesColorYellow: 1
+#  contrabandInventory: # DeltaV - remove contrabandInventory and emaggedInventory
+#    Multitool: 1
+#  emaggedInventory:
+#    ClothingHandsGlovesColorYellow: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/youtool.yml
@@ -13,8 +13,8 @@
     FlashlightLantern: 5
     ClothingHandsGlovesColorYellowBudget: 3
     SprayPainter: 3
-# DeltaV - begin changes
   # Some engineer forgot to take the multitool out the youtool when working on it, happens.
+# DeltaV - begin changes
 #  contrabandInventory:
 #    Multitool: 1
 #  emaggedInventory:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Removes multitool from YouTool contra inventory, removes insuls from YouTool EMAG inventory
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Requested to do so by Engineering roadmap team lead
## Technical details
<!-- Summary of code changes for easier review. -->
n/a
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
n/a
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
rawr x3
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Statisticians have found YouTools to be 101% less likely to spontaneously stock insulated gloves and multitools after tampering, with a 1% margin of error. If the statistics say so, it must be true.
