### PR TITLE
Allow prisoners to roll an antagonist role.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -5,7 +5,6 @@
   playTimeTracker: JobPrisoner
   startingGear: PrisonerGear
   alwaysUseSpawner: true
-  canBeAntag: false
 #  whitelistRequired: true
   icon: "JobIconPrisoner"
   supervisors: job-supervisors-security


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Talks on the general channel of the discord prompted me to make this PR.This would allow perma prisoners to roll antagonistic roles.

## Why / Balance
Perma prisoners are seen as powerless due to their inability to escape and it usually devolves to something akin to keeping watch of kids just so they don't get hurt doing stupid shit. My intent is for this is to make perma look less like a child-care facility and more like a prison.
They currently already have a tracker implanted so rolling antag as a perma is gonna be a hard thing to execute but I think it's gonna be a fun challenge.

## Technical details
1 YAML line change.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Prisoners now are elegible for antagonistic roles like traitor, II and thief.
