### PR TITLE
fix admin changelog

### DIFF
--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -912,7 +912,7 @@ Entries:
   url: https://github.com/space-wizards/space-station-14/pull/35961
 - author: SlamBamActionman
   changes:
-  - message: 'Any adminlog chat alert that includes an antag now has "[ANTAG: entityName]"
+  - message: 'Any adminlog chat alert that includes an antag now has "\[ANTAG: entityName]"
       appended to the end.'
     type: Tweak
   id: 113


### PR DESCRIPTION
## About the PR
it was using [ to create an invalid markup tag

fixed it and added exception handling

## Media
fun fact markup parsing ignores invalid colours :rocket: 
![04:46:16](https://github.com/user-attachments/assets/74e3e124-4960-45a8-a1af-47c79df73eb3)

weh
![04:47:27](https://github.com/user-attachments/assets/1a3abce5-d716-437d-9270-03f9ce26d864)

**Changelog**
:cl: [color=green]Weh[/color]
- fix: Fixed [italic]admin changelogs[/italic] [color=red]being visible[/color].
