### PR TITLE
rewrite id computer toggle code

### DIFF
--- a/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
+++ b/Content.Client/Access/UI/IdCardConsoleBoundUserInterface.cs
@@ -43,6 +43,7 @@ namespace Content.Client.Access.UI
             _window.CrewManifestButton.OnPressed += _ => SendMessage(new CrewManifestOpenUiMessage());
             _window.PrivilegedIdButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent(PrivilegedIdCardSlotId));
             _window.TargetIdButton.OnPressed += _ => SendMessage(new ItemSlotButtonPressedEvent(TargetIdCardSlotId));
+            _window.OnToggleAccess += id => SendMessage(new IdCardConsoleToggleMessage(id)); // DeltaV
 
             _window.OnClose += Close;
             _window.OpenCentered();

--- a/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
+++ b/Content.Client/Access/UI/IdCardConsoleWindow.xaml.cs
@@ -30,6 +30,8 @@ namespace Content.Client.Access.UI
         // The job that will be picked if the ID doesn't have a job on the station.
         private static ProtoId<JobPrototype> _defaultJob = "Passenger";
 
+        public event Action<ProtoId<AccessLevelPrototype>>? OnToggleAccess; // DeltaV
+
         public IdCardConsoleWindow(IdCardConsoleBoundUserInterface owner, IPrototypeManager prototypeManager,
             List<ProtoId<AccessLevelPrototype>> accessLevels)
         {
@@ -73,7 +75,8 @@ namespace Content.Client.Access.UI
 
             foreach (var (id, button) in _accessButtons.ButtonsList)
             {
-                button.OnPressed += _ => SubmitData();
+                var copied = id; // DeltaV
+                button.OnPressed += _ => OnToggleAccess?.Invoke(id);
             }
         }
 
@@ -198,7 +201,7 @@ namespace Content.Client.Access.UI
                 FullNameLineEdit.Text,
                 JobTitleLineEdit.Text,
                 // Iterate over the buttons dictionary, filter by `Pressed`, only get key from the key/value pair
-                _accessButtons.ButtonsList.Where(x => x.Value.Pressed).Select(x => x.Key).ToList(),
+                [], // DeltaV - don't send list of accesses
                 jobProtoDirty ? _jobPrototypeIds[JobPresetOptionButton.SelectedId] : string.Empty);
         }
     }

--- a/Content.Server/Access/Systems/IdCardConsoleSystem.cs
+++ b/Content.Server/Access/Systems/IdCardConsoleSystem.cs
@@ -17,7 +17,7 @@ using Content.Shared.Access;
 namespace Content.Server.Access.Systems;
 
 [UsedImplicitly]
-public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
+public sealed partial class IdCardConsoleSystem : SharedIdCardConsoleSystem // DeltaV - made partial
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly StationRecordsSystem _record = default!;
@@ -37,6 +37,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         SubscribeLocalEvent<IdCardConsoleComponent, ComponentStartup>(UpdateUserInterface);
         SubscribeLocalEvent<IdCardConsoleComponent, EntInsertedIntoContainerMessage>(UpdateUserInterface);
         SubscribeLocalEvent<IdCardConsoleComponent, EntRemovedFromContainerMessage>(UpdateUserInterface);
+        InitializeToggle(); // DeltaV
     }
 
     private void OnWriteToTargetIdMessage(EntityUid uid, IdCardConsoleComponent component, WriteToTargetIdMessage args)
@@ -136,6 +137,7 @@ public sealed class IdCardConsoleSystem : SharedIdCardConsoleSystem
         }
 
         UpdateStationRecord(uid, targetId, newFullName, newJobTitle, job);
+        return; // DeltaV - use custom access toggle message, stop here
 
         if (!newAccessList.TrueForAll(x => component.AccessLevels.Contains(x)))
         {

--- a/Content.Server/_DV/Access/Systems/IdCardConsoleSystem.Toggle.cs
+++ b/Content.Server/_DV/Access/Systems/IdCardConsoleSystem.Toggle.cs
@@ -1,0 +1,59 @@
+using Content.Shared.Access;
+using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
+using Content.Shared.Database;
+using System.Linq;
+
+namespace Content.Server.Access.Systems;
+
+public sealed partial class IdCardConsoleSystem
+{
+    private void InitializeToggle()
+    {
+        Subs.BuiEvents<IdCardConsoleComponent>(IdCardConsoleComponent.IdCardConsoleUiKey.Key, subs =>
+        {
+            subs.Event<IdCardConsoleToggleMessage>(OnToggle);
+        });
+    }
+
+    private void OnToggle(Entity<IdCardConsoleComponent> ent, ref IdCardConsoleToggleMessage args)
+    {
+        if (ent.Comp.TargetIdSlot.Item is not {} targetId ||
+            ent.Comp.PrivilegedIdSlot.Item is not {} privilegedId ||
+            !PrivilegedIdIsAuthorized(ent, ent) ||
+            // malf client
+            !_prototype.HasIndex(args.Id))
+        {
+            return;
+        }
+
+        // malf client
+        var user = args.Actor;
+        if (!ent.Comp.AccessLevels.Contains(args.Id))
+        {
+            _sawmill.Warning($"User {ToPrettyString(user)} tried to write unknown access tag.");
+            return;
+        }
+
+        if (!TryComp<AccessComponent>(targetId, out var access))
+            return;
+
+        // malf client
+        var privilegedPerms = _accessReader.FindAccessTags(privilegedId).ToHashSet();
+        if (!privilegedPerms.Contains(args.Id))
+            return;
+
+        var adding = !access.Tags.Contains(args.Id);
+        if (adding)
+            access.Tags.Add(args.Id);
+        else
+            access.Tags.Remove(args.Id);
+        Dirty(targetId, access);
+
+        var verb = adding ? "added" : "removed";
+        var prefix = adding ? "to" : "from";
+        // TODO: only log changes when ejecting the id
+        _adminLogger.Add(LogType.Action, LogImpact.Medium,
+            $"{ToPrettyString(user):user} has {verb} access level '{args.Id}' {prefix} {ToPrettyString(targetId):entity}");
+    }
+}

--- a/Content.Shared/_DV/Access/IdCardConsoleUI.cs
+++ b/Content.Shared/_DV/Access/IdCardConsoleUI.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Access;
+
+/// <summary>
+/// UI message for toggling an access level on an ID card console.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class IdCardConsoleToggleMessage(ProtoId<AccessLevelPrototype> id) : BoundUserInterfaceMessage
+{
+    public readonly ProtoId<AccessLevelPrototype> Id = id;
+}


### PR DESCRIPTION
## About the PR
just send the access to toggle

## Why / Balance
- fix borg id chips / agent ids not being writable because of hidden accesses
- no longer have to deal with ping unsetting access
- it should never have been send server a list for every click least insane impl

AA logging is also much shorter as it just logs the changed access not n! accesses

## Technical details
just send the access to toggle

## Media
![09:32:25](https://github.com/user-attachments/assets/39e6d7c9-96dd-4a18-93db-0716f5231d09)


**Changelog**
:cl:
- tweak: ID computer now toggles accesses so it works nicer when spam clicking.
- fix: Fixed not being able to change borg id chip access.
