### PR TITLE
Added stuff to vending machine stocks

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 3850 # DeltaV
+  cost: 3875# DeltaV
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 3875# DeltaV
+  cost: 3875 # DeltaV
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -33,7 +33,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 3650 # DeltaV
+  cost: 3850 # DeltaV
   category: cargoproduct-category-name-service
   group: market
 
@@ -43,7 +43,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockAutoDrobeFilled
-  cost: 2250 # DeltaV
+  cost: 2450 # DeltaV
   category: cargoproduct-category-name-service
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -118,15 +118,17 @@
     ClothingHandsGlovesColorPurple: 2
     ClothingEyesGlassesCheapSunglasses: 3
     # DO NOT ADD MORE, USE UNIFORM DYING
-    ClothingUniformJumpsuitSuitBlackAlt: 2 # DeltaV - add dark suit
-    ClothingUniformJumpsuitSuitBlack: 2 # DeltaV - add black suit
-    ClothingUniformJumpsuitSuitWhiteAlt: 2 # DeltaV - add negative suit
-    ClothingUniformJumpsuitSuitBrown: 2 # DeltaV - add brown suit
-    ClothingUniformJumpsuitSuitBrownMob: 2 # DeltaV - add gangster's attire
-    ClothingUniformJumpsuitSuitBlackMob: 2 # DeltaV - add mobster's attire
-    ClothingUniformJumpsuitSuitWhiteMob: 2 # DeltaV - add mafioso's attire
-    ClothingUniformBrownSuit: 2 # DeltaV - add brown suit
-    ClothingUniformBrownSuitSkirt: 2 # DeltaV - add brown suitskirt
+    # Begin DeltaV additions
+    ClothingUniformJumpsuitSuitBlackAlt: 2
+    ClothingUniformJumpsuitSuitBlack: 2
+    ClothingUniformJumpsuitSuitWhiteAlt: 2
+    ClothingUniformJumpsuitSuitBrown: 2
+    ClothingUniformJumpsuitSuitBrownMob: 2
+    ClothingUniformJumpsuitSuitBlackMob: 2
+    ClothingUniformJumpsuitSuitWhiteMob: 2
+    ClothingUniformBrownSuit: 2
+    ClothingUniformBrownSuitSkirt: 2
+    # End DeltaV additions
   contrabandInventory:
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -128,7 +128,7 @@
     ClothingUniformJumpsuitSuitWhiteMob: 2
     ClothingUniformBrownSuit: 2
     ClothingUniformBrownSuitSkirt: 2
-    ClothingHeadHatBowlerHat: 2
+    ClothingShoesLeather: 2
     ClothingShoesBootsLaceup: 2
     # End DeltaV additions
   contrabandInventory:

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -128,6 +128,8 @@
     ClothingUniformJumpsuitSuitWhiteMob: 2
     ClothingUniformBrownSuit: 2
     ClothingUniformBrownSuitSkirt: 2
+    ClothingHeadHatBowlerHat: 2
+    ClothingShoesBootsLaceup: 2
     # End DeltaV additions
   contrabandInventory:
     ClothingMaskNeckGaiter: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -64,6 +64,7 @@
     ClothingUniformJumpsuitJeansBrown: 2
     ClothingUniformJumpsuitLostTourist: 2
     # End Nyano Additions
+    ClothingShoesTourist: 2 # DeltaV - add tourist shoes
     # DO NOT ADD MORE, USE UNIFORM DYING
     ClothingShoesColorBlack: 8
     ClothingShoesColorBrown: 4
@@ -117,6 +118,15 @@
     ClothingHandsGlovesColorPurple: 2
     ClothingEyesGlassesCheapSunglasses: 3
     # DO NOT ADD MORE, USE UNIFORM DYING
+    ClothingUniformJumpsuitSuitBlackAlt: 2 # DeltaV - add dark suit
+    ClothingUniformJumpsuitSuitBlack: 2 # DeltaV - add black suit
+    ClothingUniformJumpsuitSuitWhiteAlt: 2 # DeltaV - add negative suit
+    ClothingUniformJumpsuitSuitBrown: 2 # DeltaV - add brown suit
+    ClothingUniformJumpsuitSuitBrownMob: 2 # DeltaV - add gangster's attire
+    ClothingUniformJumpsuitSuitBlackMob: 2 # DeltaV - add mobster's attire
+    ClothingUniformJumpsuitSuitWhiteMob: 2 # DeltaV - add mafioso's attire
+    ClothingUniformBrownSuit: 2 # DeltaV - add brown suit
+    ClothingUniformBrownSuitSkirt: 2 # DeltaV - add brown suitskirt
   contrabandInventory:
     ClothingMaskNeckGaiter: 2
     ClothingUniformJumpsuitTacticool: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/donut.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/donut.yml
@@ -5,6 +5,9 @@
     FoodDonutApple: 3
     FoodDonutPink: 3
     FoodDonutBungo: 3
+    FoodDonutPlain: 3 # DeltaV - add plain donut
+    FoodDonutHomer: 2 # DeltaV - add sprinkled donut
+    FoodDonutMeat: 3 # DeltaV - add meat donut
   contrabandInventory:
     FoodBagel: 2
     FoodBagelPoppy: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/donut.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/donut.yml
@@ -5,9 +5,11 @@
     FoodDonutApple: 3
     FoodDonutPink: 3
     FoodDonutBungo: 3
-    FoodDonutPlain: 3 # DeltaV - add plain donut
-    FoodDonutHomer: 2 # DeltaV - add sprinkled donut
-    FoodDonutMeat: 3 # DeltaV - add meat donut
+    # Begin DeltaV additions
+    FoodDonutPlain: 3
+    FoodDonutHomer: 2
+    FoodDonutMeat: 3
+    # End DeltaV additions
   contrabandInventory:
     FoodBagel: 2
     FoodBagelPoppy: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -14,6 +14,7 @@
     ClothingEyesHudSecurity: 2
     ClothingEyesEyepatchHudSecurity: 2
     ClothingBeltSecurityWebbing: 5
+    ClothingBeltSecurity: 5 # DeltaV - added security belt to SecTech
     CombatKnife: 3
     Zipties: 12
     RiotShield: 2
@@ -24,6 +25,7 @@
     ClothingHeadCage: 2 # Nyanotrasen - Insulative headgear
     ClothingOuterArmorPlateCarrier: 2 # DeltaV - moved body armour from SecDrobe to SecTech
     ClothingOuterArmorDuraVest: 2
+    ClothingOuterArmorReflective: 2 # DeltaV - added reflective vest to sectech
     ClothingHeadHelmetBasic: 2 # DeltaV - added helmets to the SecTech. Another line of defense between the tide and your grey matter.
     BreachingCharge: 8 # DeltaV - added breaching charges
   # security officers need to follow a diet regimen!

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sec.yml
@@ -1,6 +1,7 @@
 - type: vendingMachineInventory
   id: SecTechInventory
   startingInventory:
+    HoloprojectorSecurity: 3 # DeltaV - added holobarrier to SecTech
     SecurityWhistle: 5
     Handcuffs: 8
     GrenadeFlashBang: 4

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -29,7 +29,7 @@
     ClothingHeadsetPrison: 3 # DeltaV - prison headsets in secdrobe
     ClothingOuterStasecSweater: 2 # DeltaV - add sweaters to secdrobe
     ClothingOuterCoatStasec: 2 # DeltaV - replace ClothingOuterWinterSec
-    ClothingOuterWinterSec: 2 # DeltaV - add sec winter coats (variant)
+#    ClothingOuterWinterSec: 2 # DeltaV - removed this
     ClothingNeckCWPSec: 3 # DeltaV - add cold weather ponchos
 ##    ClothingOuterArmorBasic: 2 # DeltaV - moved body armour from SecDrobe to SecTech
 ##    ClothingOuterArmorBasicSlim: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -29,7 +29,7 @@
     ClothingHeadsetPrison: 3 # DeltaV - prison headsets in secdrobe
     ClothingOuterStasecSweater: 2 # DeltaV - add sweaters to secdrobe
     ClothingOuterCoatStasec: 2 # DeltaV - replace ClothingOuterWinterSec
-    ClothingOuterWinterSec: 2 # DeltaV - add ClothingOuterWinterSec
+    ClothingOuterWinterSec: 2 # DeltaV - add sec winter coats (variant)
     ClothingNeckCWPSec: 3 # DeltaV - add cold weather ponchos
 ##    ClothingOuterArmorBasic: 2 # DeltaV - moved body armour from SecDrobe to SecTech
 ##    ClothingOuterArmorBasicSlim: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/secdrobe.yml
@@ -19,20 +19,24 @@
     ClothingUniformJumpsuitSecGrey: 3
     ClothingUniformJumpskirtSecGrey: 3
     ClothingUniformJumpsuitSecBlue: 3
+    ClothingUniformJumpsuitSecSummer: 3 # DeltaV - add summer security uniform
     ClothingUniformJumpskirtSecBlue: 3 # DeltaV - new skirt sprited, added to secdrobe
     ClothingUniformJumpsuitSecFormal: 1 # DeltaV - add formal uniform to secdrobe
     ClothingUniformJumpskirtSecFormal: 1 # DeltaV - add formal uniform to secdrobe
     ClothingHeadsetSecurity: 3
+    ClothingUniformJumpsuitPrisoner: 3 # DeltaV - added prison jumpsuits
+    ClothingUniformJumpskirtPrisoner: 3 # DeltaV - added prison jumpskirts
     ClothingHeadsetPrison: 3 # DeltaV - prison headsets in secdrobe
     ClothingOuterStasecSweater: 2 # DeltaV - add sweaters to secdrobe
     ClothingOuterCoatStasec: 2 # DeltaV - replace ClothingOuterWinterSec
-    ClothingNeckCWPSec: 2 # DeltaV - add cold weather ponchos
+    ClothingOuterWinterSec: 2 # DeltaV - add ClothingOuterWinterSec
+    ClothingNeckCWPSec: 3 # DeltaV - add cold weather ponchos
 ##    ClothingOuterArmorBasic: 2 # DeltaV - moved body armour from SecDrobe to SecTech
 ##    ClothingOuterArmorBasicSlim: 2
     ClothingNeckScarfStripedRed: 3
     ClothingEyesBlindfold: 1
     ClothingShoesBootsCombat: 1
-#    ClothingShoesBootsWinterSec: 2 # DeltaV - removed for incongruency
+    ClothingShoesBootsWinterSec: 2
 #   ClothingHeadHelmetJustice: 1 # DeltaV - lrp
   contrabandInventory:
 #    ClothingMaskClownSecurity: 1 # DeltaV - removed for incongruency

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -6,7 +6,7 @@
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
     # Begin DeltaV Additions
-    FoodPSD: 5
+    FoodPSB: 5
     FoodTinMRE: 3
     FoodTinPeaches: 3
     BoxMRE: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -6,8 +6,24 @@
     FoodSnackMREBrownie: 5
     FoodCondimentPacketKetchup: 5
     # Begin DeltaV Additions
+    FoodPSD: 5
+    FoodTinMRE: 3
+    FoodTinPeaches: 3
+    BoxMRE: 3
+    ReagentTinPowderedMilk: 2
     ReagentTinPowderedMilkSoy: 2
     ReagentTinPowderedJuiceOrange: 1
+    ReagentTinPowderedJuiceLime: 1
+    ReagentTinPowderedJuiceWatermelon: 1
+    ReagentTinPowderedJuiceApple: 1
+    ReagentTinPowderedJuiceBerry: 1
+    ReagentTinPowderedJuicePineapple: 1
+    ReagentTinPowderedJuiceTomato: 1
+    ReagentTinPowderedJuiceBanana: 1
+    ReagentTinPowderedJuiceCarrot: 1
+    ReagentTinPowderedJuiceCherry: 1
+    ReagentTinPowderedJuiceGrape: 1
+    ReagentTinPowderedJuiceLemon: 1
     # End DeltaV Additions
   contrabandInventory:
     FoodTinMRE: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -105,7 +105,7 @@
     ClothingHeadHatFedoraChoc: 1
     ClothingHeadHatFedoraWhite: 1
     ClothingHeadHatFedoraBlack: 1
-    ClothingShoesLeather: 1
+    ClothingHeadHatBowlerHat: 1
     ClothingUniformFuneralSuit: 1
     ClothingUniformFuneralSuitSkirt: 1
     ClothingHeadTechPriest: 2 # moved from robodrobe

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -36,6 +36,12 @@
     Gohei: 2
     ClothingOuterSuitWitchRobes: 2
     ClothingHeadHatWitch1: 2
+    ClothingHeadHatWitch: 2 # DeltaV - add witch hat (all black)
+    ClothingHeadHatAnimalCatBrown: 2 # DeltaV - add brown cat hat
+    ClothingHeadHatAnimalCat: 2 # DeltaV - add gray cat hat
+    ClothingOuterWizardFake: 2 # DeltaV - add fake wizard robes
+    ClothingShoesWizardFake: 2 # DeltaV - add fake wizard shoes
+    ClothingHeadHatWizardFake: 2 # DeltaV - add fake wizard hats
     ClothingHeadHatRedRacoon: 2
     ClothingOuterRedRacoon: 2
     ClothingHeadPaperSack: 2
@@ -94,6 +100,14 @@
     ClothingNeckTieDet: 1
     ClothingHeadHatFedoraBrown: 1
     ClothingHeadHatFedoraGrey: 1
+    ClothingHeadHatFedoraChoc: 1
+    ClothingHeadHatFedoraWhite: 1
+    ClothingHeadHatFedoraBlack: 1
+    ClothingHeadHatBowlerHat: 1
+    ClothingShoesBootsLaceup: 1
+    ClothingShoesLeather: 1
+    ClothingUniformFunuralSuit: 1
+    ClothingUniformFunuralSuitSkirt: 1
     ClothingHeadTechPriest: 2 # moved from robodrobe
     ClothingOuterRobeTechPriest: 2
     ClothingMaskBlushingClown: 1 # moved from emag inventory

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -36,12 +36,14 @@
     Gohei: 2
     ClothingOuterSuitWitchRobes: 2
     ClothingHeadHatWitch1: 2
-    ClothingHeadHatWitch: 2 # DeltaV - add witch hat (all black)
-    ClothingHeadHatAnimalCatBrown: 2 # DeltaV - add brown cat hat
-    ClothingHeadHatAnimalCat: 2 # DeltaV - add gray cat hat
-    ClothingOuterWizardFake: 2 # DeltaV - add fake wizard robes
-    ClothingShoesWizardFake: 2 # DeltaV - add fake wizard shoes
-    ClothingHeadHatWizardFake: 2 # DeltaV - add fake wizard hats
+    # Begin DeltaV additions
+    ClothingHeadHatWitch: 2
+    ClothingHeadHatAnimalCatBrown: 2
+    ClothingHeadHatAnimalCat: 2
+    ClothingOuterWizardFake: 2
+    ClothingShoesWizardFake: 2
+    ClothingHeadHatWizardFake: 2
+    # End DeltaV additions
     ClothingHeadHatRedRacoon: 2
     ClothingOuterRedRacoon: 2
     ClothingHeadPaperSack: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -106,8 +106,8 @@
     ClothingHeadHatBowlerHat: 1
     ClothingShoesBootsLaceup: 1
     ClothingShoesLeather: 1
-    ClothingUniformFunuralSuit: 1
-    ClothingUniformFunuralSuitSkirt: 1
+    ClothingUniformFuneralSuit: 1
+    ClothingUniformFuneralSuitSkirt: 1
     ClothingHeadTechPriest: 2 # moved from robodrobe
     ClothingOuterRobeTechPriest: 2
     ClothingMaskBlushingClown: 1 # moved from emag inventory

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -105,8 +105,6 @@
     ClothingHeadHatFedoraChoc: 1
     ClothingHeadHatFedoraWhite: 1
     ClothingHeadHatFedoraBlack: 1
-    ClothingHeadHatBowlerHat: 1
-    ClothingShoesBootsLaceup: 1
     ClothingShoesLeather: 1
     ClothingUniformFuneralSuit: 1
     ClothingUniformFuneralSuitSkirt: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
@@ -18,15 +18,15 @@
     ClothingOuterCoatBomber: 3
     ClothingHeadHatSantahat: 2
     ClothingHeadHatXmasCrown: 2
-    ClothingOuterWinterCoatColorRed: 2 # DeltaV - add red winter coats
-    ClothingOuterWinterCoatColorOrange: 2 # DeltaV - add orange winter coats
-    ClothingOuterWinterCoatColorYellow: 2 # DeltaV - add yellow winter coats
-    ClothingOuterWinterCoatColorGreen: 2 # DeltaV - add green winter coats
-    ClothingOuterWinterCoatColorBlue: 2 # DeltaV - add blue winter coats
-    ClothingOuterWinterCoatColorPurple: 2 # DeltaV - add purple winter coats
-    ClothingOuterWinterCoatColorBrown: 2 # DeltaV - add brown winter coats
-    ClothingOuterWinterCoatColorBlack: 2 # DeltaV - add black winter coats
-    ClothingOuterWinterCoatColorWhite: 2 # DeltaV - add white winter coats
+    ClothingOuterWinterColorRed: 2 # DeltaV - add red winter coats
+    ClothingOuterWinterColorOrange: 2 # DeltaV - add orange winter coats
+    ClothingOuterWinterColorYellow: 2 # DeltaV - add yellow winter coats
+    ClothingOuterWinterColorGreen: 2 # DeltaV - add green winter coats
+    ClothingOuterWinterColorBlue: 2 # DeltaV - add blue winter coats
+    ClothingOuterWinterColorPurple: 2 # DeltaV - add purple winter coats
+    ClothingOuterWinterColorBrown: 2 # DeltaV - add brown winter coats
+    ClothingOuterWinterColorBlack: 2 # DeltaV - add black winter coats
+    ClothingOuterWinterColorWhite: 2 # DeltaV - add white winter coats
 
   emaggedInventory:
     ClothingNeckScarfStripedSyndieGreen: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
@@ -18,15 +18,17 @@
     ClothingOuterCoatBomber: 3
     ClothingHeadHatSantahat: 2
     ClothingHeadHatXmasCrown: 2
-    ClothingOuterWinterColorRed: 2 # DeltaV - add red winter coats
-    ClothingOuterWinterColorOrange: 2 # DeltaV - add orange winter coats
-    ClothingOuterWinterColorYellow: 2 # DeltaV - add yellow winter coats
-    ClothingOuterWinterColorGreen: 2 # DeltaV - add green winter coats
-    ClothingOuterWinterColorBlue: 2 # DeltaV - add blue winter coats
-    ClothingOuterWinterColorPurple: 2 # DeltaV - add purple winter coats
-    ClothingOuterWinterColorBrown: 2 # DeltaV - add brown winter coats
-    ClothingOuterWinterColorBlack: 2 # DeltaV - add black winter coats
-    ClothingOuterWinterColorWhite: 2 # DeltaV - add white winter coats
+    # Begin DeltaV additions
+    ClothingOuterWinterColorRed: 2
+    ClothingOuterWinterColorOrange: 2
+    ClothingOuterWinterColorYellow: 2
+    ClothingOuterWinterColorGreen: 2
+    ClothingOuterWinterColorBlue: 2
+    ClothingOuterWinterColorPurple: 2
+    ClothingOuterWinterColorBrown: 2
+    ClothingOuterWinterColorBlack: 2
+    ClothingOuterWinterColorWhite: 2
+    # End DeltaV additions
 
   emaggedInventory:
     ClothingNeckScarfStripedSyndieGreen: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/winterdrobe.yml
@@ -18,6 +18,15 @@
     ClothingOuterCoatBomber: 3
     ClothingHeadHatSantahat: 2
     ClothingHeadHatXmasCrown: 2
+    ClothingOuterWinterCoatColorRed: 2 # DeltaV - add red winter coats
+    ClothingOuterWinterCoatColorOrange: 2 # DeltaV - add orange winter coats
+    ClothingOuterWinterCoatColorYellow: 2 # DeltaV - add yellow winter coats
+    ClothingOuterWinterCoatColorGreen: 2 # DeltaV - add green winter coats
+    ClothingOuterWinterCoatColorBlue: 2 # DeltaV - add blue winter coats
+    ClothingOuterWinterCoatColorPurple: 2 # DeltaV - add purple winter coats
+    ClothingOuterWinterCoatColorBrown: 2 # DeltaV - add brown winter coats
+    ClothingOuterWinterCoatColorBlack: 2 # DeltaV - add black winter coats
+    ClothingOuterWinterCoatColorWhite: 2 # DeltaV - add white winter coats
 
   emaggedInventory:
     ClothingNeckScarfStripedSyndieGreen: 3

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -101,13 +101,13 @@
         Slash: 0.9
         Piercing: 0.9
         Heat: 0.65 # DeltaV - changed from 60% resistant to 35%
-  # Begin DeltaV subtractions
+  # Begin DeltaV removals
   #- type: Reflect
   #  reflectProb: 1
   #  reflects:
   #    - Energy
   #  reflectingInHands: false
-  # End DeltaV subtractions
+  # End DeltaV removals
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -100,12 +100,14 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.4 # this technically means it protects against fires pretty well? -heat is just for lasers and stuff, not atmos temperature
-  - type: Reflect
-    reflectProb: 1
-    reflects:
-      - Energy
-    reflectingInHands: false
+        Heat: 0.65 # DeltaV - changed from 60% resistant to 35%
+  # Begin DeltaV subtractions
+  #- type: Reflect
+  #  reflectProb: 1
+  #  reflects:
+  #    - Energy
+  #  reflectingInHands: false
+  # End DeltaV subtractions
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -100,14 +100,12 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.65 # DeltaV - changed from 60% resistant to 35%
-  # Begin DeltaV removals
-  #- type: Reflect
-  #  reflectProb: 1
-  #  reflects:
-  #    - Energy
-  #  reflectingInHands: false
-  # End DeltaV removals
+        Heat: 0.75 # DeltaV - changed from 60% resistant to 25%
+  - type: Reflect
+    reflectProb: 0.75 # DeltaV - changed from 100% reflect to 75%
+    reflects:
+      - Energy
+    reflectingInHands: false
 
 - type: entity
   parent: [ClothingOuterBaseLarge, AllowSuitStorageClothing, BaseSyndicateContraband ]

--- a/Resources/Prototypes/_DV/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/_DV/Catalog/Cargo/cargo_vending.yml
@@ -14,6 +14,6 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockSustenanceFilled
-  cost: 750
+  cost: 1450
   category: Service
   group: market


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Added tons of stuff to vending machine stocks. Specifically..

To Autodrobe, added:
- witch hat (black with red hair)
- brown cat hat
- black cat hat
- wizard robes, fake hat, shoes (all of them are fake)
- dark brown fedora
- white fedora
- black fedora
- bowler hat
- funeral suit/suitskirt

To Monkin' Donuts, added:
- plain donuts
- donut (it has sprinkles :D)
- meat donut

To SecDrobe, added:
- summer security uniform
- prisoner jumpsuit/jumpskirt
- +1 security cold weather poncho
- security winter boots

To SecTech, added: 
- holobarrier projector
- security belt
- reflective vest (nerfed this while I was at it, now has 25% heat resistance, 75% reflection chance)

To Sustenance Vendor, added:
- tinned meat
- tinned peaches
- M.R.E (the box)
- a ton of powdered juices and powdered milk that wasn't there before

To ClothesMate, added:
- dark suit
- black suit
- negative suit
- brown suit
- gangster's attire
- mobster's attire
- mafioso's attire
- brown suit/suitskirt
- laceup shoes
- leather shoes

To WinterDrobe, added:
- all coloured winter coats that we had in the code but for some reason didn't let anyone access???

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
For the Autodrobe, ClothesMate, WinterDrobe, and SecDrobe additions, I think giving people more options in terms of clothes is always better. It's drip or drown in Nanotrasen obviously so we want people to have the ability to choose what to wear. In terms of balance, I don't think I'm suddenly 10x more robust wearing a blue winter coat than the regular winter coat so I think I'm safe in that end.

For the Monkin' Donuts additions, we have SO many "basic" donuts that people basically can't access (half because it's too expensive to make donuts yourself as a chef and also just I want more fat cop jokes 💢). Specifically for the meat donut, I think it's nice to give carnivores one more snack option that is "readily" (barely) available. Currently carnivores can ONLY eat sus jerky for snacks I think so yeah... In terms of balancing yes technically there's more food on the station which technically makes chef's job slightly less important but.. I think it's pretty negligible since it doesn't even add that much more food.

For Sustenance Vendor additions, the entire theme of the vendor is MRE/tinned food. Why would it NOT have the full array of tinned foods/juices? Currently in-game we HAVE it programmed in to exist but there is literally 0 way to get *looks at notes* tin of powdered berry juice. I just think it fits much more thematically with the vendor's entire purpose. In terms of balancing, all this does is give perma's more drink/food options. Sec neglects perma quite a bit so I see this more as a win for perma rather than a loss for anyone. And since the Sustenance Vendor acts the same as a vending machine (there's a chance it just isn't stocked with some stuff which means you hypothetically can get tons of items that are out of stock), it isn't like I'm removing the need for sec to worry about permas' well-being. It's more just a QoL change.

Lastly, for the SecTech additions, it's simply stuff sec probably should be allowed to have access to. Security belt is a no-brainer since.. we have the chest rig in the machine already, why not a belt? The holobarrier projector is useful and sure technically we could argue that the warden should print it instead of being able to use the SecTech but my counter-argument is that it spawns in lockers already + seclites are basically the same but also get to be in the SecTech so why wouldn't the holobarrier be? Finally, the reflective vest is literally the only armour that gives sec any heat resistance. Honestly I plan on making another PR to let epi be able to research the thing so warden can print more but this is a stop-gap to both test its current stats' balancing and also simply to get the ball rolling. I'm pretty sure almost all of sec doesn't even know this thing exists so getting people aware of it is probably nice. In terms of balancing... uh... nothing here is going to help sec win against any major threats I think. Probably. So I doubt balancing is a huge issue.

## Technical details
<!-- Summary of code changes for easier review. -->
I honestly don't know how to best summarize the code.. just read what I wrote in the About the PR section. I'm sorry.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Tons more stuff to ClothesMate, Autodrobe, WinterDrobe, SecDrobe, Monkin' Donuts Vending Machine, Sustenance Vendor, and SecTech. Check the PR for specifics.  