### PR TITLE
Allow shields to be used as weapons

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -59,6 +59,16 @@
                   max: 2
     - type: StaticPrice
       price: 100
+    # Begin DeltaV additions
+    - type: MeleeWeapon
+      canWideSwing: false
+      damage:
+        types:
+          Blunt: 3
+      soundHit:
+        collection: MetalThud
+      bluntStaminaDamageFactor: 1.5
+    # End DeltaV additions
 
 #Security Shields
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Enabled shields to be used as weapons

## Why / Balance
Shields are neat, being able to use them as a melee weapon (with little overall blunt but some stamina damage) seems like a neat idea.

## Technical details
Simple addition of a new component

## Media
Don't think I need to add much but here's the image I'm imagining of me walking down the hallways on a nice peaceful greenshift.
![image](https://github.com/user-attachments/assets/312031f1-240b-4d52-849b-916d1142947a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- add: Shields can now be used as melee weapons for a small amount of damage. No wide swings.
