### PR TITLE
Fix sales by making ATS station-owned

### DIFF
--- a/Content.Server/_DV/Cargo/Systems/CargoSystem.ATS.cs
+++ b/Content.Server/_DV/Cargo/Systems/CargoSystem.ATS.cs
@@ -6,6 +6,7 @@ using Content.Server.Station.Systems;
 using Content.Shared.Cargo.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Shuttles.Components;
+using Content.Shared.Station.Components;
 using Content.Shared.Tiles;
 using Content.Shared.Whitelist;
 using Robust.Shared.Configuration;
@@ -46,7 +47,7 @@ public sealed partial class CargoSystem
             return;
 
         if (_gridFillEnabled)
-            SetupTradePost();
+            SetupTradePost(args);
     }
 
     private void SetGridFill(bool enabled)
@@ -54,11 +55,11 @@ public sealed partial class CargoSystem
         _gridFillEnabled = enabled;
         if (enabled && _ticker.RunLevel != GameRunLevel.PreRoundLobby) // Ensure run level is in game
         {
-            SetupTradePost();
+            SetupTradePost(null);
         }
     }
 
-    private void SetupTradePost()
+    private void SetupTradePost(StationInitializedEvent? args)
     {
         if (Exists(CargoMap))
             return;
@@ -78,6 +79,10 @@ public sealed partial class CargoSystem
         var gridUid = grid.Value;
         EnsureComp<ProtectedGridComponent>(gridUid);
         EnsureComp<TradeStationComponent>(gridUid);
+        if (args is { } arg)
+        {
+            EnsureComp<StationMemberComponent>(gridUid).Station = arg.Station;
+        }
 
         var shuttleComp = EnsureComp<ShuttleComponent>(gridUid);
         shuttleComp.AngularDamping = 10000;


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- ats now counts as part of the station

## Why / Balance
- new economy code needs that
- technically this makes ats affected by events like power checks
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
- StationMemberComponent

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: ATS sale palettes work now

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
