### PR TITLE
bring back biochemical research tree + reorganise some stuff

### DIFF
--- a/Resources/Locale/en-US/_DV/research/technologies.ftl
+++ b/Resources/Locale/en-US/_DV/research/technologies.ftl
@@ -1,3 +1,5 @@
+research-discipline-biochemical = Biochemical
+
 # Industrial
 research-technology-aerial-extraction = Aerial Extraction
 research-technology-matter-energy-conversion = Matter-Energy Conversion
@@ -6,6 +8,9 @@ research-technology-matter-energy-conversion = Matter-Energy Conversion
 research-technology-cloning = Cloning
 
 # Civilian
+research-technology-civilian-mechs = Civilian Mechs
+
+# Biochemical
 research-technology-syringe-gun = Syringe Gun
 research-technology-basic-augmentation = Basic Augmentation
 research-technology-implanted-tools = Implanted Tools

--- a/Resources/Prototypes/Entities/Structures/Machines/research.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/research.yml
@@ -15,6 +15,7 @@
   - type: TechnologyDatabase
     supportedDisciplines:
     - Industrial
+    - Biochemical # DeltaV
     - Arsenal
     - Experimental
     - CivilianServices

--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -51,7 +51,7 @@
   - BorgModuleAnomaly
   - BorgModuleGardening
   - BorgModuleHarvesting
-  - BorgModuleDefibrillator
+  #- BorgModuleDefibrillator # DeltaV - made a default module
   - BorgModuleAdvancedTreatment
 
 - type: latheRecipePack

--- a/Resources/Prototypes/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/robotics.yml
@@ -185,6 +185,7 @@
   result: BorgModuleAdvancedTreatment
 
 - type: latheRecipe
+  abstract: true # DeltaV - made roundstart
   parent: BaseGoldBorgModuleRecipe
   id: BorgModuleDefibrillator
   result: BorgModuleDefibrillator

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -19,7 +19,7 @@
 
 - type: technology
   id: CritterMechs
-  name: research-technology-critter-mechs
+  name: research-technology-civilian-mechs # DeltaV
   icon:
     sprite: Objects/Specific/Mech/mecha.rsi
     state: hamtr
@@ -36,6 +36,17 @@
   - HamtrPeripheralsElectronics
   - MechEquipmentGrabberSmall
   - VimHarness
+  # Begin DeltaV Additions - moved from HONK tech
+  - HonkerHarness
+  - HonkerLArm
+  - HonkerRArm
+  - HonkerLLeg
+  - HonkerRLeg
+  - HonkerCentralElectronics
+  - HonkerPeripheralsElectronics
+  - HonkerTargetingElectronics
+  - MechEquipmentHorn
+  # End DeltaV Additions
 
 - type: technology
   id: AudioVisualCommunication
@@ -124,14 +135,27 @@
   icon:
     sprite: Structures/Machines/stasis_bed.rsi
     state: icon
-  discipline: CivilianServices
-  tier: 2
+  discipline: Biochemical # DeltaV
+  tier: 1 # DeltaV - was 2
   cost: 7500
   recipeUnlocks:
   - StasisBedMachineCircuitboard
   - CryoPodMachineCircuitboard
   - CryostasisBeaker
   - SyringeCryostasis
+
+- type: technology
+  id: MechanizedTreatment
+  name: research-technology-mechanized-treatment
+  icon:
+    sprite: Mobs/Silicon/chassis.rsi
+    state: medical
+  discipline: Biochemical
+  tier: 1 # DeltaV - was 2
+  cost: 5000
+  recipeUnlocks:
+  - BorgModuleAdvancedTreatment
+  #- BorgModuleDefibrillator # DeltaV - made roundstart
 
 - type: technology
   id: AdvancedCleaning
@@ -146,25 +170,27 @@
   - AdvMopItem
   - MegaSprayBottle
 
-- type: technology
-  id: HONKMech
-  name: research-technology-honk-mech
-  icon:
-    sprite: Objects/Specific/Mech/mecha.rsi
-    state: honker
-  discipline: CivilianServices
-  tier: 2
-  cost: 7500
-  recipeUnlocks:
-  - HonkerHarness
-  - HonkerLArm
-  - HonkerRArm
-  - HonkerLLeg
-  - HonkerRLeg
-  - HonkerCentralElectronics
-  - HonkerPeripheralsElectronics
-  - HonkerTargetingElectronics
-  - MechEquipmentHorn
+# Begin DeltaV Removals - waste of points nobody makes, moved into civilian mechs
+#- type: technology
+#  id: HONKMech
+#  name: research-technology-honk-mech
+#  icon:
+#    sprite: Objects/Specific/Mech/mecha.rsi
+#    state: honker
+#  discipline: CivilianServices
+#  tier: 2
+#  cost: 7500
+#  recipeUnlocks:
+#  - HonkerHarness
+#  - HonkerLArm
+#  - HonkerRArm
+#  - HonkerLLeg
+#  - HonkerRLeg
+#  - HonkerCentralElectronics
+#  - HonkerPeripheralsElectronics
+#  - HonkerTargetingElectronics
+#  - MechEquipmentHorn
+# End DeltaV Removals
 
 - type: technology
   id: AdvancedSpray
@@ -211,7 +237,7 @@
   icon:
     sprite: Objects/Specific/Chemistry/beaker_bluespace.rsi
     state: beakerbluespace
-  discipline: CivilianServices
+  discipline: Biochemical # DeltaV
   tier: 3
   cost: 10000
   recipeUnlocks:

--- a/Resources/Prototypes/_DV/Research/biochemical.yml
+++ b/Resources/Prototypes/_DV/Research/biochemical.yml
@@ -1,15 +1,4 @@
-- type: technology
-  id: SyringeGun
-  name: research-technology-syringe-gun
-  icon:
-    sprite: Objects/Weapons/Guns/Cannons/syringe_gun.rsi
-    state: syringe_gun
-  discipline: CivilianServices
-  tier: 2
-  cost: 10000
-  recipeUnlocks:
-    - LauncherSyringe
-    - MiniSyringe
+# Tier 1
 
 - type: technology
   id: BasicAugmentation
@@ -17,12 +6,27 @@
   icon:
     sprite: _DV/Objects/Augments/power.rsi
     state: cell
-  discipline: CivilianServices
-  tier: 2
+  discipline: Biochemical
+  tier: 1
   cost: 5000
   recipeUnlocks:
   - AugmentPowerCellSlotCasing
   - AugmentRechargerCasing
+
+- type: technology
+  id: SyringeGun
+  name: research-technology-syringe-gun
+  icon:
+    sprite: Objects/Weapons/Guns/Cannons/syringe_gun.rsi
+    state: syringe_gun
+  discipline: Biochemical
+  tier: 1
+  cost: 10000
+  recipeUnlocks:
+  - LauncherSyringe
+  - MiniSyringe
+
+# Tier 2
 
 - type: technology
   id: ImplantedTools
@@ -30,7 +34,7 @@
   icon:
     sprite: _DV/Objects/Augments/arm.rsi
     state: base
-  discipline: CivilianServices
+  discipline: Biochemical
   tier: 2
   cost: 10000
   technologyPrerequisites: [ BasicAugmentation ]
@@ -41,3 +45,4 @@
   - AugmentSurgeryPanelElectronics
   - AugmentPaperworkPanelElectronics
 
+# Tier 3

--- a/Resources/Prototypes/_DV/Research/disciplines.yml
+++ b/Resources/Prototypes/_DV/Research/disciplines.yml
@@ -1,0 +1,11 @@
+- type: techDiscipline
+  id: Biochemical
+  name: research-discipline-biochemical
+  color: "#449ae6"
+  icon:
+    sprite: Interface/Misc/research_disciplines.rsi
+    state: biochemical
+  tierPrerequisites:
+    1: 0
+    2: 1
+    3: 1

--- a/Resources/Prototypes/_Shitmed/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_Shitmed/Recipes/Lathes/robotics.yml
@@ -1,4 +1,5 @@
 - type: latheRecipe
+  abstract: true # DeltaV - it's a default module
   id: BorgModuleSurgery
   result: BorgModuleSurgery
   categories:

--- a/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
@@ -8,12 +8,14 @@
   icon:
     sprite: _Shitmed/Objects/Specific/Medical/Surgery/e-scalpel.rsi
     state: e-scalpel-on
-  discipline: CivilianServices
+  discipline: Biochemical # DeltaV
   tier: 2
   cost: 10000
   recipeUnlocks:
-  - BorgModuleAdvancedTreatment
-  - BorgModuleDefibrillator
+  # Begin DeltaV Removals - moved back to its original tech / made default module
+  #- BorgModuleAdvancedTreatment
+  #- BorgModuleDefibrillator
+  # End DeltaV Removals
   - EnergyScalpel
   - EnergyCautery
   - AdvancedRetractor
@@ -25,7 +27,7 @@
   icon:
     sprite: _Shitmed/Clothing/Hands/Gloves/mechanical_surgery_gloves.rsi
     state: icon
-  discipline: CivilianServices
+  discipline: Biochemical # DeltaV
   tier: 2
   cost: 10000
   recipeUnlocks:
@@ -38,7 +40,7 @@
   icon:
     sprite: _Shitmed/Mobs/Species/IPC/organs.rsi
     state: eyes
-  discipline: CivilianServices
+  discipline: Biochemical # DeltaV
   tier: 2
   cost: 15000
   recipeUnlocks:
@@ -56,7 +58,7 @@
   icon:
     sprite: _Shitmed/Structures/Machines/autodoc.rsi
     state: idle
-  discipline: CivilianServices
+  discipline: Biochemical # DeltaV
   tier: 2
   cost: 10000
   recipeUnlocks:
@@ -71,7 +73,7 @@
 #  icon:
 #    sprite: _Shitmed/Objects/Specific/Medical/Surgery/omnimed.rsi
 #    state: omnimed
-#  discipline: CivilianServices
+#  discipline: Biochemical # DeltaV
 #  tier: 3
 #  cost: 10000
 #  recipeUnlocks:

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -179,6 +179,7 @@
   defaultModules:
   - BorgModuleTreatment
   - BorgModuleSurgery # DeltaV
+  - BorgModuleDefibrillator # DeltaV
 
   radioChannels:
   - Science


### PR DESCRIPTION
## About the PR
- readded the biochemical discipline, some techs were moved to t1 to keep it balanced
- made borg defib module roundstart because defibs are roundstart, absolutely no excuse for this being a t2 civ that never gets researched before the round ends
- moved honk tech since nobody ever made it, its a free addition to the renamed civilian mechs tech

## Why / Balance
we have enough techs already for a minimal tree, even more soon :trollface:

## Media
mediborg real
![11:56:43](https://github.com/user-attachments/assets/e999d4ae-e314-4309-9b4d-98b20161041e)

4 T1 / 5 T2 / 1 T3
![11:59:44](https://github.com/user-attachments/assets/07003f0b-e59e-4fb3-a879-b19210b828b2)

meme tech is folded into this
![12:00:24](https://github.com/user-attachments/assets/c7e89fc8-c0e3-46d8-b16d-3f760ee0ba38)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
new techs may need to be changed to biochem when they get added

**Changelog**
:cl:
- add: Added back the Biochemical research discipline! Medical related techs are in it now.
- remove: Removed the HONK mech research, it's now part of Civilian Mechs.
- tweak: Medical cyborgs now get the defibrillator module by default.