### PR TITLE
make organ insertion surgeries slot-based, add posibrain surgery

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -380,6 +380,25 @@
 
 - type: entity
   parent: SurgeryBase
+  id: SurgeryRemoveBorgBrain
+  name: Remove Positronic Brain
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Surgery
+    requirement: SurgeryOpenIncision
+    steps:
+    # TODO: ipc surgery steps
+    - SurgeryStepSawBones
+    - SurgeryStepClampInternalBleeders
+    - SurgeryStepRemoveOrgan
+  - type: SurgeryPartCondition
+    part: Torso
+  - type: SurgeryOrganCondition
+    organ:
+    - type: BorgBrain
+
+- type: entity
+  parent: SurgeryBase
   id: SurgeryInsertBrain
   name: Insert Brain
   categories: [ HideSpawnMenu ]
@@ -390,13 +409,25 @@
     - SurgeryStepSawBones
     - SurgeryStepInsertOrgan
     - SurgeryStepSealOrganWound
-  - type: SurgeryPartCondition
-    part: Head
+  - type: SurgeryOrganSlotCondition
+    organSlot: brain
   - type: SurgeryOrganCondition
     organ:
     - type: Brain
     inverse: true
     reattaching: true
+
+- type: entity
+  parent: SurgeryInsertBrain
+  id: SurgeryInsertBorgBrain
+  name: Insert Positronic Brain
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryOrganSlotCondition
+    organSlot: posbrain
+  - type: SurgeryOrganCondition
+    organ:
+    - type: BorgBrain
 
 - type: entity
   parent: SurgeryBase
@@ -428,8 +459,8 @@
     - SurgeryStepSawBones
     - SurgeryStepInsertHeart
     - SurgeryStepSealOrganWound
-  - type: SurgeryPartCondition
-    part: Torso
+  - type: SurgeryOrganSlotCondition
+    organSlot: heart
   - type: SurgeryOrganCondition
     organ:
     - type: Heart
@@ -466,8 +497,8 @@
     - SurgeryStepSawBones
     - SurgeryStepInsertLiver
     - SurgeryStepSealOrganWound
-  - type: SurgeryPartCondition
-    part: Torso
+  - type: SurgeryOrganSlotCondition
+    organSlot: liver
   - type: SurgeryOrganCondition
     organ:
     - type: Liver
@@ -504,8 +535,8 @@
     - SurgeryStepSawBones
     - SurgeryStepInsertLungs
     - SurgeryStepSealOrganWound
-  - type: SurgeryPartCondition
-    part: Torso
+  - type: SurgeryOrganSlotCondition
+    organSlot: lungs
   - type: SurgeryOrganCondition
     organ:
     - type: Lung
@@ -542,8 +573,8 @@
     - SurgeryStepSawBones
     - SurgeryStepInsertStomach
     - SurgeryStepSealOrganWound
-  - type: SurgeryPartCondition
-    part: Torso
+  - type: SurgeryOrganSlotCondition
+    organSlot: stomach
   - type: SurgeryOrganCondition
     organ:
     - type: Stomach
@@ -580,8 +611,8 @@
     - SurgeryStepSawBones
     - SurgeryStepInsertEyes
     - SurgeryStepSealOrganWound
-  - type: SurgeryPartCondition
-    part: Head
+  - type: SurgeryOrganSlotCondition
+    organSlot: eyes
   - type: SurgeryOrganCondition
     organ:
     - type: Eyes


### PR DESCRIPTION
## About the PR
if a bodypart doesnt have an organ slot it won't list insertion as an option, currently you see "Insert brain" as a surgery option for IPCs heads when they dont have a brain slot there (or at all since its called posbrain).

also added posibrain insert/remove surgery for ipcs. currently it only works if the posibrain is active, to reboot it you have to take it out, wait for someone to take it, insert it *after* it has a mind. consider it a feature to make them more complex than borgs :trollface:

## Why / Balance
a gibbed IPC never being able to be an ipc again is bad

## Technical details


## Media
no brain in head
![11:47:19](https://github.com/user-attachments/assets/74d43d3a-4b8a-4764-b13a-0769e51fad8b)

brain in torso! (and no misleading lung/liver surgeries that you couldn't actually complete)
![11:47:24](https://github.com/user-attachments/assets/274e6c0d-76e8-427d-b4d5-5ad607301c7b)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed not being able to remove/insert posibrains from IPC torsos.