### PR TITLE
Buff glimmer wisp

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -134,12 +134,13 @@
   # combat
   - type: Gun
     fireRate: 0.7
+    burstFireRate: 3
     soundGunshot:
       collection: MagicMissile
     showExamineText: false
-    selectedMode: SemiAuto
+    selectedMode: Burst
     availableModes:
-    - SemiAuto
+    - Burst
   - type: HitscanBatteryAmmoProvider
     proto: WispLash
     fireCost: 1


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
made it shoot a 3 round burst at a higher fire-rate

## Why / Balance
these things require 300 glimmer minimum to spawn, they should be slightly more evil. eventually they should also be unpullable but forced inherit is evil.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: Glimmer wisps are now deadlier, psionics beware