### PR TITLE
fix autodoc tending infinite loop

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -356,6 +356,7 @@
     state: scalpel
   - type: SurgeryStepEmoteEffect
   - type: SurgeryDamageChangeEffect # DeltaV
+    sleepModifier: 0
     damage:
       types:
         Slash: 4


### PR DESCRIPTION
## About the PR
removed open incision damage when sedated so autodoc tending steps dont have an infinite loop

works locally, the 2 damage saved is completely irrelevant for player surgeons
