### PR TITLE
Harpies' sound can only be changed by themselves

### DIFF
--- a/Content.Server/Instruments/SwappableInstrumentComponent.cs
+++ b/Content.Server/Instruments/SwappableInstrumentComponent.cs
@@ -11,4 +11,11 @@ public sealed partial class SwappableInstrumentComponent : Component
     /// </summary>
     [DataField("instrumentList", required: true)]
     public Dictionary<string, (byte, byte)> InstrumentList = new();
+
+    // Frontier: harpy instruments
+    /// <summary>
+    /// When true, only the instrument entity itself can swap its sound.
+    /// </summary>
+    [DataField]
+    public bool OnlySetBySelf;
 }

--- a/Content.Server/Instruments/SwappableInstrumentSystem.cs
+++ b/Content.Server/Instruments/SwappableInstrumentSystem.cs
@@ -25,6 +25,9 @@ public sealed class SwappableInstrumentSystem : EntitySystem
         if (!TryComp<InstrumentComponent>(uid, out var instrument))
             return;
 
+        if (component.OnlySetBySelf && uid != args.User) // Frontier: restrict instrument changes
+            return; // Frontier: restrict instrument changes
+
         var priority = 0;
         foreach (var entry in component.InstrumentList)
         {

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -22,6 +22,7 @@
       "Piano": {1: 0}
       "Church Organ": {19: 0}
       "Harp": {46: 0}
+    onlySetBySelf: true
   - type: UserInterface
     interfaces:
       enum.InstrumentUiKey.Key:

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -22,7 +22,7 @@
       "Piano": {1: 0}
       "Church Organ": {19: 0}
       "Harp": {46: 0}
-    onlySetBySelf: true
+    onlySetBySelf: true # Frontier
   - type: UserInterface
     interfaces:
       enum.InstrumentUiKey.Key:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Cherry-pick of https://github.com/new-frontiers-14/frontier-station-14/pull/1978.
Harpies can no longer have their instrument set by others.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Silly but not really intended

## Technical details
<!-- Summary of code changes for easier review. -->
Changes SwappableInstrument component/system and Harpy prototype. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have tested all added content and changes.
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: whatston3, foxcurl
- fix: Harpies can no longer have their instruments changed by other people.
