### PR TITLE
Make noospheric fry not immediately blow up probers

### DIFF
--- a/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
@@ -102,7 +102,7 @@ internal sealed class NoosphericFryRule : StationEventSystem<NoosphericFryRuleCo
         var queryReactive = EntityQueryEnumerator<SharedGlimmerReactiveComponent, TransformComponent, PhysicsComponent>();
         while (queryReactive.MoveNext(out var reactive, out _, out var xform, out var physics))
         {
-            // shoot out three bolts of lighting...
+            // shoot out one bolt of lighting...
             _glimmerReactiveSystem.BeamRandomNearProber(reactive, 1, 12);
 
             // try to anchor if we can

--- a/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
+++ b/Content.Server/Nyanotrasen/StationEvents/Events/NoosphericFryRule.cs
@@ -103,7 +103,7 @@ internal sealed class NoosphericFryRule : StationEventSystem<NoosphericFryRuleCo
         while (queryReactive.MoveNext(out var reactive, out _, out var xform, out var physics))
         {
             // shoot out three bolts of lighting...
-            _glimmerReactiveSystem.BeamRandomNearProber(reactive, 3, 12);
+            _glimmerReactiveSystem.BeamRandomNearProber(reactive, 1, 12);
 
             // try to anchor if we can
             if (!xform.Anchored)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
reduced amount of lightning from 3 bolts to 1 to prevent probers from auto blowing themselves before glimmer can get critical

## Why / Balance
This prevents the prober self detonating because of random gamerules to an extent. serves the main purpose of having glimmer prober explosions need to be deliberate, instead of them exploding on their own due to funny gamerules.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
