### PR TITLE
Alternate Aloxadone Recipe

### DIFF
--- a/Resources/Prototypes/_NF/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_NF/Recipes/Reactions/medicine.yml
@@ -1,0 +1,12 @@
+- type: reaction
+  id: NFAloxadone
+  impact: Medium
+  reactants:
+    Cryoxadone:
+      amount: 1
+    Dermaline:
+      amount: 2
+    Siderlac:
+      amount: 2
+  products:
+      Aloxadone: 4


### PR DESCRIPTION
## About the PR
Added an alternate Aloxadone recipe based off of the [New Frontier's alternate recipe](https://github.com/new-frontiers-14/frontier-station-14/blob/master/Resources/Prototypes/_NF/Recipes/Reactions/medicine.yml#L41). It uses siderlac, dermaline, and cryoxadone!

## Why / Balance
Any experienced chemist knows that siderlac is basically a waste of alox and stelli, since caustic damage is somewhat rare and sigy exists. And the chemists feels less pain for accidently grinding down aloe and galaxythistle in the same batch. One can claim "skill issue" but when you have to mindlessly grind down 30 aloe and galaxythistle and accidently make some siderlac, it would be nice to be able to do do something with the siderlac other than make cogni.

As far as the components go, both recipes have a component that treats caustic and non-caustic burns, so that makes sense. As far as balance goes, chemists are still dependent on botany for the botanical chems but it gives chemists more versatility on how they decide to use their supply of stelli.

## Technical details
Added a single YAML file.

## Media

https://github.com/user-attachments/assets/c975ad5e-c460-45fb-a4a3-625cd9f855c4

![image](https://github.com/user-attachments/assets/e262f88a-4c91-4737-8cc5-89d8251eb9ed)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None that I know of.

**Changelog**
:cl:
- add: added an alternate Aloxadone recipe that uses siderlac, dermaline, and cryoxadone.
