### PR TITLE
Adds NanoTask to PDAs that were missing it

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -483,6 +483,7 @@
     preinstalled:
     - CrewManifestCartridge
     - NotekeeperCartridge
+    - NanoTaskCartridge
     - NewsReaderCartridge
     - NanoChatCartridge
     - MailMetricsCartridge
@@ -509,6 +510,7 @@
     preinstalled:
     - CrewManifestCartridge
     - NotekeeperCartridge
+    - NanoTaskCartridge
     - NewsReaderCartridge
     - StockTradingCartridge # DeltaV - StockTrading
     - NanoChatCartridge # DeltaV
@@ -849,6 +851,7 @@
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
+      - NanoTaskCartridge
       - NewsReaderCartridge
       - GlimmerMonitorCartridge
       - NanoChatCartridge # DeltaV
@@ -875,6 +878,7 @@
     preinstalled:
       - CrewManifestCartridge
       - NotekeeperCartridge
+      - NanoTaskCartridge
       - NewsReaderCartridge
       - GlimmerMonitorCartridge
       - NanoChatCartridge # DeltaV
@@ -1277,6 +1281,7 @@
     preinstalled:
     - CrewManifestCartridge
     - NotekeeperCartridge
+    - NanoTaskCartridge
     - NewsReaderCartridge
     - StockTradingCartridge # DeltaV - StockTrading
     - NanoChatCartridge # DeltaV


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added NanoTask to the preinstalled list of PDAs where it was missing.

## Why / Balance
Everyone should have access to NanoTask as a base PDA application. It was excluded from certain PDAs due to DeltaV changes to applications that aren't present upstream.

## Technical details
Added the NanoTask cartridge to 

- QuartermasterPDA
- CargoPDA
- RnDPDA
- SciencePDA
- ReporterPDA

Which further updated their child PDAs:

- ChaplainPDA
- SeniorResearcherPDA
- CargoAssistantPDA
- PsionicMantisPDA
- DeckWorkerPDA
- InventoryAssociatePDA
- LabTechPDA
- XenoarchPDA
- RoboticistPDA

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Roboticist PDA before:
![image](https://github.com/user-attachments/assets/a6127438-7c28-4435-9ae9-b1cdd8ce7009)
Roboticist PDA after:
![image](https://github.com/user-attachments/assets/021af756-4203-4144-b24a-6494818f428f)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Epistemics, Logistics, and Reporter PDAs should now have NanoTask pre-installed
