### PR TITLE
Make battery guns smaller

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -5,7 +5,7 @@
   components:
   - type: Sprite
   - type: Item
-    size: Huge
+    size: Large # DeltaV - was "Huge"
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
     quickEquip: false

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -5,7 +5,7 @@
   components:
   - type: Sprite
   - type: Item
-    size: Large # DeltaV - was "Huge"
+    size: Large # DeltaV - was Huge
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_retro.rsi
     quickEquip: false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
made battery guns large instead of huge (2x4 instead of 4x4)

## Why / Balance
especially needed for things like the laser rifle, ik60, base energy gun, etc.
these things are starting to be good alternatives and their smaller size should aid in that. I always thought it looked weird having such a huge space in your bag for such a small sprite as well.

## Technical details
changes baseweaponbattery instead of individually, anything that does need to be larger should already be listed as such.
## Media
![image](https://github.com/user-attachments/assets/20650177-cc94-4af9-ab08-8b984822ec3e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Battery weapons have been modified for better ergonomics.
