### PR TITLE
fix robo neuroticist access

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/identification_cards.yml
@@ -362,5 +362,5 @@
     - NuclearOperative
     - SyndicateAgent
     - External
-    - Research
+    - Robotics
     - Maintenance

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Robotics/id_chips.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Robotics/id_chips.yml
@@ -90,5 +90,5 @@
     - SyndicateAgent
     - NuclearOperative
     - External
-    - Research
+    - Robotics
     - Maintenance


### PR DESCRIPTION
## About the PR
robotics not research

**Changelog**
:cl:
- fix: Fixed robo-neuroticists not being able to lock their evil borgs.