### PR TITLE
FTL times shuttle changes

### DIFF
--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -80,8 +80,9 @@ space_wind = true
 
 [shuttle]
 arrivals = false
-cooldown = 50 # 40 longer than default
-startup_time = 11 # double the default, makes it take longer to enter FTL allowing assaults on the ship
+cooldown = 60 # 50 longer than the default
+startup_time = 10 # 4.5 seconds longer than the default
+travel_time = 5 # 15 seconds less than the default
 emergency_dock_time = 360 # an extra 2 minutes over the default
 emergency_transit_time_min = 90
 auto_call_time = 120 # rounds are longer

--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -81,6 +81,7 @@ space_wind = true
 [shuttle]
 arrivals = false
 cooldown = 90 # 80 longer than default
+startup_time = 11 # double the default, makes it take longer to enter FTL allowing assaults on the ship
 emergency_dock_time = 360 # an extra 2 minutes over the default
 emergency_transit_time_min = 90
 auto_call_time = 120 # rounds are longer

--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -80,7 +80,7 @@ space_wind = true
 
 [shuttle]
 arrivals = false
-cooldown = 90 # 80 longer than default
+cooldown = 50 # 40 longer than default
 startup_time = 11 # double the default, makes it take longer to enter FTL allowing assaults on the ship
 emergency_dock_time = 360 # an extra 2 minutes over the default
 emergency_transit_time_min = 90


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR modifies the cooldown between FTL travels down to 60 seconds but raises the wind up before FTLing to 10 seconds, and the travel time down to 5 seconds.

## Why / Balance
I find 1 minute 30 seconds between FTLs way too long but I don't care that much, this is mostly to show another alternative on how to balance the FTL times.

## Technical details
Changed Cvars: `startup_time`, `travel_time`, `arrival_time`.

## Media

https://github.com/user-attachments/assets/e637d6d4-f22b-475b-ab0a-452dcd852175


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
The audio still plays matching the 5.5 seconds instead of the 11 of this PR.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- tweak: Shuttle FTL changes! FTL cooldown has been reduced to 60 seconds, the windup before going into FTL lasts 10 seconds while the travel itself takes only 5 seconds now.
