### PR TITLE
Dump entire intellicard when polymorphing

### DIFF
--- a/Content.Shared/_DV/Containers/ContentContainerSystem.cs
+++ b/Content.Shared/_DV/Containers/ContentContainerSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Shared._DV.Polymorph;
+using Content.Shared.Intellicard;
 using Content.Shared.Mind.Components;
 using Robust.Shared.Containers;
 
@@ -40,6 +41,13 @@ public sealed class ContentContainerSystem : EntitySystem
                 {
                     if (HasComp<MindContainerComponent>(entity))
                     {
+                        _found.Add(entity);
+                        continue;
+                    }
+
+                    if (HasComp<IntellicardComponent>(entity))
+                    {
+                        // Dump out the WHOLE intellicard rather than just the entities contained inside.
                         _found.Add(entity);
                         continue;
                     }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Ensure intellicards are dropped instead of RR'ing the AI player.
Fixes https://github.com/DeltaV-Station/Delta-v/issues/3538

## Why / Balance
RR'ing AI bad.

## Technical details
Simple fix for just dropping the intellicard directly instead of recursing into the container.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- fix: Kitsune holding intellicards no longer round remove AI players

