### PR TITLE
Shark PSB 1984, replace with tinned meat

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -88,7 +88,7 @@
   - EmergencyOxygen
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
-  - EmergencyWaterVapor # DeltaV
+  - EmergencyWaterBreatherCarnivore # DeltaV
 
 - type: loadoutGroup
   id: GroupEVATank
@@ -97,7 +97,7 @@
   loadouts:
   - LoadoutSpeciesEVANitrogen
   - LoadoutSpeciesEVAOxygen
-  - LoadoutSpeciesEVAWaterVapor # DeltaV
+  - LoadoutSpeciesPocketDoubleWaterBreatherCarnivore # DeltaV
 
 - type: loadoutGroup
   id: GroupPocketTankDouble
@@ -106,7 +106,7 @@
   loadouts:
   - LoadoutSpeciesPocketDoubleNitrogen
   - LoadoutSpeciesPocketDoubleOxygen
-  - LoadoutSpeciesPocketDoubleWaterVapor # DeltaV
+  - LoadoutSpeciesPocketDoubleWaterBreatherCarnivore # DeltaV
 
 # Command
 - type: loadoutGroup
@@ -189,9 +189,9 @@
   # - CommonBackpack
   # - CommonSatchel
   # - CommonDuffel
-  - BackpackHoP 
-  - SatchelHoP 
-  - HopDuffel 
+  - BackpackHoP
+  - SatchelHoP
+  - HopDuffel
   # End of DeltaV changes
   - HoPBackpackIan
 
@@ -543,7 +543,7 @@
   - EmergencyOxygenClown
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
-  - EmergencyWaterVaporClown # DeltaV
+  - EmergencyWaterBreatherCarnivoreClown # DeltaV
 
 - type: loadoutGroup
   id: MimeHead
@@ -603,7 +603,7 @@
   - EmergencyOxygenMime
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
-  - EmergencyWaterVaporMime # DeltaV
+  - EmergencyWaterBreatherCarnivoreMime # DeltaV
 
 - type: loadoutGroup
   id: MusicianJumpsuit
@@ -910,7 +910,7 @@
   - EmergencyOxygenExtended
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
-  - EmergencyWaterVaporExtended # DeltaV
+  - EmergencyWaterBreatherCarnivoreExtended # DeltaV
 
 # Science
 - type: loadoutGroup
@@ -1243,7 +1243,7 @@
   - EmergencyOxygenSecurity
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
-  - EmergencyWaterVaporSecurity # DeltaV
+  - EmergencyWaterBreatherCarnivoreSecurity # DeltaV
 
 - type: loadoutGroup
   id: SecurityStar
@@ -1443,7 +1443,7 @@
   - EmergencyOxygenMedical
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
-  - EmergencyWaterVaporMedical # DeltaV
+  - EmergencyWaterBreatherCarnivoreMedical # DeltaV
 
 # Wildcards
 - type: loadoutGroup
@@ -1489,7 +1489,7 @@
   - EmergencyOxygenSyndicate
   - LoadoutSpeciesVoxNitrogen
   - EmergencyIPCBox # DeltaV
-  - EmergencyWaterVaporSyndicate # DeltaV
+  - EmergencyWaterBreatherCarnivoreSyndicate # DeltaV
 
 - type: loadoutGroup
   id: GroupSpeciesBreathTool

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/emergency.yml
@@ -45,8 +45,8 @@
 
 - type: entity
   parent: BoxSurvivalBrigmedic
-  id: BoxSurvivalBrigmedicWaterVapor
-  suffix: MedSec H2O
+  id: BoxSurvivalBrigmedicWaterBreatherCarnivore
+  suffix: MedSec H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -55,7 +55,7 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen
     - id: Flare
-    - id: FoodPSB
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   # Intentionally wrong picture on the box. NT did not care enough to change it.
   - type: Label
@@ -63,8 +63,8 @@
 
 - type: entity
   parent: BoxSurvival
-  id: BoxSurvivalWaterVapor
-  suffix: Standard H2O
+  id: BoxSurvivalWaterBreatherCarnivore
+  suffix: Standard H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -73,15 +73,15 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen
     - id: Flare
-    - id: FoodPSB
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-water
 
 - type: entity
   parent: BoxSurvivalEngineering
-  id: BoxSurvivalEngineeringWaterVapor
-  suffix: Extended H2O
+  id: BoxSurvivalEngineeringWaterBreatherCarnivore
+  suffix: Extended H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -90,15 +90,15 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen
     - id: Flare
-    - id: FoodPSB
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-water
 
 - type: entity
   parent: BoxSurvivalSecurity
-  id: BoxSurvivalSecurityWaterVapor
-  suffix: Security H2O
+  id: BoxSurvivalSecurityWaterBreatherCarnivore
+  suffix: Security H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -107,15 +107,15 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen
     - id: Flare
-    - id: FoodPSB
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-water
 
 - type: entity
   parent: BoxSurvivalMedical
-  id: BoxSurvivalMedicalWaterVapor
-  suffix: Medical H2O
+  id: BoxSurvivalMedicalWaterBreatherCarnivore
+  suffix: Medical H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -124,15 +124,15 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen
     - id: Flare
-    - id: FoodPSB
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-water
 
 - type: entity
   parent: BoxHug
-  id: BoxHugWaterVapor
-  suffix: Emergency H2O
+  id: BoxHugWaterBreatherCarnivore
+  suffix: Emergency H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -141,15 +141,15 @@
     - id: EmergencyMedipen
     - id: SpaceMedipen
     - id: Flare
-    - id: FoodPSB
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-water
 
 - type: entity
-  parent: BoxSurvivalWaterVapor
-  id: BoxMimeWaterVapor
-  suffix: Mime, Emergency H2O
+  parent: BoxSurvivalWaterBreatherCarnivore
+  id: BoxMimeWaterBreatherCarnivore
+  suffix: Mime, Emergency H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -164,8 +164,8 @@
 
 - type: entity
   parent: BoxSurvivalSyndicate
-  id: BoxSurvivalSyndicateWaterVapor
-  suffix: Syndicate H2O
+  id: BoxSurvivalSyndicateWaterBreatherCarnivore
+  suffix: Syndicate H2O Carni
   components:
   - type: StorageFill
     contents:
@@ -173,7 +173,7 @@
     - id: ExtendedEmergencyWaterVaporTankFilled
     - id: EmergencyMedipen
     - id: SpaceMedipen
-    - id: FoodPSB
+    - id: FoodTinMRE
     - id: DrinkWaterBottleFull
   - type: Label
     currentLabel: reagent-name-water

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/survival.yml
@@ -1,6 +1,6 @@
 # Species
 - type: loadoutEffectGroup
-  id: WaterBreather
+  id: WaterBreatherCarnivore
   effects:
   - !type:SpeciesLoadoutEffect
     species:
@@ -8,89 +8,89 @@
 
 # Basic
 - type: loadout
-  id: EmergencyWaterVapor
+  id: EmergencyWaterBreatherCarnivore
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   storage:
     back:
-    - BoxSurvivalWaterVapor
+    - BoxSurvivalWaterBreatherCarnivore
 
 # Clown
 - type: loadout
-  id: EmergencyWaterVaporClown
+  id: EmergencyWaterBreatherCarnivoreClown
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   storage:
     back:
-    - BoxHugWaterVapor
+    - BoxHugWaterBreatherCarnivore
 
 # Mime
 - type: loadout
-  id: EmergencyWaterVaporMime
+  id: EmergencyWaterBreatherCarnivoreMime
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   storage:
     back:
-    - BoxMimeWaterVapor
+    - BoxMimeWaterBreatherCarnivore
 
 # Engineering / Extended
 - type: loadout
-  id: EmergencyWaterVaporExtended
+  id: EmergencyWaterBreatherCarnivoreExtended
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   storage:
     back:
-    - BoxSurvivalEngineeringWaterVapor
+    - BoxSurvivalEngineeringWaterBreatherCarnivore
 
 # Medical
 - type: loadout
-  id: EmergencyWaterVaporMedical
+  id: EmergencyWaterBreatherCarnivoreMedical
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   storage:
     back:
-    - BoxSurvivalMedicalWaterVapor
+    - BoxSurvivalMedicalWaterBreatherCarnivore
 
 # Security
 - type: loadout
-  id: EmergencyWaterVaporSecurity
+  id: EmergencyWaterBreatherCarnivoreSecurity
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   storage:
     back:
-    - BoxSurvivalSecurityWaterVapor
+    - BoxSurvivalSecurityWaterBreatherCarnivore
 
 # Syndicate
 - type: loadout
-  id: EmergencyWaterVaporSyndicate
+  id: EmergencyWaterBreatherCarnivoreSyndicate
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   storage:
     back:
-    - BoxSurvivalWaterVapor
+    - BoxSurvivalWaterBreatherCarnivore
 
 # Full EVA Tank, Any Species
 - type: loadout
-  id: LoadoutSpeciesEVAWaterVapor
+  id: LoadoutSpeciesEVAWaterBreatherCarnivore
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   equipment:
     suitstorage: WaterVaporTankFilled
 
 # Species-appropriate Double Emergency Tank in Pocket 1
 - type: loadout
-  id: LoadoutSpeciesPocketDoubleWaterVapor
+  id: LoadoutSpeciesPocketDoubleWaterBreatherCarnivore
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   equipment:
     pocket1: DoubleEmergencyWaterVaporTankFilled
 
@@ -114,12 +114,12 @@
     - BoxSurvivalBrigmedicNitrogen
 
 - type: loadout
-  id: EmergencyWaterVaporCorpsman
+  id: EmergencyWaterBreatherCarnivoreCorpsman
   effects:
   - !type:GroupLoadoutEffect
-    proto: WaterBreather
+    proto: WaterBreatherCarnivore
   equipment:
-    mask: BoxSurvivalBrigmedicWaterVapor
+    mask: BoxSurvivalBrigmedicWaterBreatherCarnivore
 
 - type: loadout
   id: LoadoutSpeciesBreathToolCorpsman


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Sharks have tinned meat instead of PSBs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Sharks cant eat most of the PSBs, Mimes still keep their baguette cause its unique to their survival box, sorry mimes!

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Feroxi now get tinned meat in their survival boxes instead of PSB, except you mimes, you get to keep your freshly baked bread