### PR TITLE
Adds Search tab to AAC and updates layout

### DIFF
--- a/Content.Client/_DV/AACTablet/UI/AACBoundUserInterface.cs
+++ b/Content.Client/_DV/AACTablet/UI/AACBoundUserInterface.cs
@@ -1,5 +1,6 @@
 using Content.Shared._DV.AACTablet;
 using Content.Shared._DV.QuickPhrase;
+using Robust.Client.UserInterface;
 using Robust.Shared.Prototypes;
 
 namespace Content.Client._DV.AACTablet.UI;
@@ -17,21 +18,12 @@ public sealed class AACBoundUserInterface : BoundUserInterface
     {
         base.Open();
         _window?.Close();
-        _window = new AACWindow();
-        _window.OpenCentered();
-
+        _window = this.CreateWindow<AACWindow>();
         _window.PhraseButtonPressed += OnPhraseButtonPressed;
-        _window.OnClose += Close;
     }
 
     private void OnPhraseButtonPressed(ProtoId<QuickPhrasePrototype> phraseId)
     {
         SendMessage(new AACTabletSendPhraseMessage(phraseId));
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-        _window?.Orphan();
     }
 }

--- a/Content.Client/_DV/AACTablet/UI/AACWindow.xaml
+++ b/Content.Client/_DV/AACTablet/UI/AACWindow.xaml
@@ -1,9 +1,15 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Title="AAC Tablet"
-    Resizable="False"
+    Resizable="True"
     SetSize="540 300"
     MinSize="540 300">
-    <ScrollContainer HScrollEnabled="False" Name="WindowBody">
-    </ScrollContainer>
+    <TabContainer Name="WindowBody" TabTitle="Search" VerticalExpand="True" MouseFilter="Pass">
+        <BoxContainer Orientation="Vertical" Name="Search" MinSize="540 200">
+            <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" Margin="4 4" />
+            <ScrollContainer HorizontalExpand="True" VerticalExpand="True">
+                <BoxContainer Name="SearchResults" Orientation="Vertical" HorizontalExpand="True" />
+            </ScrollContainer>
+        </BoxContainer>
+    </TabContainer>
 </controls:FancyWindow>


### PR DESCRIPTION
## Licensing (added 2026-01-12)
The contents of this PR are also MIT-licensed and you may port it to any server you wish.
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- Made the TabContainer the top level control instead of the ScrollContainer
- Added a Search tab
- Allowed the window to be resized

## Why / Balance
- Finding phrases in the AAC can be difficult if you don't already know where to look.
- Going from phrases at the bottom of one tab to the bottom of another required excessive scrolling.
- Scroll position was not maintained, which meant scrolling was always required for phrases that weren't at the top of the tab.

## Technical details
<!-- Summary of code changes for easier review. -->
- Changed the AAC xaml
- Added a filter method for the search bar
- Updated AACBoundUserInterface to follow other BoundUserInterface standards and reduce frame lag

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
https://github.com/user-attachments/assets/ce7586b7-2784-4b1c-8168-13f669f74158


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: AAC Tablet now has a searchable tab
- tweak: AAC Tablet no longer has its tabs hidden by scrolling

