### PR TITLE
add ai detector from ss13

### DIFF
--- a/Content.Shared/_DV/Physics/CollidingVisualsComponent.cs
+++ b/Content.Shared/_DV/Physics/CollidingVisualsComponent.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._DV.Physics;
+
+/// <summary>
+/// Changes an appearance data string depending on active collisions with fixtures.
+/// </summary>
+[RegisterComponent, Access(typeof(CollidingVisualsSystem))]
+public sealed partial class CollidingVisualsComponent : Component
+{
+    /// <summary>
+    /// A whitelist entities must match to be counted for collisions.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    /// The string to use for appearance data when no fixtures are being collided with.
+    /// </summary>
+    [DataField]
+    public string Default = "none";
+
+    /// <summary>
+    /// The list of fixtures to check for collisions, first one colliding is used so is most important.
+    /// </summary>
+    [DataField(required: true)]
+    public List<string> Fixtures = new();
+
+    /// <summary>
+    /// Actively colliding fixtures.
+    /// </summary>
+    [DataField]
+    public HashSet<string> Active = new();
+}
+
+[Serializable, NetSerializable]
+public enum CollidingVisuals : byte
+{
+    Layer,
+    Fixture
+}

--- a/Content.Shared/_DV/Physics/CollidingVisualsSystem.cs
+++ b/Content.Shared/_DV/Physics/CollidingVisualsSystem.cs
@@ -1,0 +1,64 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.Physics.Events;
+
+namespace Content.Shared._DV.Physics;
+
+public sealed class CollidingVisualsSystem : EntitySystem
+{
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CollidingVisualsComponent, StartCollideEvent>(OnStartCollide);
+        SubscribeLocalEvent<CollidingVisualsComponent, EndCollideEvent>(OnEndCollide);
+    }
+
+    private void OnStartCollide(Entity<CollidingVisualsComponent> ent, ref StartCollideEvent args)
+    {
+        if (_whitelist.IsWhitelistFail(ent.Comp.Whitelist, args.OtherEntity))
+            return;
+
+        // update active fixtures and state
+        var state = ent.Comp.Default;
+        foreach (var id in ent.Comp.Fixtures)
+        {
+            if (args.OurFixtureId == id)
+            {
+                ent.Comp.Active.Add(id);
+                state = id;
+                break;
+            }
+        }
+
+        SetState(ent, state);
+    }
+
+    private void OnEndCollide(Entity<CollidingVisualsComponent> ent, ref EndCollideEvent args)
+    {
+        if (_whitelist.IsWhitelistFail(ent.Comp.Whitelist, args.OtherEntity))
+            return;
+
+        ent.Comp.Active.Remove(args.OurFixtureId);
+
+        // find the first state that is still active
+        var state = ent.Comp.Default;
+        foreach (var id in ent.Comp.Fixtures)
+        {
+            if (ent.Comp.Active.Contains(id))
+            {
+                state = id;
+                break;
+            }
+        }
+
+        SetState(ent, state);
+    }
+
+    public void SetState(EntityUid uid, string state)
+    {
+        _appearance.SetData(uid, CollidingVisuals.Fixture, state);
+    }
+}

--- a/Content.Shared/_DV/Whitelist/AiDetectableComponent.cs
+++ b/Content.Shared/_DV/Whitelist/AiDetectableComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Whitelist;
+
+/// <summary>
+/// Component added to AI eye entity that lets it get detected by the syndicate ai detector.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AiDetectableComponent : Component;

--- a/Resources/Locale/en-US/_DV/store/uplink/deception.ftl
+++ b/Resources/Locale/en-US/_DV/store/uplink/deception.ftl
@@ -1,0 +1,4 @@
+uplink-observation-kit-desc-deltav = Includes a syndicate crew monitor, high-capacity power cell and security hud disguised as sunglasses.
+
+uplink-ai-detector-name = AI Detector
+uplink-ai-detector-desc = This multitool has a custom display that changes color depending on how close the AI's camera is to you. Use it to stay clear of snooping eyes!

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -210,7 +210,7 @@ uplink-micro-bomb-implanter-desc = Explode on death or manual activation with th
 
 # Bundles
 uplink-observation-kit-name = Observation Kit
-uplink-observation-kit-desc = Includes syndicate crew monitor, high power cell and security hud disguised as sunglasses.
+uplink-observation-kit-desc = Includes surveillance camera monitor board and security hud disguised as sunglasses.
 
 uplink-emp-kit-name = Electrical Disruptor Kit
 uplink-emp-kit-desc = The ultimate reversal on energy-based weaponry: Disables disablers, stuns stunbatons, discharges laser guns! Contains 3 EMP grenades and an EMP implanter. Note: Does not disrupt actual firearms.

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -478,9 +478,7 @@
     - state: ai_camera
       shader: unshaded
       map: ["base"]
-  - type: Tag # DeltaV - AI detector
-    tags:
-    - AiDetectable
+  - type: AiDetectable # DeltaV - AI detector
 
 # The holographic representation of the AI that is projected from a holopad.
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -478,6 +478,9 @@
     - state: ai_camera
       shader: unshaded
       map: ["base"]
+  - type: Tag # DeltaV - AI detector
+    tags:
+    - AiDetectable
 
 # The holographic representation of the AI that is projected from a holopad.
 - type: entity

--- a/Resources/Prototypes/_DV/Catalog/Uplink/deception.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/deception.yml
@@ -1,0 +1,29 @@
+- type: listing
+  id: Observationkit
+  name: uplink-observation-kit-name
+  description: uplink-observation-kit-desc-deltav
+  icon:
+    sprite: Objects/Storage/boxicons.rsi
+    state: tracks
+  productEntity: Observationskit
+  discountCategory: usualDiscounts
+  discountDownTo:
+    Telecrystal: 3
+  cost:
+    Telecrystal: 6
+  categories:
+  - UplinkDeception
+
+- type: listing
+  id: MultitoolAiDetector
+  name: uplink-ai-detector-name
+  description: uplink-ai-detector-desc
+  icon:
+    sprite: Objects/Tools/multitool.rsi
+    state: icon
+  productEntity: MultitoolAiDetector
+  cost:
+    Telecrystal: 1
+  categories:
+  - UplinkDeception
+

--- a/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_DV/Catalog/uplink_catalog.yml
@@ -78,20 +78,6 @@
       - SurplusBundle
 
 - type: listing
-  id: Observationkit
-  name: uplink-observation-kit-name
-  description: uplink-observation-kit-desc
-  icon: { sprite: /Textures/Objects/Storage/boxicons.rsi, state: tracks }
-  productEntity: Observationskit
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 3
-  cost:
-    Telecrystal: 6 # DeltaV - Price Goes up, but the goods are better!
-  categories:
-  - UplinkDeception
-
-- type: listing
   id: UplinkSyndicateRadioImplanter
   name: uplink-syndicate-radio-implanter-name
   description: uplink-syndicate-radio-implanter-desc

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/ai_detector.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/ai_detector.yml
@@ -47,7 +47,7 @@
           red: { state: "red-unlit" }
   - type: CollidingVisuals
     whitelist:
-      tags:
+      components:
       - AiDetectable
     fixtures:
     - red

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/ai_detector.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/ai_detector.yml
@@ -42,7 +42,7 @@
     visuals:
       enum.CollidingVisuals.Fixture:
         enum.CollidingVisuals.Layer:
-          default: { state: "green-unlit" }
+          none: { state: "green-unlit" }
           yellow: { state: "yellow-unlit" }
           red: { state: "red-unlit" }
   - type: CollidingVisuals

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/ai_detector.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/ai_detector.yml
@@ -1,0 +1,57 @@
+- type: entity
+  parent: Multitool
+  id: MultitoolAiDetector
+  suffix: AI Detector
+  components:
+  - type: Sprite
+    layers:
+    - state: icon
+    - state: green-unlit
+      shader: unshaded
+      map: [ enum.CollidingVisuals.Layer ]
+  - type: Physics
+    canCollide: true
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape: !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemMask
+        restitution: 0.3  # fite me
+        friction: 0.2
+      yellow:
+        shape: !type:PhysShapeCircle
+          radius: 12
+        density: 0
+        hard: false
+        mask:
+        - GhostImpassable
+      red:
+        shape: !type:PhysShapeCircle
+          radius: 5
+        density: 0
+        hard: false
+        mask:
+        - GhostImpassable
+  - type: CollisionWake # don't stop checking for AI just because this isn't moving
+    enabled: false
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.CollidingVisuals.Fixture:
+        enum.CollidingVisuals.Layer:
+          default: { state: "green-unlit" }
+          yellow: { state: "yellow-unlit" }
+          red: { state: "red-unlit" }
+  - type: CollidingVisuals
+    whitelist:
+      tags:
+      - AiDetectable
+    fixtures:
+    - red
+    - yellow
+  - type: MappingCategories # don't map valid multitool by mistake
+    categories:
+    - Syndicate

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -1,6 +1,9 @@
 ## This is for Nyano and Delta V tags
 
 - type: Tag
+  id: AiDetectable
+
+- type: Tag
   id: Bayonet #Craftable Musket
 
 - type: Tag

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -1,9 +1,6 @@
 ## This is for Nyano and Delta V tags
 
 - type: Tag
-  id: AiDetectable
-
-- type: Tag
   id: Bayonet #Craftable Musket
 
 - type: Tag


### PR DESCRIPTION
## About the PR
for only 1 tc you can now know when AI is near/watching you!
it goes yellow when in a 12 tile radius ( a little less than a screen) and red when in a 5 tile radius (basically on you)

## Why / Balance
traitors have no wait to work around AI besides minibombing it which is obviously massively out of proportion if they just need to steal stuff

ss13 parity, at least with yogstation

## Technical details
added `CollidingVisualsComponent` to check collide start/end and control appearance 

## Media
![04:08:18](https://github.com/user-attachments/assets/b9ee6b46-1891-4a4e-9185-75ea9a4e5336)

![04:22:03](https://github.com/user-attachments/assets/1ddb44f5-3160-46e5-9d2a-323948ce6b4b)

![04:22:09](https://github.com/user-attachments/assets/962f7ab7-6544-4d9f-b86a-1037329b514b)

ghosts dont set it off despite colliding with the fixtures
![04:45:03](https://github.com/user-attachments/assets/f5142850-cbb3-423f-9a99-341ed417d72d)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: Added the AI detector to traitor and nukie uplinks for 1 TC.
