### PR TITLE
Move security cyborg modules to security techfab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -333,6 +333,7 @@
     emagDynamicPacks:
     - SecurityCybernetics # having sechud eyes is good for evil people
     - SecurityHardsuits
+    - BorgModulesSecurityDeltaV # DeltaV - secfab borg modules
   - type: MaterialStorage
     whitelist:
       tags:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -40,7 +40,7 @@
 
 - type: latheRecipePack
   parent:
-  - BorgModulesDeltaV # DeltaV
+  #- BorgModulesDeltaV # DeltaV
   - BorgModulesShitmed # Shitmed change
   id: BorgModules
   recipes:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -71,6 +71,7 @@
 - type: latheRecipePack
   parent:
   - SecurityEquipmentDeltaV # DeltaV
+  - BorgModulesSecurityDeltaV # DeltaV
   - SecurityCybernetics # Shitmed change
   id: SecurityEquipment
   recipes:

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/robotics.yml
@@ -33,12 +33,16 @@
   recipes:
   - ClothingEyesHudDiagnostic
 
+#- type: latheRecipePack
+#  id: BorgModulesDeltaV
+
 - type: latheRecipePack
-  id: BorgModulesDeltaV
+  id: BorgModulesSecurityDeltaV
   recipes:
   - BorgModuleSecurityChase
   - BorgModuleSecurityEscalate
   - BorgModuleSecurityBastion
+  - BorgModuleFauna
 
 - type: latheRecipePack
   id: PowerAugments

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
@@ -62,7 +62,6 @@
   id: SecurityEquipmentDeltaV
   recipes:
   - EncryptionKeySyndie # reverse engineered
-  - BorgModuleFauna
   - ClothingHeadHelmetInsulated
   - ClothingHeadCage
   - ClothingShoesBootsSecurityMagboots


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
The security modules previously printable in the exosuit fabricator are moved to the security techfab. An emag allows them to be printed at the exosuit fabricator and other lathes.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Firstly, the fauna defense module only was restricted to the secfab, despite the security cyborg modules being similar in lethality. This makes the module placement somewhat more cohesive, and maybe people will learn that the fauna defense module exists.

Partially satisfies some of the things mentioned in https://github.com/DeltaV-Station/Delta-v/issues/3060, specifically security borgs needing the assistance of the department to be constructed. While they can still be constructed, any upgrades require security approval.

The emag allowing them to be printable in the exosuit fabricator and techfabs might subvert this somewhat, but the fauna defense module could be printed by emagged techfabs before, so I followed this pattern. This also allows for any station member who manages to emag a secborg to make their upgrades.

Potential issue of secoffs just upgrading the borgs themselves instead of letting the roboticist do it, since sec can unlock secborgs.

## Technical details
<!-- Summary of code changes for easier review. -->
Commented out BorgModulesDeltaV instead of removing it since it seemed like it could be a useful future category, and it was present as a parent for BorgModules (also commented out there).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have tested all added content and changes.
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Security cyborg modules have been moved to the secfab.
