### PR TITLE
Health Analyzer Reactivation

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -171,10 +171,10 @@
                     </PanelContainer>
                     <TextureRect Name="NoDataTex"
                                  Access="Public"
-                                 SetSize="64 64"
+                                 SetSize="96 96"
                                  Visible="false"
                                  Stretch="KeepAspectCentered"
-                                 TexturePath="/Textures/Interface/Misc/health_analyzer_out_of_range.png"/>
+                                 TexturePath="/Textures/Interface/Misc/health_analyzer_out_of_range.png"/> <!-- Delta V - Size changed to 96 96 to be consistent with shitmed -->
                     <BoxContainer Margin="5 0 0 0"
                                   Orientation="Vertical"
                                   VerticalAlignment="Top">

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -174,7 +174,7 @@
                                  SetSize="96 96"
                                  Visible="false"
                                  Stretch="KeepAspectCentered"
-                                 TexturePath="/Textures/Interface/Misc/health_analyzer_out_of_range.png"/> <!-- Delta V - Size changed to 96 96 to be consistent with shitmed -->
+                                 TexturePath="/Textures/Interface/Misc/health_analyzer_out_of_range.png"/> <!-- DeltaV - Size changed to 96 96 to be consistent with shitmed -->
                     <BoxContainer Margin="5 0 0 0"
                                   Orientation="Vertical"
                                   VerticalAlignment="Top">

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -63,13 +63,11 @@ public sealed partial class HealthAnalyzerComponent : Component
     [DataField]
     public SoundSpecifier ScanningEndSound = new SoundPathSpecifier("/Audio/Items/Medical/healthscanner.ogg");
 
-    // Begin DeltaV - Analyzer Reactivation
     /// <summary>
-    /// If the last state of the health analyzer was active.
+    /// DeltaV - If the last state of the health analyzer was active.
     /// </summary>
     [DataField]
     public bool IsAnalyzerActive = false;
-    // End DeltaV - Analyzer Reactivation
 
     /// <summary>
     /// Whether to show up the popup

--- a/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
+++ b/Content.Server/Medical/Components/HealthAnalyzerComponent.cs
@@ -63,6 +63,14 @@ public sealed partial class HealthAnalyzerComponent : Component
     [DataField]
     public SoundSpecifier ScanningEndSound = new SoundPathSpecifier("/Audio/Items/Medical/healthscanner.ogg");
 
+    // Begin DeltaV - Analyzer Reactivation
+    /// <summary>
+    /// If the last state of the health analyzer was active.
+    /// </summary>
+    [DataField]
+    public bool IsAnalyzerActive = false;
+    // End DeltaV - Analyzer Reactivation
+
     /// <summary>
     /// Whether to show up the popup
     /// </summary>

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -100,7 +100,7 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             {
                 //Range too far, disable updates
                 //StopAnalyzingEntity((uid, component), patient);
-                PauseAnalyzingEntity((uid, component), patient); // Delta V - Analyzer Reactivation
+                PauseAnalyzingEntity((uid, component), patient, component.CurrentBodyPart); // Delta V - Analyzer Reactivation
                 continue;
             }
 
@@ -219,12 +219,12 @@ public sealed class HealthAnalyzerSystem : EntitySystem
     /// </summary>
     /// <param name="healthAnalyzer">The health analyzer that's receiving the updates</param>
     /// <param name="target">The entity to analyze</param>
-    private void PauseAnalyzingEntity(Entity<HealthAnalyzerComponent> healthAnalyzer, EntityUid target)
+    private void PauseAnalyzingEntity(Entity<HealthAnalyzerComponent> healthAnalyzer, EntityUid target, EntityUid? part = null)
     {
         if (!healthAnalyzer.Comp.IsAnalyzerActive)
             return;
 
-        UpdateScannedUser(healthAnalyzer, target, false);
+        UpdateScannedUser(healthAnalyzer, target, false, part);
         healthAnalyzer.Comp.IsAnalyzerActive = false;
     }
     // End Delta V - Analyzer Reactivation

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -99,12 +99,11 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             if (component.MaxScanRange != null && !_transformSystem.InRange(patientCoordinates, transform.Coordinates, component.MaxScanRange.Value))
             {
                 //Range too far, disable updates
-                //StopAnalyzingEntity((uid, component), patient);
-                PauseAnalyzingEntity((uid, component), patient, component.CurrentBodyPart); // Delta V - Analyzer Reactivation
+                PauseAnalyzingEntity((uid, component), patient, component.CurrentBodyPart); // DeltaV - Analyzer Reactivation
                 continue;
             }
 
-            component.IsAnalyzerActive = true; // Delta V - Scanner Reactivation
+            component.IsAnalyzerActive = true; // DeltaV - Analyzer Reactivation
             UpdateScannedUser(uid, patient, true, component.CurrentBodyPart); // Shitmed Change
         }
     }
@@ -213,9 +212,8 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         UpdateScannedUser(healthAnalyzer, target, false);
     }
 
-    // Begin Delta V - Analyzer Reactivation
     /// <summary>
-    /// If the scanner is active, sends one last update and sets it to inactive.
+    /// DeltaV - If the scanner is active, sends one last update and sets it to inactive.
     /// </summary>
     /// <param name="healthAnalyzer">The health analyzer that's receiving the updates</param>
     /// <param name="target">The entity to analyze</param>
@@ -227,7 +225,6 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         UpdateScannedUser(healthAnalyzer, target, false, part);
         healthAnalyzer.Comp.IsAnalyzerActive = false;
     }
-    // End Delta V - Analyzer Reactivation
 
     // Shitmed Change Start
     /// <summary>

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -99,10 +99,12 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             if (component.MaxScanRange != null && !_transformSystem.InRange(patientCoordinates, transform.Coordinates, component.MaxScanRange.Value))
             {
                 //Range too far, disable updates
-                StopAnalyzingEntity((uid, component), patient);
+                //StopAnalyzingEntity((uid, component), patient);
+                PauseAnalyzingEntity((uid, component), patient); // Delta V - Analyzer Reactivation
                 continue;
             }
 
+            component.IsAnalyzerActive = true; // Delta V - Scanner Reactivation
             UpdateScannedUser(uid, patient, true, component.CurrentBodyPart); // Shitmed Change
         }
     }
@@ -210,6 +212,22 @@ public sealed class HealthAnalyzerSystem : EntitySystem
 
         UpdateScannedUser(healthAnalyzer, target, false);
     }
+
+    // Begin Delta V - Analyzer Reactivation
+    /// <summary>
+    /// If the scanner is active, sends one last update and sets it to inactive.
+    /// </summary>
+    /// <param name="healthAnalyzer">The health analyzer that's receiving the updates</param>
+    /// <param name="target">The entity to analyze</param>
+    private void PauseAnalyzingEntity(Entity<HealthAnalyzerComponent> healthAnalyzer, EntityUid target)
+    {
+        if (!healthAnalyzer.Comp.IsAnalyzerActive)
+            return;
+
+        UpdateScannedUser(healthAnalyzer, target, false);
+        healthAnalyzer.Comp.IsAnalyzerActive = false;
+    }
+    // End Delta V - Analyzer Reactivation
 
     // Shitmed Change Start
     /// <summary>


### PR DESCRIPTION


<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
If you move out of range with a health analyzer and then back into range, it will set your health analyzer window back to active! No more re-scanning the same patient!

## Why / Balance
God, its annoying to have to rescan a patient if you have to run to the chem locker to make sure they havent been treated by someone else, or if you have to move two feet away during surgery to pick up a body part that someone brought in. This is a QoL fix, pure and simple.

## Technical details
When one moves out of the scanning range, the scanned entities are no longer set to `null`. Instead, it will keep checking the range in the Update loop and once they are back within range, it will send an update back to the analyzer. Since setting the  scanner to inactive requires you to send the whole payload of health information (found in `Content.Shared\MedicalScanner\HealthAnalyzerScannedUserMessage.cs`), we also have to save the health analyzer state so that we only send the inactivation once, thus I added `IsAnalyzerActive` to the `HealthAnalyzerComponent` that tracks the last state of the health analyzer.

Also fixed the size of the Out of Range sprite to be more consistent with the shitmed sprites found in the analyzer window. It will no longer resize that image if you go out (or back into) range.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
https://github.com/user-attachments/assets/bb39642e-e36e-4d76-9fe3-d8e3fd13183e


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Health analyzers will now become active again if you move back into range of your patient!
