### PR TITLE
Change traitor ratio for more traitors

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -197,8 +197,8 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
-      max: 8
-      playerRatio: 10
+      max: 12
+      playerRatio: 8
       blacklist:
         components:
         - AntagImmune

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -197,8 +197,8 @@
     selectionTime: IntraPlayerSpawn
     definitions:
     - prefRoles: [ Traitor ]
-      max: 12
-      playerRatio: 8
+      max: 12 # DeltaV - raised from 8
+      playerRatio: 8 # DeltaV - lowered from 12
       blacklist:
         components:
         - AntagImmune

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -198,7 +198,7 @@
     definitions:
     - prefRoles: [ Traitor ]
       max: 12 # DeltaV - raised from 8
-      playerRatio: 8 # DeltaV - lowered from 12
+      playerRatio: 8 # DeltaV - lowered from 10
       blacklist:
         components:
         - AntagImmune


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
player to traitor ratio made 8:1
max traitor amount raised from 8 to 12
## Why / Balance
Traitor is the most snoozefest gamemode right now unless your one of the 8 people that rolled it. this should add some more spice to the mode while avoiding the absolute chaose that was 16 traitors

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- tweak:  More traitors will be assigned during traitor rounds

