### PR TITLE
Sleepy rev

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -363,7 +363,7 @@ public sealed partial class RevenantSystem
 
         args.Handled = true;
 
-        var duration = 5; // Duration of the mass sleep
+        var duration = 15; // Duration of the sleep effect
         foreach (var entity in _lookup.GetEntitiesInRange(uid, component.SleepRadius))
         {
             if (HasComp<MobStateComponent>(entity) && entity != uid)

--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.Abilities.cs
@@ -29,6 +29,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Utility;
 using Robust.Shared.Map.Components;
 using Content.Shared.Whitelist;
+
 // Begin DeltaV Changes
 using Robust.Shared.Prototypes;
 using Content.Shared.StatusEffect;

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -204,6 +204,17 @@ public sealed partial class RevenantComponent : Component
     [DataField]
     public ProtoId<AlertPrototype> EssenceAlert = "Essence";
 
+    // Begin DeltaV Changes
+    [DataField]
+    public FixedPoint2 SleepCost = 5;
+
+    [DataField]
+    public Vector2 SleepDebuffs = new(2, 5);
+
+    [DataField]
+    public float SleepRadius = 1.5f;
+    // End DeltaV Changes
+
     #region Visualizer
     [DataField("state")]
     public string State = "idle";

--- a/Content.Shared/Revenant/SharedRevenant.cs
+++ b/Content.Shared/Revenant/SharedRevenant.cs
@@ -62,6 +62,11 @@ public sealed partial class RevenantMalfunctionActionEvent : InstantActionEvent
 {
 }
 
+// Begin DeltaV Changes
+public sealed partial class RevenantSleepActionEvent : InstantActionEvent
+{
+}
+// End DeltaV Changes
 
 [NetSerializable, Serializable]
 public enum RevenantVisuals : byte

--- a/Resources/Locale/en-US/store/revenant-catalog.ftl
+++ b/Resources/Locale/en-US/store/revenant-catalog.ftl
@@ -9,3 +9,7 @@ revenant-blight-desc = Infects all nearby organisms with an infectious disease t
 
 revenant-malfunction-name = Malfunction
 revenant-malfunction-desc = Makes nearby electronics stop working properly. Using it leaves you vulnerable to attacks for a long period of time.
+
+# Begin DeltaV Changes
+revenant-sleep-name = Sleep
+revenant-sleep-desc = Puts nearby people to sleep, leaving them vulnerable. Using it leaves you vulnerable to attacks for a short time.

--- a/Resources/Locale/en-US/store/revenant-catalog.ftl
+++ b/Resources/Locale/en-US/store/revenant-catalog.ftl
@@ -13,3 +13,4 @@ revenant-malfunction-desc = Makes nearby electronics stop working properly. Usin
 # Begin DeltaV Changes
 revenant-sleep-name = Sleep
 revenant-sleep-desc = Puts nearby people to sleep, leaving them vulnerable. Using it leaves you vulnerable to attacks for a short time.
+# End DeltaV Changes

--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -46,3 +46,17 @@
     icon: Interface/Actions/malfunction.png
     event: !type:RevenantMalfunctionActionEvent
     useDelay: 20
+
+# Begin DeltaV Changes
+- type: entity
+  id: ActionRevenantSleep
+  name: Sleep
+  description: Costs 5 Essence.
+  components:
+  - type: InstantAction
+    icon:
+      sprite: _DV/Interface/Actions/actions_psionics.rsi
+      state: mass_sleep
+    event: !type:RevenantSleepActionEvent
+    useDelay: 20
+# End DeltaV Changes

--- a/Resources/Prototypes/Catalog/revenant_catalog.yml
+++ b/Resources/Prototypes/Catalog/revenant_catalog.yml
@@ -49,3 +49,17 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+# Begin DeltaV Changes
+- type: listing
+  id: RevenantSleep
+  name: revenant-sleep-name
+  description: revenant-sleep-desc
+  productAction: ActionRevenantSleep
+  cost:
+    StolenEssence: 5
+  categories:
+  - RevenantAbilities
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+# End DeltaV Changes


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Gives Revs the ability to put people to sleep, just like back when they were scary. (I can't believe I got out of comfy bed to knock this out real quick)

## Why / Balance
As it stands right now, Revenants have basically one strat to actually be antagonistic, and this is either be kind of annoying and tear up floor tiles, or break the burn chamber and round end the station. Neither of these are actually scary, nor all that fun for either the rev or the station. This gives them... not quite the same level of ability as they used to have, but something akin to it that will hopefully bring back some of that old, tense and scary RP that revs used to have. It's also really easy to get, all you have to do is slurp up at least one soul.

## Technical details
So this actually touches quite a bit of upstream code, but from what I can tell they want to give this ability back when they refactor diseases, which is only a week away. Suffice to say, I am too impatient to wait that week so I stole mass sleep code and made it Revenant-ed instead.

## Media

https://github.com/user-attachments/assets/5707f8bf-8cb8-41a3-b7a6-48e381d83108




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added the Sleep ability to revenants. Chaplain's beware!


