### PR TITLE
 Revert polymorphed entities before gibbing if revert on death.

### DIFF
--- a/Content.IntegrationTests/Tests/Body/GibTest.cs
+++ b/Content.IntegrationTests/Tests/Body/GibTest.cs
@@ -28,8 +28,8 @@ public sealed class GibTest
         Assert.That(client.EntMan.EntityExists(nuid1));
         Assert.That(client.EntMan.EntityExists(nuid2));
 
-        await server.WaitAssertion(() => server.System<BodySystem>().GibBody(target1, gibOrgans: false));
-        await server.WaitAssertion(() => server.System<BodySystem>().GibBody(target2, gibOrgans: true));
+        await server.WaitAssertion(() => server.System<BodySystem>().GibBody(target1, acidify: false));
+        await server.WaitAssertion(() => server.System<BodySystem>().GibBody(target2, acidify: true));
 
         await pair.RunTicksSync(5);
         await pair.WaitCommand("dirty");

--- a/Content.Server/Body/Systems/BodySystem.cs
+++ b/Content.Server/Body/Systems/BodySystem.cs
@@ -13,6 +13,8 @@ using Content.Shared.Movement.Systems;
 using Robust.Shared.Audio;
 using Robust.Shared.Timing;
 using System.Numerics;
+using Content.Server.Polymorph.Components;
+using Content.Server.Polymorph.Systems;
 
 // Shitmed Change
 using System.Linq;
@@ -30,6 +32,7 @@ public sealed class BodySystem : SharedBodySystem
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!; // Shitmed Change
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedMindSystem _mindSystem = default!;
+    [Dependency] private readonly PolymorphSystem _polymorph = default!;
 
     public override void Initialize()
     {
@@ -103,7 +106,7 @@ public sealed class BodySystem : SharedBodySystem
 
     public override HashSet<EntityUid> GibBody(
         EntityUid bodyId,
-        bool gibOrgans = false,
+        bool acidify = false,
         BodyComponent? body = null,
         bool launchGibs = true,
         Vector2? splatDirection = null,
@@ -121,11 +124,23 @@ public sealed class BodySystem : SharedBodySystem
             return new HashSet<EntityUid>();
         }
 
+        // If a polymorph configured to revert on death is gibbed without dying,
+        // revert it then gib so the parent is gibbed instead of the polymorph.
+        if (TryComp<PolymorphedEntityComponent>(bodyId, out var polymorph)
+            && polymorph.Configuration.RevertOnDeath)
+        {
+            _polymorph.Revert(bodyId);
+            if (polymorph.Configuration.TransferDamage)
+                GibBody(polymorph.Parent, acidify, null, launchGibs: launchGibs, splatDirection: splatDirection,
+                splatModifier: splatModifier, splatCone:splatCone);
+            return new HashSet<EntityUid>();
+        }
+
         var xform = Transform(bodyId);
         if (xform.MapUid is null)
             return new HashSet<EntityUid>();
 
-        var gibs = base.GibBody(bodyId, gibOrgans, body, launchGibs: launchGibs,
+        var gibs = base.GibBody(bodyId, acidify, body, launchGibs: launchGibs,
             splatDirection: splatDirection, splatModifier: splatModifier, splatCone: splatCone,
             gib: gib, contents: contents); // Shitmed Change
 

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -211,7 +211,6 @@ namespace Content.Server.Explosion.EntitySystems
         {
             if (!TryComp(uid, out TransformComponent? xform))
                 return;
-
             _body.GibBody(xform.ParentUid, true);
             args.Handled = true;
         }

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -211,14 +211,7 @@ namespace Content.Server.Explosion.EntitySystems
         {
             if (!TryComp(uid, out TransformComponent? xform))
                 return;
-            if (component.DeleteItems)
-            {
-                var items = _inventory.GetHandOrInventoryEntities(xform.ParentUid);
-                foreach (var item in items)
-                {
-                    Del(item);
-                }
-            }
+
             _body.GibBody(xform.ParentUid, true);
             args.Handled = true;
         }

--- a/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/KitchenSpikeSystem.cs
@@ -166,7 +166,7 @@ namespace Content.Server.Kitchen.EntitySystems
             _transform.SetCoordinates(victimUid, Transform(uid).Coordinates);
             // THE WHAT?
             // TODO: Need to be able to leave them on the spike to do DoT, see ss13.
-            var gibs = _bodySystem.GibBody(victimUid, gibOrgans: true); // DeltaV: spawn organs
+            var gibs = _bodySystem.GibBody(victimUid, acidify: true); // DeltaV: spawn organs
             foreach (var gib in gibs) {
                 // Begin DeltaV changes: Only delete limbs instead of organs
                 if (HasComp<BodyPartComponent>(gib))

--- a/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/Systems/ArtifactCrusherSystem.cs
@@ -109,7 +109,7 @@ public sealed class ArtifactCrusherSystem : SharedArtifactCrusherSystem
             if (!TryComp<BodyComponent>(contained, out var body))
                 Del(contained);
 
-            var gibs = _body.GibBody(contained, body: body, gibOrgans: true);
+            var gibs = _body.GibBody(contained, body: body, acidify: true);
             foreach (var gib in gibs)
             {
                 ContainerSystem.Insert((gib, null, null, null), crusher.OutputContainer);

--- a/Content.Server/_DV/Chapel/SacrificialAltarSystem.cs
+++ b/Content.Server/_DV/Chapel/SacrificialAltarSystem.cs
@@ -71,7 +71,7 @@ public sealed class SacrificialAltarSystem : SharedSacrificialAltarSystem
 
         // finally gib the targets old body
         if (TryComp<BodyComponent>(target, out var body))
-            _body.GibBody(target, gibOrgans: true, body, launchGibs: true);
+            _body.GibBody(target, acidify: true, body, launchGibs: true);
         else
             QueueDel(target);
     }

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -313,7 +313,7 @@ public partial class SharedBodySystem
 
     public virtual HashSet<EntityUid> GibBody(
         EntityUid bodyId,
-        bool gibOrgans = false,
+        bool acidify = false,
         BodyComponent? body = null,
         bool launchGibs = true,
         Vector2? splatDirection = null,
@@ -343,7 +343,7 @@ public partial class SharedBodySystem
                 playAudio: false, launchGibs: true, launchDirection: splatDirection, launchImpulse: GibletLaunchImpulse * splatModifier,
                 launchImpulseVariance: GibletLaunchImpulseVariance, launchCone: splatCone);
 
-            if (!gibOrgans)
+            if (!acidify)
                 continue;
 
             foreach (var organ in GetPartOrgans(part.Id, part.Component))
@@ -355,6 +355,11 @@ public partial class SharedBodySystem
         }
 
         var bodyTransform = Transform(bodyId);
+        _audioSystem.PlayPredicted(gibSoundOverride, bodyTransform.Coordinates, null);
+
+        if (acidify)
+            return gibs;
+
         if (TryComp<InventoryComponent>(bodyId, out var inventory))
         {
             foreach (var item in _inventory.GetHandOrInventoryEntities(bodyId))
@@ -363,7 +368,7 @@ public partial class SharedBodySystem
                 gibs.Add(item);
             }
         }
-        _audioSystem.PlayPredicted(gibSoundOverride, bodyTransform.Coordinates, null);
+
         return gibs;
     }
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -368,7 +368,6 @@ public partial class SharedBodySystem
                 gibs.Add(item);
             }
         }
-
         return gibs;
     }
 


### PR DESCRIPTION
## About the PR
Early merge of https://github.com/space-wizards/space-station-14/pull/36645
Revert polymorphed entities before gibbing if revert on death.

## Why / Balance
Gibbing should count as death and revert. Prevents brain and items like nuke disk from being lost in null space on the parent entity. Also allows polymorphs without damage transfer to be able to revert once gibbed.

## Technical details
made some small changes to the gib trigger moving acidify logic to gib system

## Media
see original PR

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
none

**Changelog**
:cl: SolStar
- fix: Fixed an edge case where items could be lost in nullspace.
