### PR TITLE
remove raffle from fish

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -195,8 +195,7 @@
       rules: ghost-role-information-space-dragon-summoned-carp-rules
       mindRoles:
       - MindRoleGhostRoleTeamAntagonist
-      raffle:
-        settings: short
+      raffle: null # DeltaV - disable raffle for fish
     - type: GhostTakeoverAvailable
     - type: HTN
       rootTask:


### PR DESCRIPTION
## About the PR
makes dragon very hard as fish get spawnkilled from bad AI or get lost in space before they can be useful

**Changelog**
:cl:
- tweak: Removed raffles from carp ghost roles. Rrrr!