### PR TITLE
Speedmerge chatty lathes

### DIFF
--- a/Content.Server/Lathe/Components/LatheAnnouncingComponent.cs
+++ b/Content.Server/Lathe/Components/LatheAnnouncingComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Lathe.Components;
+
+/// <summary>
+/// Causes this entity to announce onto the provided channels when it receives new recipes from its server
+/// </summary>
+[RegisterComponent]
+public sealed partial class LatheAnnouncingComponent : Component
+{
+    /// <summary>
+    /// Radio channels to broadcast to when a new set of recipes is received
+    /// </summary>
+    [DataField(required: true)]
+    public List<ProtoId<RadioChannelPrototype>> Channels = new();
+}

--- a/Content.Server/Lathe/LatheSystem.cs
+++ b/Content.Server/Lathe/LatheSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.Materials;
 using Content.Server.Popups;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
+using Content.Server.Radio.EntitySystems;
 using Content.Server.Stack;
 using Content.Shared.Atmos;
 using Content.Shared.Chemistry.Components;
@@ -21,6 +22,7 @@ using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Lathe;
 using Content.Shared.Lathe.Prototypes;
+using Content.Shared.Localizations;
 using Content.Shared.Materials;
 using Content.Shared.Power;
 using Content.Shared.ReagentSpeed;
@@ -54,6 +56,7 @@ namespace Content.Server.Lathe
         [Dependency] private readonly SharedSolutionContainerSystem _solution = default!;
         [Dependency] private readonly StackSystem _stack = default!;
         [Dependency] private readonly TransformSystem _transform = default!;
+        [Dependency] private readonly RadioSystem _radio = default!;
 
         /// <summary>
         /// Per-tick cache
@@ -68,6 +71,7 @@ namespace Content.Server.Lathe
             SubscribeLocalEvent<LatheComponent, MapInitEvent>(OnMapInit);
             SubscribeLocalEvent<LatheComponent, PowerChangedEvent>(OnPowerChanged);
             SubscribeLocalEvent<LatheComponent, TechnologyDatabaseModifiedEvent>(OnDatabaseModified);
+            SubscribeLocalEvent<LatheAnnouncingComponent, TechnologyDatabaseModifiedEvent>(OnTechnologyDatabaseModified);
             SubscribeLocalEvent<LatheComponent, ResearchRegistrationChangedEvent>(OnResearchRegistrationChanged);
 
             SubscribeLocalEvent<LatheComponent, LatheQueueRecipeMessage>(OnLatheQueueRecipeMessage);
@@ -364,6 +368,41 @@ namespace Content.Server.Lathe
         private void OnDatabaseModified(EntityUid uid, LatheComponent component, ref TechnologyDatabaseModifiedEvent args)
         {
             UpdateUserInterfaceState(uid, component);
+        }
+
+        private void OnTechnologyDatabaseModified(Entity<LatheAnnouncingComponent> ent, ref TechnologyDatabaseModifiedEvent args)
+        {
+            if (args.NewlyUnlockedRecipes is null)
+                return;
+
+            if (!TryGetAvailableRecipes(ent.Owner, out var potentialRecipes))
+                return;
+
+            var recipeNames = new List<string>();
+            foreach (var recipeId in args.NewlyUnlockedRecipes)
+            {
+                if (!potentialRecipes.Contains(new(recipeId)))
+                    continue;
+
+                if (!_proto.TryIndex(recipeId, out LatheRecipePrototype? recipe))
+                    continue;
+
+                var itemName = GetRecipeName(recipe!);
+                recipeNames.Add(Loc.GetString("lathe-unlock-recipe-radio-broadcast-item", ("item", itemName)));
+            }
+
+            if (recipeNames.Count == 0)
+                return;
+
+            var message = Loc.GetString(
+                "lathe-unlock-recipe-radio-broadcast",
+                ("items", ContentLocalizationManager.FormatList(recipeNames))
+            );
+
+            foreach (var channel in ent.Comp.Channels)
+            {
+                _radio.SendRadioMessage(ent.Owner, message, channel, ent.Owner, escapeMarkup: false);
+            }
         }
 
         private void OnResearchRegistrationChanged(EntityUid uid, LatheComponent component, ref ResearchRegistrationChangedEvent args)

--- a/Content.Server/Research/Systems/ResearchSystem.Technology.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Technology.cs
@@ -119,15 +119,17 @@ public sealed partial class ResearchSystem
         }
 
         component.UnlockedTechnologies.Add(technology.ID);
+        var addedRecipes = new List<string>();
         foreach (var unlock in technology.RecipeUnlocks)
         {
             if (component.UnlockedRecipes.Contains(unlock))
                 continue;
             component.UnlockedRecipes.Add(unlock);
+            addedRecipes.Add(unlock);
         }
         Dirty(uid, component);
 
-        var ev = new TechnologyDatabaseModifiedEvent();
+        var ev = new TechnologyDatabaseModifiedEvent(addedRecipes);
         RaiseLocalEvent(uid, ref ev);
     }
 

--- a/Content.Shared/Research/Components/TechnologyDatabaseComponent.cs
+++ b/Content.Shared/Research/Components/TechnologyDatabaseComponent.cs
@@ -54,7 +54,7 @@ public sealed partial class TechnologyDatabaseComponent : Component
 /// server to all of it's clients.
 /// </remarks>
 [ByRefEvent]
-public readonly record struct TechnologyDatabaseModifiedEvent;
+public readonly record struct TechnologyDatabaseModifiedEvent(List<string>? NewlyUnlockedRecipes);
 
 /// <summary>
 /// Event raised on a database after being synchronized

--- a/Content.Shared/Research/Systems/BlueprintSystem.cs
+++ b/Content.Shared/Research/Systems/BlueprintSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Research.Prototypes;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
+using System.Linq;
 
 namespace Content.Shared.Research.Systems;
 
@@ -64,7 +65,7 @@ public sealed class BlueprintSystem : EntitySystem
 
         _container.Insert(blueprint.Owner, _container.GetContainer(ent, ent.Comp.ContainerId));
 
-        var ev = new TechnologyDatabaseModifiedEvent();
+        var ev = new TechnologyDatabaseModifiedEvent(blueprint.Comp.ProvidedRecipes.Select(it => it.Id).ToList());
         RaiseLocalEvent(ent, ref ev);
         return true;
     }

--- a/Content.Shared/Research/Systems/SharedResearchSystem.cs
+++ b/Content.Shared/Research/Systems/SharedResearchSystem.cs
@@ -301,7 +301,7 @@ public abstract class SharedResearchSystem : EntitySystem
         component.UnlockedRecipes.Add(recipe);
         Dirty(uid, component);
 
-        var ev = new TechnologyDatabaseModifiedEvent();
+        var ev = new TechnologyDatabaseModifiedEvent(new List<string> { recipe });
         RaiseLocalEvent(uid, ref ev);
     }
 }

--- a/Resources/Locale/en-US/lathe/lathesystem.ftl
+++ b/Resources/Locale/en-US/lathe/lathesystem.ftl
@@ -1,1 +1,3 @@
 lathe-popup-material-not-used = This material is not used in this machine.
+lathe-unlock-recipe-radio-broadcast = This lathe is now capable of producing the following recipes: {$items}
+lathe-unlock-recipe-radio-broadcast-item = [bold]{$item}[/bold]

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -431,6 +431,8 @@
         - Sheet
         - RawMaterial
         - Ingot
+  - type: LatheAnnouncing
+    channels: [Security]
 
 - type: entity
   id: AmmoTechFab
@@ -505,6 +507,8 @@
     board: MedicalTechFabCircuitboard
   - type: StealTarget
     stealGroup: MedicalTechFabCircuitboard
+  - type: LatheAnnouncing
+    channels: [Medical]
 
 - type: entity
   parent: BaseLathe

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -72,6 +72,8 @@
     board: EngineeringTechFabCircuitboard
   - type: StealTarget
     stealGroup: EngineeringTechFabCircuitboard
+  - type: LatheAnnouncing
+    channels: [Engineering]
 
 - type: entity
   parent: BaseTechFabDepartamental
@@ -106,6 +108,8 @@
     board: LogisticsTechFabCircuitboard
   - type: StealTarget
     stealGroup: LogisticsTechFabCircuitboard
+  - type: LatheAnnouncing
+    channels: [Supply]
 
 - type: entity
   parent: BaseTechFabDepartamental
@@ -141,6 +145,8 @@
     board: ServiceTechFabCircuitboard
   - type: StealTarget
     stealGroup: ServiceTechFabCircuitboard
+  - type: LatheAnnouncing
+    channels: [Service]
 
 - type: entity
   parent: BaseTechFabDepartamental


### PR DESCRIPTION
(cherry picked from commit [5d38ae56de87faa4c16c46a5eac7c9a12add597f](https://github.com/space-wizards/space-station-14/commit/5d38ae56de87faa4c16c46a5eac7c9a12add597f))

## About the PR
Cherry-picked chatty lathes from Wizden, made the DeltaV techfabs (besides epistemics for obvious reasons) chatty too.

## Why / Balance
This makes it clearer to departments what they're getting out of epistemics.

## Technical details
- cherry pick from wizden
- make the deltav ones chatty

## Media
![grafik](https://github.com/user-attachments/assets/632a7b8d-829c-4bfa-84c9-5892213718b8)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Techfabs now announce on their departments' radio channels when they receive new recipes to fabricate
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
