### PR TITLE
HoS Kit Buff -X-01 Improvements

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -805,7 +805,7 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
     maxCharge: 2400 # DeltaV - Double charge
-    startingCharge: 2400
+    startingCharge: 2400 # DeltaV - Double charge
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 72 # DeltaV - Triple recharge rate

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -804,10 +804,10 @@
     stealGroup: WeaponEnergyShotgun
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 2400 # DeltaV - Double charge
-    startingCharge: 2400
+    maxCharge: 1200
+    startingCharge: 1200
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 72 # DeltaV - Triple recharge rate
+    autoRechargeRate: 24
     autoRechargePause: true
     autoRechargePauseTime: 30

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -804,10 +804,10 @@
     stealGroup: WeaponEnergyShotgun
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 1200
-    startingCharge: 1200
+    maxCharge: 2400 # DeltaV - Double charge
+    startingCharge: 2400
   - type: BatterySelfRecharger
     autoRecharge: true
-    autoRechargeRate: 24
+    autoRechargeRate: 72 # DeltaV - Triple recharge rate
     autoRechargePause: true
     autoRechargePauseTime: 30

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -76,19 +76,19 @@
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
   - type: Battery
-    maxCharge: 1500
-    startingCharge: 1500
+    maxCharge: 1000
+    startingCharge: 1000
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
-    fireCost: 50
+    fireCost: 25
   - type: EnergyGun
     fireModes:
     - proto: BulletDisabler
-      fireCost: 50
+      fireCost: 25
       name: disable
       state: disabler
     - proto: BulletEnergyGunLaser
-      fireCost: 100
+      fireCost: 50
       name: lethal
       state: lethal
     # - proto: BulletEnergyGunIon

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -76,8 +76,8 @@
     soundEmpty:
       path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
   - type: Battery
-    maxCharge: 1000
-    startingCharge: 1000
+    maxCharge: 1500
+    startingCharge: 1500
   - type: ProjectileBatteryAmmoProvider
     proto: BulletDisabler
     fireCost: 50
@@ -116,6 +116,9 @@
     price: 750
   - type: StealTarget
     stealGroup: WeaponEnergyGunMultiphase
+  - type: BatterySelfRecharger
+    autoRecharge: true
+    autoRechargeRate: 25
 
 - type: entity
   name: miniature energy gun

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -116,9 +116,6 @@
     price: 750
   - type: StealTarget
     stealGroup: WeaponEnergyGunMultiphase
-  - type: BatterySelfRecharger
-    autoRecharge: true
-    autoRechargeRate: 25
 
 - type: entity
   name: miniature energy gun


### PR DESCRIPTION
2<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Simply lets the X-01 self charge, and speeds up the self charge of the Energy Shotgun. Also increases the size of both of their batteries

## Why / Balance
The X-01 was in desperate need of a buff

## Technical details
Halved the firing cost of the X-01

## Media
X-01 Disable+Lethal
![image](https://github.com/user-attachments/assets/9d4b62e6-c51d-4eee-b27a-862b8c47b23a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Heads of Security rejoice, your equipment has been re-tuned. The X-01 now has been streamlined and can fire twice as many shots before needing a charge