### PR TITLE
make it easier to cut limb off

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Parts/base.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/base.yml
@@ -17,7 +17,7 @@
     - trigger:
         !type:DamageTypeTrigger
         damageType: Slash
-        damage: 100 # DeltaV - was 150
+        damage: 60 # DeltaV - was 150
       behaviors:
       - !type:GibPartBehavior { }
     - trigger:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
100 damage to 60 for limb removal

## Why / Balance
u just go into crit instead of losing an arm rn. booo

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Limbs will now delimb at 60 slash, from 100. 
