### PR TITLE
prevent climbing while being carried

### DIFF
--- a/Content.Shared/Climbing/Systems/ClimbSystem.cs
+++ b/Content.Shared/Climbing/Systems/ClimbSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._DV.Carrying; // DeltaV
 using Content.Shared.ActionBlocker;
 using Content.Shared.Buckle.Components;
 using Content.Shared.Climbing.Components;
@@ -154,6 +155,11 @@ public sealed partial class ClimbSystem : VirtualController
         // If already climbing then don't show outlines.
         if (TryComp(args.Dragged, out ClimbingComponent? climbing) && climbing.IsClimbing)
             return;
+
+        // Begin DeltaV Additions - prevent climbing for carried mobs
+        if (HasComp<BeingCarriedComponent>(args.Dragged))
+            return;
+        // End DeltaV Additions
 
         var canVault = args.User == args.Dragged
             ? CanVault(component, args.User, uid, out _)


### PR DESCRIPTION
## About the PR
title

## Why / Balance
bug bad

## Technical details
:trollface:

## Media
cant drag urist mcfelinid onto climbable entities
![05:36:25](https://github.com/user-attachments/assets/fc0a3721-727d-4777-ab81-ce8e0445114d)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
mib neuralyzer