### PR TITLE
IPC paradox clone radio fix

### DIFF
--- a/Content.Server/_DV/Radio/EncryptionKeySystem.cs
+++ b/Content.Server/_DV/Radio/EncryptionKeySystem.cs
@@ -1,0 +1,37 @@
+using Content.Server.Cloning;
+using Content.Shared.Cloning.Events;
+using Content.Shared.Radio.Components;
+using Robust.Server.Containers;
+
+namespace Content.Server._DV.Radio;
+
+public sealed partial class EncryptionKeySystem : EntitySystem
+{
+    [Dependency] private readonly CloningSystem _clone = default!;
+    [Dependency] private readonly ContainerSystem _container = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<EncryptionKeyHolderComponent, CloningEvent>(OnClone);
+    }
+
+    // This is basically just for IPCs
+    public void OnClone(Entity<EncryptionKeyHolderComponent> keyHolder, ref CloningEvent args)
+    {
+        if (!args.Settings.CopyInternalStorage)
+            return;
+
+        if (!TryComp<EncryptionKeyHolderComponent>(args.CloneUid, out var clonesComp))
+            return;
+
+        var keys = keyHolder.Comp.KeyContainer.ContainedEntities;
+
+        foreach (var key in keys)
+        {
+            var spawned = _clone.CopyItem(key, Transform(keyHolder).Coordinates);
+            if (spawned != null)
+                _container.InsertOrDrop(spawned.Value, clonesComp.KeyContainer);
+        }
+    }
+}


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
IPC paradox clones didn't properly their encryption keys. Now they do! This is a mald pr.

Resolves: #3542

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: IPC paradoxes now get the real versions headsets.
