### PR TITLE
Disable mob pushing

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -20,7 +20,7 @@ quick_lottery = true
 generator_enabled = false
 
 [movement]
-mob_pushing = true
+mob_pushing = false
 
 [physics]
 # Makes mapping annoying

--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -9,7 +9,7 @@ role_timer_override = "DeltaV"
 showgreentext = false # focus more on telling a story
 
 [movement]
-mob_pushing = true
+mob_pushing = false
 
 # New players can't join a server without admins
 [game.panic_bunker]


### PR DESCRIPTION
## About the PR
Turn off mob collision

## Why / Balance
Feature is badly implemented an causing headaches in several departments. Stations are not built for people being unable to share a door.
Overall feels unfinished and unpolished, not production ready

## Technical details
turn setting off

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- remove: Disabled mob pushing for the time being
