### PR TITLE
Make the surgery dirtiness status also reflect gloves & mask

### DIFF
--- a/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
+++ b/Content.Client/_DV/Surgery/SurgeryCleanSystem.cs
@@ -1,5 +1,7 @@
 using Content.Client.Items;
 using Content.Shared._DV.Surgery;
+using Content.Shared.Inventory;
+using Robust.Shared.Containers;
 
 namespace Content.Client._DV.Surgery;
 
@@ -8,11 +10,14 @@ namespace Content.Client._DV.Surgery;
 /// </summary>
 public sealed class SurgeryCleanSystem : SharedSurgeryCleanSystem
 {
+    [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
-        Subs.ItemStatus<SurgeryDirtinessComponent>(ent => new SurgeryDirtinessItemStatus(ent, EntityManager));
+        Subs.ItemStatus<SurgeryDirtinessComponent>(ent => new SurgeryDirtinessItemStatus(ent, EntityManager, _inventory, _container));
     }
 
     public override bool RequiresCleaning(EntityUid target)

--- a/Content.Client/_DV/Surgery/SurgeryDirtinessItemStatus.cs
+++ b/Content.Client/_DV/Surgery/SurgeryDirtinessItemStatus.cs
@@ -1,6 +1,10 @@
+using System.Numerics;
 using Content.Client.UserInterface.Controls;
 using Content.Shared._DV.Surgery;
+using Content.Shared._Shitmed.Medical.Surgery.Tools;
 using Content.Shared.FixedPoint;
+using Content.Shared.Inventory;
+using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 
 namespace Content.Client._DV.Surgery;
@@ -9,12 +13,23 @@ public sealed class SurgeryDirtinessItemStatus : SplitBar
 {
     private readonly IEntityManager _entMan;
     private readonly EntityUid _uid;
+    private readonly InventorySystem _inventory;
+    private readonly SharedContainerSystem _container;
     private FixedPoint2? _dirtiness = null;
+    private FixedPoint2? _gloveDirtiness = null;
 
-    public SurgeryDirtinessItemStatus(EntityUid uid, IEntityManager entMan)
+    private static readonly Color SelfCleanColor = new Color(0xD1, 0xD5, 0xD9);
+    private static readonly Color SelfDirtyColor = new Color(0xE9, 0x3D, 0x58);
+    private static readonly Color GloveCleanColor = new Color(0xAB, 0xE9, 0xFB);
+    private static readonly Color GloveDirtyColor = new Color(0xE9, 0x64, 0x3A);
+
+    public SurgeryDirtinessItemStatus(EntityUid uid, IEntityManager entMan, InventorySystem inventory, SharedContainerSystem container)
     {
         _uid = uid;
         _entMan = entMan;
+        _inventory = inventory;
+        _container = container;
+        MinBarSize = new Vector2(10, 0);
         Margin = new Thickness(4);
         MinHeight = 16;
         MaxHeight = 16;
@@ -27,19 +42,58 @@ public sealed class SurgeryDirtinessItemStatus : SplitBar
         if (!_entMan.TryGetComponent<SurgeryDirtinessComponent>(_uid, out var comp))
             return;
 
-        if (_dirtiness == comp.Dirtiness)
+        var isTool = _entMan.HasComponent<SurgeryToolComponent>(_uid);
+
+        if (_dirtiness == comp.Dirtiness && !isTool)
             return;
         _dirtiness = comp.Dirtiness;
 
-        Clear();
+        if (isTool && _container.TryGetContainingContainer((_uid, null, null), out var container))
+        {
+            var user = container.Owner;
 
-        var amount = FixedPoint2.Min(_dirtiness.Value / 100, 1);
-        var remaining = 1 - amount;
+            FixedPoint2? glovesDirtiness =
+                _inventory.TryGetSlotEntity(user, "gloves", out var gloves)
+                    ? _entMan.TryGetComponent<SurgeryDirtinessComponent>(_uid, out var glovesComp)
+                        ? glovesComp.Dirtiness
+                        : FixedPoint2.Zero
+                    : null;
 
-        if (amount != FixedPoint2.Zero)
-            AddEntry(amount.Float(), amount < 0.5 ? Color.RosyBrown : Color.Red);
+            if (_gloveDirtiness == glovesDirtiness)
+                return;
+            _gloveDirtiness = glovesDirtiness;
 
-        if (remaining != FixedPoint2.Zero)
-            AddEntry(remaining.Float(), Color.SlateGray);
+            Clear();
+
+            var toolAmount = FixedPoint2.Min(_dirtiness.Value / 100, 1);
+            var gloveAmount = FixedPoint2.Min((_gloveDirtiness ?? 0) / 100, 1);
+            var remaining = 1 - toolAmount - gloveAmount;
+
+            var clean = (_dirtiness + (_gloveDirtiness ?? 0)) < 50;
+            var maskOn = _inventory.TryGetSlotEntity(user, "mask", out var _);
+            var isFine = clean && maskOn && _gloveDirtiness is not null;
+
+            if (toolAmount != FixedPoint2.Zero)
+                AddEntry(toolAmount.Float() * 100, isFine ? SelfCleanColor : SelfDirtyColor);
+
+            if (gloveAmount != FixedPoint2.Zero)
+                AddEntry(gloveAmount.Float() * 100, isFine ? GloveCleanColor : GloveDirtyColor);
+
+            if (remaining > FixedPoint2.Zero)
+                AddEntry(remaining.Float() * 100, Color.SlateGray);
+        }
+        else
+        {
+            Clear();
+
+            var amount = FixedPoint2.Min(_dirtiness.Value / 100, 1);
+            var remaining = 1 - amount;
+
+            if (amount != FixedPoint2.Zero)
+                AddEntry(amount.Float(), amount < 0.5 ? SelfCleanColor : SelfDirtyColor);
+
+            if (remaining != FixedPoint2.Zero)
+                AddEntry(remaining.Float(), Color.SlateGray);
+        }
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The surgery dirtiness status on tools now reflects the dirtiness of the gloves as a separate segment, and also turns red if a mask isn't being worn.

## Why / Balance
- it's hard to tell when you start doing damage because of additive

## Technical details
- updated the surgery dirtiness status item

## Media
![grafik](https://github.com/user-attachments/assets/a8d9c0de-9cf0-4dd8-91dd-d98991cc0ec5)
![grafik](https://github.com/user-attachments/assets/53ed8134-0490-4a49-9c49-2f85ae3fdb80)


<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The clean meter of a surgery tool in the hotbar now also indicates the cleanliness of the gloves and absence of a mask
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
