### PR TITLE
Deal damage when dragging downed people

### DIFF
--- a/Content.Client/_DV/DamageOnDrag/DamageOnDragSystem.cs
+++ b/Content.Client/_DV/DamageOnDrag/DamageOnDragSystem.cs
@@ -1,0 +1,5 @@
+using Content.Shared._DV.DamageOnDrag;
+
+namespace Content.Client._DV.DamageOnDrag;
+
+public sealed class DamageOnDragSystem : SharedDamageOnDragSystem;

--- a/Content.Server/_DV/DamageOnDrag/DamageOnDragSystem.cs
+++ b/Content.Server/_DV/DamageOnDrag/DamageOnDragSystem.cs
@@ -1,0 +1,29 @@
+using Content.Server.Body.Components;
+using Content.Server.Body.Systems;
+using Content.Shared._DV.DamageOnDrag;
+using Content.Shared.Damage;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared._DV.DamageOnDrag;
+
+public class DamageOnDragSystem : SharedDamageOnDragSystem
+{
+    [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private BloodstreamSystem _bloodstream = default!;
+
+    protected override void HandleBloodstreamDamage(Entity<DamageOnDragComponent> ent, ref MoveEvent args)
+    {
+        if (!TryComp<BloodstreamComponent>(ent, out var bloodstream) || bloodstream.BleedAmount <= 0)
+            return;
+
+        var factor = (args.NewPosition.Position - args.OldPosition.Position).Length();
+        var normalDamage = ent.Comp.Bleeding * factor;
+
+        _damageable.TryChangeDamage(ent, normalDamage);
+
+        if (ent.Comp.BleedingWorsenAmount is not {} amount)
+            return;
+
+        _bloodstream.TryModifyBleedAmount(ent, amount * factor);
+    }
+}

--- a/Content.Shared/_DV/DamageOnDrag/DamageOnDragComponent.cs
+++ b/Content.Shared/_DV/DamageOnDrag/DamageOnDragComponent.cs
@@ -1,0 +1,33 @@
+using Content.Shared.Damage;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.DamageOnDrag;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class DamageOnDragComponent : Component
+{
+    /// <summary>
+    ///     The amount of damage dealt per meter of drag
+    /// </summary>
+    [DataField(required: true)]
+    public DamageSpecifier Damage = default!;
+
+    /// <summary>
+    ///     The amount of damage dealt per meter of drag, if the target is bleeding
+    /// </summary>
+    [DataField]
+    public DamageSpecifier Bleeding = default!;
+
+    /// <summary>
+    ///     How much to worsen bleeding by per meter of drag, if the target is bleeding
+    /// </summary>
+    [DataField]
+    public float? BleedingWorsenAmount = 4f;
+
+    /// <summary>
+    ///     How much damage can be dealt before the entity will stop taking damage from drag
+    /// </summary>
+    [DataField]
+    public FixedPoint2 DamageUpperBound = 250;
+}

--- a/Content.Shared/_DV/DamageOnDrag/SharedDamageOnDragSystem.cs
+++ b/Content.Shared/_DV/DamageOnDrag/SharedDamageOnDragSystem.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Damage;
+using Robust.Shared.GameObjects;
+
+namespace Content.Shared._DV.DamageOnDrag;
+
+public abstract class SharedDamageOnDragSystem : EntitySystem
+{
+    [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private MobStateSystem _mobState = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<DamageOnDragComponent, MoveEvent>(OnMove);
+    }
+
+    private void OnMove(Entity<DamageOnDragComponent> ent, ref MoveEvent args)
+    {
+        if (TerminatingOrDeleted(ent))
+            return;
+
+        var dragging = _mobState.IsIncapacitated(ent);
+        if (!dragging)
+            return;
+
+        if (TryComp<DamageableComponent>(ent, out var damage) && damage.TotalDamage >= ent.Comp.DamageUpperBound)
+            return;
+
+        var factor = (args.NewPosition.Position - args.OldPosition.Position).Length();
+        var normalDamage = ent.Comp.Damage * factor;
+
+        _damageable.TryChangeDamage(ent, normalDamage);
+        HandleBloodstreamDamage(ent, ref args);
+    }
+
+    protected virtual void HandleBloodstreamDamage(Entity<DamageOnDragComponent> ent, ref MoveEvent args)
+    {
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -256,6 +256,13 @@
         Heat: -0.07
       groups:
         Brute: -0.07
+  - type: DamageOnDrag # DeltaV - damage on dragging downed people
+    damage:
+      groups:
+        Brute: 0.8
+    bleeding:
+      types:
+        Poison: 0.2
   - type: Fingerprint
   - type: Blindable
   # Other

--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -66,6 +66,10 @@
       60: 0.7
       80: 0.5 # DeltaV - was 90
       100: 0.3 # DeltaV - was 120, which is irrelvant?
+  - type: DamageOnDrag # DeltaV - damage on dragging downed people
+    damage:
+      groups:
+        Brute: 0.8
   - type: SiliconDownOnDead
   - type: Speech
   - type: Deathgasp


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Species now take damage when being dragged on the floor in a dead or critical state.

## Why / Balance
- we have rollerbeds
- maybe let the medical professional come and get the patient instead of leaving a bloody trail to medical
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
- new DamageOnDragComponent & its system that gets added to existing mob protototypes

## Media
https://github.com/user-attachments/assets/3a554082-58de-47cb-bf31-dc968385ef77

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Dragging downed people on the floor now deals damage to them
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
