### PR TITLE
various access related fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -314,7 +314,7 @@
     tags:
     - Borg
   - type: AccessReader
-    access: [["Command"], ["Research"]]
+    access: [["Command"], ["Research"], ["Robotics"]] # DeltaV - add Robotics
     breakOnAccessBreaker: false # DeltaV - prevent emag metachecking by unlocking without an id
   - type: SlavedBorg # DeltaV: NT borgs are enslaved to the AI by default
     law: ObeyAI
@@ -375,7 +375,7 @@
     groups:
     - AllAccess #Randomized access would be fun. AllAccess is the best i can think of right now that does make it too hard for it to enter the station or navigate it..
   - type: AccessReader
-    access: [["Command"], ["Research"]]
+    access: [["Command"], ["Robotics"]] # DeltaV - Robotics instead of Research
   - type: StartIonStormed
     ionStormAmount: 3
   - type: IonStormTarget

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -77,6 +77,9 @@
         whitelist:
           components:
           - IdCard
+        blacklist: # DeltaV - prevent removing access using borg id chips
+          tags:
+          - IdChip
       denialSound:
         path: /Audio/Machines/custom_deny.ogg
       doAfter: 0.5

--- a/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/access_configurator.yml
@@ -22,8 +22,7 @@
       - Armory
       - Atmospherics
       - Bar
-      #- Brig #Delta V: Removed Brig Access
-      - Boxer #Delta V: Add Boxer Access
+      #- Brig # DeltaV - Removed Brig Access
       - Detective
       - Captain
       - Cargo
@@ -31,8 +30,6 @@
       - Chemistry
       - ChiefEngineer
       - ChiefMedicalOfficer
-      - Clown #Delta V: Add Clown Access
-      - Corpsman # DeltaV: Add Corpsman access
       - Command
       - Engineering
       - External
@@ -42,30 +39,35 @@
       - Janitor
       - Kitchen
       - Lawyer
-      - Library #Delta V: Add Library Access
-      - Mail #Nyanotrasen: Add Mail Access
       - Maintenance
-      - Mantis #Nyanotrasen: Add Mantis Access
       - Medical
-      - Mime #Delta V: Add Mime Access
-      - Musician #Delta V: Add Musician Access
-      - Paramedic # Delta V - adds Paramedic access
-      - Psychologist #Delta V: Add Psychologist Access
       - Quartermaster
-      - Reporter #Delta V: Add Reporter Access
       - Research
       - ResearchDirector
-      - Robotics # DeltaV: Robotics access
       - Salvage
       - Security
       - Service
-      - Surgery # Delta V: Add Surgery access
       - Theatre
-      - Zookeeper #Delta V: Add Zookeeper Access
-      - ChiefJustice  #Delta V: Add Chief Justice Access
-      - Prosecutor  #Delta V: Add Prosecutor Access
-      - Justice  #Delta V: Add Justice Access
-      - Clerk  #Delta V: Add Clerk Access
+      # Begin DeltaV Additions
+      - Boxer
+      - ChiefJustice
+      - Clerk
+      - Clown
+      - Corpsman
+      - Justice
+      - Library
+      - Mail
+      - Mantis
+      - Mime
+      - Musician
+      - Paramedic
+      - Prosecutor
+      - Psychologist
+      - Reporter
+      - Robotics
+      - Surgery
+      - Zookeeper
+      # End DeltaV Additions
       privilegedIdSlot:
         name: id-card-console-privileged-id
         ejectSound: /Audio/Machines/id_swipe.ogg
@@ -144,14 +146,25 @@
     - SyndicateAgent
     - Wizard
     # Begin DeltaV Additions
+    - Boxer
     - ChiefJustice
     - Clerk
-    - Justice
+    - Clown
+    - Corpsman
     - DV-SpareSafe
-    - Orders
+    - Justice
+    - Library
+    - Mail
+    - Mantis
+    - Mime
+    - Musician
+    - Paramedic
     - Prosecutor
+    - Psychologist
+    - Reporter
     - Robotics
     - Surgery
+    - Zookeeper
     # End DeltaV Additions
     privilegedIdSlot:
       name: id-card-console-privileged-id

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -57,6 +57,9 @@
 - type: Tag
   id: HudMedicalSecurity #Craftable Corpsman Glasses
 
+- type: Tag # prevents ID chips being used for an id computer privileged id
+  id: IdChip
+
 - type: Tag
   id: MagazinePistolSpecial # For the .38 special ammo and pistol
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -734,9 +734,6 @@
 - type: Tag
   id: Ice
 
-- type: Tag # prevents ID chips being used for an id computer privileged id
-  id: IdChip
-
 - type: Tag
   id: Igniter
 


### PR DESCRIPTION
## About the PR
- reorganized access config to not be conflict minefield, synced admin config so it has robotics
- fixed SNR not being able to unlock generic/derelict borgs. generic borg still has research access but derelict is only command+robotics now - fixes #3225
- fixed being able to use borg id chips in access configurator to remove access from things...

![01:57:28](https://github.com/user-attachments/assets/45dc3505-d2ed-44df-828e-ecd7446f572c)

:cl:
DELTAVADMIN:
- fix: Fixed admin access configurator not having every access.