### PR TITLE
Increase playtime requirements for nuke ops agent

### DIFF
--- a/Resources/Prototypes/_DV/Roles/Jobs/requirement_overrides.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/requirement_overrides.yml
@@ -206,8 +206,7 @@
     - !type:RoleTimeRequirement # Give them an understanding of basic forensics.
       role: JobDetective
       time: 21600 # 6 hours
-
-    # Antags
+  antags:
     NukeopsMedic:
     - !type:RoleTimeRequirement # They should be able to make advanced brutes + pyra quickly
       role: JobChemist

--- a/Resources/Prototypes/_DV/Roles/Jobs/requirement_overrides.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/requirement_overrides.yml
@@ -206,3 +206,12 @@
     - !type:RoleTimeRequirement # Give them an understanding of basic forensics.
       role: JobDetective
       time: 21600 # 6 hours
+
+    # Antags
+    NukeopsMedic:
+    - !type:RoleTimeRequirement # They should be able to make advanced brutes + pyra quickly
+      role: JobChemist
+      time: 36000 # 10 hours
+    - !type:RoleTimeRequirement # Give them a good understanding of how medical works
+      role: JobMedicalDoctor
+      time: 7200 # 2 hours (+ the time it takes to unlock medical doctor)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Increased playtime requirements for nuke ops agent:
Chemistry: 4 hours -> **10 hours**
Medical doctor: 0 hours -> **2 hours**

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Lyndo mentioned this in a previous PR ([this](https://github.com/DeltaV-Station/Delta-v/pull/3096#issuecomment-2708462010)) but I also heard feedback from people that they had absolutely unusable agents, not being able to make chems, or creating razorium inside people.

And it makes sense, 4 hours is just way to little to be able to make advanced chems with a reasonable speed (and definitely impossible if only using the guidebook)
Also added medical doctor requirements so they know not to create razorium inside people - since MD needs 7 hours of intern time that is around 9 hours total, good enough.

## Technical details
<!-- Summary of code changes for easier review. -->
using requirement_overrides for real now
Also still couldn't figure out how to remove all job access on the test server so the best I could do for testing is to ensure the server is not throwing errors at me

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Increased chemistry and medical doctor playtime requirements for the nuclear operative agent
