### PR TITLE
Reduce FTL cooldown + increase range

### DIFF
--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -19,7 +19,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
     [Dependency] protected readonly SharedTransformSystem XformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
-    public const float FTLRange = 256f;
+    public const float FTLRange = 512f; // DeltaV - Was 256f.
     public const float FTLBufferRange = 8f;
 
     private EntityQuery<MapGridComponent> _gridQuery;

--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -80,7 +80,7 @@ space_wind = true
 
 [shuttle]
 arrivals = false
-cooldown = 120 # 110 longer than default
+cooldown = 60 # 50 longer than default
 emergency_dock_time = 360 # an extra 2 minutes over the default
 emergency_transit_time_min = 90
 auto_call_time = 120 # rounds are longer

--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -80,7 +80,7 @@ space_wind = true
 
 [shuttle]
 arrivals = false
-cooldown = 60 # 50 longer than default
+cooldown = 90 # 80 longer than default
 emergency_dock_time = 360 # an extra 2 minutes over the default
 emergency_transit_time_min = 90
 auto_call_time = 120 # rounds are longer


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR reduces the cooldown between FTL travels and doubles it's range.

## Why / Balance
People were arguing on discord that the timer was too long.
The longer range should help with traveling to ATS that spawns far away.

## Technical details
Changed the DeltaV config for CVars.
Touched `SharedShuttleSystem.cs` to increase the range of the FTL.

## Media
New range (Double the previous)
![image](https://github.com/user-attachments/assets/83a4af95-ccb1-4e75-830b-04f1516ee57a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing as far as I got to test.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The cooldown between FTL travels has been reduced by 30 seconds and the range which you can FTL to has been doubled.
