### PR TITLE
Add missing recipes to assorted lathes

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -1,6 +1,8 @@
 ## Static
 
 - type: latheRecipePack
+  parent:
+  - ServiceStaticDeltaV # DeltaV
   id: ServiceStatic
   recipes:
   - Bucket

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -7,6 +7,8 @@
 
 - type: latheRecipePack
   id: PartsStatic
+  parent:
+  - PartsStaticDeltaV # DeltaV
   recipes:
   - Igniter
   - ModularReceiver

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -156,11 +156,13 @@
     - MaterialsStatic
     - BasicChemistryStatic
     - ChemistryStatic
+    - PowerCellsStatic
     dynamicPacks:
     - ScienceEquipment
     - ScienceClothing
     - ScienceWeapons
     - Chemistry
+    - PowerCells
   - type: Machine
     board: EpistemicsTechFabCircuitboard
   - type: StealTarget

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/service.yml
@@ -7,6 +7,12 @@
   - TapeRecorder
 
 - type: latheRecipePack
+  id: ServiceStaticDeltaV
+  recipes:
+  - TrashBag
+  - LightReplacer
+
+- type: latheRecipePack
   id: ServiceBoardsStaticDeltaV
   recipes:
   - DeepFryerMachineCircuitboard

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
@@ -12,3 +12,8 @@
   id: LVCablesStatic
   recipes:
   - CableStack
+
+- type: latheRecipePack
+  id: PartsStaticDeltaV
+  recipes:
+  - Beaker


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR & Why
- epistemics has power cells now for robotics
- service has trash bags and light replacers because these were accidentally omitted the first time around
- engineering has beakers for building machines that take beakers

## Technical details
- add recipes to lathe packs
- add lathe packs to lathes

## Media
![image](https://github.com/user-attachments/assets/ef17cad5-f91b-4dd7-bfdf-70ed0a482090)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added power cells to epistemics techfab, trash bags and light replacers to the service techfab, and beakers to the engineering techfab
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
