### PR TITLE
fix borg emag metacheck

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -313,6 +313,7 @@
     - AllAccessBorg
   - type: AccessReader
     access: [["Command"], ["Research"]]
+    breakOnAccessBreaker: false # DeltaV - prevent emag metachecking by unlocking without an id
   - type: SlavedBorg # DeltaV: NT borgs are enslaved to the AI by default
     law: ObeyAI
   - type: ShowJobIcons


### PR DESCRIPTION
## About the PR
this has existed basically forever, if a borg got emagged its access reader was disabled so anyone can unlock it without an id

1 line fix