### PR TITLE
fix ipcs not being able to disarm

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -106,6 +106,8 @@
   - type: EmitBuzzWhileDamaged
   - type: CanHostGuardian
   - type: WeldingHealable
+  - type: CombatMode # DeltaV - let IPCs disarm
+    canDisarm: true
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
title

## Why / Balance
fixes #3370

## Technical details
it was missing canDisarm from base species because it didnt inherit from it
copy paste ops :rocket: 

**Changelog**
:cl:
- fix: Fixed IPCs not being able to disarm people.
