### PR TITLE
Add blueprint support at TechFabs

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -32,6 +32,18 @@
     - SecurityExplosives
     - SecurityEquipment
     - SecurityWeapons
+  - type: BlueprintReceiver
+    whitelist:
+      tags:
+      - BlueprintAutolathe
+  - type: ContainerContainer
+    containers:
+      machine_board: !type:Container
+      machine_parts: !type:Container
+      blueprint: !type:Container
+  - type: EmptyOnMachineDeconstruct
+    containers:
+    - blueprint
 
 - type: entity
   parent: BaseTechFabDepartamental


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
Blueprints are completely useless as of right now without the autolathe, this should allow people to insert them into any departamental techfab (Except meds and security).

## Technical details
Copy-paste ops.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- fix: Fixed departamental TechFabs not being able to accept blueprints.
