### PR TITLE
remove summon guns and summon magic event spells

### DIFF
--- a/Resources/Locale/en-US/_DV/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/_DV/store/spellbook-catalog.ftl
@@ -1,0 +1,3 @@
+# DeltaV spellbook catalogs
+
+spellbook-event-summon-ghosts-description-deltav = Summons ghosts for all to see! Disables refunds when bought!

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -70,7 +70,7 @@ spellbook-staff-animation-description = Bring inanimate objects to life!
 # Events
 
 spellbook-event-summon-ghosts-name = Summon Ghosts
-spellbook-event-summon-ghosts-description = Summons ghosts for all to see! Disables refunds when bought! 
+spellbook-event-summon-ghosts-description = Who ya gonna call?
 
 spellbook-event-summon-guns-name = Summon Guns
 spellbook-event-summon-guns-description = AK47s for everyone! Places a random gun in front of everybody. Disables refunds when bought!

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -70,7 +70,7 @@ spellbook-staff-animation-description = Bring inanimate objects to life!
 # Events
 
 spellbook-event-summon-ghosts-name = Summon Ghosts
-spellbook-event-summon-ghosts-description = Who ya gonna call?
+spellbook-event-summon-ghosts-description = Summons ghosts for all to see! Disables refunds when bought! # DeltaV 
 
 spellbook-event-summon-guns-name = Summon Guns
 spellbook-event-summon-guns-description = AK47s for everyone! Places a random gun in front of everybody. Disables refunds when bought!

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -70,7 +70,7 @@ spellbook-staff-animation-description = Bring inanimate objects to life!
 # Events
 
 spellbook-event-summon-ghosts-name = Summon Ghosts
-spellbook-event-summon-ghosts-description = Summons ghosts for all to see! Disables refunds when bought! # DeltaV 
+spellbook-event-summon-ghosts-description = Summons ghosts for all to see! Disables refunds when bought! 
 
 spellbook-event-summon-guns-name = Summon Guns
 spellbook-event-summon-guns-description = AK47s for everyone! Places a random gun in front of everybody. Disables refunds when bought!

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -266,46 +266,46 @@
     stock: 1
 
 # Event
-- type: listing
-  id: SpellbookEventSummonGhosts
-  name: spellbook-event-summon-ghosts-name
-  description: spellbook-event-summon-ghosts-description
-  productAction: ActionSummonGhosts
-  cost:
-    WizCoin: 0
-  categories:
-  - SpellbookEvents
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+#- type: listing
+#  id: SpellbookEventSummonGhosts
+#  name: spellbook-event-summon-ghosts-name
+#  description: spellbook-event-summon-ghosts-description
+#  productAction: ActionSummonGhosts
+#  cost:
+#    WizCoin: 0
+#  categories:
+#  - SpellbookEvents
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
-- type: listing
-  id: SpellbookEventSummonGuns
-  name: spellbook-event-summon-guns-name
-  description: spellbook-event-summon-guns-description
-  productAction: ActionSummonGuns
-  cost:
-    WizCoin: 2
-  categories:
-  - SpellbookEvents
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-  disableRefund: true
+#- type: listing
+#  id: SpellbookEventSummonGuns
+#  name: spellbook-event-summon-guns-name
+#  description: spellbook-event-summon-guns-description
+#  productAction: ActionSummonGuns
+#  cost:
+#    WizCoin: 2
+#  categories:
+#  - SpellbookEvents
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
+#  disableRefund: true
 
-- type: listing
-  id: SpellbookEventSummonMagic
-  name: spellbook-event-summon-magic-name
-  description: spellbook-event-summon-magic-description
-  productAction: ActionSummonMagic
-  cost:
-    WizCoin: 2
-  categories:
-  - SpellbookEvents
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
-  disableRefund: true
+#- type: listing
+#  id: SpellbookEventSummonMagic
+#  name: spellbook-event-summon-magic-name
+#  description: spellbook-event-summon-magic-description
+#  productAction: ActionSummonMagic
+#  cost:
+#    WizCoin: 2
+#  categories:
+#  - SpellbookEvents
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
+#  disableRefund: true
 
 # Upgrades
 - type: listing

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -265,8 +265,8 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-# Event
-#- type: listing
+# Event 
+#- type: listing # DeltaV - Commented out
 #  id: SpellbookEventSummonGhosts
 #  name: spellbook-event-summon-ghosts-name
 #  description: spellbook-event-summon-ghosts-description
@@ -279,7 +279,7 @@
 #  - !type:ListingLimitedStockCondition
 #    stock: 1
 
-#- type: listing
+#- type: listing # DeltaV - Commented out
 #  id: SpellbookEventSummonGuns
 #  name: spellbook-event-summon-guns-name
 #  description: spellbook-event-summon-guns-description
@@ -293,7 +293,7 @@
 #    stock: 1
 #  disableRefund: true
 
-#- type: listing
+#- type: listing # DeltaV - Commented out
 #  id: SpellbookEventSummonMagic
 #  name: spellbook-event-summon-magic-name
 #  description: spellbook-event-summon-magic-description

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -265,8 +265,8 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-# Event 
-- type: listing 
+# Event
+- type: listing
   id: SpellbookEventSummonGhosts
   name: spellbook-event-summon-ghosts-name
   description: spellbook-event-summon-ghosts-description

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -269,7 +269,7 @@
 - type: listing
   id: SpellbookEventSummonGhosts
   name: spellbook-event-summon-ghosts-name
-  description: spellbook-event-summon-ghosts-description
+  description: spellbook-event-summon-ghosts-description-deltav
   productAction: ActionSummonGhosts
   cost:
     WizCoin: 2

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -269,7 +269,7 @@
 - type: listing
   id: SpellbookEventSummonGhosts
   name: spellbook-event-summon-ghosts-name
-  description: spellbook-event-summon-ghosts-description-deltav
+  description: spellbook-event-summon-ghosts-description-deltav # DeltaV
   productAction: ActionSummonGhosts
   cost:
     WizCoin: 2

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -266,18 +266,19 @@
     stock: 1
 
 # Event 
-#- type: listing # DeltaV - Commented out
-#  id: SpellbookEventSummonGhosts
-#  name: spellbook-event-summon-ghosts-name
-#  description: spellbook-event-summon-ghosts-description
-#  productAction: ActionSummonGhosts
-#  cost:
-#    WizCoin: 0
-#  categories:
-#  - SpellbookEvents
-#  conditions:
-#  - !type:ListingLimitedStockCondition
-#    stock: 1
+- type: listing 
+  id: SpellbookEventSummonGhosts
+  name: spellbook-event-summon-ghosts-name
+  description: spellbook-event-summon-ghosts-description
+  productAction: ActionSummonGhosts
+  cost:
+    WizCoin: 2
+  categories:
+  - SpellbookEvents
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+  disableRefund: true
 
 #- type: listing # DeltaV - Commented out
 #  id: SpellbookEventSummonGuns


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
the gun and spell item event spells

makes ghosts disable refunds and cost 2 wizcoin

## Why / Balance
So we can playtest it without worrying about a player pressing the "everyone gets a gun" button

wizard should not be able to run showghosts simply by existing
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
