### PR TITLE
add unset air sensor for burn chambers

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -1,0 +1,19 @@
+# put this in a burn chamber or something you don't want to have show up as dangerous
+- type: entity
+  parent: AirSensor
+  id: AirSensorUnset
+  suffix: Unset
+  components:
+  - type: AtmosMonitor
+    temperatureThresholdId: ignore
+    pressureThresholdId: ignore
+    gasThresholdPrototypes:
+      Oxygen: ignore
+      Nitrogen: ignore
+      CarbonDioxide: ignore
+      Plasma: ignore
+      Tritium: ignore
+      WaterVapor: ignore
+      Ammonia: ignore
+      NitrousOxide: ignore
+      Frezon: ignore


### PR DESCRIPTION
## About the PR
mapping gaming

replace ones in burnchambers or anything that would otherwise be danger by default with this

it has everything off
![10:16:49](https://github.com/user-attachments/assets/b634ef66-205c-4258-b951-76b9d457fecf)
