### PR TITLE
Reptilians and Feroxi can't eat chocolate bars (womp womp)

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -41,7 +41,7 @@
     state: boritos
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketBoritosTrash
 
 - type: entity
@@ -57,7 +57,7 @@
     state: cnds
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketCnDsTrash
 
 - type: entity
@@ -74,7 +74,7 @@
     state: cheesiehonkers
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketCheesieTrash
 
 - type: entity
@@ -92,7 +92,7 @@
     state: chips
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketChipsTrash
 
 - type: entity
@@ -131,8 +131,7 @@
   - type: Item
   - type: Tag
     tags:
-      - FoodSnack
-      - ReptilianFood
+      - FoodSnack # DeltaV - removed ReptilianFood tag since chocolate isn't fruit or meat
   - type: SolutionContainerManager
     solutions:
       food:
@@ -191,7 +190,7 @@
     state: pistachio
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketPistachioTrash
   - type: Tag
     tags:
@@ -213,7 +212,7 @@
   - type: Item
     heldPrefix: popcorn
   - type: Food
-    trash: 
+    trash:
     - FoodPacketPopcornTrash
 
 - type: entity
@@ -229,7 +228,7 @@
     state: raisins
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketRaisinsTrash
   - type: Tag
     tags:
@@ -248,7 +247,7 @@
     state: semki
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketSemkiTrash
 
 - type: entity
@@ -264,7 +263,7 @@
     state: susjerky
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketSusTrash
   - type: Tag
     tags:
@@ -283,7 +282,7 @@
     state: syndicakes
   - type: Item
   - type: Food
-    trash: 
+    trash:
     - FoodPacketSyndiTrash
 
 - type: entity
@@ -308,7 +307,7 @@
   - type: Sprite
     state: ramen
   - type: Food
-    trash: 
+    trash:
     - FoodPacketCupRamenTrash
 
 - type: entity
@@ -351,7 +350,7 @@
         - ReagentId: Soysauce
           Quantity: 2
   - type: Food
-    trash: 
+    trash:
     - FoodPacketChowMeinTrash
 
 - type: entity
@@ -380,7 +379,7 @@
         - ReagentId: Soysauce
           Quantity: 2
   - type: Food
-    trash: 
+    trash:
     - FoodPacketDanDanTrash
 
 - type: entity
@@ -406,7 +405,7 @@
     heldPrefix: packet
     size: Tiny
   - type: Food
-    trash: 
+    trash:
     - FoodCookieFortune
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -41,7 +41,7 @@
     state: boritos
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketBoritosTrash
 
 - type: entity
@@ -57,7 +57,7 @@
     state: cnds
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketCnDsTrash
 
 - type: entity
@@ -74,7 +74,7 @@
     state: cheesiehonkers
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketCheesieTrash
 
 - type: entity
@@ -92,7 +92,7 @@
     state: chips
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketChipsTrash
 
 - type: entity
@@ -190,7 +190,7 @@
     state: pistachio
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketPistachioTrash
   - type: Tag
     tags:
@@ -212,7 +212,7 @@
   - type: Item
     heldPrefix: popcorn
   - type: Food
-    trash:
+    trash: 
     - FoodPacketPopcornTrash
 
 - type: entity
@@ -228,7 +228,7 @@
     state: raisins
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketRaisinsTrash
   - type: Tag
     tags:
@@ -247,7 +247,7 @@
     state: semki
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketSemkiTrash
 
 - type: entity
@@ -263,7 +263,7 @@
     state: susjerky
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketSusTrash
   - type: Tag
     tags:
@@ -282,7 +282,7 @@
     state: syndicakes
   - type: Item
   - type: Food
-    trash:
+    trash: 
     - FoodPacketSyndiTrash
 
 - type: entity
@@ -307,7 +307,7 @@
   - type: Sprite
     state: ramen
   - type: Food
-    trash:
+    trash: 
     - FoodPacketCupRamenTrash
 
 - type: entity
@@ -350,7 +350,7 @@
         - ReagentId: Soysauce
           Quantity: 2
   - type: Food
-    trash:
+    trash: 
     - FoodPacketChowMeinTrash
 
 - type: entity
@@ -379,7 +379,7 @@
         - ReagentId: Soysauce
           Quantity: 2
   - type: Food
-    trash:
+    trash: 
     - FoodPacketDanDanTrash
 
 - type: entity
@@ -405,7 +405,7 @@
     heldPrefix: packet
     size: Tiny
   - type: Food
-    trash:
+    trash: 
     - FoodCookieFortune
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/ration.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/ration.yml
@@ -75,6 +75,7 @@
   - type: Tag
     tags:
     - Fruit # DeltaV - Allow anyone to eat it, hopefully
+    - ReptilianFood # DeltaV - Allows feroxi (shark people) to eat it
 
 - type: entity
   name: soy sustenance bar


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Made it so reptilains and feroxi can't eat chocolate bars

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Chocolate bars are neither meat or fruit.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed ReptilianFood tag from FoodSnackChocolateBar

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Feroxi and Reptilians cannot eat chocolate bars anymore. Go on, cry.