### PR TITLE
Rebalance licoxide for new cheaper recipes

### DIFF
--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -162,9 +162,17 @@
   color: "#FDD023"
   metabolisms:
     Poison:
+      metabolismRate: 3.00 # DeltaV - licoxide is cheaper now, so adjust it accordingly
       effects:
+      - !type:Emote # DeltaV - licoxide makes you scream now
+        emote: Scream
+        probability: 0.3
+      - !type:HealthChange # DeltaV - licoxide has consequences now
+        damage:
+          types:
+            Shock: 4
       - !type:Electrocute
-        probability: 0.35
+        probability: 0.15 # DeltaV - was 0.35, this should not be guaranteed for a cheaper chem
 
 - type: reagent
   id: Razorium


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Licoxide now flushes out of your system faster, can make you scream, and is less likely to shock you

## Why / Balance
- instastun chemical is a bit overpowered for its new cheaper source
- make it work more similarly to razorium
- deltav centcom logs indicate that licoxide was seldom used in its old position of a somewhat expensive traitor chem, so this isn't affecting them too much

## Technical details
- tweak the metabolism

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Licoxide now flushes out of your system faster & is less likely to stun you, but deals shock damage and may induce screaming
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
