### PR TITLE
Make pacifists be able to use disablers

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -482,6 +482,7 @@
     - Taser
     - Sidearm
     - ConcealCarry # DeltaV - can be stowed in military boots for now
+  - type: PacifismAllowedGun # DeltaV - allow pacifist to use the disabler
 
 - type: entity
   name: disabler

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -549,6 +549,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 260
+  - type: PacifismAllowedGun # DeltaV - allow pacifist to use the disabler
 
 - type: entity
   name: taser


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Made the disabler, practice disabler, and the smg variant usable by pacifists

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They no longer do any form of damage other than stamina. Stun batons in stun mode can already be used by pacifists, which is an inconsistency.
Either:
- Make stun batons and any other form of stunning unusable 
- Make stun weapons that do not do damage usable

I think the second option is better, because this provides a middle ground for pacifist characters, allowing them to play security. And if the player takes pacifism seriously, then they will not touch disablers for RP reasons rather than mechanical ones.

## Technical details
<!-- Summary of code changes for easier review. -->
PacifismAllowedGunComponent

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Pacifists can now use disablers
