### PR TITLE
fire alarm 1984

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/fire_alarm.yml
@@ -41,7 +41,7 @@
       - FireAlarm
   - type: Clickable
   - type: InteractionOutline
-  - type: FireAlarm
+  #- type: FireAlarm # DeltaV - disable fire alarms
   - type: AtmosAlertsDevice
     group: FireAlarm
   - type: ContainerFill


### PR DESCRIPTION
## About the PR
removes fire alarm functionality, they can still be linked but wont do anything when you click then

## Why / Balance
fire alarms serve no real purpose but are a huge burden for mappers

most mobs are fast enough that you cant make enough distance that a fire alarm would be positioned in a way to stop them and players can just open them. making them need prying would have the same effect as everyone would carry crowbars

they also have *nothing* to do with fires, air alarms do that

they can be repurposed in the future but right now they wont do anything

:cl:
- tweak: Fire alarms (the ones you manually pull to troll atmos techs) no longer do anything.