### PR TITLE
revert tactical hacking

### DIFF
--- a/Content.Server/Wires/BaseToggleWireAction.cs
+++ b/Content.Server/Wires/BaseToggleWireAction.cs
@@ -29,9 +29,7 @@ public abstract partial class BaseToggleWireAction : BaseWireAction
 
     public override bool Cut(EntityUid user, Wire wire)
     {
-        if (!base.Cut(user, wire)) // Nyanotrasen - Tactical hacking
-            return false;
-
+        base.Cut(user, wire);
         ToggleValue(wire.Owner, false);
 
         if (TimeoutKey != null)
@@ -44,9 +42,7 @@ public abstract partial class BaseToggleWireAction : BaseWireAction
 
     public override bool Mend(EntityUid user, Wire wire)
     {
-        if (!base.Mend(user, wire)) // Nyanotrasen - Tactical hacking
-            return false;
-
+        base.Mend(user, wire);
         ToggleValue(wire.Owner, true);
 
         return true;

--- a/Content.Server/Wires/WiresComponent.cs
+++ b/Content.Server/Wires/WiresComponent.cs
@@ -48,8 +48,8 @@ public sealed partial class WiresComponent : Component
     ///     If this should follow the layout saved the first time the layout dictated by the
     ///     layout ID is generated, or if a new wire order should be generated every time.
     /// </summary>
-    [DataField("alwaysRandomize")]
-    public bool AlwaysRandomize { get; private set; } = true; // Nyanotrasen - Always randomize wires
+    [DataField]
+    public bool AlwaysRandomize { get; private set; }
 
     /// <summary>
     ///     Per wire status, keyed by an object.


### PR DESCRIPTION
## About the PR
reverts #168:
- wires are only randomized between departments now
- devices like air alarms all share the same wires
- snipping non-power wires no longer has a chance to shock you

## Why / Balance
insanely fucking annoying for engi if you want to say cut ai access on a bunch of things

for tiders:
- doors dont have an access wire which nyano had so the main reason it was added doesn't exist
- bolting can be undone trivially by anyone with the doors remote or the AI
  welding is also sneakier as if you run up with the welder on theres no sound compared to screwing a panel open which will instantly attract 20 validhunters
- you can trivially bypass it for anchorable things by unanchoring then snipping all but 1 wire to isolate power
- you can easily bypass it for doors/air alarms by turning off/removing the apc then snipping away
- doesnt make sense as low voltage low current wires being snipped (with plastic handle wirecutters too :trollface:) shouldnt hurt you or send you to the floor, especially based on pure rng

if you want to break into somewhere it also rewards figuring out the department's wire layout beforehand so you can get in faster

with #3372 tiders can disable apcs without access if they figure out which wire it is but anyone was already able to screw -> pry to kill an apc anyway

## Breaking changes
removed the wire fields nyano added, nothing here used them though

**Changelog**
:cl:
- remove: Removed non-power wires having a chance to shock you.
- remove: All wires are no longer randomized, it's the same behaviour as upstream now.