### PR TITLE
Foldable clothing fix

### DIFF
--- a/Content.Shared/Clothing/Components/FoldableClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/FoldableClothingComponent.cs
@@ -35,11 +35,11 @@ public sealed partial class FoldableClothingComponent : Component
     /// Which layers does this hide when Unfolded? See <see cref="HumanoidVisualLayers"/> and <see cref="HideLayerClothingComponent"/>
     /// </summary>
     [DataField]
-    public HashSet<HumanoidVisualLayers>? UnfoldedHideLayers = new();
+    public HashSet<HumanoidVisualLayers>? UnfoldedHideLayers = null; // DeltaV - null, was new()
 
     /// <summary>
     /// Which layers does this hide when folded? See <see cref="HumanoidVisualLayers"/> and <see cref="HideLayerClothingComponent"/>
     /// </summary>
     [DataField]
-    public HashSet<HumanoidVisualLayers>? FoldedHideLayers = new();
+    public HashSet<HumanoidVisualLayers>? FoldedHideLayers = null; // DeltaV - null, was new()
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixes https://github.com/DeltaV-Station/Delta-v/issues/3541 so that foldable clothes can be folded while being worn.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
everyone knows you have to take off a jacket to unzip it

## Technical details
<!-- Summary of code changes for easier review. -->
FoldableClothingSystem checks if FoldedHideLayers or UnfoldedHideLayers is not null so that hidden layers aren't set while equipped, but the default is an empty hashset despite clothes with an empty hashset not modifying hidden layers. Makes the default null instead of an empty hashset.
Bandanas still work as expected.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have tested all added content and changes.
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Jumpsuits can be folded and jackets can be zipped while being worn again.
