### PR TITLE
Cleanup + proper divide of epistemics access

### DIFF
--- a/Resources/Prototypes/Access/research.yml
+++ b/Resources/Prototypes/Access/research.yml
@@ -11,5 +11,3 @@
   tags:
   - ResearchDirector
   - Research
-  - Mantis # DeltaV - Psionic Mantis, see Resources/Prototypes/_DV/Access/epistemics.yml
-  - Robotics # DeltaV: Robotics access

--- a/Resources/Prototypes/Access/service.yml
+++ b/Resources/Prototypes/Access/service.yml
@@ -40,7 +40,7 @@
   - Service
   - Janitor
   - Theatre
-  - Chapel
+  #- Chapel # DeltaV - Chapel is from Epistemics not service.
   - Lawyer
   - Boxer # DeltaV - Add Boxer access
   - Clown # DeltaV - Add Clown access

--- a/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/door_remote.yml
@@ -93,6 +93,7 @@
   - type: Access
     groups:
     - Research
+    - Epistemics # DeltaV - Add our access
 
 - type: entity
   parent: [DoorRemoteDefault, BaseCommandContraband]

--- a/Resources/Prototypes/_DV/Access/epistemics.yml
+++ b/Resources/Prototypes/_DV/Access/epistemics.yml
@@ -5,3 +5,10 @@
 - type: accessLevel
   id: Robotics
   name: id-card-access-level-robotics
+
+- type: accessGroup
+  id: Epistemics
+  tags:
+  - Robotics
+  - Mantis
+  - Chapel


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR makes the chapel properly work under the mystagogue's door remote and moves the DV (and chapel) access to a Epistemics group.

## Why / Balance
Bug fix + cleanup.

## Technical details
N/A

## Media

https://github.com/user-attachments/assets/d9750515-da81-4e77-b692-6c9e3f629084


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Mystagogue's remote not affecting the chapel.
