### PR TITLE
Minor Security Kit Change + Cell Recharger buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -56,6 +56,10 @@
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
+  # Begin DeltaV additions
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
+  # End DeltaV additions
 
 - type: entity
   parent: ClothingShoesMilitaryBase
@@ -158,6 +162,10 @@
     sprite: _DV/Clothing/Shoes/Boots/winterbootssec.rsi # DeltaV - resprite boots to meet standards
   - type: Clothing
     sprite: _DV/Clothing/Shoes/Boots/winterbootssec.rsi # DeltaV - resprite boots to meet standards
+  # Begin DeltaV additions
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
+  # End DeltaV additions
 
 - type: entity
   parent: [ClothingShoesBaseWinterBoots, BaseSyndicateContraband]

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -86,6 +86,10 @@
       visible: false
   - type: Machine
     board: CellRechargerCircuitboard
+  # Begin DeltaV additions
+  - type: Charger
+    chargeRate: 40
+  # End DeltaV additions
   - type: WiresPanel
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/_DV/Entities/Clothing/Shoes/winter-boots.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Shoes/winter-boots.yml
@@ -99,7 +99,7 @@
     sprite: _DV/Clothing/Shoes/Boots/winterbootshop.rsi
 
 - type: entity
-  parent: ClothingShoesBaseWinterBoots
+  parent: [ClothingShoesBaseWinterBoots, ClothingShoesMilitaryBase, BaseSecurityContraband] # DeltaV - added ClothingShoesMilitaryBase, BaseSecurityContraband to parents
   id: ClothingShoesBootsWinterHeadOfSecurity
   name: HoS's winter boots
   components:
@@ -107,6 +107,10 @@
     sprite: _DV/Clothing/Shoes/Boots/winterbootshos.rsi
   - type: Clothing
     sprite: _DV/Clothing/Shoes/Boots/winterbootshos.rsi
+  # Begin DeltaV additions
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
+  # End DeltaV additions
 
 - type: entity
   parent: ClothingShoesBaseWinterBoots

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
@@ -6,6 +6,7 @@
   - ClothingNeckShockCollar
   - ClothingOuterArmorPlateCarrier # plate carrier body armour
   - ClothingOuterArmorDuraVest # stabproof vest body armour
+  - ClothingOuterArmorReflective
   - HoloprojectorSecurity
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_DV/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/security.yml
@@ -181,6 +181,15 @@
     Plastic: 1000
 
 - type: latheRecipe
+  id: ClothingOuterArmorReflective
+  result: ClothingOuterArmorReflective
+  completetime: 10
+  materials:
+    Steel: 500
+    Plastic: 1250
+    Glass: 250
+
+- type: latheRecipe
   id: ClothingHeadCage
   result: ClothingHeadCage
   completetime: 4


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Added the ability to put knives and things into HoS winter boots, made HoS winter boots, security winter boots, and combat boots all receive the buff to negate speed penalty from injury by 50% to be same as jackboots, put the reflective vest into security techfab (starting recipes), buffed cell rechargers to charge twice as fast compared to regular rechargers (20W -> 40W)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The boots is pretty self explanatory. They are boots. Only reason why they differ is the sprite. Why would HoS winter boots for example be worse than jackboots? Affects only sec. 

Added reflective vests to security techfab simply because other vests are there already and since I introduced it into the SecTech vendor, might as well let sec print the thing. They cost 5 steel, 12.5 plastic, and 2.5 glass to make. I don't think I'll be adding it to the security loadout since it's far more niche than the other two vests and thus generally shouldn't be the starting vest of an officer (if they even choose to wear it). Affects only sec / antags who steal a secfab

Buffed cell rechargers. This needs explaining. Simply, current cell rechargers are complete garbage. Like there is literally no reason to make them. A regular recharger does exactly what it can do but charges more. I've only ever seen people build cell rechargers on accident. This change makes it so that cell rechargers are slightly more viable, recharging cells twice as fast. This means that people actually have a reason to use it since the charger specifically designed to charge power cells can charge power cells better. Will affect anyone who uses rechargers.

## Technical details
<!-- Summary of code changes for easier review. -->
Added ClothingShoesMilitaryBase, BaseSecurityContraband as parents to ClothingShoesBootsWinterHeadOfSecurity
Added ClothingSlowOnDamageModifier as 0.5 to ClothingShoesBootsWinterSec, ClothingShoesBootsWinterHeadOfSecurity, ClothingShoesBootsCombat
Added ClothingOuterArmorReflective to Delta-v\Resources\Prototypes\_DV\Recipes\Lathes\Packs\security.yml
Added a recipe for ClothingOuterArmorReflective in Delta-v\Resources\Prototypes\_DV\Recipes\Lathes\security.yml
Added a Charger type with a chargeRate of 40 to PowerCellRecharger

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Made Security Winter Boots, HoS Winter Boots, and Combat Boots behave the same as jackboots
- add: Reflective vests can now be printed in sec techfabs for 5 steel, 12.5 plastic, and 2.5 glass
- tweak: Cell Rechargers charge twice as fast compared to regular Rechargers (40W compared to 20W)
