### PR TITLE
Add a salvage expedition board to the LO's locker

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -26,8 +26,6 @@
   - OreBagOfHolding
 
 - type: latheRecipePack
-  parent:
-  - LogisticsBoards # DeltaV
   id: CargoBoards
   recipes:
   - OreProcessorIndustrialMachineCircuitboard

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -13,7 +13,6 @@
   - MiningDrill
   - MineralScannerEmpty
   - OreProcessorIndustrialMachineCircuitboard
-  - SalvageExpeditionsComputerCircuitboard # DeltaV
   - ClothingMaskWeldingGas
 
 - type: technology

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
@@ -12,6 +12,7 @@
     - id: MiningShuttleConsoleCircuitboard
     - id: StockTradingCartridge
     - id: LogisticsTechFabCircuitboard
+    - id: SalvageExpeditionsComputerCircuitboard
     - id: LunchboxCommandFilledRandom
       prob: 0.3
 

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/logistics.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/logistics.yml
@@ -12,8 +12,3 @@
   - WeaponCrusher
   - WeaponCrusherDagger
   - WeaponCrusherGlaive
-
-- type: latheRecipePack
-  id: LogisticsBoards
-  recipes:
-  - SalvageExpeditionsComputerCircuitboard

--- a/Resources/Prototypes/_DV/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/electronics.yml
@@ -1,9 +1,4 @@
 - type: latheRecipe
-  parent: BaseSilverCircuitboardRecipe
-  id: SalvageExpeditionsComputerCircuitboard
-  result: SalvageExpeditionsComputerCircuitboard
-
-- type: latheRecipe
   parent: BaseCircuitboardRecipe
   id: AlertsComputerCircuitboard
   result: AlertsComputerCircuitboard


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds a salvage expedition board to the LO's locker to facilitate salvage's access to expeditions, they still have to buy a shuttle or wait for EPI to get shuttlecraft.

## Why / Balance

> I believe salvage gets access to them often way too late due to either epi research being slow for a salvage board, or money gain in logi being too slow to be able to buy a shuttle. I understand that they shouldn't be available from the roundstart because some salvies would just leave the station and not interact much, but only having time for one expedition before evac gets here is a bit ridiculous. I think the LO should start with a expedition board in their locker, but keep the shuttle prices the same. That way, salvage is locked behind our own departments lack of resources and can assist for that goal, and not being reliant on epi choosing what they want to research

[Kinda a WYCI request.](https://discord.com/channels/968983104247185448/1322726989777338539/1348057633692848138)

## Technical details
Funny 1 YAML line change.

## Media
![image](https://github.com/user-attachments/assets/92ad2416-ad0b-4fae-98c8-2bee84814bfc)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: A salvage expeditions computer board spawns inside the LO's locker now.
- remove: Removed the salvage expeditions computer board from research and lathes.
