### PR TITLE
lockout admin assistant after too much playtime

### DIFF
--- a/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Command/administrative_assistant.yml
@@ -6,6 +6,10 @@
   requirements:
   - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
     time: 90000 # 25 hours
+  - !type:DepartmentTimeRequirement
+    department: Command
+    time: 54000 #15 hrs
+    inverted: true # no playing this after 15 hours of it
   startingGear: AdminAssistantGear
   icon: "JobIconAdminAssitant"
   supervisors: job-supervisors-command


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
if you have 15+ hours as command you can no longer play admin assistant

## Why / Balance
solves #3289 

admin assistant players refused to stop maining the role solely to validhunt people who walk into bridge. A lot of people are tired of this role being terrible and 15 hours is MORE than generous  to learn basic command duties.

## Technical details
yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak:  if you have 15 hours on command you can no longer play as admin assistant