### PR TITLE
Fix sec winter coats being unable to hold weaponry in suit storage

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -366,7 +366,7 @@
 
 ##########################################################
 - type: entity
-  parent: [ClothingOuterArmorHoS, ClothingOuterWinterCoatToggleable, BaseSecurityCommandContraband]
+  parent: [ClothingOuterArmorHoS, ClothingOuterArmoredWinterCoatToggleable, BaseSecurityCommandContraband] # DeltaV - Replaced ClothingOuterWinterCoatToggleable with ClothingOuterArmoredWinterCoatToggleable
   id: ClothingOuterWinterHoS
   name: head of security's armored winter coat
   description: A sturdy, utilitarian winter coat designed to protect a head of security from any brig-bound threats and hypothermic events.
@@ -739,7 +739,7 @@
 
 ################################################################
 - type: entity
-  parent: [ClothingOuterArmorWarden, ClothingOuterWinterCoatToggleable, BaseSecurityContraband]
+  parent: [ClothingOuterArmorWarden, ClothingOuterArmoredWinterCoatToggleable, BaseSecurityContraband] # DeltaV - Replaced ClothingOuterWinterCoatToggleable with ClothingOuterArmoredWinterCoatToggleable
   id: ClothingOuterWinterWarden
   name: warden's armored winter coat
   description: A sturdy, utilitarian winter coat designed to protect a warden from any brig-bound threats and hypothermic events.

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -1,5 +1,52 @@
 - type: entity
-  parent: ClothingOuterWinterCoat
+  abstract: true
+  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing]
+  id: ClothingOuterArmoredWinterCoat
+  components:
+  - type: TemperatureProtection
+    heatingCoefficient: 1.1
+    coolingCoefficient: 0.1
+  - type: Item
+    size: Normal
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.75
+        Slash: 0.75
+        Piercing: 0.75
+        Heat: 0.75
+  - type: Food
+    requiresSpecialDigestion: true
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 30
+        reagents:
+        - ReagentId: Fiber
+          Quantity: 30
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+  - type: StaticPrice
+    price: 50
+
+- type: entity
+  abstract: true
+  parent: ClothingOuterArmoredWinterCoat
+  id: ClothingOuterArmoredWinterCoatToggleable
+  components:
+  - type: ToggleableClothing
+    clothingPrototype: ClothingHeadHatHoodWinterDefault
+    slot: head
+  - type: ContainerContainer
+    containers:
+      toggleable-clothing: !type:ContainerSlot {}
+      storagebase: !type:Container
+        ents: []
+
+- type: entity
+  parent: ClothingOuterArmoredWinterCoat
   id: ClothingOuterWinterCCWarden
   name: central command's armored winter coat
   description: A tough, utilitarian coat designed for the wardens of Central Command. Reinforced kevlar plating and high quality fur allow the user to look stylish while staying protected.
@@ -15,7 +62,6 @@
         Slash: 0.7
         Piercing: 0.4 #Stronger than the warden's armored jacket, because shenanigans and CC spends alot of money.
         Heat: 0.75
-  - type: AllowSuitStorage
 
 - type: entity
   parent: ClothingOuterWinterCoat
@@ -40,7 +86,7 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/denim_jacket.rsi
 
 - type: entity
-  parent: ClothingOuterWinterCoat
+  parent: ClothingOuterArmoredWinterCoat
   id: ClothingOuterStasecSweater
   name: station security sweater
   description: A thick synthetic sweater with reinforced shoulders and elbows, enough to warm even the harshest security officer's cold heart.
@@ -49,17 +95,9 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/stasecsweater.rsi
   - type: Clothing
     sprite: _DV/Clothing/OuterClothing/WinterCoats/stasecsweater.rsi
-  - type: Armor
-    modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
-  - type: AllowSuitStorage
 
 - type: entity
-  parent: ClothingOuterStasecSweater
+  parent: ClothingOuterArmoredWinterCoat
   id: ClothingOuterCoatStasec
   name: station security coat
   description: A warm and comfortable winter coat, reinforced with durathread and compliant with Station Security uniform standards.
@@ -70,7 +108,7 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/staseccoat.rsi
 
 - type: entity
-  parent: ClothingOuterStasecSweater
+  parent: ClothingOuterArmoredWinterCoat
   id: ClothingOuterCoatStasecHoS
   name: head of security's coat
   description: A warm and comfortable winter coat, reinforced with durathread and compliant with Station Security uniform standards. This version is adorned with gold trim.
@@ -81,7 +119,7 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/hoscoat.rsi
 
 - type: entity
-  parent: ClothingOuterStasecSweater
+  parent: ClothingOuterArmoredWinterCoat
   id: ClothingOuterCoatStasecWarden
   name: warden's coat
   description: A warm and comfortable winter coat, reinforced with durathread and compliant with Station Security uniform standards. This version features ice-white trim.
@@ -92,7 +130,7 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/armourercoat.rsi
 
 - type: entity
-  parent: ClothingOuterStasecSweater
+  parent: ClothingOuterArmoredWinterCoat
   id: ClothingOuterCoatStasecDet
   name: detective's coat
   description: A warm and comfortable winter coat, reinforced with durathread and compliant with Station Security uniform standards. This version is detective plum.
@@ -103,7 +141,7 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/detcoat.rsi
 
 - type: entity
-  parent: ClothingOuterStasecSweater
+  parent: ClothingOuterArmoredWinterCoat
   id: ClothingOuterCoatStasecCorpsman
   name: corpsman's coat
   description: A warm and comfortable winter coat, reinforced with durathread and compliant with Station Security uniform standards. This version is corpsman blue.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Did an awful and evil thing, but it should suffice until I try to PR a better way of handling winter coats upstream.

## Why / Balance
Fixes #3260

## Technical details
Evil stuff:
- Created a copy paste of the winter coat to avoid the parenting of the gas tank. It's called `ClothingOuterArmoredWinterCoat` it comes with basic security armor and parents from `AllowSuitStorageClothing`
- Replaced where applicable on upstream armored coats that I saw necessary.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I hope nothing.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Security winter coats are now able to hold weaponry in the suit storage slot again.
