### PR TITLE
remove cmo pill chemmaster flatpack

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
@@ -70,7 +70,6 @@
     - id: ClothingShoesBootsWinterChiefMedicalOfficer
     - id: LunchboxCommandFilledRandom
       prob: 0.3
-    - id: ChemMasterFlatpack # So the chemist can make pills
     - id: MedBioFabricatorFlatpack # Replaced the shitmed board
     - id: AutoclaveFlatpack # Make sure surgeons have access to an autoclave
     - id: Multitool # Ensure the flatpacks can be used without having to beg a tool


### PR DESCRIPTION
## About the PR
replaced by #3329

## Why / Balance
chemists are actually able to make pills now, it purpose is outdated

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Removed the chemmaster flatpack from CMO's locker as pills can be made from the beaker slot.
