### PR TITLE
Gamblagator tweaks

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Power/powercells.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseItem
   id: GamblagatorCapacitor
-  name: gamblagator fuse
+  name: gamblagator capacitor
   description: A capacitor made with the positive charge of bluespace crystals, designed to power the Gamblagator rifle. Theoretically possible to recharge but a suitable recharger has not yet been developed.
   components:
   - type: Tag
@@ -11,8 +11,8 @@
     proto: GamblagatorLaser
     fireCost: 1000
   - type: Battery
-    maxCharge: 1000 # Shenanigan Prevention
-    startingCharge: 1000
+    maxCharge: 3000 # Shenanigan Prevention
+    startingCharge: 3000
   - type: Item
     storedRotation: -90
   - type: PowerCell

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -388,7 +388,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 0.3
+    fireRate: 1
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Day 1 patch. It's def a little undertuned
shots per fuse 1 -> 3
fire-rate 0.3 -> 1
also fixed the name of the fuses

## Why / Balance
currently the max damage potential of this thing is only 600, rather low when compared to the beam devs 3000. with these changes it will bump this to 1800 damage. the fire rate was stinky and made you have to sit there and wait 3 seconds after wielding, it feels way too clunky this way and this should remedy that. future PR's will be made if this gun under/over performs

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Gamblagator now has more shots per capacitor.


