### PR TITLE
Fix for our airlocks and windoors accesses

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/access.yml
@@ -125,7 +125,7 @@
 
 # Maintenance
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockMaintCommandLocked
   id: AirlockMaintChiefJusticeLocked
   suffix: ChiefJustice, Locked
   components:
@@ -141,9 +141,11 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsJustice ]
+  - type: Wires
+    layoutId: AirlockJustice
 
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockMaintJusticeLocked
   id: AirlockMaintProsecutorLocked
   suffix: Prosecutor, Locked
   components:
@@ -152,7 +154,7 @@
       board: [ DoorElectronicsProsecutor ]
 
 - type: entity
-  parent: AirlockMaint
+  parent: AirlockAirlockMaintJusticeLockedMaint
   id: AirlockMaintClerkLocked
   suffix: Clerk, Locked
   components:
@@ -168,8 +170,6 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsCorpsman ]
-  - type: Wires
-    layoutId: AirlockCommand
 
 - type: entity
   parent: AirlockMedical
@@ -197,7 +197,7 @@
     containers:
       board: [ DoorElectronicsRobotics ]
 
-#Add airlocks from upstream roles
+# Add airlocks from upstream roles
 - type: entity
   parent: AirlockServiceLocked
   id: AirlockBoxerLocked
@@ -476,8 +476,6 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsCorpsman ]
-  - type: Wires
-    layoutId: AirlockCommand
 
 - type: entity
   parent: AirlockMaintMedLocked

--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/access.yml
@@ -154,7 +154,7 @@
       board: [ DoorElectronicsProsecutor ]
 
 - type: entity
-  parent: AirlockAirlockMaintJusticeLockedMaint
+  parent: AirlockMaintJusticeLocked
   id: AirlockMaintClerkLocked
   suffix: Clerk, Locked
   components:

--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -17,8 +17,6 @@
   components:
   - type: Sprite
     sprite: _DV/Structures/Doors/Airlocks/Standard/roboticist.rsi
-  - type: Wires
-    layoutId: AirlockScience
 
 # Glass
 
@@ -41,5 +39,3 @@
   components:
   - type: Sprite
     sprite: _DV/Structures/Doors/Airlocks/Glass/roboticist.rsi
-  - type: Wires
-    layoutId: AirlockScience

--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/airlocks.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Airlocks/airlocks.yml
@@ -7,6 +7,8 @@
     sprite: _DV/Structures/Doors/Airlocks/Standard/justice.rsi
   - type: PaintableAirlock
     department: Justice
+  - type: Wires
+    layoutId: AirlockJustice
 
 - type: entity
   parent: AirlockScience
@@ -15,6 +17,8 @@
   components:
   - type: Sprite
     sprite: _DV/Structures/Doors/Airlocks/Standard/roboticist.rsi
+  - type: Wires
+    layoutId: AirlockScience
 
 # Glass
 
@@ -27,6 +31,8 @@
     sprite: _DV/Structures/Doors/Airlocks/Glass/justice.rsi
   - type: PaintableAirlock
     department: Justice
+  - type: Wires
+    layoutId: AirlockJustice
 
 - type: entity
   parent: AirlockScienceGlass
@@ -35,3 +41,5 @@
   components:
   - type: Sprite
     sprite: _DV/Structures/Doors/Airlocks/Glass/roboticist.rsi
+  - type: Wires
+    layoutId: AirlockScience

--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/Windoors/windoor.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: Windoor
+  parent: WindoorCargoLocked
   id: WindoorMailLocked
   suffix: Mail, Locked
   components:
@@ -8,7 +8,7 @@
       board: [ DoorElectronicsMail ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureCargoLocked
   id: WindoorSecureMailLocked
   suffix: Mail, Locked
   components:
@@ -17,7 +17,7 @@
       board: [ DoorElectronicsMail ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureMedicalLocked
   id: WindoorSecureParamedicLocked
   suffix: Paramedic, Locked
   components:
@@ -26,16 +26,18 @@
       board: [ DoorElectronicsParamedic ]
 
 - type: entity
-  parent: WindoorSecure
-  id: WindoorSecureChiefJusticeLocked
-  suffix: Chief Justice, Locked
+  parent: Windoor
+  id: WindoorJusticeLocked
+  suffix: Justice, Locked
   components:
   - type: ContainerFill
     containers:
-      board: [ DoorElectronicsChiefJustice ]
+      board: [ DoorElectronicsJustice ]
+  - type: Wires
+    layoutId: AirlockJustice
 
 - type: entity
-  parent: WindoorSecure
+  parent: [ WindoorSecure, WindoorJusticeLocked ]
   id: WindoorSecureJusticeLocked
   suffix: Justice, Locked
   components:
@@ -44,7 +46,16 @@
       board: [ DoorElectronicsJustice ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureCommandLocked
+  id: WindoorSecureChiefJusticeLocked
+  suffix: Chief Justice, Locked
+  components:
+  - type: ContainerFill
+    containers:
+      board: [ DoorElectronicsChiefJustice ]
+
+- type: entity
+  parent: WindoorSecureJusticeLocked
   id: WindoorSecureProsecutorLocked
   suffix: Prosecutor, Locked
   components:
@@ -53,7 +64,7 @@
       board: [ DoorElectronicsProsecutor ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureJusticeLocked
   id: WindoorSecureClerkLocked
   suffix: Clerk, Locked
   components:
@@ -62,7 +73,7 @@
       board: [ DoorElectronicsClerk ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureJusticeLocked
   id: WindoorSecureLawyerLocked
   suffix: Lawyer, Locked
   components:
@@ -71,7 +82,7 @@
       board: [ DoorElectronicsLawyer ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureScienceLocked
   id: WindoorSecureMantisLocked
   suffix: Mantis, Locked
   components:
@@ -80,7 +91,7 @@
       board: [ DoorElectronicsMantis ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureScienceLocked
   id: WindoorSecureRoboticsLocked
   suffix: Robotics, Locked
   components:
@@ -89,7 +100,7 @@
       board: [ DoorElectronicsRobotics ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureMedicalLocked
   id: WindoorSecureSurgeryLocked
   suffix: Surgery, Locked
   components:
@@ -99,7 +110,7 @@
 
 #Add windoors from upstream roles
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureServiceLocked
   id: WindoorSecureBoxerLocked
   suffix: Boxer, Locked
   components:
@@ -108,7 +119,7 @@
       board: [ DoorElectronicsBoxer ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureServiceLocked
   id: WindoorSecureClownLocked
   suffix: Clown, Locked
   components:
@@ -117,7 +128,7 @@
       board: [ DoorElectronicsClown ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureServiceLocked
   id: WindoorSecureMimeLocked
   suffix: Mime, Locked
   components:
@@ -126,7 +137,7 @@
       board: [ DoorElectronicsMime ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureServiceLocked
   id: WindoorSecureMusicianLocked
   suffix: Musician, Locked
   components:
@@ -135,7 +146,7 @@
       board: [ DoorElectronicsMusician ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureServiceLocked
   id: WindoorSecureReporterLocked
   suffix: Reporter, Locked
   components:
@@ -144,7 +155,7 @@
       board: [ DoorElectronicsReporter ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureServiceLocked
   id: WindoorSecureLibraryLocked
   suffix: Library, Locked
   components:
@@ -153,7 +164,7 @@
       board: [ DoorElectronicsLibrary ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureServiceLocked
   id: WindoorSecureZookeeperLocked
   suffix: Zookeeper, Locked
   components:
@@ -162,18 +173,16 @@
       board: [ DoorElectronicsZookeeper ]
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureSecurityLocked
   id: WindoorSecureCorpsmanLocked
   suffix: Corpsman, Locked
   components:
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsCorpsman ]
-  - type: Wires
-    layoutId: AirlockCommand
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureMedicalLocked
   id: WindoorSecurePsychologistLocked
   suffix: Psychologist, Locked
   components:

--- a/Resources/Prototypes/_DV/Wires/layouts.yml
+++ b/Resources/Prototypes/_DV/Wires/layouts.yml
@@ -1,4 +1,8 @@
 - type: wireLayout
+  parent: Airlock
+  id: AirlockJustice
+
+- type: wireLayout
   id: FireLock
   wires:
   - !type:PowerWireAction


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR does what the title says, assigns the correct parenting depending on the situation the airlock / windoor is used at.
Also changes the corpsman wire layout from the command one to sec.
(Also fixes a comment that was bugging me)

## Why / Balance
Bugfix + consistency.

## Technical details
Made a new layout for the wires access, it's just a parenting from the airlock one, it's made for justice.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
The CJ's maints airlock now inherits from the command maints airlock, which doesn't have proper wiring yet, but i'll PR a fix upstream either tomorrow or saturday.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: General service's windoors now properly follow the wires layout properly.
- tweak: Corpsman's airlock and windoor no longer uses the command wire layout, it uses the security one instead.