### PR TITLE
fix mediborg and secborg jobs not having access

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Player/silicon.yml
@@ -6,7 +6,9 @@
   - type: ContainerFill
     containers:
       borg_brain:
-      - MMIFilled
+      - PositronicBrain
+      borg_id_chip:
+      - IdChipBorgAA
   - type: ItemSlots
     slots:
       cell_slot:
@@ -23,7 +25,9 @@
   - type: ContainerFill
     containers:
       borg_brain:
-      - MMIFilled
+      - PositronicBrain
+      borg_id_chip:
+      - IdChipBorgAA
   - type: ItemSlots
     slots:
       cell_slot:


### PR DESCRIPTION
## About the PR
also fixed them having MMIs, other borgs were changed to posibrains a while ago

**Changelog**
:cl:
- fix: Fixed job-picked mediborgs and secborgs not having any access.
