### PR TITLE
Reduced price of the overlord board

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1017,9 +1017,9 @@
   productEntity: OverlordCircuitBoard # DeltaV: replaced antimov with overlord
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5 # DeltaV: was 10
+    Telecrystal: 7 # DeltaV: was 10
   cost:
-    Telecrystal: 8 # DeltaV: was 14
+    Telecrystal: 10 # DeltaV: was 14
   categories:
   - UplinkDisruption
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1017,9 +1017,9 @@
   productEntity: OverlordCircuitBoard # DeltaV: replaced antimov with overlord
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 16 # DeltaV: was 10
+    Telecrystal: 10
   cost:
-    Telecrystal: 20 # DeltaV: was 14
+    Telecrystal: 14
   categories:
   - UplinkDisruption
   conditions:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1017,9 +1017,9 @@
   productEntity: OverlordCircuitBoard # DeltaV: replaced antimov with overlord
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 10
+    Telecrystal: 5 # DeltaV: was 10
   cost:
-    Telecrystal: 14
+    Telecrystal: 8 # DeltaV: was 14
   categories:
   - UplinkDisruption
   conditions:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Reduced the price of the overlord board.

## Why / Balance
> Most of the jobs don't even start with 20 TC. On top of that, getting to the AI itself is already a huge challenge, not to mention unlocking its upload console. I have literally never seen an Overlord convert even be attempted, which is a shame because it sounds like a very fun minor antag moment. Assuming that you can afford the lawboard, purchasing it literally leaves you with nothing else, so you can't even emag the console or breach your way through with C4s.

[WYCI suggestion](https://discord.com/channels/968983104247185448/1346927709674143754)
## Technical details
Funny two YAML lines change.

## Media
![image](https://github.com/user-attachments/assets/ffa433d5-48bb-432f-b9d4-bc0d65d84cea)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The overlord board price is back to 14 TC with a possible discount to 10 TC.