### PR TITLE
make steel heal caustic for ipcs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -45,6 +45,14 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 100
+  - type: Healing # DeltaV - steel heals caustic damage for IPCs
+    delay: 1
+    damageContainers:
+    - Silicon
+    - HumanoidSilicon
+    damage:
+      types:
+        Caustic: -5
   - type: Stack
     stackType: Steel
     baseLayer: base

--- a/Resources/ServerInfo/Guidebook/Mobs/IPCs.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/IPCs.xml
@@ -36,7 +36,10 @@
   </Box>
   <Box HorizontalAlignment="Stretch">
     <GuideEntityEmbed Entity="CableApcStack" Caption="Cables (any type)"/>
-    Cables can be used to repair [color=yellow]Burns[/color].
+    Cables can be used to repair [color=yellow]Burns[/color], except for caustic.
+
+    <GuideEntityEmbed Entity="SheetSteel" Caption="Steel Sheets"/>
+    Steel can be used to repair [color=yellow]Caustic[/color] damage.
   </Box>
   <Box HorizontalAlignment="Stretch">
     <GuideEntityEmbed Entity="SheetGlass" Caption="Glass Sheets (any type)"/>


### PR DESCRIPTION
## About the PR
1 sheet heals 5 caustic, 24 will heal an ipc from death to full

updated guidebook too

## Why / Balance
fixes #3182

**Changelog**
:cl:
- tweak: IPCs can now use steel to heal Caustic damage.