### PR TITLE
rework holofan to be like tg

### DIFF
--- a/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignProjectorComponent.cs
@@ -1,0 +1,37 @@
+using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Holosign;
+
+/// <summary>
+/// A holosign projector that uses <c>LimitedCharges</c> instead of a power cell slot.
+/// If there is already a sign on the clicked tile it reclaims it for a charge instead of stacking it.
+/// Currently there is no spawning prediction so signs are spawned once in a container and moved out to allow prediction.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(ChargeHolosignSystem))]
+public sealed partial class ChargeHolosignProjectorComponent : Component
+{
+    /// <summary>
+    /// The entity to spawn.
+    /// </summary>
+    [DataField(required: true)]
+    public EntProtoId SignProto;
+
+    /// <summary>
+    /// Component on <see cref="SignProto"/> to check for duplicates.
+    /// </summary>
+    [DataField(required: true)]
+    public string SignComponentName;
+
+    public Type SignComponent = default!;
+
+    /// <summary>
+    /// Container to store sign entities in before they are "spawned" on use.
+    /// </summary>
+    [DataField]
+    public string ContainerId = "signs";
+
+    [ViewVariables]
+    public Container Container = default!;
+}

--- a/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
@@ -46,7 +46,7 @@ public sealed class ChargeHolosignSystem : EntitySystem
             return;
 
         var containers = Comp<ContainerManagerComponent>(ent);
-        for (int i = 0; i < charges.MaxCharges; i++)
+        for (var i = 0; i < charges.MaxCharges; i++)
         {
             if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out _))
             {

--- a/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
@@ -1,0 +1,115 @@
+using Content.Shared.Charges.Components;
+using Content.Shared.Charges.Systems;
+using Content.Shared.Coordinates.Helpers;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Storage;
+using Robust.Shared.Containers;
+using Robust.Shared.Map;
+using System.Linq;
+
+namespace Content.Shared._DV.Holosign;
+
+public sealed class ChargeHolosignSystem : EntitySystem
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly SharedChargesSystem _charges = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private HashSet<Entity<IComponent>> _signs = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<ChargeHolosignProjectorComponent, BeforeRangedInteractEvent>(OnBeforeInteract);
+    }
+
+    private void OnInit(Entity<ChargeHolosignProjectorComponent> ent, ref ComponentInit args)
+    {
+        ent.Comp.Container = _container.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
+        ent.Comp.SignComponent = EntityManager.ComponentFactory.GetRegistration(ent.Comp.SignComponentName).Type;
+    }
+
+    private void OnMapInit(Entity<ChargeHolosignProjectorComponent> ent, ref MapInitEvent args)
+    {
+        if (!TryComp<LimitedChargesComponent>(ent, out var charges))
+            return;
+
+        var containers = Comp<ContainerManagerComponent>(ent);
+        for (int i = 0; i < charges.MaxCharges; i++)
+        {
+            if (!TrySpawnInContainer(ent.Comp.SignProto, ent, ent.Comp.ContainerId, out _))
+            {
+                Log.Error($"Failed to spawn sign {ent.Comp.SignProto} for {ToPrettyString(ent)}!");
+                return;
+            }
+        }
+    }
+
+    private void OnBeforeInteract(Entity<ChargeHolosignProjectorComponent> ent, ref BeforeRangedInteractEvent args)
+    {
+        if (args.Handled || !args.CanReach ||
+            HasComp<StorageComponent>(args.Target) || // if it's a storage component like a bag, we ignore usage so it can be stored
+            !TryComp<LimitedChargesComponent>(ent, out var charges))
+            return;
+
+        // first check if there's any existing holofans to clear
+        var coords = args.ClickLocation.SnapToGrid(EntityManager);
+        var mapCoords = _transform.ToMapCoordinates(coords);
+        _signs.Clear();
+        _lookup.GetEntitiesInRange(ent.Comp.SignComponent, mapCoords, 0.25f, _signs);
+        if (_signs.Count == 0)
+            TryPlaceSign((ent, ent, charges), coords, args.User);
+        else
+            TryRemoveSign((ent, ent, charges), _signs.First(), args.User);
+
+        args.Handled = true;
+    }
+
+    public bool TryPlaceSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityCoordinates coords, EntityUid user)
+    {
+        var container = ent.Comp1.Container;
+        if (container.Count == 0 || !_charges.TryUseCharge((ent, ent.Comp2)))
+        {
+            _popup.PopupClient(Loc.GetString("charge-holoprojector-no-charges", ("item", ent)), ent, user);
+            return false;
+        }
+
+        var placed = container.ContainedEntities.First(); // checked Count beforehand so this won't fail
+        _transform.SetCoordinates(placed, coords);
+        _transform.AnchorEntity(placed);
+        return true;
+    }
+
+    public bool TryRemoveSign(Entity<ChargeHolosignProjectorComponent, LimitedChargesComponent> ent, EntityUid sign, EntityUid user)
+    {
+        // don't overfill
+        if (ent.Comp2.Charges >= ent.Comp2.MaxCharges)
+        {
+            _popup.PopupClient(Loc.GetString("charge-holoprojector-charges-full", ("item", ent)), sign, user);
+            return false;
+        }
+
+        if (!_container.Insert(sign, ent.Comp1.Container, force: true))
+        {
+            Log.Error($"Failed to insert holosign {ToPrettyString(sign)} back into {ToPrettyString(ent)}!");
+            return false;
+        }
+
+        _charges.AddCharges(ent, 1, ent);
+
+        var userIdentity = Identity.Name(user, EntityManager);
+        _popup.PopupPredicted(
+            Loc.GetString("charge-holoprojector-reclaim", ("sign", sign)),
+            Loc.GetString("charge-holoprojector-reclaim-others", ("sign", sign), ("user", userIdentity)),
+            ent,
+            user);
+        return true;
+    }
+}

--- a/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
+++ b/Content.Shared/_DV/Holosign/ChargeHolosignSystem.cs
@@ -32,6 +32,10 @@ public sealed class ChargeHolosignSystem : EntitySystem
 
     private void OnInit(Entity<ChargeHolosignProjectorComponent> ent, ref ComponentInit args)
     {
+        // its required, funny test is still funny
+        if (string.IsNullOrEmpty(ent.Comp.SignComponentName))
+            return;
+
         ent.Comp.Container = _container.EnsureContainer<Container>(ent, ent.Comp.ContainerId);
         ent.Comp.SignComponent = EntityManager.ComponentFactory.GetRegistration(ent.Comp.SignComponentName).Type;
     }

--- a/Content.Shared/_DV/Whitelist/HolofanComponent.cs
+++ b/Content.Shared/_DV/Whitelist/HolofanComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Whitelist;
+
+/// <summary>
+/// Marker component for holofans, used for reclaiming charges of the projector.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class HolofanComponent : Component;

--- a/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
+++ b/Resources/Locale/en-US/_DV/tools/charge-holoprojector.ftl
@@ -1,0 +1,4 @@
+charge-holoprojector-no-charges = {CAPITALIZE(THE($item))} is empty, reclaim an old holosign first!
+charge-holoprojector-charges-full = {CAPITALIZE(THE($item))} is full, it can't reclaim more charges!
+charge-holoprojector-reclaim = You stop projecting {THE($sign)}.
+charge-holoprojector-reclaim-others = {CAPITALIZE($user)} stops projecting {THE($sign)}.

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -51,17 +51,28 @@
         swap: false
 
 - type: entity
-  parent: Holoprojector
+  parent: BaseItem # DeltaV - remove powercell requirement
   id: HolofanProjector
   name: holofan projector
   description: Stop suicidal passengers from killing everyone during atmos emergencies.
   components:
-  - type: HolosignProjector
+  - type: ChargeHolosignProjector # DeltaV - different implementation using charges
     signProto: HoloFan
-    chargeUse: 120
+    signComponentName: Holofan # DeltaV
+    #chargeUse: 120 # DeltaV
   - type: Sprite
     sprite: Objects/Devices/Holoprojectors/atmos.rsi
     state: icon
+  # Begin DeltaV Additions
+  - type: Item
+    storedRotation: -90
+  - type: LimitedCharges
+    maxCharges: 6 # same as it was on a medium cell
+    charges: 6
+  - type: ContainerContainer
+    containers:
+      signs: !type:Container
+  # End DeltaV Additions
   - type: Tag
     tags:
       - HolofanProjector
@@ -76,12 +87,13 @@
 - type: entity
   parent: HolofanProjector
   id: HolofanProjectorEmpty
+  categories: [ HideSpawnMenu ] # DeltaV - this is identical to the normal one
   suffix: Empty
-  components:
-  - type: ItemSlots
-    slots:
-      cell_slot:
-        name: power-cell-slot-component-slot-name-default
+  #components: # DeltaV - no cell slot for empty one
+  #- type: ItemSlots
+  #  slots:
+  #    cell_slot:
+  #      name: power-cell-slot-component-slot-name-default
 
 - type: entity
   parent: Holoprojector

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -28,7 +28,7 @@
 
 - type: entity
   id: HoloFan
-  parent: HolosignWetFloor
+  parent: BaseHolosign # DeltaV - don't include TimedDespawn
   name: holofan
   description: A barrier of hard light that blocks air, but nothing else.
   components:
@@ -41,10 +41,13 @@
         shape:
           !type:PhysShapeAabb
             bounds: "-0.5,-0.5,0.5,0.5"
-  - type: TimedDespawn
-    lifetime: 180
+  #- type: TimedDespawn # DeltaV - no despawning for holofans
+  #  lifetime: 180
+  - type: Transform # DeltaV
+    noRot: true
   - type: Airtight
     noAirWhenFullyAirBlocked: false
+  - type: Holofan # DeltaV - for whitelisting
 
 - type: entity
   id: HolosignSecurity

--- a/Resources/Prototypes/_DV/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Holographic/projections.yml
@@ -1,0 +1,23 @@
+# like HolosignWetFloor but no sprite or crucially, TimedDespawn
+# this is so holofans can never run out
+- type: entity
+  abstract: true
+  id: BaseHolosign
+  placement:
+    mode: SnapgridCenter
+  components:
+  - type: Transform
+    anchored: true
+  - type: Physics
+    bodyType: Static
+    canCollide: false
+  - type: Damageable
+    damageContainer: Inorganic
+  - type: Destructible
+    thresholds:
+      - trigger:
+          !type:DamageTrigger
+          damage: 30
+        behaviors:
+          - !type:DoActsBehavior
+            acts: [ "Destruction" ]


### PR DESCRIPTION
## About the PR
instead of a battery it uses 6 limited charges like flashes to place holofans
you can then click on existing holofans to reclaim charges (if its not full already)

holofans no longer despawn automatically so you dont have to keep refreshing them manually

## Why / Balance
its almost identical to this on tg

micromanaging stealing batteries from maints lockers is awful "gameplay", and if you dont do that than either:
- you patiently wait 10 years for a charger to finish
- you forget to recharge and have a paperweight to prevent a tritfire spreading, have fun

it also means for non atmos that once the atmos takes down holofans in an area its probably fine, compared to the 3 minute despawn time for a ~10 second fix

the upgrading is pathetic, you essentially get nothing until 1 hour in and you have a microreactor so you can crank out infinite holofans. high-cap cells offer no convenience over just getting another cell from maints

this lets you reclaim holofans immediately when you are done with something like fixing a hole to let air back in easily

holofans not despawning is fine since:
- **anyone with a holofan can steal them instantly** so if you are using it to hold in a burn chamber just wait for someone to prank you :trollface:
- explosions still delete holofans, and now your projector permanently loses charge for it
- if you are using them in a permanent setup you are less likely to check on it than before, so theres more opportunity for someone to mess with them than if you are camping it to refresh every 3 minutes

may need to make the recipe more expensive if it turns out too powerful

## Technical details
its all predicted thanks to using a container instead of spawning/deleting the holofans

## Media
no reclaiming when full
![09:35:35](https://github.com/user-attachments/assets/13ae789a-3e7b-49cb-b278-6e1f97013dcd)

fans really dont have TimedDespawnComponent
![09:40:01](https://github.com/user-attachments/assets/5b3e3a19-4ebb-4736-b76e-3e26686af9ba)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Holofans now work like in SS13, you can place up to 6 at once with charges reclaimed by removing unused holofans.
- remove: Removed the battery requirement from holofan projectors.