### PR TITLE
make synthesis specialist free agent in character menu

### DIFF
--- a/Resources/Prototypes/_DV/Roles/MindRoles/mind_roles.yml
+++ b/Resources/Prototypes/_DV/Roles/MindRoles/mind_roles.yml
@@ -52,7 +52,7 @@
   name: Synthesis Specialist Role
   components:
   - type: MindRole
-    roleType: TeamAntagonist
+    roleType: FreeAgent
     antagPrototype: SynthesisSpecialist
     exclusiveAntag: true
   - type: SynthesisRole


### PR DESCRIPTION
## About the PR
consistency with its ghost role rules

## Why / Balance
resolves #3290

**Changelog**
:cl:
- fix: Fixed Synthesis Specialists not being listed as Free Agent in the character menu.
