### PR TITLE
Fix the paramedic locker fill

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -184,11 +184,16 @@
       - id: ClothingHandsGlovesLatex
       - id: ClothingHeadsetMedical
       - id: ClothingMaskSterile
-      - id: ClothingShoesBootsWinterParamedic # DeltaV - Add departmental winter boots
-      - id: BoxBodyBag # DeltaV - Give paramedics a body bag
-      - id: MedkitFilled
+      # Begin DeltaV additions
+      - id: ClothingShoesBootsWinterParamedic
+      - id: BoxBodyBag
+      - id: EmergencyRollerBedSpawnFolded
+      - id: EmergencyJawsOfLife
+      - id: HandheldCrewMonitor
+      - id: LunchboxMedicalFilledRandom
         prob: 0.3
-      - id: LunchboxMedicalFilledRandom # DeltaV - Lunchboxes!
+      # End DeltaV additions
+      - id: MedkitFilled
         prob: 0.3
 
 - type: entity
@@ -208,13 +213,15 @@
       - id: ClothingHandsGlovesLatex
       - id: ClothingHeadsetMedical
       - id: ClothingMaskSterile
-      - id: ClothingShoesBootsWinterParamedic # DeltaV - Add departmental winter boots
-      - id: BoxBodyBag # DeltaV - Give paramedics a body bag
-      - id: EmergencyRollerBedSpawnFolded # DeltaV - move paramedic loadout to locker
-      - id: EmergencyJawsOfLife # DeltaV - Add Emergency Jaws of Life
-      - id: HandheldCrewMonitor # DeltaV - Give Paramedics useful tools on spawn
+      # Begin DeltaV additions
+      - id: ClothingShoesBootsWinterParamedic
+      - id: BoxBodyBag
+      - id: EmergencyRollerBedSpawnFolded
+      - id: EmergencyJawsOfLife
+      - id: HandheldCrewMonitor
+      - id: LunchboxMedicalFilledRandom
+        prob: 0.3
+      # End DeltaV additions
       - id: HandheldGPSBasic
       - id: MedkitFilled
-        prob: 0.3
-      - id: LunchboxMedicalFilledRandom # DeltaV - Lunchboxes!
         prob: 0.3


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixes the non-hardsuit paramedic locker fill.

## Why / Balance
Fixes #3357.

## Technical details
Copy-Paste ops.

## Media
![image](https://github.com/user-attachments/assets/8dcbe586-fc13-4c68-b79a-dc6fcfcfc4cb)
![image](https://github.com/user-attachments/assets/09884b7b-4659-47e8-b939-581a8fc13894)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: All paramedic lockers properly starts with the paramedic tools inside.
