### PR TITLE
add vent critter spawn location to scrubbers

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -164,6 +164,7 @@
     - type: Weldable
     - type: AtmosMonitoringConsoleDevice
       navMapBlip: GasVentScrubber
+    - type: VentCritterSpawnLocation # DeltaV
     - type: GuideHelp
       guides:
       - AirScrubber


### PR DESCRIPTION
## About the PR
so glacier has vent critters outside of AI sat

**Changelog**
:cl:
- fix: Fixed glacier only getting vent critters in the AI satellite.