### PR TITLE
reign in heights a bit

### DIFF
--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -136,13 +136,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// The minimum height for this species
     /// </summary>
     [DataField("minHeight")]
-    public float MinHeight = 0.85f; // DeltaV - less trolling with the heights
+    public float MinHeight = 0.9f; // DeltaV - less trolling with the heights
 
     /// <summary>
     /// The maximum height for this species
     /// </summary>
     [DataField("maxHeight")]
-    public float MaxHeight = 1.2f; // DeltaV - less trolling with the heights
+    public float MaxHeight = 1.1f; // DeltaV - less trolling with the heights
 
     /// <summary>
     /// The default height for this species

--- a/Resources/Prototypes/_DV/Species/Oni.yml
+++ b/Resources/Prototypes/_DV/Species/Oni.yml
@@ -12,6 +12,7 @@
   lastNames: NamesOniLocation
   naming: LastNoFirst
   baseScale: "1.2, 1.2"
+  maxHeight: 1.05
 
 - type: markingPoints
   id: MobOniMarkingLimits

--- a/Resources/Prototypes/_DV/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Species/felinid.yml
@@ -8,6 +8,7 @@
   dollPrototype: MobFelinidDummy
   skinColoration: Hues
   baseScale: "0.8, 0.8"
+  minHeight: 0.95
 
 - type: markingPoints
   id: MobFelinidMarkingLimits

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -8,6 +8,7 @@
   dollPrototype: MobHarpyDummy
   skinColoration: HumanToned
   baseScale: "0.9, 0.9"
+  minHeight: 0.95
 
 - type: speciesBaseSprites
   id: MobHarpySprites

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -13,6 +13,7 @@
   lastNames: NamesRodentiaLast
   naming: LastFirst
   baseScale: "0.8, 0.8"
+  minHeight: 0.95
 
 - type: speciesBaseSprites
   id: MobRodentiaSprites

--- a/Resources/Prototypes/_Impstation/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Species/thaven.yml
@@ -16,6 +16,7 @@
   - Female
   - Unsexed
   baseScale: "1, 1.05" # DeltaV - make sure Thaven are still scaled w/ CD records
+  maxHeight: 1.05 # DeltaV
 
 - type: speciesBaseSprites
   id: MobThavenSprites


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
all species can now only slide their height +/- 10%.
Felinid, Rodentia, Harpy can only go -5%/+10%
Oni, Thaven can only go +5%/-10%

## Why / Balance
giga silly

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Heights have been normalized a bit; default species now have a range of +/- 10%
- tweak: Felinid, Rodentia, Harpy can only go -5%/+10% height
- tweak: Oni, Thaven can only go +5%/-10% height

