### PR TITLE
give weh slippers waddling

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -68,6 +68,8 @@
       collection: FootstepLizardSlippers
       params:
         variation: 0.02
+  - type: WaddleWhenWorn # DeltaV - upstream removed waddling
+    tumbleIntensity: 10 # smaller than clown shoes
   - type: Construction
     graph: ClothingShoeSlippersLizard
     node: shoes


### PR DESCRIPTION
## About the PR
i forgot to do this ages ago

## Why / Balance
weh slippers are literally reskinned ducky skippers but dont have it because they dont inherit from them

they are 100% identical look at them
![11:26:37](https://github.com/user-attachments/assets/1123ab0a-fb20-4bc8-932e-dad705134564)

## Media
so real
![11:27:12](https://github.com/user-attachments/assets/a7cf7bce-2689-4299-8696-1154e94d7b4c)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed weh slippers not being bouncy...
