### PR TITLE
Fix Slime (Mob) Digestion / Metabolism

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -8,6 +8,8 @@
       sprite: Mobs/Species/Slime/organs.rsi
       state: brain-slime
     - type: Stomach
+    - type: Organ # DeltaV - Shitmed: added organ type, allowing slimes to metabolize and digest.
+      slotId: core
     - type: Metabolizer
       maxReagents: 3
       metabolizerTypes: [ Slime ]

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -8,7 +8,7 @@
       sprite: Mobs/Species/Slime/organs.rsi
       state: brain-slime
     - type: Stomach
-    - type: Organ # DeltaV - Shitmed: added organ type, allowing slimes to metabolize and digest.
+    - type: Organ # DeltaV - added organ type, allowing slimes to metabolize and digest.
       slotId: core
     - type: Metabolizer
       maxReagents: 3


### PR DESCRIPTION
## About the PR
Added the organ type to slime mobs' core organ, allowing the slimes to digest and metabolize reagents. 

## Why / Balance
Why is this needed:
- Ghost role slimes were starving and dehydrated without any way for food or drink to satiate them.
- Without the food and drink getting metabolized, it piled up in the stomach and didn't allow for any more to be eaten/drunk.
- Medical staff attempting to heal slimes got frustrated at their inability to effectively practice medicine on an organism that doesn't metabolize medicine

Balance implications:
- Allows slime people to replace their existing slime cores with inferior mob slime cores (40% lower volume, 20% slower metabolism, 50% fewer reagents concurrently processed). 

## Technical details
2 lines added to slime (mob) core organ prototype, classifying it as an organ in the 'core' organ slot, shared between slime people and slimes. 

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Unsure what, if anything, this would break.

**Changelog**

:cl:
- fix: Slimes can now digest and metabolize food, drinks, medicine, and other reagents.

