### PR TITLE
Cherrypick "Move medical locker fills to entityTables (#36249)" from upstream

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -49,7 +49,7 @@
     - id: ClothingEyesHudMedical
     - !type:GroupSelector
       children:
-      - !type:NestedSelector # DeltaV - Add our surgery caps. See Resources\Prototypes\_DV\Catalog\Fills\Lockers\medical.yml
+      - !type:NestedSelector # DeltaV - Add our surgery caps. See Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
         tableId: SurgeryCapsDeltaV
       - id: ClothingHeadHatSurgcapGreen
         weight: 0.1
@@ -59,7 +59,7 @@
         weight: 0.90
     - !type:GroupSelector
       children:
-      - !type:NestedSelector # DeltaV - Add our scrubs. See Resources\Prototypes\_DV\Catalog\Fills\Lockers\medical.yml
+      - !type:NestedSelector # DeltaV - Add our scrubs. See Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
         tableId: ScrubsDeltaV
       - id: UniformScrubsColorBlue
         weight: 0.5
@@ -123,7 +123,7 @@
   id: LockerFillParamedic
   table: !type:AllSelector
     children:
-    - !type:NestedSelector # DeltaV - Adds our modifications. See Resources\Prototypes\_DV\Catalog\Fills\Lockers\medical.yml
+    - !type:NestedSelector # DeltaV - Adds our modifications. See Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
       tableId: LockerFillParamedicDeltaV
     #- id: ClothingOuterHardsuitVoidParamed # DeltaV - Removed to allow a locker without hardsuits.
     - id: ClothingOuterCoatParamedicWB

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -1,116 +1,79 @@
-- type: entity
-  id: LockerMedicineFilled
-  suffix: Filled
-  parent: LockerMedicine
-  components:
-  - type: StorageFill
-    contents:
-      - id: BoxSyringe
-      - id: ChemistryBottleEpinephrine
-        amount: 1
-      - id: Brutepack
-        amount: 2
-      - id: Ointment
-        amount: 2
-      - id: Bloodpack
-        amount: 2
-      - id: Gauze
+- type: entityTable
+  id: LockerFillMedicine
+  table: !type:AllSelector
+    children:
+    - id: BoxSyringe
+    - id: ChemistryBottleEpinephrine
+    - id: Brutepack
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: Ointment
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: Bloodpack
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: Gauze
 
 - type: entity
+  parent: LockerMedicine
+  id: LockerMedicineFilled
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillMedicine
+
+- type: entity
+  parent: LockerWallMedical
   id: LockerWallMedicalFilled
   name: medicine wall locker
   suffix: Filled
-  parent: LockerWallMedical
   components:
-  - type: StorageFill
-    contents:
-      - id: BoxSyringe
-      - id: ChemistryBottleEpinephrine
-        amount: 1
-      - id: Brutepack
-        amount: 2
-      - id: Ointment
-        amount: 2
-      - id: Bloodpack
-        amount: 2
-      - id: Gauze
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillMedicine
 
+- type: entityTable
+  id: LockerFillMedicalDoctor
+  table: !type:AllSelector
+    children:
+    - id: HandheldHealthAnalyzer
+      prob: 0.6
+    - id: ClothingHeadMirror
+      prob: 0.1
+    - id: ClothingHandsGlovesLatex
+    - id: ClothingHeadsetMedical
+    - id: ClothingEyesHudMedical
+    - !type:GroupSelector
+      children:
+      - id: ClothingHeadHatSurgcapGreen
+        weight: 0.1
+      - id: ClothingHeadHatSurgcapPurple
+        weight: 0.05
+      - id: ClothingHeadHatSurgcapBlue
+        weight: 0.90
+    - !type:GroupSelector
+      children:
+      - id: UniformScrubsColorBlue
+        weight: 0.5
+      - id: UniformScrubsColorGreen
+        weight: 0.1
+      - id: UniformScrubsColorPurple
+        weight: 0.05
+    - id: ClothingMaskSterile
 
 - type: entity
+  parent: LockerMedical
   id: LockerMedicalFilled
   suffix: Filled
-  parent: LockerMedical
   components:
-  - type: StorageFill
-    contents:
-      - id: HandheldHealthAnalyzer
-        prob: 0.6
-      - id: ClothingHeadMirror
-        prob: 0.1
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetMedical
-      - id: ClothingEyesHudMedical
-#Yea. Those probs are fucked. Nothing I can do about orGroup behavior. Everything below this line is DeltaV.
-#If Wizden ever adds new Probs, throw their probs out, but keep new items if added
-      - id: ClothingHeadHatSurgcapGreen
-        prob: 0.1
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapPurple
-        prob: 0.11
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapBlue
-        prob: 0.12
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapCyan
-        prob: 0.13
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapBlack
-        prob: 0.15
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapPink
-        prob: 0.16
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapRainbow
-        prob: 0.18
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapWhite
-        prob: 0.19
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapCybersun
-        prob: 0.02
-        orGroup: Surgcaps
-      - id: UniformScrubsColorBlue
-        prob: 0.1
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorGreen
-        prob: 0.11
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorPurple
-        prob: 0.12
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorCyan
-        prob: 0.13
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorBlack
-        prob: 0.15
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorPink
-        prob: 0.16
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorRainbow
-        prob: 0.18
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorWhite
-        prob: 0.19
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorCybersun
-        prob: 0.02
-        orGroup: Surgshrubs
-      - id: NitrousOxideTankFilled
-        prob: 0.3
-      - id: ClothingMaskSterile
-      - id: LunchboxMedicalFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillMedicalDoctor
 
 - type: entity
   parent: LockerWallMedical
@@ -118,103 +81,64 @@
   name: medical doctor's wall locker
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: HandheldHealthAnalyzer
-        prob: 0.6
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetMedical
-      - id: ClothingEyesHudMedical
-      - id: ClothingHeadHatSurgcapGreen
-        prob: 0.1
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapPurple
-        prob: 0.05
-        orGroup: Surgcaps
-      - id: ClothingHeadHatSurgcapBlue
-        prob: 0.90
-        orGroup: Surgcaps
-      - id: UniformScrubsColorBlue
-        prob: 0.5
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorGreen
-        prob: 0.1
-        orGroup: Surgshrubs
-      - id: UniformScrubsColorPurple
-        prob: 0.05
-        orGroup: Surgshrubs
-      - id: ClothingMaskSterile
-      - id: LunchboxMedicalFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillMedicalDoctor
+
+- type: entityTable
+  id: LockerFillChemistry
+  table: !type:AllSelector
+    children:
+    - id: BoxSyringe
+    - id: BoxBeaker
+    - id: BoxBeaker
+      prob: 0.3
+    - id: BoxPillCanister
+    - id: BoxBottle
+    - id: BoxVial
+    - id: PlasmaChemistryVial
+    - id: ChemBag
+    - id: ClothingHandsGlovesLatex
+    - id: ClothingHeadsetMedical
+    - id: ClothingMaskSterile
+    - id: HandLabeler
+      prob: 0.5
 
 - type: entity
+  parent: LockerChemistry
   id: LockerChemistryFilled
   suffix: Filled
-  parent: LockerChemistry
   components:
-  - type: StorageFill
-    contents:
-      - id: BoxSyringe
-      - id: BoxBeaker
-      - id: BoxBeaker
-        prob: 0.3
-      - id: BoxPillCanister
-      - id: BoxBottle
-      - id: BoxVial
-      - id: PlasmaChemistryVial
-      - id: ChemBag
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetMedical
-      - id: ClothingMaskSterile
-      - id: HandLabeler
-        prob: 0.5
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillChemistry
+
+- type: entityTable
+  id: LockerFillParamedic
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterHardsuitVoidParamed
+    - id: ClothingOuterCoatParamedicWB
+    - id: ClothingHeadHatParamedicsoft
+    - id: ClothingOuterWinterPara
+    - id: ClothingUniformJumpsuitParamedic
+    - id: ClothingUniformJumpskirtParamedic
+    - id: ClothingEyesHudMedical
+    - id: ClothingHandsGlovesLatex
+    - id: ClothingHeadsetMedical
+    - id: ClothingMaskSterile
+    - id: HandheldGPSBasic
+    - id: MedkitFilled
+      prob: 0.3
 
 - type: entity
-  id: LockerParamedicFilled # DeltaV - Paramedic locker without suit
+  parent: LockerParamedic
+  id: LockerParamedicFilled
   suffix: Filled
-  parent: LockerParamedic
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterCoatParamedicWB
-      - id: ClothingHeadHatParamedicsoft
-      - id: ClothingUniformJumpsuitParamedic
-      - id: ClothingUniformJumpskirtParamedic
-      - id: ClothingEyesHudMedical
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetMedical
-      - id: ClothingMaskSterile
-      - id: ClothingShoesBootsWinterParamedic # DeltaV - Add departmental winter boots
-      - id: BoxBodyBag # DeltaV - Give paramedics a body bag
-      - id: MedkitFilled
-        prob: 0.3
-      - id: LunchboxMedicalFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
-
-- type: entity
-  id: LockerParamedicFilledHardsuit # DeltaV - Paramedic locker with suit
-  suffix: Filled, Hardsuit
-  parent: LockerParamedic
-  components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterHardsuitVoidParamed
-      - id: ClothingOuterCoatParamedicWB
-      - id: ClothingHeadHatParamedicsoft
-      - id: ClothingOuterWinterPara
-      - id: ClothingUniformJumpsuitParamedic
-      - id: ClothingUniformJumpskirtParamedic
-      - id: ClothingEyesHudMedical
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetMedical
-      - id: ClothingMaskSterile
-      - id: ClothingShoesBootsWinterParamedic # DeltaV - Add departmental winter boots
-      - id: BoxBodyBag # DeltaV - Give paramedics a body bag
-      - id: EmergencyRollerBedSpawnFolded # DeltaV - move paramedic loadout to locker
-      - id: EmergencyJawsOfLife # DeltaV - Add Emergency Jaws of Life
-      - id: HandheldCrewMonitor # DeltaV - Give Paramedics useful tools on spawn
-      - id: HandheldGPSBasic
-      - id: MedkitFilled
-        prob: 0.3
-      - id: LunchboxMedicalFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: LockerFillParamedic

--- a/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/medical.yml
@@ -49,6 +49,8 @@
     - id: ClothingEyesHudMedical
     - !type:GroupSelector
       children:
+      - !type:NestedSelector # DeltaV - Add our surgery caps. See Resources\Prototypes\_DV\Catalog\Fills\Lockers\medical.yml
+        tableId: SurgeryCapsDeltaV
       - id: ClothingHeadHatSurgcapGreen
         weight: 0.1
       - id: ClothingHeadHatSurgcapPurple
@@ -57,6 +59,8 @@
         weight: 0.90
     - !type:GroupSelector
       children:
+      - !type:NestedSelector # DeltaV - Add our scrubs. See Resources\Prototypes\_DV\Catalog\Fills\Lockers\medical.yml
+        tableId: ScrubsDeltaV
       - id: UniformScrubsColorBlue
         weight: 0.5
       - id: UniformScrubsColorGreen
@@ -119,7 +123,9 @@
   id: LockerFillParamedic
   table: !type:AllSelector
     children:
-    - id: ClothingOuterHardsuitVoidParamed
+    - !type:NestedSelector # DeltaV - Adds our modifications. See Resources\Prototypes\_DV\Catalog\Fills\Lockers\medical.yml
+      tableId: LockerFillParamedicDeltaV
+    #- id: ClothingOuterHardsuitVoidParamed # DeltaV - Removed to allow a locker without hardsuits.
     - id: ClothingOuterCoatParamedicWB
     - id: ClothingHeadHatParamedicsoft
     - id: ClothingOuterWinterPara

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/medical.yml
@@ -120,3 +120,71 @@
     containers:
       entity_storage: !type:NestedSelector
         tableId: SurgeonLockerFill
+
+- type: entityTable
+  id: SurgeryCapsDeltaV
+  table: !type:GroupSelector
+    children:
+    - id: ClothingHeadHatSurgcapCyan
+      weight: 0.13
+    - id: ClothingHeadHatSurgcapBlack
+      weight: 0.15
+    - id: ClothingHeadHatSurgcapPink
+      weight: 0.16
+    - id: ClothingHeadHatSurgcapRainbow
+      weight: 0.18
+    - id: ClothingHeadHatSurgcapWhite
+      weight: 0.19
+    - id: ClothingHeadHatSurgcapCybersun
+      weight: 0.02
+
+- type: entityTable
+  id: ScrubsDeltaV
+  table: !type:GroupSelector
+    children:
+    - id: UniformScrubsColorCyan
+      weight: 0.13
+    - id: UniformScrubsColorBlack
+      weight: 0.15
+    - id: UniformScrubsColorPink
+      weight: 0.16
+    - id: UniformScrubsColorRainbow
+      weight: 0.18
+    - id: UniformScrubsColorWhite
+      weight: 0.19
+    - id: UniformScrubsColorCybersun
+      weight: 0.02
+
+- type: entityTable
+  id: LockerFillMedicalDoctorDeltaV
+  table: !type:AllSelector
+    children:
+    - id: NitrousOxideTankFilled
+      prob: 0.3
+    - id: LunchboxMedicalFilledRandom
+      prob: 0.3
+
+- type: entityTable
+  id: LockerFillParamedicDeltaV
+  table: !type:AllSelector
+    children:
+    - id: ClothingShoesBootsWinterParamedic
+    - id: BoxBodyBag
+    - id: EmergencyRollerBedSpawnFolded
+    - id: EmergencyJawsOfLife
+    - id: HandheldCrewMonitor
+    - id: LunchboxMedicalFilledRandom
+      prob: 0.3
+
+- type: entity
+  parent: LockerParamedic
+  id: LockerParamedicFilledHardsuit
+  suffix: Filled, Hardsuit
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: LockerFillParamedic
+        - id: ClothingOuterHardsuitVoidParamed


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR makes the `medical.yml` file use entity tables, also added our stuff already.

## Why / Balance

- Better fix of #3357
- StorageFill is evil.
- Less copy-paste stuff.
- 1 PR less to worry about in the upstream merge.

## Technical details
Shitload of `entityTable`s.

## Media
![image](https://github.com/user-attachments/assets/ee5ace63-2473-4385-889d-600dbc94ad8e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
I think I didn't omit anything, but yell at me if I did.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A