### PR TITLE
add apc wires

### DIFF
--- a/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
+++ b/Content.Client/Power/APC/UI/ApcMenu.xaml.cs
@@ -65,6 +65,13 @@ namespace Content.Client.Power.APC.UI
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
+                // Begin DeltaV Additions - set it to Disabled when power wire is snipped
+                if (!castState.PowerEnabled)
+                {
+                    ExternalPowerStateLabel.Text = Loc.GetString("apc-menu-power-state-disabled");
+                    ExternalPowerStateLabel.SetOnlyStyleClass(StyleNano.StyleClassPowerStateNone);
+                }
+                // End DeltaV Additions
             }
 
             if (ChargeBar != null)

--- a/Content.Server/Power/Components/PowerNetworkBatteryComponent.cs
+++ b/Content.Server/Power/Components/PowerNetworkBatteryComponent.cs
@@ -112,6 +112,16 @@ namespace Content.Server.Power.Components
             set => NetworkBattery.Efficiency = value;
         }
 
+        /// <summary>
+        /// DeltaV - Disables power I/O, controlled by <c>PowerBatteryWireAction</c>.
+        /// </summary>
+        [DataField]
+        public bool PowerEnabled
+        {
+            get => NetworkBattery.Enabled;
+            set => NetworkBattery.Enabled = value;
+        }
+
         [ViewVariables]
         public PowerState.Battery NetworkBattery { get; } = new();
     }

--- a/Content.Server/Power/EntitySystems/ApcSystem.cs
+++ b/Content.Server/Power/EntitySystems/ApcSystem.cs
@@ -168,7 +168,7 @@ public sealed class ApcSystem : EntitySystem
 
         var state = new ApcBoundInterfaceState(apc.MainBreakerEnabled,
             (int) MathF.Ceiling(battery.CurrentSupply), apc.LastExternalState,
-            charge);
+            charge, battery.Enabled); // DeltaV
 
         _ui.SetUiState((uid, ui), ApcUiKey.Key, state);
     }

--- a/Content.Server/Wires/BaseWireAction.cs
+++ b/Content.Server/Wires/BaseWireAction.cs
@@ -141,6 +141,6 @@ public abstract partial class BaseWireAction : IWireAction
     /// <returns>true if powered, false otherwise</returns>
     protected bool IsPowered(EntityUid uid)
     {
-        return WiresSystem.IsPowered(uid, EntityManager);
+        return WiresSystem.HasPower(uid); // DeltaV - support APC power checks
     }
 }

--- a/Content.Server/Wires/WiresSystem.cs
+++ b/Content.Server/Wires/WiresSystem.cs
@@ -19,7 +19,7 @@ using Robust.Shared.Random;
 
 namespace Content.Server.Wires;
 
-public sealed class WiresSystem : SharedWiresSystem
+public sealed partial class WiresSystem : SharedWiresSystem // DeltaV - made partial
 {
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;

--- a/Content.Server/_DV/Wires/WiresSystem.Power.cs
+++ b/Content.Server/_DV/Wires/WiresSystem.Power.cs
@@ -1,0 +1,17 @@
+using Content.Server.Power.Components;
+using Content.Server.Power.EntitySystems;
+
+namespace Content.Server.Wires;
+
+public sealed partial class WiresSystem
+{
+    public bool HasPower(EntityUid uid)
+    {
+        // for APCs check if the power wire isn't snipped/pulsed
+        if (TryComp<PowerNetworkBatteryComponent>(uid, out var comp))
+            return comp.PowerEnabled;
+
+        // for other devices check for APCPowerReceiver
+        return this.IsPowered(uid, EntityManager);
+    }
+}

--- a/Content.Shared/APC/SharedApc.cs
+++ b/Content.Shared/APC/SharedApc.cs
@@ -181,13 +181,15 @@ namespace Content.Shared.APC
         public readonly int Power;
         public readonly ApcExternalPowerState ApcExternalPower;
         public readonly float Charge;
+        public readonly bool PowerEnabled; // DeltaV
 
-        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge)
+        public ApcBoundInterfaceState(bool mainBreaker, int power, ApcExternalPowerState apcExternalPower, float charge, bool powerEnabled) // DeltaV - add powerEnabled
         {
             MainBreaker = mainBreaker;
             Power = power;
             ApcExternalPower = apcExternalPower;
             Charge = charge;
+            PowerEnabled = powerEnabled; // DeltaV
         }
 
         public bool Equals(ApcBoundInterfaceState? other)
@@ -197,7 +199,8 @@ namespace Content.Shared.APC
             return MainBreaker == other.MainBreaker &&
                    Power == other.Power &&
                    ApcExternalPower == other.ApcExternalPower &&
-                   MathHelper.CloseTo(Charge, other.Charge);
+                   MathHelper.CloseTo(Charge, other.Charge) &&
+                   PowerEnabled == other.PowerEnabled; // DeltaV
         }
 
         public override bool Equals(object? obj)

--- a/Resources/Locale/en-US/_DV/ui/power-apc.ftl
+++ b/Resources/Locale/en-US/_DV/ui/power-apc.ftl
@@ -1,0 +1,1 @@
+apc-menu-power-state-disabled = Disabled

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -89,6 +89,11 @@
     interfaces:
       enum.ApcUiKey.Key:
         type: ApcBoundUserInterface
+      enum.WiresUiKey.Key: # DeltaV - APC wires
+        type: WiresBoundUserInterface
+  - type: Wires # DeltaV - APC wires
+    boardName: wires-board-name-apc
+    layoutId: APC
   - type: ActivatableUI
     inHandsOnly: false
     key: enum.ApcUiKey.Key

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/APC.yml
@@ -38,6 +38,7 @@
           conditions:
             - !type:WirePanel
               open: true
+            - !type:AllWiresCut # DeltaV - APC wires
           steps:
             - tool: Prying
               doAfter: 4

--- a/Resources/Prototypes/_DV/Wires/layouts.yml
+++ b/Resources/Prototypes/_DV/Wires/layouts.yml
@@ -15,3 +15,13 @@
   - !type:PowerWireAction
   - !type:AccessWireAction
   - !type:LogWireAction
+
+- type: wireLayout
+  id: APC
+  wires:
+  - !type:PowerWireAction
+    pulseTimeout: 60 # double the times of airlock wires so it's more useful
+  - !type:PowerWireAction
+    pulseTimeout: 30
+  - !type:AiInteractWireAction
+  - !type:AccessWireAction


### PR DESCRIPTION
## About the PR
apc now has wires:
- 2 power wires which disable the apc battery entirely. 60/30s timeout when pulsed, twice as long as doors
  light is fucked because
- ai access so you can counter ai toggling an apc constantly
- access for trolling, no real impact compared to now where you can screw -> crowbar an apc to kill it

to deconstruct an apc you now have to cut all the wires so trolling requires insuls

## Why / Balance
we love ai spam toggling an apc
we love instantly deconstructing apcs

## Technical details
there was no reason upstream pr tried networking it since nothing in shared/client used it. if wires get moved to shared itll conflict automatically so it can be done properly then

## Media
ai access disabled, ai cant use apc
![04:24:39](https://github.com/user-attachments/assets/924ecabc-43b4-460d-8a37-858500e9f7f1)

deconstructing real
![04:18:26](https://github.com/user-attachments/assets/a56ffce9-f206-464a-bde9-ceb46e93404b)

![04:21:24](https://github.com/user-attachments/assets/11d3a80c-1c04-4ed5-820f-75ed3b657e68)

all lights go off when power is cut
![04:57:03](https://github.com/user-attachments/assets/6a8b670e-5d6a-4626-9400-a5c0524c9da7)

power wires snipped, it says Disabled in the ui
![08:21:49](https://github.com/user-attachments/assets/b97ef892-a4ea-4fe0-b602-950b5e34f93f)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: APCs now have wires, notably the AI access wire which can be snipped to prevent the AI from toggling APCs.
