### PR TITLE
add water vapor order to cargo

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/_DV/Catalog/Cargo/cargo_atmospherics.yml
@@ -1,0 +1,9 @@
+- type: cargoProduct
+  id: AtmosphericsWaterVapor
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 1100
+  category: cargoproduct-category-name-atmospherics
+  group: market


### PR DESCRIPTION
## About the PR
title, same cost as air

## Why / Balance
- feroxi will need water vapor
- only 1 map (tortuga) has a miner so there is usually no permanent source of vapor, thus this is required to keep them hydrated
- fog

## Media
![07:06:50](https://github.com/user-attachments/assets/dd550151-c0bf-4ee4-a1e8-6d16894609dc)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Water vapor canisters can now be purchased by logistics.
