### PR TITLE
Add BiologicalMetaphysical to various ShowHealthBar/Icons

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -12,8 +12,16 @@
   abstract: true
   categories: [ HideSpawnMenu ]
   components:
+    # Begin DeltaV Changes - Kitsune
   - type: ShowHealthBars
+    damageContainers:
+    - Biological
+    - BiologicalMetaphysical
   - type: ShowHealthIcons
+    damageContainers:
+    - Biological
+    - BiologicalMetaphysical
+    # End DeltaV Changes - Kitsune
   - type: ShowTriageIcons # DeltaV - Medical Records
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Eyes/hud.yml
@@ -14,9 +14,11 @@
   - type: ShowHealthBars
     damageContainers:
     - Biological
+    - BiologicalMetaphysical # DeltaV - Kitsune
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+    - BiologicalMetaphysical # DeltaV - Kitsune
   - type: Tag
     tags:
     - HudMedical

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -251,6 +251,7 @@
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+    - BiologicalMetaphysical # DeltaV - Kitsune
 
 - type: entity
   parent: BaseBorgModuleSyndie

--- a/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
@@ -46,6 +46,8 @@
     - type: ShowHealthBars
       damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV - Kitsune
     - type: ShowHealthIcons
       damageContainers:
       - Biological
+      - BiologicalMetaphysical # DeltaV - Kitsune

--- a/Resources/Prototypes/borg_types.yml
+++ b/Resources/Prototypes/borg_types.yml
@@ -194,9 +194,11 @@
   - type: ShowHealthBars
     damageContainers:
     - Biological
+    - BiologicalMetaphysical # DeltaV - Kitsune
   - type: ShowHealthIcons
     damageContainers:
     - Biological
+    - BiologicalMetaphysical # DeltaV - Kitsune
   - type: FabricateCandy # DeltaV - The medical cyborg can generate candies filled with medicine.
     actions:
     - ActionFabricateLollipop


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Kitsune can be seen on medical HUDs and similar equipment.

## Technical details
- BiologicalMetaphysical everywhere

## Media
![grafik](https://github.com/user-attachments/assets/b08e7fa0-de39-424a-91ab-f8e572b6e3a3)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Kitsune can now have their health seen by medical HUDs and similar equipment
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
