### PR TITLE
Command Boozeomat

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -53,6 +53,8 @@
   - type: VendingMachineRestock
     canRestock:
     - BoozeOMatInventory
+    - BoozeOMatUnlockedInventory # DeltaV - Make maint booz-o-mat refillable
+    - BoozeOMatCommandInventory # DeltaV - Make command booz-o-mat refillable
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/commandboozeomat.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/commandboozeomat.yml
@@ -36,5 +36,4 @@
     DrinkWhiskeyBottleFull: 2
     DrinkWineBottleFull: 3
     DrinkChampagneBottleFull: 1 #because the premium drink
-    DrinkAngobittersBottleFull: 1 # DeltaV - Angostura Bitters Bottle
-  #emaggedInventory:
+    DrinkAngobittersBottleFull: 1 #Angostura Bitters Bottle

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/commandboozeomat.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/commandboozeomat.yml
@@ -38,4 +38,3 @@
     DrinkChampagneBottleFull: 1 #because the premium drink
     DrinkAngobittersBottleFull: 1 # DeltaV - Angostura Bitters Bottle
   #emaggedInventory:
-

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/commandboozeomat.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/commandboozeomat.yml
@@ -1,0 +1,41 @@
+- type: vendingMachineInventory
+  id: BoozeOMatCommandInventory
+  startingInventory:
+    DrinkGlass: 10 #Kept glasses at top for ease to differentiate from booze.
+    DrinkShotGlass: 5
+    DrinkGlassCoupeShaped: 5
+    DrinkVacuumFlask: 2
+    DrinkFlaskBar: 2
+    DrinkShaker: 2
+    DrinkJigger: 1
+    DrinkIceBucket: 1
+    BarSpoon: 1
+    CustomDrinkJug: 1 #to allow for custom drinks in the soda/booze dispensers
+    DrinkAbsintheBottleFull: 1
+    DrinkBlueCuracaoBottleFull: 1
+    DrinkCognacBottleFull: 2
+    DrinkCoconutWaterCarton: 1
+    DrinkMilkCarton: 1
+    DrinkCreamCarton: 2
+    DrinkGinBottleFull: 2
+    DrinkGildlagerBottleFull: 1 #if champagne gets less because its premium, then gildlager should match this and have two
+    DrinkGrenadineBottleFull: 1
+    DrinkJuiceLimeCarton: 2
+    DrinkJuiceLemonCarton: 2
+    DrinkJuiceOrangeCarton: 2
+    DrinkJuiceTomatoCarton: 1
+    DrinkCoffeeLiqueurBottleFull: 1
+    DrinkMelonLiquorBottleFull: 2
+    DrinkPatronBottleFull: 1
+    DrinkRumBottleFull: 2
+    DrinkSodaWaterCan: 4
+    DrinkTequilaBottleFull: 1
+    DrinkTonicWaterCan: 4
+    DrinkVermouthBottleFull: 1
+    DrinkVodkaBottleFull: 1
+    DrinkWhiskeyBottleFull: 2
+    DrinkWineBottleFull: 3
+    DrinkChampagneBottleFull: 1 #because the premium drink
+    DrinkAngobittersBottleFull: 1 # DeltaV - Angostura Bitters Bottle
+  #emaggedInventory:
+

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
@@ -7,7 +7,7 @@
     DrinkVacuumFlask: 1
     DrinkFlaskBar: 1
     DrinkShaker: 4
-    BarSpoon: 1 #Qualety of life
+    BarSpoon: 1 #quality of life
     CustomDrinkJug: 2 #to allow for custom drinks in the soda/booze dispensers
     DrinkAleBottleFull: 8
     DrinkBeerBottleFull: 8

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedboozeomat.yml
@@ -7,6 +7,7 @@
     DrinkVacuumFlask: 1
     DrinkFlaskBar: 1
     DrinkShaker: 4
+    BarSpoon: 1 #Qualety of life
     CustomDrinkJug: 2 #to allow for custom drinks in the soda/booze dispensers
     DrinkAleBottleFull: 8
     DrinkBeerBottleFull: 8

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/vending_machines.yml
@@ -29,9 +29,19 @@
 - type: entity
   parent: VendingMachineBooze
   id: VendingMachineBoozeUnlocked
-  suffix: Unlocked
+  suffix: Unlocked, Maint
   components:
   - type: VendingMachine
     pack: BoozeOMatUnlockedInventory
   - type: AccessReader
     enabled: false
+
+- type: entity
+  parent: VendingMachineBooze
+  id: VendingMachineBoozeCommand
+  suffix: Command
+  components:
+  - type: VendingMachine
+    pack: BoozeOMatCommandInventory
+  - type: AccessReader
+    access: [["Command"]]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I have long thought there should be a command version of the booze-o-mat, as the bartender version can't be used by all command members, and the maintenance one is, well, just that for maintenance bars. So this brings a Booze-o-mat to command with a more select stock

There is also some quality of life stuff.
And was prompted to PR it #3488 So here i am.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Stated above

## Technical details
<!-- Summary of code changes for easier review. -->
- There is now a command Booze-O-Mat with its own select inventory.
- The command and maintenance versions can now be refilled with a booze-o-mat restock.
- Added a single bar spoon to the maintenance version.
- Gave the maintenance version the "Maint" suffix.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/1d4244c9-aef1-4029-bbc0-1397de628fde)
![image](https://github.com/user-attachments/assets/5bf84cfd-8da2-4fd3-a3eb-dd13487625f1)
![image](https://github.com/user-attachments/assets/bfb95d03-1c39-4317-a928-e5fb680ce4bb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->