### PR TITLE
Tape recorder and cassette tape to every TechFab

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -413,6 +413,7 @@
     - SecurityAmmoStatic
     - SecurityWeaponsStatic
     - SecurityRubberAmmoStatic # DeltaV
+    - ReportingStatic # DeltaV
     dynamicPacks:
     - SalvageSecurityBoards
     - SalvageSecurityWeapons
@@ -492,6 +493,7 @@
     - MedicalClothingStatic
     - EmptyMedkitsStatic
     - SurgeryStatic
+    - ReportingStatic # DeltaV
     dynamicPacks:
     - Chemistry
     - CyberneticsMedical # Shitmed change

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -59,6 +59,7 @@
     - ElectronicsStatic
     - LightsStatic
     - MaterialsStatic
+    - ReportingStatic
     dynamicPacks:
     - AdvancedTools
     - PowerCells
@@ -96,6 +97,7 @@
     - PartsStatic
     - LVCablesStatic
     - CargoStatic
+    - ReportingStatic
     dynamicPacks:
     - Equipment
     - Mining
@@ -167,6 +169,7 @@
     - BasicChemistryStatic
     - ChemistryStatic
     - PowerCellsStatic
+    - ReportingStatic
     dynamicPacks:
     - ScienceEquipment
     - ScienceClothing

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/service.yml
@@ -1,12 +1,6 @@
 ## Static
 
 - type: latheRecipePack
-  id: ReportingStatic
-  recipes:
-  - CassetteTape
-  - TapeRecorder
-
-- type: latheRecipePack
   id: ServiceStaticDeltaV
   recipes:
   - TrashBag

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
@@ -18,3 +18,9 @@
   recipes:
   - Beaker
   - HandLabeler
+
+- type: latheRecipePack
+  id: ReportingStatic
+  recipes:
+  - CassetteTape
+  - TapeRecorder


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR allows every departamental TechFab to be able to print the tape recorder and the cassette tape.

## Why / Balance
Everyone can spawn with it in the loadout and it's a generally useful tool for keeping records.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Now the tape recorder is able to be printed at every departamental TechFab.