### PR TITLE
Buff sec suits to have more heat resistance

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -22,7 +22,7 @@
         Piercing: 0.60
         Radiation: 0.75
         Caustic: 0.75
-        Heat: 0.75
+        Heat: 0.6
     staminaDamageCoefficient: 0.3 # It's a hardsuit, duh
   - type: ClothingSpeedModifier
     walkModifier: 0.75
@@ -68,7 +68,7 @@
         Piercing: 0.65
         Radiation: 0.80
         Caustic: 0.80
-        Heat: 0.80
+        Heat: 0.7
     staminaDamageCoefficient: 0.3 # still a hardsuit
   - type: ClothingSpeedModifier
     walkModifier: 0.85
@@ -160,7 +160,7 @@
         Piercing: 0.50
         Radiation: 0.75
         Caustic: 0.75
-        Heat: 0.75
+        Heat: 0.5
     staminaDamageCoefficient: 0.2
   - type: ClothingSpeedModifier
     walkModifier: 0.80


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
security officer hardsuit 25% -> 40%
corpsman suit 15% -> 30%
HoS suit 25% -> 50%

## Why / Balance
 theres a lot of reasons to do this, sec wont get annihilated anymore because one officer died with the beam devastator, gamblagator, or even the captains pistol. sec having very little heat res on their hardsuits is a lil silly.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Security hardsuits are more resistant to heat.
