### PR TITLE
Make civilian implanters require an open incision to work

### DIFF
--- a/Content.Shared/_DV/Implants/ImplanterSurgerySystem.cs
+++ b/Content.Shared/_DV/Implants/ImplanterSurgerySystem.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using Content.Shared._Shitmed.Medical.Surgery.Steps.Parts;
+using Content.Shared.Body.Components;
+using Content.Shared.Body.Part;
+using Content.Shared.Body.Systems;
+using Content.Shared.DoAfter;
+using Content.Shared.Implants;
+
+namespace Content.Shared._DV.Implants;
+
+public sealed class ImplanterSurgerySystem : EntitySystem
+{
+    [Dependency] private readonly SharedBodySystem _body = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<BodyComponent, AddImplantAttemptEvent>(OnAttemptImplant);
+    }
+
+    private void OnAttemptImplant(Entity<BodyComponent> ent, ref AddImplantAttemptEvent args)
+    {
+        if (HasComp<ImplanterSurgerylessComponent>(args.Implanter))
+            return;
+
+        var child = _body.GetBodyChildrenOfType(ent, BodyPartType.Torso).Select(it => it.Id).FirstOrDefault();
+
+        if (HasComp<IncisionOpenComponent>(child))
+            return;
+
+        args.Cancel();
+    }
+}

--- a/Content.Shared/_DV/Implants/ImplanterSurgerylessComponent.cs
+++ b/Content.Shared/_DV/Implants/ImplanterSurgerylessComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Implants;
+
+/// <summary>
+///     Indicator that an implanter doesn't require surgery to work
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ImplanterSurgerylessComponent : Component;

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -151,6 +151,7 @@
             False: {state: implanter1}
     - type: Tag
       tags: []
+    - type: ImplanterSurgeryless # DeltaV - syndicate implanters are exempt from surgery requirements
 
 #Fun implanters
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Civilian implanters (i.e. not syndicate implanters) require an open incision to be implanted, requiring surgical intervention.

## Why / Balance
As it is, civilian implanters are essentially all reward and no inconvenience, resulting in e.g. command and security members using tracking implanters designed for prisoners on themselves because of the pure utility. Rather than trying to legislate this under powergaming, making it require surgery means that there has to be an actual consideration and effort if it's worth it to go under for a bit for future safety or not.

## Technical details
- new ImplanterSurgerySystem that blocks implanting if there isn't an open torso incision unless there's a ImplanterSurgerylessComponent 

## Media

https://github.com/user-attachments/assets/af537925-b0d3-48f1-9055-fad6a765731d



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Civilian implanters (non Syndicate implanters) now require an incision to be surgically opened to be implanted
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
