### PR TITLE
return ahelp to f1, add alternate keybind for staff help chooser

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -40,12 +40,13 @@ namespace Content.Client.Input
             common.AddFunction(ContentKeyFunctions.ResetZoom);
             common.AddFunction(ContentKeyFunctions.InspectEntity);
             common.AddFunction(ContentKeyFunctions.ToggleRoundEndSummaryWindow);
-            // DeltaV - Begin NanoChat keybinds
+            // Begin DeltaV Additions
+            common.AddFunction(ContentKeyFunctions.OpenAHelpCuratorChat);
             common.AddFunction(ContentKeyFunctions.NanoChatNavigateUp);
             common.AddFunction(ContentKeyFunctions.NanoChatNavigateDown);
             common.AddFunction(ContentKeyFunctions.NanoChatNavigateUpUnread);
             common.AddFunction(ContentKeyFunctions.NanoChatNavigateDownUnread);
-            // DeltaV - End NanoChat keybinds
+            // End DeltaV Additions
 
             // Not in engine, because engine cannot check for sanbox/admin status before starting placement.
             common.AddFunction(ContentKeyFunctions.EditorCopyObject);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -227,6 +227,7 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.OpenGuidebook);
             AddButton(ContentKeyFunctions.OpenInventoryMenu);
             AddButton(ContentKeyFunctions.OpenAHelp);
+            AddButton(ContentKeyFunctions.OpenAHelpCuratorChat); // DeltaV
             AddButton(ContentKeyFunctions.OpenActionsMenu);
             AddButton(ContentKeyFunctions.OpenEmotesMenu);
             AddButton(ContentKeyFunctions.ToggleRoundEndSummaryWindow);

--- a/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
+++ b/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
@@ -98,8 +98,9 @@
         Access="Internal"
         Icon="{xe:Tex '/Textures/Interface/info.svg.192dpi.png'}"
         BoundKey = "{x:Static is:ContentKeyFunctions.OpenAHelp}"
-        ToolTip="{Loc 'ui-options-function-open-staff-chats-deltav'}" MinSize="42 64"
+        ToolTip="{Loc 'ui-options-function-open-staff-chats-deltav'}"
+        MinSize="42 64"
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonOpenLeft}"
-        /> <!--DeltaV - Rename to Curator Chat-->
+        /> <!-- DeltaV - Changed tooltip -->
 </widgets:GameTopMenuBar>

--- a/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
+++ b/Content.Client/_RMC14/Mentor/StaffHelpUIController.cs
@@ -123,7 +123,7 @@ public sealed class StaffHelpUIController : UIController, IOnSystemChanged<Bwoin
     public void OnSystemLoaded(BwoinkSystem system)
     {
         CommandBinds.Builder
-            .BindBefore(ContentKeyFunctions.OpenAHelp,
+            .BindBefore(ContentKeyFunctions.OpenAHelpCuratorChat, // DeltaV - change keybind
                 InputCmdHandler.FromDelegate(_ => ToggleWindow()),
                 typeof(AHelpUIController))
             .Register<StaffHelpUIController>();

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -24,12 +24,13 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction CycleChatChannelForward = "CycleChatChannelForward";
         public static readonly BoundKeyFunction CycleChatChannelBackward = "CycleChatChannelBackward";
         public static readonly BoundKeyFunction EscapeContext = "EscapeContext";
-        // DeltaV - Begin NanoChat keybinds
+        // Begin DeltaV Additions
+        public static readonly BoundKeyFunction OpenAHelpCuratorChat = "OpenAHelpCuratorChat";
         public static readonly BoundKeyFunction NanoChatNavigateUp = "NanoChatNavigateUp";
         public static readonly BoundKeyFunction NanoChatNavigateDown = "NanoChatNavigateDown";
         public static readonly BoundKeyFunction NanoChatNavigateUpUnread = "NanoChatNavigateUpUnread";
         public static readonly BoundKeyFunction NanoChatNavigateDownUnread = "NanoChatNavigateDownUnread";
-        // DeltaV - End NanoChat keybinds
+        // End DeltaV Additions
         public static readonly BoundKeyFunction OpenCharacterMenu = "OpenCharacterMenu";
         public static readonly BoundKeyFunction OpenEmotesMenu = "OpenEmotesMenu";
         public static readonly BoundKeyFunction OpenCraftingMenu = "OpenCraftingMenu";

--- a/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/NewPlayer.xml
@@ -6,7 +6,7 @@ You and your fellow crewmates are tasked with working together, surviving, and h
 
 [bold]Make sure to follow all server rules.[/bold] You can ask questions or report rule breaks to the [color=#EB2D3A][bold]admin team[/bold][/color] by using the [bold]admin help menu[/bold]. ([italic]accessible by pressing [/italic][color=yellow][bold][keybind="OpenAHelp"/][/bold][/color])
 
-Curators' goal is to present an interesting and enjoyable game experience. They may do this through influencing the round as a spectator through events. You can contact a curator for an event or need general game help by using the Curator Chat menu. ([italic]accessible by pressing [/italic][color=yellow][bold][keybind="OpenAHelp"/][/bold][/color])
+Curators' goal is to present an interesting and enjoyable game experience. They may do this through influencing the round as a spectator through events. You can contact a curator for an event or if you need general game help by using the Curator Chat menu. ([italic]accessible by pressing [/italic][color=yellow][bold][keybind="OpenAHelp"/][/bold][/color])
 
 More detailed guides about [italic]specific jobs[/italic] and [italic]mechanics[/italic] can be found [textlink="here." link="SS14"/]
 

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -266,6 +266,10 @@ binds:
 - function: OpenAHelp
   type: State
   key: F1
+- function: OpenAHelpCuratorChat # DeltaV
+  type: State
+  key: F1
+  mod1: Shift
 - function: OpenInventoryMenu
   type: State
   key: I


### PR DESCRIPTION
## About the PR
F1 is back to immediate ahelp window, hold shift for the staff help window
you can still use the UI to open staff help and choose curator chat too

also fixed bad grammar in the new player guidebook

## Why / Balance
hotkey hot ui cold :brain: 

fixes #3108

**Changelog**
:cl:
- tweak: Pressing F1 is back to immediately opening AHelp, hold shift to open curator chat.
