### PR TITLE
make red and blue soap clean dirt faster

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -138,6 +138,8 @@
       - punishment
   - type: CleansForensics
     cleanDelay: 8.0
+  - type: SurgeryCleansDirt # DeltaV - evil soap is fast
+    cleanDelay: 2
   - type: Residue
     residueAdjective: residue-slippery
     residueColor: residue-red
@@ -230,6 +232,8 @@
         reagents:
         - ReagentId: SoapReagent
           Quantity: 240
+  - type: SurgeryCleansDirt # DeltaV - omega soap is fast
+    cleanDelay: 2
   - type: Residue
     residueAdjective: residue-slippery
     residueColor: residue-blue


### PR DESCRIPTION
## About the PR
4s -> 2s for both of them

## Why / Balance
bluespace and evil soap -> fast at cleaning tools

**Changelog**
:cl:
- tweak: Syndie and omega soap now clean dirt from surgical tools twice as fast.
