### PR TITLE
Port Game Director from Goobstation

### DIFF
--- a/Content.IntegrationTests/Tests/_DV/GameDirectorEventTaggingTest.cs
+++ b/Content.IntegrationTests/Tests/_DV/GameDirectorEventTaggingTest.cs
@@ -1,3 +1,4 @@
+using Content.Server._DV.StationEvents.Components;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents.Components;
 using Content.Shared._Goobstation.StationEvents.Metric;
@@ -34,7 +35,7 @@ public sealed class GameDirectorEventTaggingTest
                     if (!gameRule.HasComponent<StationEventComponent>())
                         continue;
 
-                    if (gameRule.HasComponent<DynamicRulesetComponent>())
+                    if (gameRule.HasComponent<DynamicRulesetComponent>() || gameRule.HasComponent<GameDirectorIgnoreComponent>())
                         continue;
 
                     gameRule.TryGetComponent<StationEventComponent>(out var stationEvent, componentFactory);

--- a/Content.IntegrationTests/Tests/_DV/GameDirectorEventTaggingTest.cs
+++ b/Content.IntegrationTests/Tests/_DV/GameDirectorEventTaggingTest.cs
@@ -1,0 +1,48 @@
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.StationEvents.Components;
+using Content.Shared._Goobstation.StationEvents.Metric;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Prototypes;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._DV;
+
+public sealed class GameDirectorEventTaggingTest
+{
+    [Test]
+    public async Task AllEventsTaggedTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var componentFactory = server.ResolveDependency<IComponentFactory>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+        var emptyChaos = new ChaosMetrics();
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var gameRule in protoMan.EnumeratePrototypes<EntityPrototype>())
+                {
+                    if (gameRule.Abstract)
+                        continue;
+
+                    if (!gameRule.HasComponent<GameRuleComponent>())
+                        continue;
+
+                    if (!gameRule.HasComponent<StationEventComponent>())
+                        continue;
+
+                    if (gameRule.HasComponent<DynamicRulesetComponent>())
+                        continue;
+
+                    gameRule.TryGetComponent<StationEventComponent>(out var stationEvent, componentFactory);
+                    Assert.That(stationEvent, Is.Not.Null, $"Station event {gameRule.ID} should have the StationEventComponent");
+
+                    Assert.That(stationEvent.Chaos, Is.Not.EqualTo(emptyChaos), $"Station event {gameRule.ID} should have a non-empty chaos value");
+                }
+            });
+        });
+    }
+}

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -496,6 +496,22 @@ public sealed class StationSystem : EntitySystem
 
         return stats;
     }
+    // Goobstation start
+    public HashSet<EntityUid> GetAllStationGrids()
+    {
+        // Collect all grids owned by stations
+        var grids = new HashSet<EntityUid>();
+
+        var query = EntityQueryEnumerator<StationDataComponent>();
+        while (query.MoveNext(out var uid, out var data))
+        {
+            // Add to the list of grids
+            grids.UnionWith(data.Grids);
+        }
+
+        return grids;
+    }
+    // Goobstation end
 
     /// <summary>
     /// Returns the first station that has a grid in a certain map.

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -1,5 +1,5 @@
 using Content.Server._Goobstation.StationEvents; // Goobstation
-using Content.Server._Goobstation.StationEvents.Metric; // Goobstation
+using Content.Shared._Goobstation.StationEvents.Metric; // Goobstation // DeltaV - shared the prototypes for our tests
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -1,3 +1,5 @@
+using Content.Server._Goobstation.StationEvents; // Goobstation
+using Content.Server._Goobstation.StationEvents.Metric; // Goobstation
 using Robust.Shared.Audio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -87,4 +89,13 @@ public sealed partial class StationEventComponent : Component
     /// </summary>
     [DataField]
     public bool OccursDuringRoundEnd = true;
+
+    // Goobstation start
+    /// <summary>
+    ///  Expected Chaos changes when this event occurs.
+    ///  Used by the GameDirector, which picks an event expected to make the desired chaos changes.
+    /// </summary>
+    [DataField("chaos")]
+    public ChaosMetrics Chaos = new ChaosMetrics();
+    // Goobstation end
 }

--- a/Content.Server/StationEvents/EventManagerSystem.cs
+++ b/Content.Server/StationEvents/EventManagerSystem.cs
@@ -54,6 +54,17 @@ public sealed class EventManagerSystem : EntitySystem
         GameTicker.AddGameRule(randomEvent);
     }
 
+    // Goobstation start
+    /// <summary>
+    /// Runs a specific named event.
+    /// </summary>
+    public void RunNamedEvent(string eventId)
+    {
+        var ent = GameTicker.AddGameRule(eventId);
+        Log.Info($"Running event {eventId} as entity {ent}");
+    }
+    // Goobstation end
+
     /// <summary>
     /// Randomly runs an event from provided EntityTableSelector.
     /// </summary>
@@ -259,7 +270,7 @@ public sealed class EventManagerSystem : EntitySystem
         return TimeSpan.Zero;
     }
 
-    private bool CanRun(EntityPrototype prototype, StationEventComponent stationEvent, int playerCount, TimeSpan currentTime)
+    public bool CanRun(EntityPrototype prototype, StationEventComponent stationEvent, int playerCount, TimeSpan currentTime) // Goobstation - we need to check if events can run from the game director
     {
         if (GameTicker.IsGameRuleActive(prototype.ID))
             return false;

--- a/Content.Server/_DV/Administration/Commands/GameDirectorCommands.cs
+++ b/Content.Server/_DV/Administration/Commands/GameDirectorCommands.cs
@@ -1,0 +1,122 @@
+using System.Linq;
+using Content.Server._Goobstation.StationEvents.Components;
+using Content.Server._Goobstation.StationEvents;
+using Content.Server.Administration;
+using Content.Shared._Goobstation.StationEvents;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+using Robust.Shared.Timing;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.Administration.Commands;
+
+[AdminCommand(AdminFlags.VarEdit)]
+public sealed class GameDirectorCommand : IConsoleCommand
+{
+    public string Command => "gamedirector";
+    public string Description => "Gets the entity UID of the Game Director if one is present";
+    public string Help => "";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var enumerator = entityManager.AllEntityQueryEnumerator<GameDirectorComponent>();
+        while (enumerator.MoveNext(out var ent, out _))
+        {
+            shell.WriteLine($"Game Director: {ent}");
+        }
+    }
+}
+
+[AdminCommand(AdminFlags.VarEdit)]
+public sealed class GameDirectorForceStoryCommand : IConsoleCommand
+{
+    public string Command => "gamedirector:forcestory";
+    public string Description => "Forces the game director to switch to a new story";
+    public string Help => "";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var gameDirector = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<GameDirectorSystem>();
+        var prototypeManager = IoCManager.Resolve<IPrototypeManager>();
+
+        if (args.Length < 1)
+        {
+            shell.WriteLine("Specify a story prototype to force");
+            return;
+        }
+
+        if (!prototypeManager.TryIndex<StoryPrototype>(args[0], out var story))
+        {
+            shell.WriteLine($"{args[0]} is not a story prototype");
+            return;
+        }
+
+        var enumerator = entityManager.AllEntityQueryEnumerator<GameDirectorComponent>();
+        while (enumerator.MoveNext(out var ent, out var comp))
+        {
+            gameDirector.SwitchStory(comp, story, gameDirector.CountActivePlayers());
+            shell.WriteLine($"Game Director {ent} switched to {args[0]}");
+        }
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+        {
+            var options = IoCManager.Resolve<IPrototypeManager>()
+                .EnumeratePrototypes<StoryPrototype>()
+                .Select(p => new CompletionOption(p.ID))
+                .OrderBy(p => p.Value);
+
+            return CompletionResult.FromHintOptions(options, "Story to force");
+        }
+
+        return CompletionResult.Empty;
+    }
+}
+
+
+[AdminCommand(AdminFlags.VarEdit)]
+public sealed class GameDirectorForceEventCommand : IConsoleCommand
+{
+    public string Command => "gamedirector:forceevent";
+    public string Description => "Forces the game director to start an event";
+    public string Help => "";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var gameDirector = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<GameDirectorSystem>();
+        var gameTiming = IoCManager.Resolve<IGameTiming>();
+
+        var enumerator = entityManager.AllEntityQueryEnumerator<GameDirectorComponent>();
+        while (enumerator.MoveNext(out var ent, out var comp))
+        {
+            comp.TimeNextEvent = gameTiming.CurTime;
+            shell.WriteLine($"Game Director {ent} forced to start an event");
+        }
+    }
+}
+
+[AdminCommand(AdminFlags.VarEdit)]
+public sealed class GameDirectorChaosCommand : IConsoleCommand
+{
+    public string Command => "gamedirector:chaos";
+    public string Description => "Causes the game director to evaluate the current amount of chaos";
+    public string Help => "";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var gameDirector = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<GameDirectorSystem>();
+
+        var enumerator = entityManager.AllEntityQueryEnumerator<GameDirectorComponent>();
+        while (enumerator.MoveNext(out var ent, out var comp))
+        {
+            var chaos = gameDirector.CalculateChaos(ent);
+            shell.WriteLine($"Game Director {ent} calculated the following amount of chaos: {chaos}");
+        }
+    }
+}

--- a/Content.Server/_DV/StationEvents/Components/GameDirectorIgnoreComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/GameDirectorIgnoreComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._DV.StationEvents.Components;
+
+/// <summary>
+///     Indicates that this event shouldn't be considered by the Game Director
+/// </summary>
+[RegisterComponent]
+public sealed partial class GameDirectorIgnoreComponent : Component;

--- a/Content.Server/_DV/StationEvents/Metric/AirAlarmMetricComponent.cs
+++ b/Content.Server/_DV/StationEvents/Metric/AirAlarmMetricComponent.cs
@@ -1,0 +1,26 @@
+using Content.Shared.Atmos.Monitor;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._DV.StationEvents.Metric;
+
+[RegisterComponent, Access(typeof(AirAlarmMetricSystem))]
+public sealed partial class AirAlarmMetricComponent : Component
+{
+    /// <summary>
+    ///   Cost of all air alarms going off
+    /// </summary>
+    [DataField]
+    public float AirAlarmCost = 300.0f;
+
+    /// <summary>
+    ///   How much each air alarm state adds to the average
+    /// </summary>
+    [DataField]
+    public Dictionary<AtmosAlarmType, FixedPoint2> Weights = new() {
+        [AtmosAlarmType.Invalid] = 0f,
+        [AtmosAlarmType.Normal] = 0f,
+        [AtmosAlarmType.Warning] = 0.5f,
+        [AtmosAlarmType.Danger] = 1f,
+        [AtmosAlarmType.Emagged] = 1.5f,
+    };
+}

--- a/Content.Server/_DV/StationEvents/Metric/AirAlarmMetricSystem.cs
+++ b/Content.Server/_DV/StationEvents/Metric/AirAlarmMetricSystem.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Server._Goobstation.StationEvents.Metric;
+using Content.Server.Atmos.Monitor.Components;
+using Content.Server.GameTicking;
+using Content.Server.Station.Systems;
+using Content.Shared._Goobstation.StationEvents.Metric;
+using Content.Shared.Atmos.Monitor;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._DV.StationEvents.Metric;
+
+/// <summary>
+///   Uses air alarms to sample station chaos across the station
+/// </summary>
+public sealed class AirAlarmMetricSystem : ChaosMetricSystem<AirAlarmMetricComponent>
+{
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+
+    public override ChaosMetrics CalculateChaos(EntityUid metric_uid, AirAlarmMetricComponent component,
+        CalculateChaosEvent args)
+    {
+        var airAlarmCounter = FixedPoint2.Zero;
+        var airAlarmBadCounter = FixedPoint2.Zero;
+
+        var stationGrids = _stationSystem.GetAllStationGrids();
+
+        var queryAirAlarm = EntityQueryEnumerator<AirAlarmComponent, TransformComponent>();
+        while (queryAirAlarm.MoveNext(out var uid, out var alarm, out var transform))
+        {
+            if (transform.GridUid == null || !stationGrids.Contains(transform.GridUid.Value))
+                continue;
+
+            airAlarmBadCounter += component.Weights.GetValueOrDefault(alarm.State, FixedPoint2.Zero);
+            airAlarmCounter += 1;
+        }
+
+        var atmosChaos = FixedPoint2.Zero;
+
+        if (airAlarmCounter > FixedPoint2.Zero)
+            atmosChaos = (airAlarmBadCounter / airAlarmCounter) * component.AirAlarmCost;
+
+        var chaos = new ChaosMetrics(new Dictionary<ChaosMetric, FixedPoint2>()
+        {
+            {ChaosMetric.Atmos, atmosChaos},
+        });
+        return chaos;
+    }
+}

--- a/Content.Server/_Goobstation/GameTicking/Rules/Components/DynamicRuleComponent.cs
+++ b/Content.Server/_Goobstation/GameTicking/Rules/Components/DynamicRuleComponent.cs
@@ -1,0 +1,54 @@
+using Content.Shared.Dataset;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.GameTicking.Rules.Components;
+
+[RegisterComponent]
+public sealed partial class DynamicRuleComponent : Component
+{
+    #region Budgets
+
+    /// <summary>
+    ///     Ignore major threats and stack one upon each other :trollface:
+    ///     Use this if chaos is your thing or you want a budget AAO
+    /// </summary>
+    [DataField] public bool Unforgiving = false;
+
+    /// <summary>
+    ///     Max threat available on lowpop
+    /// </summary>
+    [DataField] public float LowpopMaxThreat = 40f;
+
+    /// <summary>
+    ///     Maximum amount of threat available
+    /// </summary>
+    [DataField] public float MaxThreat = 100f;
+
+    /// <summary>
+    ///     
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)] public float ThreatLevel = 0f;
+
+    /// <summary>
+    ///     Used for EORG display.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)] public float RoundstartBudget = 0f;
+
+    /// <summary>
+    ///     Used for EORG display.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)] public float MidroundBudget = 0f;
+
+    #endregion
+
+    #region Gamerules
+
+    [DataField] public ProtoId<DatasetPrototype> RoundstartRulesPool;
+
+    /// <summary>
+    ///     Used for EORG.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)] public List<(EntProtoId, EntityUid?)> ExecutedRules = new();
+
+    #endregion
+}

--- a/Content.Server/_Goobstation/GameTicking/Rules/Components/DynamicRulesetComponent.cs
+++ b/Content.Server/_Goobstation/GameTicking/Rules/Components/DynamicRulesetComponent.cs
@@ -1,0 +1,35 @@
+namespace Content.Server.GameTicking.Rules.Components;
+
+[RegisterComponent]
+public sealed partial class DynamicRulesetComponent : Component
+{
+    /// <summary>
+    ///     Localized name that will be shown at EORG
+    /// </summary>
+    [DataField] public string NameLoc;
+
+    /// <summary>
+    ///     Required minimum amount of valids to start the gamerule
+    /// </summary>
+    [DataField] public float RequiredCandidates = 1f;
+
+    /// <summary>
+    ///     Gamerule weight
+    /// </summary>
+    [DataField] public float Weight = 5f;
+
+    /// <summary>
+    ///     Initial cost for the first antagonist
+    /// </summary>
+    [DataField] public float Cost = 8f;
+
+    /// <summary>
+    ///     Cost to spawn in more antagonists
+    /// </summary>
+    [DataField] public float ScalingCost = 1f;
+
+    /// <summary>
+    ///     High impact indicated that all other high impact rulesets are to be removed.
+    /// </summary>
+    [DataField] public bool HighImpact = false;
+}

--- a/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
@@ -1,0 +1,233 @@
+﻿using Content.Server._Goobstation.StationEvents.Metric;
+using Content.Shared.EntityTable.EntitySelectors;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Server._Goobstation.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(GameDirectorSystem))]
+public sealed partial class GameDirectorComponent : Component
+{
+
+    /// <summary>
+    ///   How long until the next check for an event runs
+    ///   Default value is how long until first event is allowed
+    /// </summary>
+    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
+    public TimeSpan TimeNextEvent;
+
+    /// <summary>
+    ///   When the current beat started
+    /// </summary>
+    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer))]
+    public TimeSpan BeatStart;
+
+    /// <summary>
+    ///   The chaos we measured last time we ran
+    ///   This is helpful for ViewVariables and perhaps as a cache to hold chaos for other functions to use.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly)]
+    public ChaosMetrics CurrentChaos = new();
+
+    /// <summary>
+    ///   The story we are currently executing from stories (for easier debugging). Since it is for
+    ///   debugging, it does not need a DataField.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public ProtoId<StoryPrototype> CurrentStoryName;
+
+    /// <summary>
+    ///   Remaining beats in the story we are currently executing (a list of beat IDs)
+    /// </summary>
+    [DataField]
+    public List<ProtoId<StoryBeatPrototype>> RemainingBeats = new();
+
+    /// <summary>
+    /// Does this round start with multiple antags.
+    /// </summary>
+    [DataField]
+    public bool DualAntags;
+
+    /// <summary>
+    /// Does this round start with antags at all?.
+    /// </summary>
+    [DataField]
+    public bool NoRoundstartAntags;
+
+    /// <summary>
+    ///   Which stories the director can choose from (so we can change flavor of director by loading different stories)
+    ///   One of these get picked randomly each time the current story is exhausted.
+    /// </summary>
+    [DataField]
+    public ProtoId<StoryPrototype>[]? Stories;
+
+    /// <summary>
+    ///   A beat name we always use when we cannot find any stories to use.
+    /// </summary>
+    [DataField]
+    public ProtoId<StoryBeatPrototype> FallbackBeatName = "Peace";
+
+    /// <summary>
+    ///   All the events that are allowed to run in the current story.
+    /// </summary>
+    [DataField]
+    public List<PossibleEvent> PossibleEvents = new();
+    // Could have Chaos multipliers here, or multipliers per player (so stories are harder with more players).
+}
+
+/// <summary>
+///   A series of named StoryBeats which we want to take the station through in the given sequence.
+///   Gated by various settings such as the number of players
+/// </summary>
+[DataDefinition]
+[Prototype("story")]
+public sealed partial class StoryPrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    ///   A human-readable description string for logging / admins
+    /// </summary>
+    [DataField]
+    public string Description;
+
+    /// <summary>
+    ///   Minimum number of players on the station to pick this story
+    /// </summary>
+    [DataField]
+    public int MinPlayers = -1;
+
+    /// <summary>
+    ///   Maximum number of players on the station to pick this story
+    /// </summary>
+    [DataField]
+    public int MaxPlayers = Int32.MaxValue;
+
+    /// <summary>
+    ///   List of beat-ids in this story.
+    /// </summary>
+    [DataField]
+    public ProtoId<StoryBeatPrototype>[]? Beats;
+}
+
+/// <summary>
+///   A point in the story of the station where the dynamic system tries to achieve a certain level of chaos
+///   for instance you want a battle (goal has lots of hostiles)
+///   then the next beat you might want a restoration of peace (goal has a balanced combat score)
+///   then you might want to have the station heal up (goal has low medical, atmos and power scores)
+///
+///   In each case you create a beat and string them together into a story.
+///
+///   EndIfAnyWorse might be used for a battle to trigger when the chaos has become high enough.
+///   endIfAllBetter is suitable for when you want the station to reach a given level of peace before you subject them to
+///   the next round of chaos.
+/// </summary>
+[DataDefinition]
+[Prototype("storyBeat")]
+public sealed partial class StoryBeatPrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    ///   A human-readable description string for logging / admins
+    /// </summary>
+    [DataField]
+    public string Description;
+
+    /// <summary>
+    ///   Which chaos levels we are driving in this beat and the values we are aiming for
+    /// </summary>
+    [DataField]
+    public ChaosMetrics Goal = new ChaosMetrics();
+
+    /// <summary>
+    ///   Early end if things deteriorate too much
+    ///
+    ///   If the current metrics get worse than any of these, end the story beat
+    ///   For instance, too many hostiles or too little atmos
+    /// </summary>
+    [DataField]
+    public ChaosMetrics EndIfAnyWorse = new ChaosMetrics();
+
+    /// <summary>
+    ///   Early end if life is good enough
+    ///
+    ///   If the current metrics get better than all of these, end the story beat
+    ///   For instance, medical, atmos, hostiles are all under control.
+    /// </summary>
+    [DataField]
+    public ChaosMetrics EndIfAllBetter = new ChaosMetrics();
+
+    /// <summary>
+    ///   The number of seconds that we will remain in this state at minimum
+    /// </summary>
+    [DataField]
+    public float MinSecs = 480.0f;
+
+    /// <summary>
+    ///   The number of seconds that we will remain in this state at maximum
+    /// </summary>
+    [DataField]
+    public float MaxSecs = 1200.0f;
+
+    /// <summary>
+    ///   Seconds between events during this beat (min)
+    ///   2 minute default (120)
+    /// </summary>
+    [DataField]
+    public float EventDelayMin = 120.0f;
+
+    /// <summary>
+    ///   Seconds between events during this beat (min)
+    ///   6 minute default (360)
+    /// </summary>
+    [DataField]
+    public float EventDelayMax = 360.0f;
+
+    /// <summary>
+    ///   How many different events we choose from (at random) when performing this StoryBeat
+    /// </summary>
+    ///
+    /// The director is making a priority pick. But to ensure it doesn't ALWAYS pick the very best we actually
+    ///  pick randomly from the top few events (RandomEventLimit).
+    /// By tuning RandomEventLimit you can decide on a per beat basis how much the director is "directing" and
+    ///  how much it's acting like a random system. Some randomness is often good to spice things up.
+    [DataField]
+    public int RandomEventLimit = 3;
+}
+
+/// <summary>
+///   Caches a possible StationEvent prototype with the chaos expected (from the game rule's data)
+///   A list of PossibleEvents are built and cached by the game director.
+/// </summary>
+[DataDefinition]
+public sealed partial class PossibleEvent
+{
+    /// <summary>
+    ///   ID of a station event prototype (anomaly, spiders, pizzas, etc) that could occur
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public EntProtoId StationEvent;
+
+    /// <summary>
+    ///   Expected Chaos changes when this event occurs.
+    ///   Used by the GameDirector, which picks an event expected to make the desired chaos changes.
+    ///   Copy of the StationEventComponent.Chaos field from the relevant event.
+    /// </summary>
+    [DataField]
+    public ChaosMetrics Chaos = new();
+
+    public PossibleEvent()
+    {
+    }
+
+    public PossibleEvent(EntProtoId stationEvent, ChaosMetrics chaos)
+    {
+        StationEvent = stationEvent;
+        Chaos = chaos;
+    }
+}

--- a/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
@@ -2,6 +2,8 @@
 using Content.Shared.EntityTable.EntitySelectors;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+using Content.Shared._Goobstation.StationEvents; // DeltaV - shared the prototypes for our tests
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - shared the prototypes for our tests
 
 namespace Content.Server._Goobstation.StationEvents.Components;
 
@@ -73,131 +75,6 @@ public sealed partial class GameDirectorComponent : Component
     [DataField]
     public List<PossibleEvent> PossibleEvents = new();
     // Could have Chaos multipliers here, or multipliers per player (so stories are harder with more players).
-}
-
-/// <summary>
-///   A series of named StoryBeats which we want to take the station through in the given sequence.
-///   Gated by various settings such as the number of players
-/// </summary>
-[DataDefinition]
-[Prototype("story")]
-public sealed partial class StoryPrototype : IPrototype
-{
-    [ViewVariables]
-    [IdDataField]
-    public string ID { get; private set; } = default!;
-
-    /// <summary>
-    ///   A human-readable description string for logging / admins
-    /// </summary>
-    [DataField]
-    public string Description;
-
-    /// <summary>
-    ///   Minimum number of players on the station to pick this story
-    /// </summary>
-    [DataField]
-    public int MinPlayers = -1;
-
-    /// <summary>
-    ///   Maximum number of players on the station to pick this story
-    /// </summary>
-    [DataField]
-    public int MaxPlayers = Int32.MaxValue;
-
-    /// <summary>
-    ///   List of beat-ids in this story.
-    /// </summary>
-    [DataField]
-    public ProtoId<StoryBeatPrototype>[]? Beats;
-}
-
-/// <summary>
-///   A point in the story of the station where the dynamic system tries to achieve a certain level of chaos
-///   for instance you want a battle (goal has lots of hostiles)
-///   then the next beat you might want a restoration of peace (goal has a balanced combat score)
-///   then you might want to have the station heal up (goal has low medical, atmos and power scores)
-///
-///   In each case you create a beat and string them together into a story.
-///
-///   EndIfAnyWorse might be used for a battle to trigger when the chaos has become high enough.
-///   endIfAllBetter is suitable for when you want the station to reach a given level of peace before you subject them to
-///   the next round of chaos.
-/// </summary>
-[DataDefinition]
-[Prototype("storyBeat")]
-public sealed partial class StoryBeatPrototype : IPrototype
-{
-    [ViewVariables]
-    [IdDataField]
-    public string ID { get; private set; } = default!;
-
-    /// <summary>
-    ///   A human-readable description string for logging / admins
-    /// </summary>
-    [DataField]
-    public string Description;
-
-    /// <summary>
-    ///   Which chaos levels we are driving in this beat and the values we are aiming for
-    /// </summary>
-    [DataField]
-    public ChaosMetrics Goal = new ChaosMetrics();
-
-    /// <summary>
-    ///   Early end if things deteriorate too much
-    ///
-    ///   If the current metrics get worse than any of these, end the story beat
-    ///   For instance, too many hostiles or too little atmos
-    /// </summary>
-    [DataField]
-    public ChaosMetrics EndIfAnyWorse = new ChaosMetrics();
-
-    /// <summary>
-    ///   Early end if life is good enough
-    ///
-    ///   If the current metrics get better than all of these, end the story beat
-    ///   For instance, medical, atmos, hostiles are all under control.
-    /// </summary>
-    [DataField]
-    public ChaosMetrics EndIfAllBetter = new ChaosMetrics();
-
-    /// <summary>
-    ///   The number of seconds that we will remain in this state at minimum
-    /// </summary>
-    [DataField]
-    public float MinSecs = 480.0f;
-
-    /// <summary>
-    ///   The number of seconds that we will remain in this state at maximum
-    /// </summary>
-    [DataField]
-    public float MaxSecs = 1200.0f;
-
-    /// <summary>
-    ///   Seconds between events during this beat (min)
-    ///   2 minute default (120)
-    /// </summary>
-    [DataField]
-    public float EventDelayMin = 120.0f;
-
-    /// <summary>
-    ///   Seconds between events during this beat (min)
-    ///   6 minute default (360)
-    /// </summary>
-    [DataField]
-    public float EventDelayMax = 360.0f;
-
-    /// <summary>
-    ///   How many different events we choose from (at random) when performing this StoryBeat
-    /// </summary>
-    ///
-    /// The director is making a priority pick. But to ensure it doesn't ALWAYS pick the very best we actually
-    ///  pick randomly from the top few events (RandomEventLimit).
-    /// By tuning RandomEventLimit you can decide on a per beat basis how much the director is "directing" and
-    ///  how much it's acting like a random system. Some randomness is often good to spice things up.
-    [DataField]
-    public int RandomEventLimit = 3;
 }
 
 /// <summary>

--- a/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
@@ -98,6 +98,13 @@ public sealed partial class PossibleEvent
     [DataField]
     public ChaosMetrics Chaos = new();
 
+    // Begin DeltaV - Make Game Director VV Better
+    public override string? ToString()
+    {
+        return $"{StationEvent} {Chaos}";
+    }
+    // End DeltaV - Make Game Director VV Better
+
     public PossibleEvent()
     {
     }

--- a/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Components/GameDirectorComponent.cs
@@ -1,13 +1,15 @@
-﻿using Content.Server._Goobstation.StationEvents.Metric;
+﻿using Content.Server._DV.Administration.Commands; // DeltaV - Easier Debugging
+using Content.Server._Goobstation.StationEvents.Metric;
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - shared the prototypes for our tests
+using Content.Shared._Goobstation.StationEvents; // DeltaV - shared the prototypes for our tests
 using Content.Shared.EntityTable.EntitySelectors;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
-using Content.Shared._Goobstation.StationEvents; // DeltaV - shared the prototypes for our tests
-using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - shared the prototypes for our tests
+using Robust.Shared.Timing; // DeltaV - Easier Debugging
 
 namespace Content.Server._Goobstation.StationEvents.Components;
 
-[RegisterComponent, Access(typeof(GameDirectorSystem))]
+[RegisterComponent, Access(typeof(GameDirectorSystem), typeof(GameDirectorForceEventCommand))]
 public sealed partial class GameDirectorComponent : Component
 {
 
@@ -37,6 +39,50 @@ public sealed partial class GameDirectorComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
     public ProtoId<StoryPrototype> CurrentStoryName;
+
+    // Begin DeltaV - Easier Debugging
+    /// <summary>
+    /// Debugging only - Time until the next story
+    /// </summary>
+    [ViewVariables]
+    private TimeSpan TimeUntilNextEventVV
+    {
+        get
+        {
+            var currentTime = IoCManager.Resolve<IGameTiming>().CurTime;
+            return TimeNextEvent - currentTime;
+        }
+    }
+
+    /// <summary>
+    /// Debugging only - The current story's prototype
+    /// </summary>
+    [ViewVariables]
+    private StoryPrototype CurrentStoryVV
+    {
+        get
+        {
+            var protoMan = IoCManager.Resolve<IPrototypeManager>();
+            return protoMan.Index(CurrentStoryName);
+        }
+    }
+
+    /// <summary>
+    /// Debugging only - The current story beat's prototype
+    /// </summary>
+    [ViewVariables]
+    private StoryBeatPrototype? CurrentStoryBeatVV
+    {
+        get
+        {
+            if (RemainingBeats.Count < 1)
+                return null;
+
+            var protoMan = IoCManager.Resolve<IPrototypeManager>();
+            return protoMan.Index(RemainingBeats[0]);
+        }
+    }
+    // End DeltaV - Easier Debugging
 
     /// <summary>
     ///   Remaining beats in the story we are currently executing (a list of beat IDs)

--- a/Content.Server/_Goobstation/StationEvents/Components/SelectedGameRulesComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Components/SelectedGameRulesComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.EntityTable.EntitySelectors;
+
+namespace Content.Server._Goobstation.StationEvents.Components;
+
+
+/// <summary>
+///   All the events that are allowed to run in the current round. If this is not assigned to the game rule it will select from all of them :fire:
+/// </summary>
+[RegisterComponent]
+public sealed partial class SelectedGameRulesComponent : Component
+{
+    /// <summary>
+    ///   All the events that are allowed to run in the current round.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityTableSelector ScheduledGameRules = default!;
+}

--- a/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
@@ -1,0 +1,559 @@
+using System.Linq;
+using Content.Server._Goobstation.StationEvents.Components;
+using Content.Server._Goobstation.StationEvents.Metric;
+using Content.Server.Administration.Logs;
+using Content.Server.Chat.Managers;
+using Content.Server.GameTicking.Rules;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.StationEvents;
+using Content.Server.StationEvents.Components;
+using Content.Shared._Goobstation.CCVar;
+using Content.Shared.CCVar;
+using Content.Shared.Database;
+using Content.Shared.EntityTable;
+using Content.Shared.EntityTable.EntitySelectors;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Ghost;
+using Content.Shared.Humanoid;
+using Content.Shared.Prototypes;
+using Content.Shared.Tag;
+using JetBrains.Annotations;
+using Robust.Server.Player;
+using Robust.Shared.Configuration;
+using Robust.Shared.Enums;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using YamlDotNet.Core.Tokens;
+
+namespace Content.Server._Goobstation.StationEvents;
+
+/// <summary>
+///   Pairs a PossibleEvent with the resultant chaos and a "score" for sorting by the GameDirector
+///   Temporary class used in processing and ranking the list of events.
+/// </summary>
+public sealed class RankedEvent
+{
+    /// <summary>
+    ///   Contains the StationEvent and expected chaos delta
+    /// </summary>
+    public readonly PossibleEvent PossibleEvent;
+
+    /// <summary>
+    ///   Current chaos + PossibleEvent.Chaos at time of creation
+    /// </summary>
+    public readonly ChaosMetrics Result;
+
+    /// <summary>
+    ///   Preference for this RankedEvent, lower is better.
+    ///   Essentially the "pain" of how far Result is from the StoryBeat.Goal
+    /// </summary>
+    public readonly float Score;
+
+    public RankedEvent(PossibleEvent possibleEvent, ChaosMetrics result, float score)
+    {
+        PossibleEvent = possibleEvent;
+        Result = result;
+        Score = score;
+    }
+}
+public sealed class PlayerCount
+{
+    public int Players;
+    public int Ghosts;
+}
+
+/// <summary>
+///   A scheduler which tries to keep station chaos within a set bound over time with the most suitable
+///   good or bad events to nudge it in the correct direction.
+/// </summary>
+[UsedImplicitly]
+public sealed class GameDirectorSystem : GameRuleSystem<GameDirectorComponent>
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly EventManagerSystem _event = default!;
+    [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IComponentFactory _factory = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+    [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
+    [Dependency] private readonly IConfigurationManager _configManager = default!;
+
+    private ISawmill _sawmill = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _sawmill = _log.GetSawmill("game_rule");
+        SubscribeLocalEvent<GameDirectorComponent, EntityUnpausedEvent>(OnUnpaused);
+    }
+
+    private void OnUnpaused(EntityUid uid, GameDirectorComponent component, ref EntityUnpausedEvent args)
+    {
+        component.BeatStart += args.PausedTime;
+        component.TimeNextEvent += args.PausedTime;
+    }
+
+    protected override void Added(EntityUid uid, GameDirectorComponent scheduler, GameRuleComponent gameRule, GameRuleAddedEvent args)
+    {
+        // This deletes all existing metrics and sets them up again.
+        TrySpawnRoundstartAntags(scheduler, GetTotalPlayerCount(_playerManager.Sessions)); // Roundstart antags need to be selected in the lobby
+        if(TryComp<SelectedGameRulesComponent>(uid,out var selectedRules))
+        {
+            SetupEvents(scheduler, CountActivePlayers(), selectedRules);
+        }
+        else
+        {
+            SetupEvents(scheduler, CountActivePlayers());
+        }
+    }
+
+    /// <summary>
+    ///   Build a list of events to use for the entire story
+    /// </summary>
+    private void SetupEvents(GameDirectorComponent scheduler, PlayerCount count, SelectedGameRulesComponent? selectedRules = null)
+    {
+        scheduler.PossibleEvents.Clear();
+
+        if (selectedRules != null)
+        {
+            SelectFromTable(scheduler, count, selectedRules);
+        }
+        else
+        {
+            SelectFromAllEvents(scheduler, count);
+        }
+        LogMessage($"All possible events added");
+    }
+
+    private void SelectFromAllEvents(GameDirectorComponent scheduler, PlayerCount count)
+    {
+        foreach (var proto in GameTicker.GetAllGameRulePrototypes())
+        {
+            if (!proto.TryGetComponent<StationEventComponent>(out var stationEvent, _factory))
+                continue;
+
+            if (proto.HasComponent<DynamicRulesetComponent>()) // Block john shitcode moment
+                continue;
+
+            // Gate here on players, but not on round runtime. The story will probably last long enough for the
+            // event to be ready to run again, we'll check CanRun again before we actually launch the event.
+            if (!_event.CanRun(proto, stationEvent, count.Players, TimeSpan.MaxValue))
+                continue;
+
+            scheduler.PossibleEvents.Add(new PossibleEvent(proto.ID, stationEvent.Chaos));
+        }
+    }
+
+    private void SelectFromTable(GameDirectorComponent scheduler, PlayerCount count, SelectedGameRulesComponent? selectedRules)
+    {
+        if (selectedRules == null)
+            return;
+
+        if(!_event.TryBuildLimitedEvents(selectedRules.ScheduledGameRules, out var possibleEvents))
+            return;
+
+        foreach (var entry in possibleEvents)
+        {
+            var proto = entry.Key;
+            var stationEvent = entry.Value;
+            LogMessage(proto.ID);
+            if (proto.HasComponent<DynamicRulesetComponent>()) // Block john shitcode moment
+                continue;
+            scheduler.PossibleEvents.Add(new PossibleEvent(proto.ID, stationEvent.Chaos));
+        }
+    }
+
+
+    /// <summary>
+    ///   Decide what event to run next
+    /// </summary>
+    protected override void ActiveTick(EntityUid uid, GameDirectorComponent scheduler, GameRuleComponent gameRule, float frameTime)
+    {
+        var currTime = _timing.CurTime;
+        if (currTime < scheduler.TimeNextEvent)
+            return;
+
+        ChaosMetrics chaos = CalculateChaos(uid);
+        scheduler.CurrentChaos = chaos;
+        LogMessage($"Chaos is: {chaos}");
+
+        if (scheduler.Stories == null || scheduler.Stories.Count() <= 0)
+        {
+            // No stories (e.g. dummy game rule for printing metrics), end game rule now
+            GameTicker.EndGameRule(uid, gameRule);
+            return;
+        }
+        // Decide what story beat to work with (which sets chaos goals)
+        var count = CountActivePlayers();
+        var beat = DetermineNextBeat(scheduler, chaos, count);
+
+        // This is the first event, add an automatic delay
+        if (scheduler.TimeNextEvent == TimeSpan.Zero)
+        {
+            var minimumTimeUntilFirstEvent = _configManager.GetCVar(GoobCVars.MinimumTimeUntilFirstEvent);
+            scheduler.TimeNextEvent = _timing.CurTime + TimeSpan.FromSeconds(minimumTimeUntilFirstEvent);
+            LogMessage($"Started, first event in {minimumTimeUntilFirstEvent} seconds");
+            return;
+        }
+
+        // Pick the best events (which move the station towards the chaos desired by the beat)
+        var bestEvents = ChooseEvents(scheduler, beat, chaos, count);
+
+        // Run the best event here, if we have any to pick from.
+        if (bestEvents.Count > 0)
+        {
+            // Sorts the possible events and then picks semi-randomly.
+            // when beat.RandomEventLimit is 1 it's always the "best" event picked. Higher values
+            // allow more events to be randomly selected.
+            var chosenEvent = SelectBest(bestEvents, beat.RandomEventLimit);
+
+            _event.RunNamedEvent(chosenEvent.PossibleEvent.StationEvent);
+
+            // 2 - 6 minutes until the next event is considered, can vary per beat
+            scheduler.TimeNextEvent = currTime + TimeSpan.FromSeconds(_random.NextFloat(beat.EventDelayMin, beat.EventDelayMax));
+        }
+        else
+        {
+            // No events were run. Consider again in 30 seconds (current beat or chaos might change)
+            LogMessage($"Chaos is: {chaos} (No events ran)", false);
+            scheduler.TimeNextEvent = currTime + TimeSpan.FromSeconds(30f);
+        }
+    }
+
+    /// <summary>
+    /// Tries to spawn roundstart antags at the beginning of the round.
+    /// </summary>
+    private void TrySpawnRoundstartAntags(GameDirectorComponent scheduler, int count)
+    {
+        if (scheduler.NoRoundstartAntags)
+            return;
+
+        // Spawn antags based on GameDirectorComponent
+            var roundStartAntags = new List<EntityPrototype>();
+            var calmStartAntags = new List<EntityPrototype>();
+            foreach (var proto in GameTicker.GetAllGameRulePrototypes())
+            {
+                if (!proto.TryGetComponent<TagComponent>(out var tag, _factory))
+                    continue;
+
+                if (!proto.TryGetComponent<GameRuleComponent>(out var gameRuleComp, _factory))
+                    continue;
+
+                if (gameRuleComp.MinPlayers > count)
+                    continue;
+
+                if (proto.HasComponent<DynamicRulesetComponent>())
+                    continue;
+
+                if (_tag.HasTag(tag, "MidroundAntag"))
+                    continue;
+
+                if (_tag.HasTag(tag, "RoundstartAntag"))
+                {
+                    roundStartAntags.Add(proto);
+                }
+                else if (_tag.HasTag(tag, "CalmAntag"))
+                {
+                    calmStartAntags.Add(proto);
+                }
+            }
+
+            if (!scheduler.DualAntags)
+            {
+                if (roundStartAntags.Count == 0)
+                {
+                    LogMessage("No valid roundstart antags found!");
+                    return;
+                }
+
+                LogMessage("Choosing roundstart antag");
+                var random = new Random();
+                var randomAntag = roundStartAntags[random.Next(roundStartAntags.Count)];
+                LogMessage($"Roundstart antag chosen: {randomAntag.ID}");
+
+                var ruleEnt = GameTicker.AddGameRule(randomAntag.ID);
+                GameTicker.StartGameRule(ruleEnt);
+            }
+            else
+            {
+                if (calmStartAntags.Count < 2)
+                {
+                    LogMessage("Not enough valid roundstart antags found!");
+                    return;
+                }
+
+                LogMessage("Choosing multiple roundstart antags");
+                var random = new Random();
+
+                var firstIndex = random.Next(calmStartAntags.Count);
+                var randomAntagFirst = calmStartAntags[firstIndex];
+                calmStartAntags.RemoveAt(firstIndex);
+
+                var randomAntagSecond = calmStartAntags[random.Next(calmStartAntags.Count)];
+
+                LogMessage($"Roundstart antags chosen: 1: {randomAntagFirst.ID} 2: {randomAntagSecond.ID}");
+
+                var ruleFirstEnt = GameTicker.AddGameRule(randomAntagFirst.ID);
+                var ruleSecondEnt = GameTicker.AddGameRule(randomAntagSecond.ID);
+
+                GameTicker.StartGameRule(ruleFirstEnt);
+                GameTicker.StartGameRule(ruleSecondEnt);
+            }
+    }
+
+    /// <summary>
+    ///   Count the active players and ghosts on the server.
+    ///   Players gates which stories and events are available
+    ///   Ghosts can be used to gate certain events (which require ghosts to occur)
+    /// </summary>
+    private PlayerCount CountActivePlayers()
+    {
+        var allPlayers = _playerManager.Sessions.ToList();
+        var count = new PlayerCount();
+        foreach (var player in allPlayers)
+        {
+            // TODO: A
+            if (player.AttachedEntity != null)
+            {
+                // TODO: Consider a custom component here instead of HumanoidAppearanceComponent to represent
+                //        "significant enough to count as a whole player"
+                if (HasComp<HumanoidAppearanceComponent>(player.AttachedEntity))
+                    count.Players += 1;
+                else if (HasComp<GhostComponent>(player.AttachedEntity))
+                    count.Ghosts += 1;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    ///   Count all the players on the server.
+    /// </summary>
+    public int GetTotalPlayerCount(IList<ICommonSession> pool)
+    {
+        var count = 0;
+        foreach (var session in pool)
+        {
+            if (session.Status is SessionStatus.Disconnected or SessionStatus.Zombie)
+                continue;
+
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    ///   Sorts the possible events and then picks semi-randomly.
+    ///   when maxRandom is 1 it's always the "best" event picked. Higher values allow more events to be randomly selected.
+    /// </summary>
+    protected RankedEvent SelectBest(List<RankedEvent> bestEvents, int maxRandom)
+    {
+        var ranked = bestEvents.OrderBy(ev => ev.Score).Take(maxRandom).ToList();
+
+        var rand = _random.NextFloat();
+        rand *= rand; // Square it, which leads to a front-weighted distribution
+                      // Of 3 items, there is (50% chance of 1, 36% chance of 2 and 14% chance of 3)
+        rand *= ranked.Count - 1;
+
+        var rankedEvent = ranked[(int) Math.Round(rand)];
+
+        // Pick this event
+        var events = String.Join(", ", ranked.Select(r => r.PossibleEvent.StationEvent));
+        LogMessage($"Picked {rankedEvent.PossibleEvent.StationEvent} from best events (in sequence) {events}");
+        return rankedEvent;
+    }
+
+    private void LogMessage(string message, bool showChat=true)
+    {
+        // TODO: LogMessage strings all require localization.
+        _adminLogger.Add(LogType.GameDirector, showChat?LogImpact.Medium:LogImpact.High, $"{message}");
+        if (showChat)
+            _chat.SendAdminAnnouncement("GameDirector " + message);
+
+    }
+    /// <summary>
+    ///   Returns the StoryBeat that should be currently used to select events.
+    ///   Advances the current story and picks new stories when the current beat is complete.
+    /// </summary>
+    private StoryBeatPrototype DetermineNextBeat(GameDirectorComponent scheduler, ChaosMetrics chaos, PlayerCount count)
+    {
+        var curTime = _timing.CurTime;
+        // Potentially Complete CurrBeat, which is always scheduler.CurrStory[0]
+        if (scheduler.RemainingBeats.Count > 0)
+        {
+            var beatName = scheduler.RemainingBeats[0];
+            var beat = _prototypeManager.Index<StoryBeatPrototype>(beatName);
+            var secsInBeat = (curTime - scheduler.BeatStart).TotalSeconds;
+
+            if (secsInBeat > beat.MaxSecs)
+            {
+                // Done with this beat (it has lasted too long)
+                _sawmill.Info($"StoryBeat {beatName} complete. It's lasted {scheduler.BeatStart} out of a maximum of {beat.MaxSecs} seconds.");
+            }
+            else if (secsInBeat > beat.MinSecs)
+            {
+                // Determine if we meet the chaos thresholds to exit this beat
+                if (!beat.EndIfAnyWorse.Empty && chaos.AnyWorseThan(beat.EndIfAnyWorse))
+                {
+                    // Done with this beat (chaos exceeded set bad level)
+                    _sawmill.Info($"StoryBeat {beatName} complete. Chaos exceeds {beat.EndIfAnyWorse} (EndIfAnyWorse).");
+                }
+                else if(!beat.EndIfAllBetter.Empty && chaos.AllBetterThan(beat.EndIfAllBetter))
+                {
+                    // Done with this beat (chaos reached set good level)
+                    _sawmill.Info($"StoryBeat {beatName} complete. Chaos better than {beat.EndIfAllBetter} (EndIfAllBetter).");
+                }
+                else
+                {
+                    return beat;
+                }
+            }
+            else
+            {
+                return beat;
+            }
+
+            // If we didn't return by here, we are done with this beat.
+            //   While RemoveAt(0) does a O(n) shift, we're shifting string pointers and usually n < 20.
+            scheduler.RemainingBeats.RemoveAt(0);
+        }
+        scheduler.BeatStart = curTime;
+
+        // Advance in the current story
+        if (scheduler.RemainingBeats.Count > 0)
+        {
+            // Return the next beat in the current story.
+            var beatName = scheduler.RemainingBeats[0];
+            var beat = _prototypeManager.Index<StoryBeatPrototype>(beatName);
+
+            LogMessage($"New StoryBeat {beatName}: {beat.Description}. Goal is {beat.Goal}");
+            return beat;
+        }
+
+        // Need to find a new story. Pick a random one which meets our needs.
+        if (scheduler.Stories != null)
+        {
+            var stories = scheduler.Stories.ToList();
+            _random.Shuffle(stories);
+
+            foreach (var storyName in stories)
+            {
+                var story = _prototypeManager.Index<StoryPrototype>(storyName);
+                if (story.MinPlayers > count.Players || story.MaxPlayers < count.Players || story.Beats == null)
+                    continue;
+
+
+                // A new story was picked. Copy the full list of beats (for us to pop beats from the front as we proceed)
+                foreach (var storyBeat in story.Beats)
+                {
+                    scheduler.RemainingBeats.Add(storyBeat);
+                }
+
+
+                scheduler.CurrentStoryName = storyName;
+                SetupEvents(scheduler, count);
+                _sawmill.Info(
+                    $"New Story {storyName}: {story.Description}. {scheduler.PossibleEvents.Count} events to use.");
+
+                var beatName = scheduler.RemainingBeats[0];
+                var beat = _prototypeManager.Index<StoryBeatPrototype>(beatName);
+
+                LogMessage($"First StoryBeat {beatName}: {beat.Description}. Goal is {beat.Goal}");
+                return beat;
+            }
+        }
+
+        // Just use the fallback beat when no stories were found. That beat does exist, right!?
+        scheduler.RemainingBeats.Add(scheduler.FallbackBeatName);
+        return _prototypeManager.Index<StoryBeatPrototype>(scheduler.FallbackBeatName);
+    }
+
+    private float RankChaosDelta(ChaosMetrics chaos)
+    {
+        // Just a sum of squares (trying to get close to 0 on every score)
+        //   Lower is better
+        // Note:  if the chaos value is above 655.36 then its square is above maxint (inside FixedPoint2) and it wraps
+        //        around. We need a full float range to handle the square.
+        return chaos.ChaosDict.Values.Sum(v => (float)(v) * (float)(v));
+    }
+
+    private List<RankedEvent> ChooseEvents(GameDirectorComponent scheduler, StoryBeatPrototype beat, ChaosMetrics chaos, PlayerCount count)
+    {
+        // TODO : Potentially filter Chaos here using CriticalLevels & DangerLevels which force us to focus on
+        //        big problems (lots of hostiles, spacing) prior to smaller ones (food & drink)
+        var desiredChange = beat.Goal.ExclusiveSubtract(chaos);
+        var result = FilterAndScore(scheduler, chaos, desiredChange, count);
+
+        if (result.Count > 0)
+            return result;
+
+
+        // Fall back to improving all scores (not just the ones the beat is focused on)
+        //   Generally this means reducing chaos (unspecified scores are desired to be 0).
+        var allDesiredChange = beat.Goal - chaos;
+        result = FilterAndScore(scheduler, chaos, allDesiredChange, count, inclNoChaos:true);
+
+        return result;
+    }
+
+    /// <summary>
+    ///   Filter only to events which improve the chaos score in alignment with desiredChange.
+    ///   Score them (lower is better) in how well they do this.
+    /// </summary>
+    private List<RankedEvent> FilterAndScore(GameDirectorComponent scheduler, ChaosMetrics chaos,
+        ChaosMetrics desiredChange, PlayerCount count, bool inclNoChaos = false)
+    {
+        var noEvent = RankChaosDelta(desiredChange);
+        var result = new List<RankedEvent>();
+
+        // Choose an event that specifically achieves chaos goals, focusing only on them.
+        foreach (var possibleEvent in scheduler.PossibleEvents)
+        {
+            // How much of the relevant chaos will be left after this event has occurred
+            var relevantChaosDelta = desiredChange.ExclusiveSubtract(possibleEvent.Chaos);
+            var rank = RankChaosDelta(relevantChaosDelta);
+
+            var allChaosAfter = chaos + possibleEvent.Chaos;
+
+            // Some events have no chaos score assigned. Treat them as if they change nothing and mix them in for flavor.
+            var noChaosEvent = inclNoChaos && possibleEvent.Chaos.Empty;
+
+            if (rank < noEvent || noChaosEvent)
+            {
+                // Look up this event's prototype and check it is ready to run.
+                var proto = _prototypeManager.Index<EntityPrototype>(possibleEvent.StationEvent);
+
+                if (!proto.TryGetComponent<StationEventComponent>(out var stationEvent, _factory))
+                    continue;
+
+                if (!_event.CanRun(proto, stationEvent, count.Players, GameTicker.RoundDuration()))
+                    continue;
+
+                result.Add(new RankedEvent(possibleEvent, allChaosAfter, rank));
+            }
+        }
+
+        return result;
+    }
+
+    public ChaosMetrics CalculateChaos(EntityUid uid)
+    {
+        // Send an event to chaos metric components on the Game Director's entity.
+        var calcEvent = new CalculateChaosEvent(new ChaosMetrics());
+        RaiseLocalEvent(uid, ref calcEvent);
+
+        var metrics = calcEvent.Metrics;
+
+        // Calculated metrics
+        metrics.ChaosDict[ChaosMetric.Combat] = metrics.ChaosDict.GetValueOrDefault(ChaosMetric.Friend) +
+                                                metrics.ChaosDict.GetValueOrDefault(ChaosMetric.Hostile);
+        return calcEvent.Metrics;
+    }
+}

--- a/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
@@ -8,6 +8,8 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.StationEvents;
 using Content.Server.StationEvents.Components;
 using Content.Shared._Goobstation.CCVar;
+using Content.Shared._Goobstation.StationEvents; // DeltaV - shared the prototypes for our tests
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - shared the prototypes for our tests
 using Content.Shared.CCVar;
 using Content.Shared.Database;
 using Content.Shared.EntityTable;

--- a/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/GameDirectorSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server._DV.StationEvents.Components; // DeltaV - ignore events from the game directors
 using Content.Server._Goobstation.StationEvents.Components;
 using Content.Server._Goobstation.StationEvents.Metric;
 using Content.Server.Administration.Logs;
@@ -141,6 +142,11 @@ public sealed class GameDirectorSystem : GameRuleSystem<GameDirectorComponent>
 
             if (proto.HasComponent<DynamicRulesetComponent>()) // Block john shitcode moment
                 continue;
+
+            // Begin DeltaV - event ignores
+            if (proto.HasComponent<GameDirectorIgnoreComponent>()) // We don't want every event in the game directors
+                continue;
+            // End DeltaV - event ignores
 
             // Gate here on players, but not on round runtime. The story will probably last long enough for the
             // event to be ready to run again, we'll check CanRun again before we actually launch the event.

--- a/Content.Server/_Goobstation/StationEvents/Metric/AnomalyMetric.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/AnomalyMetric.cs
@@ -1,0 +1,50 @@
+﻿using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Server.Spreader;
+using Content.Shared.Anomaly.Components;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._Goobstation.StationEvents.Metric;
+
+/// <summary>
+///   Measures the number and severity of anomalies on the station.
+///
+///   Writes this to the Anomaly chaos value.
+/// </summary>
+public sealed class AnomalyMetric : ChaosMetricSystem<AnomalyMetricComponent>
+{
+    public override ChaosMetrics CalculateChaos(EntityUid metricUid,
+        AnomalyMetricComponent component,
+        CalculateChaosEvent args)
+    {
+        var anomalyChaos = FixedPoint2.Zero;
+
+        // Consider each anomaly and add its stability and growth to the accumulator
+        var anomalyQ = EntityQueryEnumerator<AnomalyComponent>();
+        while (anomalyQ.MoveNext(out var uid, out var anomaly))
+        {
+            if (anomaly.Severity > 0.8f)
+            {
+                anomalyChaos += component.SeverityCost;
+            }
+
+            if (anomaly.Stability > anomaly.GrowthThreshold)
+            {
+                anomalyChaos += component.GrowingCost;
+            }
+
+            anomalyChaos += component.BaseCost;
+        }
+
+        var kudzuQ = EntityQueryEnumerator<KudzuComponent>();
+        while (kudzuQ.MoveNext(out var uid, out var kudzu))
+        {
+            anomalyChaos += 0.25f;
+        }
+
+    var chaos = new ChaosMetrics(new Dictionary<ChaosMetric, FixedPoint2>()
+        {
+            {ChaosMetric.Anomaly, anomalyChaos},
+        });
+        return chaos;
+    }
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/AnomalyMetric.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/AnomalyMetric.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server._Goobstation.StationEvents.Metric.Components;
 using Content.Server.Spreader;
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - move game director prototypes to shared
 using Content.Shared.Anomaly.Components;
 using Content.Shared.FixedPoint;
 

--- a/Content.Server/_Goobstation/StationEvents/Metric/AnomalyMetric.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/AnomalyMetric.cs
@@ -13,6 +13,8 @@ namespace Content.Server._Goobstation.StationEvents.Metric;
 /// </summary>
 public sealed class AnomalyMetric : ChaosMetricSystem<AnomalyMetricComponent>
 {
+    [Dependency] private readonly Content.Shared.Psionics.Glimmer.GlimmerSystem _glimmer = default!; // DeltaV - Glimmer
+
     public override ChaosMetrics CalculateChaos(EntityUid metricUid,
         AnomalyMetricComponent component,
         CalculateChaosEvent args)
@@ -41,6 +43,8 @@ public sealed class AnomalyMetric : ChaosMetricSystem<AnomalyMetricComponent>
         {
             anomalyChaos += 0.25f;
         }
+
+        anomalyChaos += component.GlimmerCost * _glimmer.Glimmer; // DeltaV - Glimmer
 
     var chaos = new ChaosMetrics(new Dictionary<ChaosMetric, FixedPoint2>()
         {

--- a/Content.Server/_Goobstation/StationEvents/Metric/ChaosMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/ChaosMetricSystem.cs
@@ -1,0 +1,30 @@
+using Content.Server.GameTicking;
+
+namespace Content.Server._Goobstation.StationEvents.Metric;
+
+/// <summary>
+///   Base class for systems which measure chaos.
+///   Chaos (in ChaosMetrics) is used by the GameDirector to decide which event should run next
+///   Subclasses can either calculate chaos in that instant or subscribe to events to track state
+///   over time in their component.
+/// </summary>
+public abstract class ChaosMetricSystem<T> : EntitySystem where T : Component
+{
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+    public abstract ChaosMetrics CalculateChaos(EntityUid uid, T component, CalculateChaosEvent args);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<T, CalculateChaosEvent>(OnCalculateChaos);
+    }
+
+    private void OnCalculateChaos(EntityUid uid, T component, ref CalculateChaosEvent args)
+    {
+        var ourChaos = CalculateChaos(uid, component, args);
+
+        args.Metrics += ourChaos;
+    }
+
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/ChaosMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/ChaosMetricSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.GameTicking;
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - move game director prototypes to shared
 
 namespace Content.Server._Goobstation.StationEvents.Metric;
 

--- a/Content.Server/_Goobstation/StationEvents/Metric/ChaosMetrics.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/ChaosMetrics.cs
@@ -1,0 +1,190 @@
+using System.Linq;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Goobstation.StationEvents.Metric;
+
+public enum ChaosMetric
+{
+    Hunger,
+    Thirst,
+    Charge,
+
+    Anomaly,
+
+    Friend,   // Negative score for how many friendlies on station
+    Hostile,  // Increases with hostiles
+
+    Death,
+    Medical,
+
+    Security,
+    Power,
+    Atmos,
+    Mess,
+
+    // Metrics calculated from above by Game Director:
+    Combat,   // Friend + Hostile - <0 if crew is strong. 0 if balanced (fighting). >0 indicates crew is losing.
+}
+
+/// <summary>
+///   Raised to request metrics to calculate and sum their statistics
+/// </summary>
+[ByRefEvent]
+public record struct CalculateChaosEvent(ChaosMetrics Metrics);
+
+/// <summary>
+///   This class represents a collection of chaos
+/// </summary>
+/// <remarks>
+///   This is similar to the DamageSpecifier class.
+/// </remarks>
+[DataDefinition]
+public sealed partial class ChaosMetrics : IEquatable<ChaosMetrics>
+{
+    /// <summary>
+    ///   Main chaos dictionary. Most ChaosMetrics functions exist to somehow modifying this.
+    /// </summary>
+    [IncludeDataField(customTypeSerializer:typeof(DictionarySerializer<ChaosMetric, FixedPoint2>)), ViewVariables(VVAccess.ReadWrite)]
+    public Dictionary<ChaosMetric, FixedPoint2> ChaosDict { get; set; } = new();
+
+    /// <summary>
+    ///   Whether this chaos specifier has any entries.
+    /// </summary>
+    public bool Empty => ChaosDict.Count == 0;
+
+    /// <summary>
+    ///   True if any of our values are greater than other, i.e worse.
+    /// </summary>
+    public bool AnyWorseThan(ChaosMetrics other) => ChaosDict.Any(kvp =>
+        other.ChaosDict.TryGetValue(kvp.Key, out var otherV)
+        && kvp.Value > otherV);
+
+    /// <summary>
+    ///   True if all of our values are less than other, i.e better.
+    /// </summary>
+    public bool AllBetterThan(ChaosMetrics other) => ChaosDict.All(kvp =>
+        !other.ChaosDict.TryGetValue(kvp.Key, out var otherV)
+        || kvp.Value < otherV);
+
+    #region constructors
+    /// <summary>
+    ///   Constructor that just results in an empty dictionary.
+    /// </summary>
+    public ChaosMetrics() { }
+
+    /// <summary>
+    ///   Constructor that takes another ChaosMetrics instance and copies it.
+    /// </summary>
+    public ChaosMetrics(ChaosMetrics chaos)
+    {
+        ChaosDict = new(chaos.ChaosDict);
+    }
+
+    /// <summary>
+    ///   Constructor that takes another ChaosMetrics instance and copies it.
+    /// </summary>
+    public ChaosMetrics(Dictionary<ChaosMetric, FixedPoint2> chaos)
+    {
+        ChaosDict = new(chaos);
+    }
+    #endregion
+
+    public override string? ToString()
+    {
+        return String.Join(
+            ", ",
+            ChaosDict.Select(p => String.Format(
+                "{0}: {1}",
+                p.Key, p.Value)));
+    }
+
+    /// <summary>
+    ///   Sets all chaos values to be at least as large as the given number.
+    /// </summary>
+    /// <remarks>
+    ///   Note that this only acts on chaos types present in the dictionary. It will not add new chaos types.
+    /// </remarks>
+    public void ClampMin(FixedPoint2 minValue)
+    {
+        foreach (var (key, value) in ChaosDict)
+        {
+            if (value < minValue)
+                ChaosDict[key] = minValue;
+        }
+    }
+
+    /// <summary>
+    ///   Sets all chaos values to be at most some number. Note that if a chaos type is not present in the
+    ///   dictionary, these will not be added.
+    /// </summary>
+    public void ClampMax(FixedPoint2 maxValue)
+    {
+        foreach (var (key, value) in ChaosDict)
+        {
+            if (value > maxValue)
+                ChaosDict[key] = maxValue;
+        }
+    }
+
+    /// <summary>
+    ///   This subtracts the chaos values of some other <see cref="ChaosMetrics"/> without
+    ///   adding any new chaos types.
+    /// </summary>
+    public ChaosMetrics ExclusiveSubtract(ChaosMetrics other)
+    {
+        ChaosMetrics newDamage = new(ChaosDict.ShallowClone());
+
+        foreach (var (type, value) in other.ChaosDict)
+        {
+            if (newDamage.ChaosDict.ContainsKey(type))
+                newDamage.ChaosDict[type] -= value;
+        }
+
+        return newDamage;
+    }
+
+    public static ChaosMetrics operator +(ChaosMetrics chaosA, ChaosMetrics chaosB)
+    {
+        // Copy existing dictionary from dataA
+        ChaosMetrics newDamage = new(chaosA);
+
+        // Then just add types in B
+        foreach (var entry in chaosB.ChaosDict)
+        {
+            if (!newDamage.ChaosDict.TryAdd(entry.Key, entry.Value))
+                // Key already exists, add values
+                newDamage.ChaosDict[entry.Key] += entry.Value;
+        }
+        return newDamage;
+    }
+
+    // Here we define the subtraction operator explicitly, rather than implicitly via something like X + (-1 * Y).
+    // This is faster because FixedPoint2 multiplication is somewhat involved.
+    public static ChaosMetrics operator -(ChaosMetrics chaosA, ChaosMetrics chaosB)
+    {
+        ChaosMetrics newDamage = new(chaosA);
+
+        foreach (var entry in chaosB.ChaosDict)
+        {
+            if (!newDamage.ChaosDict.TryAdd(entry.Key, -entry.Value))
+                newDamage.ChaosDict[entry.Key] -= entry.Value;
+
+        }
+        return newDamage;
+    }
+    public bool Equals(ChaosMetrics? other)
+    {
+        if (other == null || ChaosDict.Count != other.ChaosDict.Count)
+            return false;
+
+        foreach (var (key, value) in ChaosDict)
+        {
+            if (!other.ChaosDict.TryGetValue(key, out var otherValue) || value != otherValue)
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/CombatMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/CombatMetricSystem.cs
@@ -1,0 +1,141 @@
+﻿using Content.Server.Station.Systems;
+using Content.Server._Goobstation.StationEvents.Metric;
+using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Content.Shared.Inventory;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Roles;
+using Content.Shared.Tag;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Goobstation.StationEvents.Metric;
+
+/// <summary>
+///   Measures the strength of friendies and hostiles. Also calculates related health / death stats.
+///
+///   I've used 10 points per entity because later we might somehow estimate combat strength
+///   as a multiplier. We could for instance detect damage delt / recieved and look also at
+///   entity hitpoints & resistances as an analogue for danger.
+///
+///   Writes the following
+///   Friend : -10 per each friendly entity on the station (negative is GOOD in chaos)
+///   Hostile : about 10 points per hostile (those with antag roles) - varies per constants
+///   Combat: friendlies + hostiles (to represent the balance of power)
+///   Death: 20 per dead body,
+///   Medical: 10 for crit + 0.05 * damage (so 5 for 100 damage),
+/// </summary>
+public sealed class CombatMetricSystem : ChaosMetricSystem<CombatMetricComponent>
+{
+    [Dependency] private readonly SharedRoleSystem _roles = default!;
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly InventorySystem _inventory = default!;
+
+    public FixedPoint2 InventoryPower(EntityUid uid, CombatMetricComponent component)
+    {
+        // Iterate through items to determine how powerful the entity is
+        // Having a good range of offensive items in your inventory makes you more dangerous
+        var threat = FixedPoint2.Zero;
+
+        var tagsQ = GetEntityQuery<TagComponent>();
+        var allTags = new HashSet<ProtoId<TagPrototype>>();
+
+        foreach (var item in _inventory.GetHandOrInventoryEntities(uid))
+        {
+            if (tagsQ.TryGetComponent(item, out var tags)) // thanks code rabbit
+            {
+                allTags.UnionWith(tags.Tags);
+            }
+        }
+
+        foreach (var key in allTags)
+        {
+            threat += component.ItemThreat.GetValueOrDefault(key);
+        }
+
+        if (threat > component.maxItemThreat)
+            return component.maxItemThreat;
+
+        return threat;
+    }
+
+    public override ChaosMetrics CalculateChaos(EntityUid metric_uid, CombatMetricComponent combatMetric,
+        CalculateChaosEvent args)
+    {
+        // Add up the pain of all the puddles
+        var query = EntityQueryEnumerator<MindContainerComponent, MobStateComponent, DamageableComponent, TransformComponent>();
+        var hostiles = FixedPoint2.Zero;
+        var friendlies = FixedPoint2.Zero;
+
+        var medical = FixedPoint2.Zero;
+        var death = FixedPoint2.Zero;
+
+        var powerQ = GetEntityQuery<CombatPowerComponent>();
+
+        // var humanoidQ = GetEntityQuery<HumanoidAppearanceComponent>();
+        var stationGrids = _stationSystem.GetAllStationGrids();
+
+        while (query.MoveNext(out var uid, out var mind, out var mobState, out var damage, out var transform))
+        {
+            // Don't count anything that is mindless
+            if (mind.Mind == null)
+                continue;
+
+            // Only count threats currently on station, which avoids salvage threats getting counted for instance.
+            // Note this means for instance Nukies on nukie planet don't count, so the threat will spike when they arrive.
+            if (transform.GridUid == null || !stationGrids.Contains(transform.GridUid.Value))
+                // TODO: Check for NPCs here, they still count.
+                continue;
+
+            // Read per-entity scaling factor (for instance space dragon has much higher threat)
+            powerQ.TryGetComponent(uid, out var power);
+            var threatMultiple = power?.Threat ?? 1.0f;
+
+            var entityThreat = FixedPoint2.Zero;
+
+            var antag = _roles.MindIsAntagonist(mind.Mind);
+            if (antag)
+            {
+                if (mobState.CurrentState != MobState.Alive)
+                    continue;
+            }
+            else
+            {
+                // This is a friendly
+                if (mobState.CurrentState == MobState.Dead)
+                {
+                    death += combatMetric.DeadScore;
+                    continue;
+                }
+                else
+                {
+                    medical += damage.Damage.GetTotal() * combatMetric.MedicalMultiplier;
+                    if (mobState.CurrentState == MobState.Critical)
+                    {
+                        medical += combatMetric.CritScore;
+                        continue;
+                    }
+                }
+            }
+
+            // Iterate through items to determine how powerful the entity is
+            entityThreat += InventoryPower(uid, combatMetric);
+            if (antag)
+                hostiles += (entityThreat + combatMetric.HostileScore) * threatMultiple;
+            else
+                friendlies += (entityThreat + combatMetric.FriendlyScore) * threatMultiple;
+        }
+
+        var chaos = new ChaosMetrics(new Dictionary<ChaosMetric, FixedPoint2>()
+        {
+            {ChaosMetric.Friend, -friendlies}, // Friendlies are good, so make a negative chaos score
+            {ChaosMetric.Hostile, hostiles},
+
+            {ChaosMetric.Death, death},
+            {ChaosMetric.Medical, medical},
+        });
+        return chaos;
+    }
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/CombatMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/CombatMetricSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Server.Station.Systems;
 using Content.Server._Goobstation.StationEvents.Metric;
 using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - move game director prototypes to shared
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
 using Content.Shared.Inventory;

--- a/Content.Server/_Goobstation/StationEvents/Metric/Components/AnomalyMetricComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/Components/AnomalyMetricComponent.cs
@@ -1,0 +1,26 @@
+﻿using Content.Server.StationEvents.Events;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._Goobstation.StationEvents.Metric.Components;
+
+[RegisterComponent, Access(typeof(AnomalyMetric))]
+public sealed partial class AnomalyMetricComponent : Component
+{
+    /// <summary>
+    ///   Cost of a growing anomaly
+    /// </summary>
+    [DataField("growingCost")]
+    public float GrowingCost = 40.0f;
+
+    /// <summary>
+    ///   Cost of a dangerous anomaly
+    /// </summary>
+    [DataField("severityCost")]
+    public float SeverityCost = 20.0f;
+
+    /// <summary>
+    ///   Cost of any anomaly
+    /// </summary>
+    [DataField("dangerCost")]
+    public float BaseCost = 10.0f;
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/Components/AnomalyMetricComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/Components/AnomalyMetricComponent.cs
@@ -23,4 +23,12 @@ public sealed partial class AnomalyMetricComponent : Component
     /// </summary>
     [DataField("dangerCost")]
     public float BaseCost = 10.0f;
+
+    // Begin DeltaV - Glimmer
+    /// <summary>
+    ///   Cost per psi of glimmer
+    /// </summary>
+    [DataField("glimmerCost")]
+    public float GlimmerCost = 0.5f;
+    // End DeltaV - Glimmer
 }

--- a/Content.Server/_Goobstation/StationEvents/Metric/Components/CombatMetricComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/Components/CombatMetricComponent.cs
@@ -1,0 +1,57 @@
+﻿using Content.Server.StationEvents.Events;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+
+namespace Content.Server._Goobstation.StationEvents.Metric.Components;
+
+[RegisterComponent, Access(typeof(CombatMetricSystem))]
+public sealed partial class CombatMetricComponent : Component
+{
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 HostileScore = 10.0f;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 FriendlyScore = 10.0f;
+
+    /// <summary>
+    ///   Cost per point of medical damage for friendly entities
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 MedicalMultiplier = 0.05f;
+
+    /// <summary>
+    ///   Cost for friendlies who are in crit
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 CritScore = 10.0f;
+
+    /// <summary>
+    ///   Cost for friendlies who are dead
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 DeadScore = 20.0f;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public FixedPoint2 maxItemThreat = 15.0f;
+
+    /// <summary>
+    ///   ItemThreat - evaluate based on item tags how powerful a player is
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public Dictionary<string, FixedPoint2> ItemThreat =
+        new()
+        {
+            { "Taser", 2.0f },
+            { "Sidearm", 2.0f },
+            { "Rifle", 5.0f },
+            { "HighRiskItem", 2.0f },
+            { "CombatKnife", 1.0f },
+            { "Knife", 1.0f },
+            { "Grenade", 2.0f },
+            { "Bomb", 2.0f },
+            { "MagazinePistol", 0.5f },
+            { "Hacking", 1.0f },
+            { "Jetpack", 1.0f },
+        };
+
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/Components/CombatPowerComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/Components/CombatPowerComponent.cs
@@ -1,0 +1,17 @@
+﻿using Content.Server.StationEvents.Events;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._Goobstation.StationEvents.Metric.Components;
+
+/// <summary>
+///   Some entities (such as dragons) are just more dangerous
+/// </summary>
+[RegisterComponent, Access(typeof(CombatMetricSystem))]
+public sealed partial class CombatPowerComponent : Component
+{
+    /// <summary>
+    ///   Threat, expressed as a multiplier (1x is similar to a single player)
+    /// </summary>
+    [DataField("factor")]
+    public FixedPoint2 Threat = 1.0f;
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/Components/DoorMetricComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/Components/DoorMetricComponent.cs
@@ -1,0 +1,32 @@
+﻿using Content.Server.StationEvents.Events;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._Goobstation.StationEvents.Metric.Components;
+
+[RegisterComponent, Access(typeof(DoorMetricSystem))]
+public sealed partial class DoorMetricComponent : Component
+{
+    /// <summary>
+    ///   Cost of all doors emagged door
+    /// </summary>
+    [DataField("emagCost"), ViewVariables(VVAccess.ReadWrite)]
+    public float EmagCost = 200.0f;
+
+    /// <summary>
+    ///   Cost of all doors with no power
+    /// </summary>
+    [DataField("powerCost"), ViewVariables(VVAccess.ReadWrite)]
+    public float PowerCost = 100.0f;
+
+    /// <summary>
+    ///   Cost of all firedoors holding pressure
+    /// </summary>
+    [DataField("pressureCost"), ViewVariables(VVAccess.ReadWrite)]
+    public float PressureCost = 200.0f;
+
+    /// <summary>
+    ///   Cost of all firedoors holding temperature
+    /// </summary>
+    [DataField("fireCost"), ViewVariables(VVAccess.ReadWrite)]
+    public float FireCost = 400.0f;
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/Components/FoodMetricComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/Components/FoodMetricComponent.cs
@@ -1,0 +1,37 @@
+﻿using Content.Server.StationEvents.Events;
+using Content.Shared.FixedPoint;
+using Content.Shared.Nutrition.Components;
+using Content.Shared._EE.Silicon.Components; // DeltaV - we have a different namespace
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+
+namespace Content.Server._Goobstation.StationEvents.Metric.Components;
+
+[RegisterComponent, Access(typeof(FoodMetricSystem))]
+public sealed partial class FoodMetricComponent : Component
+{
+    [DataField("thirstScores", customTypeSerializer: typeof(DictionarySerializer<ThirstThreshold, FixedPoint2>))]
+    public Dictionary<ThirstThreshold, FixedPoint2> ThirstScores =
+        new()
+        {
+            { ThirstThreshold.Thirsty, 2.0f },
+            { ThirstThreshold.Parched, 5.0f },
+        };
+
+    [DataField("hungerScores", customTypeSerializer: typeof(DictionarySerializer<HungerThreshold, FixedPoint2>))]
+    public Dictionary<HungerThreshold, FixedPoint2> HungerScores =
+        new()
+        {
+            { HungerThreshold.Peckish, 2.0f },
+            { HungerThreshold.Starving, 5.0f },
+        };
+
+    [DataField("chargeScores", customTypeSerializer: typeof(DictionarySerializer<float, FixedPoint2>))]
+    public Dictionary<float, FixedPoint2> ChargeScores =
+        new()
+        {
+            { 0.80f, 1.0f },
+            { 0.35f, 2.0f },
+            { 0.10f, 5.0f },
+        };
+
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/Components/PuddleMetricComponent.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/Components/PuddleMetricComponent.cs
@@ -1,0 +1,47 @@
+﻿using Content.Server.StationEvents.Events;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
+
+namespace Content.Server._Goobstation.StationEvents.Metric.Components;
+
+[RegisterComponent, Access(typeof(PuddleMetricSystem))]
+public sealed partial class PuddleMetricComponent : Component
+{
+    // Impact Constants
+    private const float MinimalImpact = 0.02f;
+    private const float MinorImpact = 0.1f;
+    private const float ModerateImpact = 0.2f;
+    private const float MajorImpact = 0.3f;
+
+    /// <summary>
+    ///   The cost of each puddle, per mL. Note about 200 mL is one puddle.
+    ///   Example: A water puddle of 200mL would contribute (200 * 0.02) = 4 chaos points.
+    /// </summary>
+    [DataField("puddles", customTypeSerializer: typeof(DictionarySerializer<string, FixedPoint2>))]
+    public Dictionary<string, FixedPoint2> Puddles =
+        new()
+        {
+            { "Water", MinimalImpact },
+            { "SpaceCleaner", MinimalImpact },
+
+            { "Nutriment", MinorImpact },
+            { "Sugar", MinorImpact },
+            { "Ephedrine", MinorImpact },
+            { "Ale", MinorImpact },
+            { "Beer", ModerateImpact },
+
+            { "Slime", ModerateImpact },
+            { "Blood", ModerateImpact },
+            { "CopperBlood", ModerateImpact },
+            { "ZombieBlood", ModerateImpact },
+            { "AmmoniaBlood", ModerateImpact },
+            { "ChangelingBlood", ModerateImpact },
+            { "SpaceDrugs", MajorImpact },
+            { "SpaceLube", MajorImpact },
+            { "SpaceGlue", MajorImpact },
+        };
+
+    [DataField("puddleDefault")]
+    public FixedPoint2 PuddleDefault = 0.1f;
+
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
@@ -1,0 +1,135 @@
+﻿using System.Linq;
+using Content.Server.Power.Components;
+using Content.Server.Station.Systems;
+using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Server.GameTicking;
+using Content.Shared.Access.Components;
+using Content.Shared.Doors.Components;
+using Content.Shared.FixedPoint;
+
+namespace Content.Server._Goobstation.StationEvents.Metric;
+
+/// <summary>
+///   Uses doors and firelocks to sample station chaos across the station
+///
+///   Emag - EmagCost per emaged door
+///   Power - PowerCost per door or firelock with no power
+///   Atmos - PressureCost for holding spacing or FireCost for holding back fire
+/// </summary>
+public sealed class DoorMetricSystem : ChaosMetricSystem<DoorMetricComponent>
+{
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+
+    public override ChaosMetrics CalculateChaos(EntityUid metric_uid, DoorMetricComponent component,
+        CalculateChaosEvent args)
+    {
+        var firelockQ = GetEntityQuery<FirelockComponent>();
+        var airlockQ = GetEntityQuery<AirlockComponent>();
+
+        // Keep counters to calculate average at the end.
+        var doorCounter = FixedPoint2.Zero;
+        var firelockCounter = FixedPoint2.Zero;
+        var airlockCounter = FixedPoint2.Zero;
+
+        var fireCount = FixedPoint2.Zero;
+        var pressureCount = FixedPoint2.Zero;
+        var emagCount = FixedPoint2.Zero;
+        var powerCount = FixedPoint2.Zero;
+
+        // Add up the pain of all the doors
+        // Restrict to just doors on the main station
+        var stationGrids = _stationSystem.GetAllStationGrids();
+
+        var queryFirelock = EntityQueryEnumerator<DoorComponent, ApcPowerReceiverComponent, TransformComponent>();
+        while (queryFirelock.MoveNext(out var uid, out var door, out var power, out var transform))
+        {
+            if (transform.GridUid == null || !stationGrids.Contains(transform.GridUid.Value))
+                continue;
+
+            if (firelockQ.TryGetComponent(uid, out var firelock))
+            {
+                if (firelock.Temperature)
+                {
+                    fireCount += 1;
+                }
+                else if (firelock.Pressure)
+                {
+                    pressureCount += 1;
+                }
+
+                firelockCounter += 1;
+            }
+
+            if (airlockQ.TryGetComponent(uid, out var airlock))
+            {
+                if (door.State == DoorState.Emagging)
+                {
+                    var modifier = GetAccessLevelModifier(uid);
+                    emagCount += 1 + modifier;
+                }
+
+                airlockCounter += 1;
+            }
+
+            if (power.Recalculate || !power.NeedsPower)
+            {
+                powerCount += 1;
+            }
+
+            doorCounter += 1;
+        }
+
+        var emagChaos = FixedPoint2.Zero;
+        var atmosChaos = FixedPoint2.Zero;
+        var powerChaos = FixedPoint2.Zero;
+        // Calculate each stat as a fraction of all doors in the station.
+        //   That way the metrics do not "scale up"  on large stations.
+
+        if (airlockCounter > FixedPoint2.Zero)
+            emagChaos = (emagCount / airlockCounter) * component.EmagCost;
+
+        if (firelockCounter > FixedPoint2.Zero)
+            atmosChaos = (fireCount / firelockCounter) * component.FireCost +
+                         (pressureCount / firelockCounter) * component.PressureCost;
+
+        if (doorCounter > FixedPoint2.Zero)
+            powerChaos = (powerCount / doorCounter) * component.PowerCost;
+
+
+        var chaos = new ChaosMetrics(new Dictionary<ChaosMetric, FixedPoint2>()
+        {
+            {ChaosMetric.Security, emagChaos},
+            {ChaosMetric.Atmos, atmosChaos},
+            {ChaosMetric.Power, powerChaos},
+        });
+        return chaos;
+    }
+
+    private int GetAccessLevelModifier(EntityUid uid)
+    {
+        if (!TryComp<AccessReaderComponent>(uid, out var accessReaderComponent))
+            return 0;
+
+        var modifier = 0;
+        var accessSet = accessReaderComponent.AccessLists.ElementAt(0);
+        foreach (var accessPrototype in accessSet)
+        {
+            switch (accessPrototype.Id)
+            {
+                case "Security":
+                    modifier += 1;
+                    break;
+                case "Atmospherics":
+                    modifier += 1;
+                    break;
+                case "Armory":
+                    modifier += 3;
+                    break;
+                case "Command":
+                    modifier += 2;
+                    break;
+            }
+        }
+        return modifier;
+    }
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
@@ -109,7 +109,7 @@ public sealed class DoorMetricSystem : ChaosMetricSystem<DoorMetricComponent>
 
     private int GetAccessLevelModifier(EntityUid uid)
     {
-        if (!TryComp<AccessReaderComponent>(uid, out var accessReaderComponent))
+        if (!TryComp<AccessReaderComponent>(uid, out var accessReaderComponent) || accessReaderComponent.AccessLists.Count == 0) // DeltaV - not all bolted open doors have accesses
             return 0;
 
         var modifier = 0;

--- a/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Power.Components;
 using Content.Server.Station.Systems;
 using Content.Server._Goobstation.StationEvents.Metric.Components;
 using Content.Server.GameTicking;
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - move game director prototypes to shared
 using Content.Shared.Access.Components;
 using Content.Shared.Doors.Components;
 using Content.Shared.FixedPoint;

--- a/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
@@ -26,6 +26,7 @@ public sealed class DoorMetricSystem : ChaosMetricSystem<DoorMetricComponent>
     {
         var firelockQ = GetEntityQuery<FirelockComponent>();
         var airlockQ = GetEntityQuery<AirlockComponent>();
+        var boltQ = GetEntityQuery<DoorBoltComponent>(); // DeltaV - accomodate AAO in the door metrics
 
         // Keep counters to calculate average at the end.
         var doorCounter = FixedPoint2.Zero;
@@ -61,9 +62,9 @@ public sealed class DoorMetricSystem : ChaosMetricSystem<DoorMetricComponent>
                 firelockCounter += 1;
             }
 
-            if (airlockQ.TryGetComponent(uid, out var airlock))
+            if (airlockQ.TryGetComponent(uid, out var airlock) && boltQ.TryGetComponent(uid, out var bolts)) // DeltaV - accomodate AAO in the door metrics
             {
-                if (door.State == DoorState.Emagging)
+                if (door.State == DoorState.Open && bolts.BoltsDown) // DeltaV - accomodate AAO in the door metrics
                 {
                     var modifier = GetAccessLevelModifier(uid);
                     emagCount += 1 + modifier;

--- a/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/DoorMetricSystem.cs
@@ -73,7 +73,7 @@ public sealed class DoorMetricSystem : ChaosMetricSystem<DoorMetricComponent>
                 airlockCounter += 1;
             }
 
-            if (power.Recalculate || !power.NeedsPower)
+            if (!power.Powered && power.NeedsPower) // DeltaV - actually count unpowered doors for the chaos
             {
                 powerCount += 1;
             }

--- a/Content.Server/_Goobstation/StationEvents/Metric/FoodMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/FoodMetricSystem.cs
@@ -1,0 +1,85 @@
+﻿using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Shared._EE.Silicon.Components; // DeltaV - we have a different namespace
+using Content.Shared.FixedPoint;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Roles;
+
+namespace Content.Server._Goobstation.StationEvents.Metric;
+
+/// <summary>
+///   Measure crew's hunger and thirst
+///
+/// </summary>
+public sealed class FoodMetricSystem : ChaosMetricSystem<FoodMetricComponent>
+{
+    [Dependency] private readonly SharedRoleSystem _roles = default!;
+
+    public override ChaosMetrics CalculateChaos(EntityUid metric_uid, FoodMetricComponent component,
+        CalculateChaosEvent args)
+    {
+        // Gather hunger and thirst scores
+        var query = EntityQueryEnumerator<MindContainerComponent, MobStateComponent>();
+        var hungerSc = FixedPoint2.Zero;
+        var thirstSc = FixedPoint2.Zero;
+        var chargeSc = FixedPoint2.Zero;
+
+        var thirstQ = GetEntityQuery<ThirstComponent>();
+        var hungerQ = GetEntityQuery<HungerComponent>();
+        var siliconQ = GetEntityQuery<SiliconComponent>();
+
+        while (query.MoveNext(out var uid, out var mindContainer, out var mobState))
+        {
+            // Don't count anything that is mindless, do count antags
+            if (mindContainer.Mind == null)
+                continue;
+
+            if (mobState.CurrentState != MobState.Alive)
+                continue;
+
+            if (thirstQ.TryGetComponent(uid, out var thirst))
+            {
+                thirstSc += component.ThirstScores.GetValueOrDefault(thirst.CurrentThirstThreshold);
+            }
+
+            if (hungerQ.TryGetComponent(uid, out var hunger))
+            {
+                hungerSc += component.HungerScores.GetValueOrDefault(hunger.CurrentThreshold);
+            }
+
+            if (siliconQ.TryGetComponent(uid, out var silicon))
+            {
+                var chargeState = GetChargeState(silicon.ChargeState);
+                chargeSc += component.ChargeScores.GetValueOrDefault(chargeState);
+            }
+        }
+
+        var chaos = new ChaosMetrics(new Dictionary<ChaosMetric, FixedPoint2>()
+        {
+            {ChaosMetric.Hunger, hungerSc},
+            {ChaosMetric.Thirst, thirstSc},
+            {ChaosMetric.Charge, chargeSc},
+        });
+        return chaos;
+    }
+
+    private float GetChargeState(short chargeState)
+    {
+        var mid = 0.5f;
+        var low = 0.25f;
+        var critical = 0.1f;
+
+        var normalizedCharge = chargeState / 10f; // Assuming ChargeState is from 0-10
+
+        if (normalizedCharge <= critical)
+            return critical;
+        if (normalizedCharge <= low)
+            return low;
+
+        return mid;
+    }
+
+}
+

--- a/Content.Server/_Goobstation/StationEvents/Metric/FoodMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/FoodMetricSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server._Goobstation.StationEvents.Metric.Components;
 using Content.Shared._EE.Silicon.Components; // DeltaV - we have a different namespace
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - move game director prototypes to shared
 using Content.Shared.FixedPoint;
 using Content.Shared.Mind.Components;
 using Content.Shared.Mobs;

--- a/Content.Server/_Goobstation/StationEvents/Metric/PuddleMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/PuddleMetricSystem.cs
@@ -1,0 +1,45 @@
+﻿using Content.Server.Chemistry.Containers.EntitySystems;
+using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.FixedPoint;
+using Content.Shared.Fluids.Components;
+
+namespace Content.Server._Goobstation.StationEvents.Metric;
+
+/// <summary>
+///   Measure the mess of the station in puddles on the floor
+///
+///   Jani - JaniMetricComponent.Puddles points per BaselineQty of various substances
+/// </summary>
+public sealed class PuddleMetricSystem : ChaosMetricSystem<PuddleMetricComponent>
+{
+    [Dependency] private readonly SolutionContainerSystem _solutionContainerSystem = default!;
+
+    public override ChaosMetrics CalculateChaos(EntityUid metric_uid, PuddleMetricComponent component,
+        CalculateChaosEvent args)
+    {
+        // Add up the pain of all the puddles
+        var query = EntityQueryEnumerator<PuddleComponent, SolutionContainerManagerComponent>();
+        var mess = FixedPoint2.Zero;
+        while (query.MoveNext(out var puddleUid, out var puddle, out var solutionMgr))
+        {
+            if (!_solutionContainerSystem.TryGetSolution(puddleUid, puddle.SolutionName, out var puddleSolution))
+                continue;
+
+            FixedPoint2 puddleChaos = 0.0f;
+            foreach (var substance in puddleSolution.Value.Comp.Solution.Contents)
+            {
+                FixedPoint2 substanceChaos = component.Puddles.GetValueOrDefault(substance.Reagent.Prototype, component.PuddleDefault);
+                puddleChaos += substanceChaos * substance.Quantity;
+            }
+
+            mess += puddleChaos;
+        }
+
+        var chaos = new ChaosMetrics(new Dictionary<ChaosMetric, FixedPoint2>()
+        {
+            {ChaosMetric.Mess, mess}
+        });
+        return chaos;
+    }
+}

--- a/Content.Server/_Goobstation/StationEvents/Metric/PuddleMetricSystem.cs
+++ b/Content.Server/_Goobstation/StationEvents/Metric/PuddleMetricSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Content.Server.Chemistry.Containers.EntitySystems;
 using Content.Server._Goobstation.StationEvents.Metric.Components;
+using Content.Shared._Goobstation.StationEvents.Metric; // DeltaV - move game director prototypes to shared
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids.Components;

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -457,4 +457,9 @@ public enum LogType
     /// Commands related to admemes. Stuff like config changes, etc.
     /// </summary>
     AdminCommands = 98,
+
+    /// <summary>
+    /// GameDirector related game interactions.
+    /// </summary>
+    GameDirector = 599, // Goobstation // DeltaV - let's not accidentally clash with upstream numbers
 }

--- a/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
+++ b/Content.Shared/_Goobstation/CCVars/CCVars.Goob.cs
@@ -27,4 +27,12 @@ public sealed partial class GoobCVars
         CVarDef.Create("mech.gun_outside_mech", true, CVar.SERVER | CVar.REPLICATED);
 
     #endregion
+
+    #region Game Director
+
+    public static readonly CVarDef<float> MinimumTimeUntilFirstEvent =
+        CVarDef.Create("gamedirector.minimumtimeuntilfirstevent", 300f, CVar.SERVERONLY);
+
+    #endregion
+
 }

--- a/Content.Shared/_Goobstation/StationEvents/Metric/ChaosMetrics.cs
+++ b/Content.Shared/_Goobstation/StationEvents/Metric/ChaosMetrics.cs
@@ -3,7 +3,7 @@ using Content.Shared.FixedPoint;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Generic;
 using Robust.Shared.Utility;
 
-namespace Content.Server._Goobstation.StationEvents.Metric;
+namespace Content.Shared._Goobstation.StationEvents.Metric;
 
 public enum ChaosMetric
 {

--- a/Content.Shared/_Goobstation/StationEvents/StoryBeatPrototype.cs
+++ b/Content.Shared/_Goobstation/StationEvents/StoryBeatPrototype.cs
@@ -1,0 +1,92 @@
+using Robust.Shared.Prototypes;
+using Content.Shared._Goobstation.StationEvents.Metric;
+
+namespace Content.Shared._Goobstation.StationEvents;
+
+/// <summary>
+///   A point in the story of the station where the dynamic system tries to achieve a certain level of chaos
+///   for instance you want a battle (goal has lots of hostiles)
+///   then the next beat you might want a restoration of peace (goal has a balanced combat score)
+///   then you might want to have the station heal up (goal has low medical, atmos and power scores)
+///
+///   In each case you create a beat and string them together into a story.
+///
+///   EndIfAnyWorse might be used for a battle to trigger when the chaos has become high enough.
+///   endIfAllBetter is suitable for when you want the station to reach a given level of peace before you subject them to
+///   the next round of chaos.
+/// </summary>
+[DataDefinition]
+[Prototype("storyBeat")]
+public sealed partial class StoryBeatPrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    ///   A human-readable description string for logging / admins
+    /// </summary>
+    [DataField]
+    public string Description;
+
+    /// <summary>
+    ///   Which chaos levels we are driving in this beat and the values we are aiming for
+    /// </summary>
+    [DataField]
+    public ChaosMetrics Goal = new ChaosMetrics();
+
+    /// <summary>
+    ///   Early end if things deteriorate too much
+    ///
+    ///   If the current metrics get worse than any of these, end the story beat
+    ///   For instance, too many hostiles or too little atmos
+    /// </summary>
+    [DataField]
+    public ChaosMetrics EndIfAnyWorse = new ChaosMetrics();
+
+    /// <summary>
+    ///   Early end if life is good enough
+    ///
+    ///   If the current metrics get better than all of these, end the story beat
+    ///   For instance, medical, atmos, hostiles are all under control.
+    /// </summary>
+    [DataField]
+    public ChaosMetrics EndIfAllBetter = new ChaosMetrics();
+
+    /// <summary>
+    ///   The number of seconds that we will remain in this state at minimum
+    /// </summary>
+    [DataField]
+    public float MinSecs = 480.0f;
+
+    /// <summary>
+    ///   The number of seconds that we will remain in this state at maximum
+    /// </summary>
+    [DataField]
+    public float MaxSecs = 1200.0f;
+
+    /// <summary>
+    ///   Seconds between events during this beat (min)
+    ///   2 minute default (120)
+    /// </summary>
+    [DataField]
+    public float EventDelayMin = 120.0f;
+
+    /// <summary>
+    ///   Seconds between events during this beat (min)
+    ///   6 minute default (360)
+    /// </summary>
+    [DataField]
+    public float EventDelayMax = 360.0f;
+
+    /// <summary>
+    ///   How many different events we choose from (at random) when performing this StoryBeat
+    /// </summary>
+    ///
+    /// The director is making a priority pick. But to ensure it doesn't ALWAYS pick the very best we actually
+    ///  pick randomly from the top few events (RandomEventLimit).
+    /// By tuning RandomEventLimit you can decide on a per beat basis how much the director is "directing" and
+    ///  how much it's acting like a random system. Some randomness is often good to spice things up.
+    [DataField]
+    public int RandomEventLimit = 3;
+}

--- a/Content.Shared/_Goobstation/StationEvents/StoryPrototype.cs
+++ b/Content.Shared/_Goobstation/StationEvents/StoryPrototype.cs
@@ -1,0 +1,41 @@
+using Robust.Shared.Prototypes;
+using Content.Shared._Goobstation.StationEvents.Metric;
+
+namespace Content.Shared._Goobstation.StationEvents;
+
+/// <summary>
+///   A series of named StoryBeats which we want to take the station through in the given sequence.
+///   Gated by various settings such as the number of players
+/// </summary>
+[DataDefinition]
+[Prototype("story")]
+public sealed partial class StoryPrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    ///   A human-readable description string for logging / admins
+    /// </summary>
+    [DataField]
+    public string Description;
+
+    /// <summary>
+    ///   Minimum number of players on the station to pick this story
+    /// </summary>
+    [DataField]
+    public int MinPlayers = -1;
+
+    /// <summary>
+    ///   Maximum number of players on the station to pick this story
+    /// </summary>
+    [DataField]
+    public int MaxPlayers = Int32.MaxValue;
+
+    /// <summary>
+    ///   List of beat-ids in this story.
+    /// </summary>
+    [DataField]
+    public ProtoId<StoryBeatPrototype>[]? Beats;
+}

--- a/Resources/Prototypes/GameRules/cargo_gifts.yml
+++ b/Resources/Prototypes/GameRules/cargo_gifts.yml
@@ -43,6 +43,9 @@
     weight: 5
     duration: 120
     earliestStart: 20
+    chaos: # Goobstation
+      Hunger: -80
+      Thirst: -40
   - type: CargoGiftsRule
     description: cargo-gift-pizza-small
     dest: cargo-gift-dest-bar
@@ -61,6 +64,9 @@
     duration: 240
     earliestStart: 20
     minimumPlayers: 40
+    chaos: # Goobstation
+      Hunger: -300
+      Thirst: -120
   - type: CargoGiftsRule
     description: cargo-gift-pizza-large
     dest: cargo-gift-dest-bar
@@ -78,6 +84,9 @@
     duration: 240
     earliestStart: 30
     minimumPlayers: 10
+    chaos: # Goobstation
+      Atmos: -300
+      Power: -100
   - type: CargoGiftsRule
     description: cargo-gift-eng
     dest: cargo-gift-dest-eng
@@ -98,6 +107,9 @@
     duration: 120
     minimumPlayers: 40
     earliestStart: 30
+    chaos: # Goobstation
+      Hunger: -100
+      Thirst: -100
   - type: CargoGiftsRule
     description: cargo-gift-vending
     dest: cargo-gift-dest-supp
@@ -118,6 +130,8 @@
     duration: 120
     minimumPlayers: 30
     earliestStart: 20
+    chaos: # Goobstation
+      Mess: -200
   - type: CargoGiftsRule
     description: cargo-gift-cleaning
     dest: cargo-gift-dest-janitor
@@ -135,6 +149,9 @@
     duration: 120
     earliestStart: 20
     minimumPlayers: 30
+    chaos: #Goobstation
+      Medical: -200
+      Friend: 10
   - type: CargoGiftsRule
     description: cargo-gift-medical-supply
     dest: cargo-gift-dest-med
@@ -154,6 +171,8 @@
     duration: 120
     earliestStart: 10
     minimumPlayers: 40
+    chaos: # Goobstation
+      Atmos: -300
   - type: CargoGiftsRule
     description: cargo-gift-space-protection
     dest: cargo-gift-dest-supp
@@ -173,6 +192,8 @@
     duration: 120
     earliestStart: 20
     minimumPlayers: 40
+    chaos: # Goobstation
+      Atmos: -200
   - type: CargoGiftsRule
     description: cargo-gift-fire-protection
     dest: cargo-gift-dest-supp
@@ -190,6 +211,9 @@
     duration: 120
     earliestStart: 20
     minimumPlayers: 50
+    chaos: # Goobstation
+      Hostile: -100
+      Combat: -100
   - type: CargoGiftsRule
     description: cargo-gift-security-guns
     dest: cargo-gift-dest-sec
@@ -208,6 +232,9 @@
     duration: 120
     earliestStart: 20
     minimumPlayers: 50
+    chaos: # Goobstation
+      Hostile: -30
+      Combat: -30
   - type: CargoGiftsRule
     description: cargo-gift-security-riot
     dest: cargo-gift-dest-sec

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -320,7 +320,7 @@
     earliestStart: 30
     reoccurrenceDelay: 60
     minimumPlayers: 10
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:
@@ -685,7 +685,7 @@
     weight: 10
     duration: 150
     maxDuration: 300
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-mass-hallucinations-result-message
   - type: MassHallucinationsRule

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -84,6 +84,8 @@
       path: /Audio/Announcements/announce.ogg
     weight: 12 # DeltaV - was 8
     duration: 35
+    chaos: # Goobstation
+      Anomaly: 100
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-anomaly-spawn-result-message
   - type: AnomalySpawnRule
@@ -102,6 +104,8 @@
       path: /Audio/Announcements/announce.ogg
     weight: 8
     duration: 35
+    chaos: # Goobstation
+      Anomaly: 40
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-bluespace-artifact-result-message
   - type: BluespaceArtifactRule
@@ -115,6 +119,8 @@
     reoccurrenceDelay: 5
     earliestStart: 1
     duration: 1
+    chaos: # Goobstation
+      Anomaly: 40
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-bluespace-locker-result-message
   - type: BluespaceLockerRule
@@ -127,6 +133,8 @@
     weight: 10
     duration: 1
     minimumPlayers: 15
+    chaos: # Goobstation
+      Power: 100
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-breaker-flip-result-message
   - type: BreakerFlipRule
@@ -184,6 +192,12 @@
     reoccurrenceDelay: 20
     minimumPlayers: 45 # DeltaV - was 20
     duration: null
+    chaos: # Goobstation
+      Hostile: 20
+      Friend: 20
+      Combat: 40
+      Death: 100
+      Medical: 100
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-dragon-spawn-result-message
   - type: SpaceSpawnRule
@@ -215,6 +229,12 @@
     earliestStart: 30
     reoccurrenceDelay: 60 # DeltaV - was 20
     minimumPlayers: 40 # DeltaV - was 30
+    chaos: # Goobstation
+      Hostile: 20
+      Friend: 20
+      Combat: 40
+      Death: 40
+      Medical: 40
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-ninja-spawn-result-message
   - type: SpaceSpawnRule
@@ -272,6 +292,12 @@
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
+    chaos: # Goobstation
+      Hostile: 20
+      Friend: 20
+      Combat: 40
+      Death: 100
+      Medical: 100
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-revenant-spawn-result-message
   - type: RandomSpawnRule
@@ -335,6 +361,9 @@
       path: /Audio/Announcements/gas_leak.ogg # DeltaV - custom announcer
     endAnnouncement: station-event-gas-leak-end-announcement
     weight: 10 # DeltaV - was 8
+    chaos:
+      Atmos: 100
+      Medical: 50
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-gas-leak-result-message
   - type: GasLeakRule
@@ -348,6 +377,10 @@
     minimumPlayers: 10 # DeltaV - Was 15
     weight: 7
     duration: 240
+    chaos:
+      Hostile: 20
+      Friend: 20
+      Medical: 100
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-kudzu-growth-result-message
   - type: KudzuGrowthRule
@@ -382,6 +415,8 @@
       path: /Audio/Announcements/attention.ogg
     duration: 120
     maxDuration: 240
+    chaos: # Goobstation
+      Friend: 20
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-solar-flare-result-message
   - type: SolarFlareRule
@@ -412,6 +447,8 @@
     minimumPlayers: 15
     weight: 7.5 # DeltaV - was 5
     duration: 60
+    chaos: # Goobstation
+      Mess: 200
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-vent-clog-result-message
   - type: VentClogRule
@@ -428,6 +465,10 @@
     minimumPlayers: 15
     weight: 5
     duration: 30 # DeltaV: was 60, used as a delay now
+    chaos: # Goobstation
+      Hostile: 10
+      Friend: 10
+      Medical: 50
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-slimes-spawn-result-message
   - type: VentCrittersRule
@@ -449,6 +490,10 @@
     minimumPlayers: 15
     weight: 5
     duration: 30 # DeltaV: was 60, used as a delay now
+    chaos: # DeltaV
+      Hostile: 10
+      Friend: 10
+      Medical: 50
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snake-spawn-result-message
   - type: VentCrittersRule
@@ -470,6 +515,10 @@
     minimumPlayers: 15
     weight: 5
     duration: 30 # DeltaV: was 60, used as a delay now
+    chaos: # DeltaV
+      Hostile: 10
+      Friend: 10
+      Medical: 50
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-spawn-result-message
   - type: VentCrittersRule
@@ -488,6 +537,10 @@
     minimumPlayers: 30 # DeltaV - was 20
     weight: 1 # DeltaV - was 1.5
     duration: 30 # DeltaV: was 60, used as a delay now
+    chaos: # DeltaV
+      Hostile: 10
+      Friend: 10
+      Medical: 50
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-clown-spawn-result-message
   - type: VentCrittersRule
@@ -504,6 +557,11 @@
     minimumPlayers: 40
     weight: 1 # Zombies was happening basically every single survival round, so now it's super rare
     duration: 1
+    chaos: # Goobstation
+      Hostile: 40
+      Friend: 60
+      Medical: 200
+      Death: 200
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-zombie-outbreak-result-message
   - type: ZombieRule
@@ -540,6 +598,11 @@
     minimumPlayers: 30 # DeltaV - was 20
     reoccurrenceDelay: 30
     duration: 1
+    chaos: # Goobstation
+      Hostile: 20
+      Friend: 40
+      Medical: 200
+      Death: 100
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-lone-ops-spawn-result-message
   - type: RuleGrids

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -150,6 +150,8 @@
     minimumPlayers: 25
     weight: 5
     duration: 1
+    chaos: # DeltaV - Game Director
+      Friend: 50
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-bureaucratic-error-result-message
   - type: BureaucraticErrorRule
@@ -165,6 +167,8 @@
     minimumPlayers: 15
     weight: 5
     duration: 1
+    chaos: # DeltaV - Game Director
+      Friend: 50
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-clerical-error-result-message
   - type: ClericalErrorRule
@@ -177,6 +181,9 @@
     weight: 8 # DeltaV - was 10
     duration: 1
     minimumPlayers: 10
+    chaos: # DeltaV - Game Director
+      Friend: 10
+      Hostile: 10
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-closet-skeleton-result-message
   - type: RandomEntityStorageSpawnRule
@@ -313,6 +320,7 @@
     earliestStart: 30
     reoccurrenceDelay: 60
     minimumPlayers: 10
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
   - type: AntagSelection
     agentName: wizard-round-end-name
     definitions:
@@ -399,6 +407,8 @@
         volume: -4
     duration: 60
     maxDuration: 120
+    chaos: # DeltaV - Game Director
+      Power: 100
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-power-grid-check-result-message
   - type: PowerGridCheckRule
@@ -646,6 +656,10 @@
       path: /Audio/Announcements/attention.ogg # DeltaV - Use the generic announcement sound
     duration: null # the rule has to last the whole round not 1 second
     occursDuringRoundEnd: false
+    chaos: # DeltaV - Game Director
+      Hostile: 20
+      Death: 10
+      Combat: 20
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-sleeper-agents-result-message
   - type: AlertLevelInterceptionRule
@@ -671,6 +685,7 @@
     weight: 10
     duration: 150
     maxDuration: 300
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-mass-hallucinations-result-message
   - type: MassHallucinationsRule
@@ -688,6 +703,8 @@
     weight: 10
     reoccurrenceDelay: 30 # DeltaV - Was 20 #20 mins feels too short, and can scramble borgs way too much
     duration: 1
+    chaos: # DeltaV - Game Director
+      Hostile: 30
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-ion-storm-result-message
   - type: IonStormRule
@@ -714,6 +731,9 @@
     weight: 5
     minimumPlayers: 25
     reoccurrenceDelay: 20
+    chaos: # DeltaV - Game Director
+      Atmos: 50
+      Security: 50
   - type: GreytideVirusRule
     accessGroups:
     - Cargo
@@ -735,6 +755,8 @@
     reoccurrenceDelay: 20
     minimumPlayers: 4
     duration: null
+    chaos: # DeltaV - Game Director
+      Hostile: 10
   - type: SpaceSpawnRule
     spawnDistance: 0
   - type: AntagSpawner

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -114,6 +114,8 @@
     weight: 44
     earliestStart: 2
     minimumPlayers: 0
+    chaos: # DeltaV - Game Director
+      Atmos: 25
   - type: MeteorSwarm
     announcement: null
     announcementSound: null
@@ -134,6 +136,8 @@
   - type: StationEvent
     weight: 22
     minimumPlayers: 0
+    chaos: # DeltaV - Game Director
+      Atmos: 75
   - type: MeteorSwarm
     announcement: station-event-space-dust-start-announcement
     announcementSound: /Audio/Announcements/attention.ogg
@@ -154,6 +158,8 @@
   - type: StationEvent
     weight: 18
     minimumPlayers: 15
+    chaos: # DeltaV - Game Director
+      Atmos: 25
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 7
@@ -165,6 +171,8 @@
   components:
   - type: StationEvent
     weight: 10
+    chaos: # DeltaV - Game Director
+      Atmos: 50
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 3
@@ -177,6 +185,8 @@
   components:
   - type: StationEvent
     weight: 5
+    chaos: # DeltaV - Game Director
+      Atmos: 100
   - type: MeteorSwarm
     meteors:
       MeteorSmall: 2
@@ -189,6 +199,7 @@
   components:
   - type: StationEvent
     weight: 0.05
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-game-rule-urist-swarm-result-message
   - type: MeteorSwarm
@@ -216,6 +227,9 @@
     duration: 1
     earliestStart: 30
     minimumPlayers: 25
+    chaos: # DeltaV - Game Director
+      Atmos: 100
+      Medical: 20
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-immovable-rod-spawn-result-message
   - type: ImmovableRodRule

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -199,7 +199,7 @@
   components:
   - type: StationEvent
     weight: 0.05
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-game-rule-urist-swarm-result-message
   - type: MeteorSwarm

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -56,7 +56,7 @@
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-king-rat-migration-result-message
   - type: VentCrittersRule

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -28,6 +28,8 @@
     earliestStart: 15
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
+    chaos: # DeltaV - Game Director
+      Mess: 10
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-mouse-migration-result-message
   - type: VentCrittersRule
@@ -54,6 +56,7 @@
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30 # Hopefully this is enough for the Rat King's potential Army (it was not, raised from 15 -> 30)
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-king-rat-migration-result-message
   - type: VentCrittersRule
@@ -80,6 +83,8 @@
       path: /Audio/Announcements/attention.ogg
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
+    chaos: # DeltaV - Game Director
+      Mess: 30
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-cockroach-migration-result-message
   - type: VentCrittersRule
@@ -103,6 +108,8 @@
       path: /Audio/Announcements/attention.ogg
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
+    chaos: # DeltaV - Game Director
+      Mess: 10
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message
   - type: VentCrittersRule
@@ -127,6 +134,8 @@
     weight: 6
     duration: 30 # DeltaV: was 50, used as a delay now
     minimumPlayers: 30
+    chaos: # DeltaV - Game Director
+      Mess: 30
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snail-migration-result-message
   - type: VentCrittersRule

--- a/Resources/Prototypes/GameRules/random_sentience.yml
+++ b/Resources/Prototypes/GameRules/random_sentience.yml
@@ -8,6 +8,7 @@
     maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
     startAudio:
       path: /Audio/Announcements/attention.ogg
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-random-sentience-result-message
   - type: RandomSentienceRule

--- a/Resources/Prototypes/GameRules/random_sentience.yml
+++ b/Resources/Prototypes/GameRules/random_sentience.yml
@@ -8,7 +8,7 @@
     maxOccurrences: 1 # this event has diminishing returns on interesting-ness, so we cap it
     startAudio:
       path: /Audio/Announcements/attention.ogg
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-random-sentience-result-message
   - type: RandomSentienceRule

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -127,7 +127,7 @@
     weight: .5 # Hopefully this is uncommon enough, it needs to be uncommon enough that people wont waste time metaknowledging it.
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly.
     minimumPlayers: 25
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
   - type: LoadMapRule
     preloadedGrid: NTQuark
 
@@ -140,7 +140,7 @@
     weight: 2 # Its just a big ship, so it needs to be rarer to be interesting.
   - type: LoadMapRule
     preloadedGrid: Cruiser
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleCryptid
@@ -150,7 +150,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Cryptid
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleEternal
@@ -160,7 +160,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Eternal
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleFlatline
@@ -170,7 +170,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Flatline
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleGym
@@ -181,7 +181,7 @@
     weight: 5 # Its just a big ship, so it needs to be rarer to be interesting.
   - type: LoadMapRule
     preloadedGrid: Gym
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleNTIncorporation
@@ -193,7 +193,7 @@
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly. (5-6)
   - type: LoadMapRule
     preloadedGrid: NTIncorporation
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleInstigator
@@ -205,7 +205,7 @@
     earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly (3) and because antags
   - type: LoadMapRule
     preloadedGrid: Instigator
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleJoe
@@ -215,7 +215,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Joe
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleLambordeere
@@ -225,7 +225,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Lambordeere
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleManOWar
@@ -248,7 +248,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Meatzone
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleMicroshuttle
@@ -260,7 +260,7 @@
     maxOccurrences: 4
   - type: LoadMapRule
     preloadedGrid: Microshuttle
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleSpacebus
@@ -270,5 +270,5 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Spacebus
-  - type: DynamicRuleset # DeltaV - this event has no use to the game director
+  - type: GameDirectorIgnore # DeltaV - this event has no use to the game director
 

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -61,6 +61,8 @@
   components:
   - type: StationEvent
     maxOccurrences: 2 # should be the same as [copies] in shuttle_incoming_event.yml
+    chaos: # DeltaV - Game Director
+      Friend: -10
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-unknown-shuttle-cargo-lost-result-message
   - type: LoadMapRule
@@ -73,6 +75,8 @@
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming
     maxOccurrences: 2 # should be the same as [copies] in shuttle_incoming_event.yml
+    chaos: # DeltaV - Game Director
+      Friend: -10
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-unknown-shuttle-traveling-cuisine-result-message
   - type: LoadMapRule
@@ -85,6 +89,8 @@
   - type: StationEvent
     startAnnouncement: station-event-unknown-shuttle-incoming
     maxOccurrences: 3 # should be the same as [copies] in shuttle_incoming_event.yml
+    chaos: # DeltaV - Game Director
+      Friend: -10
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-unknown-shuttle-disaster-evac-pod-result-message
   - type: LoadMapRule
@@ -107,6 +113,8 @@
     startAnnouncement: null # It should be silent.
     weight: 5 # lower because weird freelance roles
     maxOccurrences: 2 # should be the same as [copies] in shuttle_incoming_event.yml
+    chaos: # DeltaV - Game Director
+      Hostile: 5
   - type: LoadMapRule
     preloadedGrid: SyndieEvacPod
 
@@ -119,6 +127,7 @@
     weight: .5 # Hopefully this is uncommon enough, it needs to be uncommon enough that people wont waste time metaknowledging it.
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly.
     minimumPlayers: 25
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
   - type: LoadMapRule
     preloadedGrid: NTQuark
 
@@ -131,6 +140,7 @@
     weight: 2 # Its just a big ship, so it needs to be rarer to be interesting.
   - type: LoadMapRule
     preloadedGrid: Cruiser
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleCryptid
@@ -140,6 +150,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Cryptid
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleEternal
@@ -149,6 +160,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Eternal
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleFlatline
@@ -158,6 +170,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Flatline
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleGym
@@ -168,6 +181,7 @@
     weight: 5 # Its just a big ship, so it needs to be rarer to be interesting.
   - type: LoadMapRule
     preloadedGrid: Gym
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleNTIncorporation
@@ -179,6 +193,7 @@
     earliestStart: 45 # late to hopefully have enough ghosts to fill all roles quickly. (5-6)
   - type: LoadMapRule
     preloadedGrid: NTIncorporation
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleInstigator
@@ -190,6 +205,7 @@
     earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly (3) and because antags
   - type: LoadMapRule
     preloadedGrid: Instigator
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleJoe
@@ -199,6 +215,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Joe
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleLambordeere
@@ -208,6 +225,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Lambordeere
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleManOWar
@@ -217,6 +235,8 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #Leaving this one because theyre like primitives and its funnier
     weight: 1 # lower because antags
     earliestStart: 50 # late to hopefully have enough ghosts to fill all roles quickly. (4) & antags
+    chaos:
+      Hostile: 20
   - type: LoadMapRule
     preloadedGrid: ManOWar
 
@@ -228,6 +248,7 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Meatzone
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleMicroshuttle
@@ -239,6 +260,7 @@
     maxOccurrences: 4
   - type: LoadMapRule
     preloadedGrid: Microshuttle
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 
 - type: entity
   id: UnknownShuttleSpacebus
@@ -248,4 +270,5 @@
     startAnnouncement: station-event-unknown-shuttle-incoming #!!
   - type: LoadMapRule
     preloadedGrid: Spacebus
+  - type: DynamicRuleset # DeltaV - this event has no use to the game director
 

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -22,7 +22,7 @@
       # Favor glimmer events just a little more than regular events.
       weight: 12
     - type: GlimmerEvent
-    - type: DynamicRuleset # glimmer events are managed by the glimmer event scheduler
+    - type: GameDirectorIgnore # glimmer events are managed by the glimmer event scheduler
 
 ## Glimmer events
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
+++ b/Resources/Prototypes/Nyanotrasen/GameRules/events.yml
@@ -9,6 +9,8 @@
         path: /Audio/Announcements/noosphericstorm.ogg
       weight: 5
       earliestStart: 15
+      chaos:
+        Anomaly: 60
     - type: NoosphericStormRule
 
 # Base glimmer event
@@ -20,6 +22,7 @@
       # Favor glimmer events just a little more than regular events.
       weight: 12
     - type: GlimmerEvent
+    - type: DynamicRuleset # glimmer events are managed by the glimmer event scheduler
 
 ## Glimmer events
 - type: entity

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -30,6 +30,8 @@
       params:
         volume: -4
     duration: null #ending is handled by MeteorSwarmRule
+    chaos:
+      Atmos: 50
   - type: PrecognitionResult
     message: psionic-power-precognition-meteor-swarm-result-message
   - type: MeteorSwarmRule
@@ -46,6 +48,9 @@
     minimumPlayers: 20
     weight: 1
     duration: 30
+    chaos:
+      Hostile: 20
+      Medical: 50
   - type: PrecognitionResult
     message: psionic-power-precognition-xeno-vents-result-message
   - type: VentCrittersRule
@@ -77,6 +82,8 @@
     minimumPlayers: 15
     weight: 4
     duration: 30
+    chaos:
+      Mess: 40
   - type: PrecognitionResult
     message: psionic-power-precognition-mothroach-spawn-result-message
   - type: VentCrittersRule

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -96,6 +96,9 @@
     minimumPlayers: 25
     maxOccurrences: 1
     duration: null
+    chaos:
+      Hostile: 20
+      Friend: 20
   - type: PrecognitionResult
     message: psionic-power-precognition-listening-post-result-message
   - type: RuleGrids
@@ -157,6 +160,12 @@
   components:
   - type: StationEvent
     duration: null
+    chaos:
+      Hostile: 20
+      Friend: 20
+      Combat: 40
+      Death: 40
+      Medical: 40
   - type: PrecognitionResult
     message: psionic-power-precognition-paradox-anomaly-result-message
   - type: ParadoxClonerRule
@@ -182,6 +191,12 @@
   - type: StationEvent
     minimumPlayers: 40 # it's really easy to find fugitives on lowpop
     duration: null
+    chaos:
+      Hostile: 20
+      Friend: 20
+      Combat: 40
+      Death: 40
+      Medical: 40
   - type: PrecognitionResult
     message: psionic-power-precognition-fugitive-result-message
   - type: FugitiveRule

--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -15,6 +15,8 @@
     minimumPlayers: 20
     maxOccurrences: 1
     duration: null
+    chaos:
+      Hostile: 10
   - type: PrecognitionResult
     message: psionic-power-precognition-syndicate-recruiter-result-message
   - type: RuleGrids
@@ -59,6 +61,8 @@
     minimumPlayers: 20
     maxOccurrences: 1
     duration: null
+    chaos:
+      Hostile: 10
   - type: PrecognitionResult
     message: psionic-power-precognition-synthesis-specialist-result-message
   - type: RuleGrids
@@ -100,6 +104,12 @@
   - type: StationEvent
     weight: 2
     minimumPlayers: 35 #big threat, but has to have ghosts to matter
+    chaos:
+      Hostile: 20
+      Friend: 20
+      Combat: 40
+      Death: 100
+      Medical: 100
   - type: LoadMapRule
     preloadedGrid: RoboNeuroticistShip
   - type: AntagSpawner

--- a/Resources/Prototypes/_DV/game_presets.yml
+++ b/Resources/Prototypes/_DV/game_presets.yml
@@ -1,0 +1,27 @@
+- type: gamePreset
+  id: TheSleeper
+  alias:
+  - calm
+  - calmdynamic
+  name: sleeper-title
+  description: sleeper-description
+  showInVote: true
+  minPlayers: 5
+  rules:
+  - CalmDynamic
+  - BasicRoundstartVariation
+  - GlimmerEventScheduler
+
+- type: gamePreset
+  id: TheGuide
+  alias:
+  - combat
+  - combatdynamic
+  name: guide-title
+  description: guide-description
+  showInVote: true
+  minPlayers: 25
+  rules:
+  - CombatDynamic
+  - BasicRoundstartVariation
+  - GlimmerEventScheduler

--- a/Resources/Prototypes/_DV/game_presets.yml
+++ b/Resources/Prototypes/_DV/game_presets.yml
@@ -5,7 +5,7 @@
   - calmdynamic
   name: sleeper-title
   description: sleeper-description
-  showInVote: true
+  showInVote: false
   minPlayers: 5
   rules:
   - CalmDynamic
@@ -19,7 +19,7 @@
   - combatdynamic
   name: guide-title
   description: guide-description
-  showInVote: true
+  showInVote: false
   minPlayers: 25
   rules:
   - CombatDynamic

--- a/Resources/Prototypes/_Goobstation/GameRules/game_director.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/game_director.yml
@@ -1,0 +1,177 @@
+
+- type: entity
+  id: GameDirector
+  parent: BaseGameRule
+  categories: [ HideSpawnMenu ]
+  # not abstract so that we can spawn an empty game director to just measure metrics
+  components:
+  - type: GameDirector
+  - type: AnomalyMetric
+  - type: CombatMetric
+  - type: DoorMetric
+  - type: FoodMetric
+  - type: PuddleMetric
+
+- type: entity
+  id: CombatDynamic
+  parent: GameDirector
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: GameRule
+    minPlayers: 25
+  - type: GameDirector
+    dualAntags: true
+    stories:
+      - RelaxedAttack
+      - ScienceAttack
+      - MajorCombat
+  - type: SelectedGameRules
+    scheduledGameRules: !type:NestedSelector
+      tableId: BasicGameRulesTable
+
+- type: entity
+  id: CalmDynamic
+  parent: GameDirector
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: GameDirector
+    noRoundstartAntags: true
+    stories:
+      - Relaxed
+      - Science
+
+- type: story
+  id: Relaxed
+  description: A small attack
+  beats:
+    - Peace
+    - AttackMild
+    - PowerIssues
+
+- type: story
+  id: Science
+  description: Science and engineering issues
+  minPlayers: 30
+  beats:
+    - Peace
+    - MadScience
+    - Peace
+    - PowerIssues
+    - RepairStation
+
+- type: story
+  id: RelaxedAttack
+  description: Mostly calm with a couple of minor problems.
+  beats:
+    - Peace
+    - AttackMild
+    - PowerIssues
+
+- type: story
+  id: ScienceAttack
+  description: Science, minor attack and then engineering issues
+  minPlayers: 30
+  beats:
+    - Peace
+    - MadScience
+    - AttackMild
+    - Peace
+    - PowerIssues
+    - RepairStation
+
+- type: story
+  id: MajorCombat
+  description: A minor and then major attack
+  minPlayers: 40
+  beats:
+    - Peace
+    - AttackMild
+    - PowerIssues
+    - Attackers
+    - RestoreOrder
+    - RepairStation
+    - Peace
+
+- type: storyBeat
+  id: Peace
+  description: Minor Chaos across a wide range
+  goal: # Try to achieve a wide range of different moderate values.
+    Combat: -200 # Friendly forces should have the upper hand
+    Anomaly: 100
+    Atmos: 200
+    Power: 100
+    Mess: 100
+    Hunger: 100
+    Thirst: 100
+    Medical: 100
+
+- type: storyBeat
+  id: PowerIssues
+  description: Create high engineering chaos
+  goal:   # Annoying engineering issues
+    Atmos: 400
+    Power: 400
+    Medical: 100
+
+- type: storyBeat
+  id: MadScience
+  description: Create high Science chaos
+  goal:
+    Anomaly: 400
+    Power: 100
+    Atmos: 100
+    Medical: 100
+  endIfAnyWorse:
+    Anomaly: 500   # Severe atmos, power or medical issues should end this beat.
+    Power: 300
+    Medical: 300
+    Death: 400
+    Combat: -100 # Friendly forces should retain the upper hand
+
+- type: storyBeat
+  id: Attackers
+  description: Drive high combat
+  goal:
+    Hostile: 100  # Quite a few hostiles
+  endIfAnyWorse:
+    Atmos: 800   # Severe atmos, power or medical issues should end this beat.
+    Power: 800
+    Medical: 600
+    Death: 400
+    Combat: -50 # Friendly forces should just retain the upper hand
+
+- type: storyBeat
+  id: AttackMild
+  description: Drive medium combat
+  goal:
+    Hostile: 40  # Perhaps 4 hostiles
+  endIfAnyWorse:
+    Atmos: 400   # Severe atmos, power or medical issues should end this beat.
+    Power: 400
+    Medical: 300
+    Death: 300
+    Combat: -100 # Friendly forces should easily retain the upper hand
+
+- type: storyBeat
+  id: RestoreOrder
+  description: Send help to quell disorder on the station
+  goal:
+    # Traitors: 0  # Try to drive down hostiles and engineering issues
+    Hostile: 10
+    Atmos: 0
+    Medical: 0
+  endIfAllBetter:
+    Atmos: 200
+    Hostile: 20
+    Medical: 200
+
+- type: storyBeat
+  id: RepairStation
+  description: Repair that station
+  goal:
+    Atmos: 0
+    Power: 0
+    Medical: 0
+  endIfAllBetter:
+    Atmos: 200
+    Power: 200

--- a/Resources/Prototypes/_Goobstation/GameRules/game_director.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/game_director.yml
@@ -101,9 +101,10 @@
     Atmos: 200
     Power: 100
     Mess: 100
-    Hunger: 100
-    Thirst: 100
-    Medical: 100
+    # DeltaV - these are untenable as baseline chaos levels
+    # Hunger: 100
+    # Thirst: 100
+    # Medical: 100
 
 - type: storyBeat
   id: PowerIssues

--- a/Resources/Prototypes/_Goobstation/GameRules/game_director.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/game_director.yml
@@ -11,6 +11,7 @@
   - type: DoorMetric
   - type: FoodMetric
   - type: PuddleMetric
+  - type: AirAlarmMetric # DeltaV - air alarms count for chaos too
 
 - type: entity
   id: CombatDynamic


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This ports the Game Director from Goobstation.

## Why / Balance
As it is, our current ways of scheduling events are purely random, only using shift time and player population with no regard for what came previously or where we'd like to be. This frequently leads to unsatisfying event scheduling. Goob Station's Game Director is a new event scheduler that fixes all of these problems in one fell swoop.

The way it works is that each Game Director has a set of stories that it can choose from, for example, a calm story may start at a peaceful station, work its way towards a minorly scuffed station, and then finish up with power issues. A difficult story may start at a peaceful station, scuff up the station, queue power issues, severely fuck with the station, try and get the security team back on its feet, try and get engineering back on its feat, followed up by a peaceful ending.

These story beats don't call for any specific events, but rather, direct the Game Director to head towards a specific metric goal: the `Attackers` beat directs the Game Director to attempt to queue events to get towards a Hostile rating of 100, but to bail out early if the Atmos, Power, Medical, or Death metrics get severely out of control.

Events themselves have estimated effects on these metrics, for example, a Revenant will be estimated to cause a lot of Medical and Death chaos, and thus, makes a viable choice if the story beat calls for those two factors. However, the Game Director is able to measure the station itself to determine where the station *actually is* in terms of these metrics, instead of assuming that every event has the same impact on the story. For example, if a Ninja gets taken out early, the Game Director will observe that the metrics haven't progressed much towards the goals of the story, and will choose another event towards this direction in due time.

## Technical details
- new CCVar to determine how long before the Game Director starts scheduling events
- new log category for Game Director status
- `StationEventComponent` has a `Chaos` property that measures its estimated impact on the story
- metric systems & components that actually do the job of measuring the story metrics
- GameDirector system & components actually do the job of choosing from available events and stories to progress the plot
- new gamerule/preset prototypes for the game directors to actually take place in (presets being located in _DV and not _Goob because I expect we'll be doing a lot of changes instead of using something close to what they have, but otherwise located under _Goob)

## Media
![image](https://github.com/user-attachments/assets/ef5a9019-0d1f-4266-948d-eaa34de71f7c)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: tom-leys, gusxyz, sowelipililimute
- add: Game Director is here from Goob Station, to offer a more thoughtful and less RNG-reliant method of scheduling events (Test Merge)
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
