### PR TITLE
dont log empty borg hand when shutting down

### DIFF
--- a/Content.Shared/_NF/Silicons/Borgs/DroppableBorgModuleSystem.cs
+++ b/Content.Shared/_NF/Silicons/Borgs/DroppableBorgModuleSystem.cs
@@ -112,7 +112,7 @@ public sealed class DroppableBorgModuleSystem : EntitySystem
                 _hands.TryGetHand(chassis, handId, out var hand, hands);
                 if (hand?.HeldEntity is {} item)
                     QueueDel(item);
-                else
+                else if (!TerminatingOrDeleted(chassis)) // don't care if its empty if the server is shutting down
                     Log.Error($"Borg {ToPrettyString(chassis)} terminated with empty hand {i} in {ToPrettyString(ent)}");
                 _hands.RemoveHand(chassis, handId, hands);
             }


### PR DESCRIPTION
## About the PR
its good that it cares about empty hand but in this case its normal as the held item has been detached during recursive deletion