### PR TITLE
Reduce gamblagator mags roundstart

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/security.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/security.yml
@@ -39,4 +39,4 @@
     - id: WeaponSniperGamblagator
     - id: GamblagatorCapacitor
       amount: !type:ConstantNumberSelector
-        value: 4
+        value: 2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
mags roundstart 5 -> 3

## Why / Balance
people are complaining too much, also allegedly this will discourage armory rushes (Doubtful)

the gun itself is also fairly strong and this should tone it down

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: gamblagator will have less ammo round-start

