### PR TITLE
experimental rcd rework

### DIFF
--- a/Resources/Locale/en-US/_DV/research/technologies.ftl
+++ b/Resources/Locale/en-US/_DV/research/technologies.ftl
@@ -1,5 +1,6 @@
 # Industrial
 research-technology-aerial-extraction = Aerial Extraction
+research-technology-matter-energy-conversion = Matter-Energy Conversion
 
 # Civilian
 research-technology-syringe-gun = Syringe Gun

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -357,10 +357,25 @@
     layers:
     - state: engineering
     - state: icon-rcd
-  - type: ItemBorgModule
-    moduleId: RCD # Frontier
+  # Begin DeltaV Removals - Changed to hands
+  #- type: ItemBorgModule
+  #  moduleId: RCD # Frontier
+  #  items:
+  #  - RCDRecharging
+  # End DeltaV Removals
+  # Begin DeltaV Additions
+  - type: DroppableBorgModule
+    moduleId: RCD
     items:
-    - RCDRecharging
+    - id: RCD
+      whitelist:
+        components:
+        - RCD
+    - id: RCDAmmo
+      whitelist:
+        components:
+        - RCDAmmo
+  # End DeltaV Additions
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: rcd-module }
 

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -43,6 +43,8 @@
   - ClothingBackpackDuffelHolding
 
 - type: latheRecipePack
+  parent:
+  - PowerCellsDeltaV # DeltaV
   id: PowerCells
   recipes:
   - PowerCellMicroreactor

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/engineering.yml
@@ -4,9 +4,13 @@
   id: AtmosToolsDeltaV
   recipes:
   - FireExtinguisherBluespace
-  - PowerCellHyper # RE
   - RCDAmmo # RE
   - RCDRecharging
+
+- type: latheRecipePack
+  id: PowerCellsDeltaV
+  recipes:
+  - PowerCellHyper # RE
 
 - type: latheRecipePack
   id: EngineeringBoardsDeltaV

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/engineering.yml
@@ -6,6 +6,7 @@
   - FireExtinguisherBluespace
   - PowerCellHyper # RE
   - RCDAmmo # RE
+  - RCDRecharging
 
 - type: latheRecipePack
   id: EngineeringBoardsDeltaV

--- a/Resources/Prototypes/_DV/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/tools.yml
@@ -8,3 +8,15 @@
     Silver: 250
     Plasma: 500
     Bluespace: 200
+
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: RCDRecharging
+  result: RCDRecharging
+  completetime: 8
+  materials:
+    Steel: 1500
+    Plastic: 500
+    Uranium: 400
+    Gold: 300
+    Bluespace: 150

--- a/Resources/Prototypes/_DV/Research/industrial.yml
+++ b/Resources/Prototypes/_DV/Research/industrial.yml
@@ -1,3 +1,5 @@
+# Tier 1
+
 - type: technology
   id: AerialExtraction
   name: research-technology-aerial-extraction
@@ -10,3 +12,17 @@
   recipeUnlocks:
   - Fulton
   - FultonBeacon
+
+# Tier 3
+
+- type: technology
+  id: MatterEnergyConversion
+  name: research-technology-matter-energy-conversion
+  icon:
+    sprite: Objects/Tools/rcd.rsi
+    state: icon
+  discipline: Industrial
+  tier: 3
+  cost: 15000
+  recipeUnlocks:
+  - RCDRecharging


### PR DESCRIPTION
## About the PR
engiborgs rcd module is now a normal rcd and rcd ammo, both of which are droppable
experimental rcd can be made with a t3 tech matter-energy conversion, costs bluespace and stuff
engiborgs can then use that to do

## Why / Balance
engiborgs are no longer infinite mat taxbots roundstart, they have to refuel
tech so engi gets something to make their lives easier later in the round


## Media
borg lost infinite tax
![04:55:41](https://github.com/user-attachments/assets/9d1b6871-dd05-4c90-9c0c-2d27b2bbb7ac)

tech real
![04:54:45](https://github.com/user-attachments/assets/c4a20c11-cf7c-4039-98b0-4fcf9eb5fb19)
![04:54:58](https://github.com/user-attachments/assets/c8cea348-07f0-4f53-a396-020007f72826)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added a new T3 industrial tech, Matter-Energy Conversion, which lets you make self-recharging RCDs.
- tweak: The borg RCD module now has to be reloaded with compressed matter or replaced with a different RCD.