### PR TITLE
Make xenoarchaeology more on par with anomaly research glimmerwise

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
@@ -21,9 +21,7 @@ public sealed partial class ArtifactAnalyzerComponent : Component
 
     // Nyano - Summary - Begin modified code block: tie artifacts to glimmer.
     /// <summary>
-    /// Ratio of research points to glimmer.
-    /// Each is 150 and added to this, so
-    /// 550 / 700 / 850 / 1000
+    /// The ratio of research points per one glimmer.
     /// </summary>
     public int ExtractRatio = 750;
     // Nyano - End modified code block.

--- a/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class ArtifactAnalyzerComponent : Component
     /// Each is 150 and added to this, so
     /// 550 / 700 / 850 / 1000
     /// </summary>
-    public int ExtractRatio = 400;
+    public int ExtractRatio = 750;
     // Nyano - End modified code block.
 
     /// <summary>


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The ratio of points per glimmer for xenoarchaeology has been nerfed to make it more in line with anomaly research

## Why / Balance
assumption: it takes about 1 minute to get 6k points from xenoarchaeology
assumption: an average anomaly is about 100 points/second around 50% severity (either a bad anomaly w/ an experimental vessel, or a decent anomaly w/ a plain one), and takes 1 minute to pulse
conclusion: an artifact will generate about twice as much glimmer for the same amount of points as an average anomaly
therefore: cut the artifact glimmer by about half in order to bring it more in line with anomaly research
![image](https://github.com/user-attachments/assets/6d1f3f2a-a716-4728-8a8e-59c02d050bf3)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Artifact extraction glimmer increase has been halved

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
