### PR TITLE
Shared stuff on lathes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -502,6 +502,7 @@
     - EmptyMedkitsStatic
     - SurgeryStatic
     - ReportingStatic # DeltaV
+    - PowerCellsStatic # DeltaV
     dynamicPacks:
     - Chemistry
     - CyberneticsMedical # Shitmed change

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -101,7 +101,7 @@
     - LVCablesStatic
     - CargoStatic
     - ReportingStatic
-    - SimpleElectronics
+    - SimpleElectronicsStatic
     dynamicPacks:
     - Equipment
     - Mining
@@ -138,7 +138,7 @@
     - LightsStatic
     - ServiceStatic
     - PartsStaticDeltaV # Add Beaker and Hand Labeler to the service techfab
-    - SimpleElectronics
+    - SimpleElectronicsStatic
     dynamicPacks:
     - Janitor
     - Instruments
@@ -176,7 +176,7 @@
     - ChemistryStatic
     - PowerCellsStatic
     - ReportingStatic
-    - SimpleElectronics
+    - SimpleElectronicsStatic
     dynamicPacks:
     - ScienceEquipment
     - ScienceClothing

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -101,6 +101,7 @@
     - LVCablesStatic
     - CargoStatic
     - ReportingStatic
+    - SimpleElectronics
     dynamicPacks:
     - Equipment
     - Mining
@@ -137,6 +138,7 @@
     - LightsStatic
     - ServiceStatic
     - PartsStaticDeltaV # Add Beaker and Hand Labeler to the service techfab
+    - SimpleElectronics
     dynamicPacks:
     - Janitor
     - Instruments
@@ -174,6 +176,7 @@
     - ChemistryStatic
     - PowerCellsStatic
     - ReportingStatic
+    - SimpleElectronics
     dynamicPacks:
     - ScienceEquipment
     - ScienceClothing

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -97,6 +97,7 @@
     staticPacks:
     - ToolsStatic
     - PartsStatic
+    - PowerCellsStatic
     - LVCablesStatic
     - CargoStatic
     - ReportingStatic
@@ -132,6 +133,7 @@
     - RingsStatic
     - ReportingStatic
     - LVCablesStatic
+    - PowerCellsStatic
     - LightsStatic
     - ServiceStatic
     - PartsStaticDeltaV # Add Beaker and Hand Labeler to the service techfab

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
@@ -26,7 +26,7 @@
   - TapeRecorder
 
 - type: latheRecipePack
-  id: SimpleElectronics
+  id: SimpleElectronicsStatic
   recipes:
   - DoorElectronics
   - StationMapElectronics

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/shared.yml
@@ -24,3 +24,14 @@
   recipes:
   - CassetteTape
   - TapeRecorder
+
+- type: latheRecipePack
+  id: SimpleElectronics
+  recipes:
+  - DoorElectronics
+  - StationMapElectronics
+  - MailingUnitElectronics
+  - APCElectronics
+  - CellRechargerCircuitboard
+  - WeaponCapacitorRechargerCircuitboard
+  - FreezerElectronics


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added both regular power cells to all lathes and a new SimpleElectronics pack which include some basic electronics that are regularly used.

## Why / Balance
QoL for IPCs and anyone that needs a cell, the simple electronics is due to request, but I personally want it for ease of APC repairs as a engineer.

## Technical details
New `SimpleElectronics` pack.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Basic power cells have been added to every TechFab except the Ammo one.
- add: Simple electronics have been added to the logistics, service and epistemics TechFabs.