### PR TITLE
Add the hand labeler to the techfabs

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -130,6 +130,7 @@
     - LVCablesStatic
     - LightsStatic
     - ServiceStatic
+    - PartsStaticDeltaV # Add Beaker and Hand Labeler to the service techfab
     dynamicPacks:
     - Janitor
     - Instruments

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
@@ -17,3 +17,4 @@
   id: PartsStaticDeltaV
   recipes:
   - Beaker
+  - HandLabeler


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR adds the hand labeler to the `PartsStaticDeltaV` thus distributing it to all the techfabs but security's. It also gives the service techfab access to the `PartsStaticDeltaV` pack so they can print regular beakers and hand labelers.

## Why / Balance
Hand labelers are useful for paperwork and organizing.
The regular beaker is useful for the botanist, while not being the best one which they can ask med for one.

## Technical details
Two lines YAML ops.

## Media
![image](https://github.com/user-attachments/assets/785c8741-bad1-4611-98a9-4211377edad8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Hand labelers are now available to be printed at every techfab but security's.
- tweak: Regular 50 units beakers are available to be printed at the service techfab.
