### PR TITLE
fix remilia etc not being healable with topicals

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -30,6 +30,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV
     damage:
       types:
         Heat: -5
@@ -81,6 +82,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV
     damage:
       types:
         Heat: -10
@@ -123,6 +125,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV
     damage:
       groups:
         Brute: -15 # 5 for each type in the group
@@ -172,6 +175,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV
     damage:
       groups:
         Brute: -30 # 10 for each type in the group
@@ -212,6 +216,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV
     damage:
       types:
         Bloodloss: -0.5 #lowers bloodloss damage
@@ -250,6 +255,7 @@
     - type: Healing
       damageContainers:
         - Biological
+        - BiologicalMetaphysical # DeltaV
       damage:
         groups:
           Brute: 5 # Tourniquets HURT!
@@ -282,6 +288,7 @@
   - type: Healing
     damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV
     damage:
       types:
         Slash: -5


### PR DESCRIPTION
## About the PR
remilia valid dog and other mobs using BiologicalMetaphysical damage container can now be healed with topicals

powergaming skeletons also no longer need to carry a bucket of milk at all times

## Why / Balance
normal bat can be healed with bruise pack
funny magic bat cant

10/10 logic

fixes #3421

**Changelog**
:cl:
- fix: Fixed not being able to heal familiars like Remilia with topicals.