### PR TITLE
fix telegnome action

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -177,18 +177,16 @@ namespace Content.Server.Abilities.Psionics
             //To unnatch the minds, do it like this.
             //Have to unnattach the minds before we reattach them via transfer. Still feels weird, but seems to work well.
             _mindSystem.TransferTo(performerMindId, null);
-            _mindSystem.TransferTo(targetMindId, null);
             // Do the transfer.
+            if (targetMind != null)
+                _mindSystem.TransferTo(targetMindId, performer, ghostCheckOverride: true, false, targetMind);
             if (performerMind != null)
                 _mindSystem.TransferTo(performerMindId, target, ghostCheckOverride: true, false, performerMind);
 
-            if (targetMind != null)
-                _mindSystem.TransferTo(targetMindId, performer, ghostCheckOverride: true, false, targetMind);
-
             if (end)
             {
-                var performerMindPowerComp = EntityManager.GetComponent<MindSwappedComponent>(performer);
-                var targetMindPowerComp = EntityManager.GetComponent<MindSwappedComponent>(target);
+                var performerMindPowerComp = Comp<MindSwappedComponent>(performer);
+                var targetMindPowerComp = Comp<MindSwappedComponent>(target);
                 _actions.RemoveAction(performer, performerMindPowerComp.MindSwapReturnActionEntity);
                 _actions.RemoveAction(target, targetMindPowerComp.MindSwapReturnActionEntity);
 

--- a/Content.Shared/Eye/VisibilityFlags.cs
+++ b/Content.Shared/Eye/VisibilityFlags.cs
@@ -9,9 +9,10 @@ namespace Content.Shared.Eye
         None   = 0,
         Normal = 1 << 0,
         Ghost  = 1 << 1,
-        Subfloor = 1 << 2,
+        Subfloor = 1 << 3, // DeltaV - 4 is occupied by PsionicInvisibility and changing that massively fucks up stuff
         // Begin DeltaV Additions
-        PsionicInvisibility = 1 << 3,
+        PsionicInvisibility = 1 << 2,
         TelegnosticProjection = PsionicInvisibility | Normal
+        // End DeltaV Additions
     }
 }


### PR DESCRIPTION
## About the PR

## Why / Balance
fixes #3312

## Technical details
swap numbers
some hardcoded bullshit somewhere was checking for 4 which is what subfloor layer uses now
cant be bothered to find where that is so this will do
setting visibility mask to 5 fixes it back to 9 and it dies

## Media
![09:51:12](https://github.com/user-attachments/assets/143b7249-50ea-4c23-85f2-696e876f3d9e)

t-ray still works so its 100% pure nyano shitcode
![10:02:12](https://github.com/user-attachments/assets/5b656b96-5c3c-4f7a-bdde-20f028ae0a77)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- fix: Fixed telegnostic projections not being able to return to body.