### PR TITLE
replace vulp insulation

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -92,8 +92,6 @@
   - type: Perishable
   - type: Damageable
     damageModifierSet: Vulpkanin
-  - type: TemperatureProtection
-    coolingCoefficient: 0.1 # fur is insulating
   - type: Vocal
     sounds:
       Male: MaleVulpkanin
@@ -102,7 +100,7 @@
   - type: DogVision
   - type: Temperature
     heatDamageThreshold: 315 # 10 lower than base
-    coldDamageThreshold: 240 # 20 lower than base
+    coldDamageThreshold: 220 # 40 lower than base, very insulating fur
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
for a very long time insulation on vulps didnt actually do anything but now it does so they get baked in hardsuits
this fixes it by replacing it with a 20 degree lower cold damage threshold, similar to how rimworld cold insulation works

## Why / Balance
fixes #3323 

**Changelog**
:cl:
- fix: Fixed vulpkanins getting [bold]cooked alive[/bold] in hardsuits.