### PR TITLE
Medical derotting adjustments

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -268,9 +268,11 @@ public sealed class SurgerySystem : SharedSurgerySystem
 
     private void OnSurgerySpecialDamageChange(Entity<SurgerySpecialDamageChangeEffectComponent> ent, ref SurgeryStepDamageChangeEvent args)
     {
+        // Begin DeltaV - this shit was killed
         // Im killing this shit soon too, inshallah.
-        if (ent.Comp.DamageType == "Rot")
-            _rot.ReduceAccumulator(args.Body, TimeSpan.FromSeconds(2147483648)); // BEHOLD, SHITCODE THAT I JUST COPY PASTED. I'll redo it at some point, pinky swear :)
+        // if (ent.Comp.DamageType == "Rot")
+        //     _rot.ReduceAccumulator(args.Body, TimeSpan.FromSeconds(2147483648)); // BEHOLD, SHITCODE THAT I JUST COPY PASTED. I'll redo it at some point, pinky swear :)
+        // End DeltaV - this shit was killed
         /*else if (ent.Comp.DamageType == "Eye"
             && TryComp(ent, out BlindableComponent? blindComp)
             && blindComp.EyeDamage > 0)

--- a/Resources/Locale/en-US/_DV/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/en-US/_DV/guidebook/chemistry/conditions.ftl
@@ -1,0 +1,1 @@
+reagent-explanation-netinadone-ribcage = the target's ribcage is open

--- a/Resources/Locale/en-US/_DV/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_DV/reagents/meta/medicine.ftl
@@ -5,3 +5,6 @@ reagent-name-cyanoxadone = cyanoxadone
 reagent-desc-cyanoxadone = A cryogenics chemical. Used to treat severe blood loss in blue-blooded creatures by regenerating hemocyanin and promoting reperfusion. Works regardless of the patient being alive or dead.
 
 reagent-desc-doxarubixadone-deltav = A cryogenics chemical. Heals certain types of cellular damage caused by dangerous gases and chemicals. Works regardless of the patient being alive or dead.
+
+reagent-name-netinadone = netinadone
+reagent-desc-netinadone = A cryogenic drug that slowly encourages rotting matter and brain tissue to regenerate.

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1203,7 +1203,7 @@
     Medicine:
       effects:
         - !type:ReduceRotting
-          seconds: 20
+          seconds: 30 # DeltaV - buff opporozidone
           conditions:
           #Patient must be dead and in a cryo tube (or something cold)
           - !type:Temperature

--- a/Resources/Prototypes/_DV/Reagents/medicine.yml
+++ b/Resources/Prototypes/_DV/Reagents/medicine.yml
@@ -79,3 +79,28 @@
           type: Arachnid
           shouldHave: true
         amount: 6
+
+- type: reagent
+  id: Netinadone
+  name: reagent-name-netinadone
+  group: Medicine
+  desc: reagent-desc-netinadone
+  physicalDesc: reagent-physical-desc-sickly
+  flavor: acid
+  color: "#e3d56d"
+  worksOnTheDead: true
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:ReduceRotting
+        seconds: 10
+        conditions:
+        - !type:HasComponent
+          bodyPart: Torso
+          explanation: reagent-explanation-netinadone-ribcage
+          components:
+          - type: RibcageOpen
+        - !type:Temperature
+          max: 150.0
+        - !type:MobStateCondition
+          mobstate: Dead

--- a/Resources/Prototypes/_DV/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_DV/Recipes/Reactions/medicine.yml
@@ -25,3 +25,16 @@
       catalyst: true
   products:
     Cyanoxadone: 2
+
+- type: reaction
+  id: Netinadone
+  minTemp: 400
+  reactants:
+    Plasma:
+      amount: 2
+    Traumoxadone:
+      amount: 1
+    Doxarubixadone:
+      amount: 1
+  products:
+    Netinadone: 2

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -563,10 +563,11 @@
   id: SurgeryStepInsertHeart
   name: Add heart
   categories: [ HideSpawnMenu ]
-  components:
-  - type: SurgerySpecialDamageChangeEffect
-    damageType: Rot
-    isConsumable: true
+  # DeltaV - no more funny rot surgery
+  # components:
+  # - type: SurgerySpecialDamageChangeEffect
+  #   damageType: Rot
+  #   isConsumable: true
 
 - type: entity
   parent: SurgeryStepBase


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This removes the heart transplant ability to remove rotting, but in its place, makes opporozidone easier to synthesise & more potent, but requiring surgery to work.

## Why / Balance
- heart transplants made rotting trivial, just print a heart using roundstart equipment and you've solved rot (and due to the derotting shitcode, permanently solve that person's rot forever)
- heart transplants as a fix for rot make 0 sense IC
- opporozidone requires more cooperation from departments than is usually tenable, that being aloe/stellibinin from botany + carp from salvage (or mutated koibean from botany) + plasma from logistics, leading to it rarely being used
- make it cheaper by dropping to a traumox/plasma/doxa formulation, but still keep surgeons involved in the process of derotting someone
- as well as by buffing the strength per 0.5 of opporozidone

## Technical details
- begone derotting shitcode from SurgerySystem.cs
- remove derotting component from heart transplants
- change opporozidone recipe
- make it more potent and require the patient to have an open lung incision

## Media
![grafik](https://github.com/user-attachments/assets/35b9dc3b-d26a-4f81-a3a3-871018aee1c4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Netinadone has been added. It can de-rot people with cryogenics and surgical intervention, and is cheaper and weaker than opporozidone.
- tweak: Opporozidone is now more effective at derotting people
- remove: Heart transplants no longer derot people to the point where they're immune to rot
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
