### PR TITLE
Allows AAC phrases to be combined

### DIFF
--- a/Content.Client/_DV/AACTablet/UI/AACBoundUserInterface.cs
+++ b/Content.Client/_DV/AACTablet/UI/AACBoundUserInterface.cs
@@ -22,7 +22,7 @@ public sealed class AACBoundUserInterface : BoundUserInterface
         _window.PhraseButtonPressed += OnPhraseButtonPressed;
     }
 
-    private void OnPhraseButtonPressed(ProtoId<QuickPhrasePrototype> phraseId)
+    private void OnPhraseButtonPressed(List<ProtoId<QuickPhrasePrototype>> phraseId)
     {
         SendMessage(new AACTabletSendPhraseMessage(phraseId));
     }

--- a/Content.Client/_DV/AACTablet/UI/AACWindow.xaml
+++ b/Content.Client/_DV/AACTablet/UI/AACWindow.xaml
@@ -4,12 +4,20 @@
     Resizable="True"
     SetSize="540 300"
     MinSize="540 300">
-    <TabContainer Name="WindowBody" TabTitle="Search" VerticalExpand="True" MouseFilter="Pass">
-        <BoxContainer Orientation="Vertical" Name="Search" MinSize="540 200">
-            <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" Margin="4 4" />
-            <ScrollContainer HorizontalExpand="True" VerticalExpand="True">
-                <BoxContainer Name="SearchResults" Orientation="Vertical" HorizontalExpand="True" />
-            </ScrollContainer>
+    <BoxContainer Orientation="Vertical">
+        <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
+            <CheckBox Name="ShouldBuffer" Text="Combine"/>
+            <LineEdit Name="BufferedString" Editable="False" HorizontalExpand="True"/>
+            <Button Name="ClearButton" Text="Oopsie daisy" TextAlign="Center"/>
+            <Button Name="SendButton" Text="Send" TextAlign="Center"/>
         </BoxContainer>
-    </TabContainer>
+        <TabContainer Name="WindowBody" TabTitle="Search" VerticalExpand="True" MouseFilter="Pass">
+            <BoxContainer Orientation="Vertical" Name="Search" MinSize="540 200">
+                <LineEdit Name="SearchBar" PlaceHolder="Search" HorizontalExpand="True" Margin="4 4" />
+                <ScrollContainer HorizontalExpand="True" VerticalExpand="True">
+                    <BoxContainer Name="SearchResults" Orientation="Vertical" HorizontalExpand="True" />
+                </ScrollContainer>
+            </BoxContainer>
+        </TabContainer>
+    </BoxContainer>
 </controls:FancyWindow>

--- a/Content.Client/_DV/AACTablet/UI/AACWindow.xaml
+++ b/Content.Client/_DV/AACTablet/UI/AACWindow.xaml
@@ -8,7 +8,7 @@
         <BoxContainer Orientation="Horizontal" HorizontalExpand="True">
             <CheckBox Name="ShouldBuffer" Text="Combine"/>
             <LineEdit Name="BufferedString" Editable="False" HorizontalExpand="True"/>
-            <Button Name="ClearButton" Text="Oopsie daisy" TextAlign="Center"/>
+            <Button Name="ClearButton" Text="Backspace" TextAlign="Center"/>
             <Button Name="SendButton" Text="Send" TextAlign="Center"/>
         </BoxContainer>
         <TabContainer Name="WindowBody" TabTitle="Search" VerticalExpand="True" MouseFilter="Pass">

--- a/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
+++ b/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
@@ -43,9 +43,8 @@ public sealed partial class AACWindow : FancyWindow
     private void BackspaceBuffer(BaseButton.ButtonEventArgs obj)
     {
         if (_phraseBuffer.Count == 0)
-        {
             return;
-        }
+
         _phraseBuffer.RemoveAt(_phraseBuffer.Count - 1);
         UpdateBufferText();
     }

--- a/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
+++ b/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class AACWindow : FancyWindow
         (int)((ParentWidth - SpaceWidth * 2) / ColumnCount - SpaceWidth * ((ColumnCount - 1f) / ColumnCount));
 
     private readonly List<ProtoId<QuickPhrasePrototype>> _phraseBuffer = [];
+    private readonly List<ProtoId<QuickPhrasePrototype>> _phraseSingle = [];
 
     public AACWindow()
     {
@@ -221,7 +222,9 @@ public sealed partial class AACWindow : FancyWindow
         }
         else
         {
-            PhraseButtonPressed?.Invoke(new List<ProtoId<QuickPhrasePrototype>> {phraseId});
+            _phraseSingle.Clear();
+            _phraseSingle.Add(phraseId);
+            PhraseButtonPressed?.Invoke(_phraseSingle);
         }
     }
 }

--- a/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
+++ b/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
@@ -55,10 +55,8 @@ public sealed partial class AACWindow : FancyWindow
         BufferedString.Text = string.Empty;
         foreach (var phraseId in _phraseBuffer)
         {
-            if (_prototype.TryIndex(phraseId, out var phrase))
-            {
-                BufferedString.Text += Loc.GetString(phrase.Text) + " ";
-            }
+            var phrase = _prototype.Index(phraseId);
+            BufferedString.Text += Loc.GetString(phrase.Text) + " ";
         }
     }
 

--- a/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
+++ b/Content.Client/_DV/AACTablet/UI/AACWindow.xaml.cs
@@ -16,7 +16,7 @@ public sealed partial class AACWindow : FancyWindow
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     private readonly List<QuickPhrasePrototype> _phrases;
     private readonly Dictionary<string, List<QuickPhrasePrototype>> _filteredPhrases = new();
-    public event Action<ProtoId<QuickPhrasePrototype>>? PhraseButtonPressed;
+    public event Action<List<ProtoId<QuickPhrasePrototype>>>? PhraseButtonPressed;
 
     private const float SpaceWidth = 10f;
     private const float ParentWidth = 540f;
@@ -25,6 +25,8 @@ public sealed partial class AACWindow : FancyWindow
     private const int ButtonWidth =
         (int)((ParentWidth - SpaceWidth * 2) / ColumnCount - SpaceWidth * ((ColumnCount - 1f) / ColumnCount));
 
+    private readonly List<ProtoId<QuickPhrasePrototype>> _phraseBuffer = [];
+
     public AACWindow()
     {
         RobustXamlLoader.Load(this);
@@ -32,8 +34,39 @@ public sealed partial class AACWindow : FancyWindow
         _phrases = _prototype.EnumeratePrototypes<QuickPhrasePrototype>().ToList();
         _phrases.Sort((a, b) => string.CompareOrdinal(a.Group, b.Group));
         SearchBar.OnTextChanged += FilterSearch;
+        SendButton.OnPressed += SendBuffer;
+        ClearButton.OnPressed += BackspaceBuffer;
         PopulateGui();
         FilterSearch(null);
+    }
+
+    private void BackspaceBuffer(BaseButton.ButtonEventArgs obj)
+    {
+        if (_phraseBuffer.Count == 0)
+        {
+            return;
+        }
+        _phraseBuffer.RemoveAt(_phraseBuffer.Count - 1);
+        UpdateBufferText();
+    }
+
+    private void UpdateBufferText()
+    {
+        BufferedString.Text = string.Empty;
+        foreach (var phraseId in _phraseBuffer)
+        {
+            if (_prototype.TryIndex(phraseId, out var phrase))
+            {
+                BufferedString.Text += Loc.GetString(phrase.Text) + " ";
+            }
+        }
+    }
+
+    private void SendBuffer(BaseButton.ButtonEventArgs obj)
+    {
+        PhraseButtonPressed?.Invoke(_phraseBuffer);
+        _phraseBuffer.Clear();
+        BufferedString.Text = string.Empty;
     }
 
     private void FilterSearch(LineEdit.LineEditEventArgs? obj)
@@ -184,6 +217,14 @@ public sealed partial class AACWindow : FancyWindow
 
     private void OnPhraseButtonPressed(ProtoId<QuickPhrasePrototype> phraseId)
     {
-        PhraseButtonPressed?.Invoke(phraseId);
+        if (ShouldBuffer.Pressed)
+        {
+            _phraseBuffer.Add(phraseId);
+            UpdateBufferText();
+        }
+        else
+        {
+            PhraseButtonPressed?.Invoke(new List<ProtoId<QuickPhrasePrototype>> {phraseId});
+        }
     }
 }

--- a/Content.Server/_DV/AACTablet/AACTabletSystem.cs
+++ b/Content.Server/_DV/AACTablet/AACTabletSystem.cs
@@ -29,13 +29,25 @@ public sealed class AACTabletSystem : EntitySystem
             ("speaker", Name(ent)),
             ("originalName", senderName));
 
-        if (!_prototype.TryIndex(message.PhraseId, out var phrase))
+        var localisedList = new List<string>();
+        foreach (var phraseProto in message.PhraseIds)
+        {
+            if (_prototype.TryIndex(phraseProto, out var phrase))
+            {
+                // Ensures each phrase is capitalised to maintain common AAC styling
+                localisedList.Add(_chat.SanitizeMessageCapital(Loc.GetString(phrase.Text)));
+            }
+        }
+
+        if (localisedList.Count <= 0)
+        {
             return;
+        }
 
         EnsureComp<VoiceOverrideComponent>(ent).NameOverride = speakerName;
 
         _chat.TrySendInGameICMessage(ent,
-            Loc.GetString(phrase.Text),
+            string.Join(" ", localisedList),
             InGameICChatType.Speak,
             hideChat: false,
             nameOverride: speakerName);

--- a/Content.Server/_DV/AACTablet/AACTabletSystem.cs
+++ b/Content.Server/_DV/AACTablet/AACTabletSystem.cs
@@ -13,6 +13,8 @@ public sealed class AACTabletSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 
+    private readonly List<string> _localisedPhrases = [];
+
     public override void Initialize()
     {
         base.Initialize();
@@ -29,25 +31,23 @@ public sealed class AACTabletSystem : EntitySystem
             ("speaker", Name(ent)),
             ("originalName", senderName));
 
-        var localisedList = new List<string>();
+        _localisedPhrases.Clear();
         foreach (var phraseProto in message.PhraseIds)
         {
             if (_prototype.TryIndex(phraseProto, out var phrase))
             {
                 // Ensures each phrase is capitalised to maintain common AAC styling
-                localisedList.Add(_chat.SanitizeMessageCapital(Loc.GetString(phrase.Text)));
+                _localisedPhrases.Add(_chat.SanitizeMessageCapital(Loc.GetString(phrase.Text)));
             }
         }
 
-        if (localisedList.Count <= 0)
-        {
+        if (_localisedPhrases.Count <= 0)
             return;
-        }
 
         EnsureComp<VoiceOverrideComponent>(ent).NameOverride = speakerName;
 
         _chat.TrySendInGameICMessage(ent,
-            string.Join(" ", localisedList),
+            string.Join(" ", _localisedPhrases),
             InGameICChatType.Speak,
             hideChat: false,
             nameOverride: speakerName);

--- a/Content.Shared/_DV/AACTablet/AACTabletUiMessages.cs
+++ b/Content.Shared/_DV/AACTablet/AACTabletUiMessages.cs
@@ -11,7 +11,7 @@ public enum AACTabletKey : byte
 }
 
 [Serializable, NetSerializable]
-public sealed class AACTabletSendPhraseMessage(ProtoId<QuickPhrasePrototype> phraseId) : BoundUserInterfaceMessage
+public sealed class AACTabletSendPhraseMessage(List<ProtoId<QuickPhrasePrototype>> phraseIds) : BoundUserInterfaceMessage
 {
-    public ProtoId<QuickPhrasePrototype> PhraseId = phraseId;
+    public List<ProtoId<QuickPhrasePrototype>> PhraseIds = phraseIds;
 }


### PR DESCRIPTION
## Licensing (added 2026-01-12)
The contents of this PR are also MIT-licensed and you may port it to any server you wish.
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Added a buffer and option to combine AAC tablet phrases in a message instead of sending them out individually.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Trying to communicate longer ideas can be very difficult to follow from the reader's end, especially if there are other conversations inserted between AAC messages. These messages also take up many lines in chat to communicate a single idea. 

## Technical details
<!-- Summary of code changes for easier review. -->
- Changed PhraseID in the button event to a list
- Added additional controls to see and send the currently buffered message

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/8f66160d-6fc8-4032-8ba5-51843cd27d40

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: The AAC Tablet can now combine phrases into a single message!
