### PR TITLE
Grant LO Funding access

### DIFF
--- a/Resources/Prototypes/Access/cargo.yml
+++ b/Resources/Prototypes/Access/cargo.yml
@@ -10,10 +10,6 @@
   id: Salvage
   name: id-card-access-level-salvage
 
-- type: accessLevel
-  id: Funding
-  name: id-card-access-level-funding
-
 - type: accessGroup
   id: Cargo
   tags:
@@ -22,3 +18,4 @@
   - Cargo
   - Mail # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
   - Orders # Delta V - Orders, see Resources/Prototypes/_DV/Access/cargo.yml
+  - Funding # DeltaV

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -33,6 +33,7 @@
   #- Brig # DeltaV - Removed brig access
   - Orders # DeltaV - Orders, see Resources/Prototypes/_DV/Access/cargo.yml
   - Cryogenics
+  - Funding # DeltaV
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_DV/Access/cargo.yml
+++ b/Resources/Prototypes/_DV/Access/cargo.yml
@@ -1,3 +1,7 @@
 - type: accessLevel
   id: Orders
   name: id-card-access-level-orders # Custom access level that allows the approval of orders
+
+- type: accessLevel
+  id: Funding
+  name: id-card-access-level-funding

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
@@ -13,6 +13,7 @@
     - id: StockTradingCartridge
     - id: LogisticsTechFabCircuitboard
     - id: SalvageExpeditionsComputerCircuitboard
+    - id: FundingAllocationComputerCircuitboard # To be removed when it's in techvault on all maps
     - id: LunchboxCommandFilledRandom
       prob: 0.3
 
@@ -24,7 +25,6 @@
     - id: ClothingShoesLeather # fancy shoes for HoP and cap TODO: move to dresser
     - id: ClothingShoesMiscWhite
     - id: ClothingShoesBootsWinterCap
-    - id: FundingAllocationComputerCircuitboard # To be removed when it's in techvault on all maps
     - id: LunchboxCommandFilledRandom
       prob: 0.3
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
LO now oversees the Funding Allocation Computer, and the FAC now doesn't include the Logistics department separately from its 75% primary cut.

## Why / Balance
LO is the command role tasked with overseeing station logistics, and this plays into that.

## Technical details
- LO now has Funding access
- Funding access is now considered part of Cargo
- spare board moved into LO locker

## Media
![grafik](https://github.com/user-attachments/assets/cbda0b51-9fe6-453f-9b4d-8f3692e2630f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Funding Allocation Computer no longer redundantly displays Logistics separately from their role as the primary station acconut
- tweak: The Funding Allocation Computer is now the responsibility of the Logistics Officer

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
