### PR TITLE
Bring Apoapsis round restart time in line with other servers

### DIFF
--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -3,6 +3,7 @@ desc               = "A medium roleplay fork based around the mysterious Noösph
 lobbyenabled       = true
 lobbyduration      = 240
 round_end_pacifist = true
+round_restart_time = 300
 contraband_examine = false # Doubtful that it's desired at all, and would require going over every item in accordance with SOP
 secret_weight_prototype = "SecretDeltaV"
 role_timer_override = "DeltaV"

--- a/Resources/ConfigPresets/DeltaV/horizon.toml
+++ b/Resources/ConfigPresets/DeltaV/horizon.toml
@@ -1,7 +1,6 @@
 [game]
 hostname           = "[EN][MRP] Delta-v (Ψ) | Horizon [US East 3]"
 soft_max_players   = 80
-round_restart_time = 300
 
 [vote]
 preset_enabled = true

--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -1,7 +1,6 @@
 [game]
 hostname           = "[EN][MRP] Delta-v (Ψ) | Periapsis [US East 2]"
 soft_max_players   = 50
-round_restart_time = 300
 
 [vote]
 preset_enabled = true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
5 minute CC time for apoapsis
<!-- What did you change? -->

## Why / Balance
Same justification as https://github.com/DeltaV-Station/Delta-v/pull/3543, more time to unwind
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
![grafik](https://github.com/user-attachments/assets/e3164b3f-8c2c-4a31-8b91-9cfaafd7e96b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Apoapsis now has 3 more minutes of wind-down time at Central Command
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
