### PR TITLE
Return of warops

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -1,3 +1,4 @@
+using Content.Server._DV.Antag; // DeltaV
 using Content.Server.RoundEnd;
 using Content.Shared.Dataset;
 using Content.Shared.NPC.Prototypes;
@@ -8,7 +9,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server.GameTicking.Rules.Components;
 
-[RegisterComponent, Access(typeof(NukeopsRuleSystem))]
+[RegisterComponent, Access(typeof(NukeopsRuleSystem), typeof(NukieOperationSystem))] // DeltaV - Auto war declare
 public sealed partial class NukeopsRuleComponent : Component
 {
     /// <summary>

--- a/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/NukeopsRuleSystem.cs
@@ -404,7 +404,7 @@ public sealed class NukeopsRuleSystem : GameRuleSystem<NukeopsRuleComponent>
         return WarConditionStatus.YesWar;
     }
 
-    private void DistributeExtraTc(Entity<NukeopsRuleComponent> nukieRule)
+    public void DistributeExtraTc(Entity<NukeopsRuleComponent> nukieRule) // DeltaV - Public so our war can work
     {
         var enumerator = EntityQueryEnumerator<StoreComponent>();
         while (enumerator.MoveNext(out var uid, out var component))

--- a/Content.Server/_DV/Antag/NukieAutoWarComponent.cs
+++ b/Content.Server/_DV/Antag/NukieAutoWarComponent.cs
@@ -1,6 +1,3 @@
-using Content.Shared._DV.Antag;
-using Robust.Shared.Analyzers;
-
 namespace Content.Server._DV.Antag;
 
 [RegisterComponent, Access(typeof(NukieOperationSystem)), AutoGenerateComponentPause]

--- a/Content.Server/_DV/Antag/NukieAutoWarComponent.cs
+++ b/Content.Server/_DV/Antag/NukieAutoWarComponent.cs
@@ -1,0 +1,14 @@
+using Content.Shared._DV.Antag;
+using Robust.Shared.Analyzers;
+
+namespace Content.Server._DV.Antag;
+
+[RegisterComponent, Access(typeof(NukieOperationSystem)), AutoGenerateComponentPause]
+public sealed partial class NukieAutoWarComponent : Component
+{
+    /// <summary>
+    ///     Automatically calls war after set time.
+    /// </summary>
+    [DataField, AutoPausedField]
+    public TimeSpan AutoWarCallTime;
+}

--- a/Content.Server/_DV/Antag/NukieOperationSystem.cs
+++ b/Content.Server/_DV/Antag/NukieOperationSystem.cs
@@ -1,26 +1,59 @@
 using Content.Server.Antag;
+using Content.Server.Chat.Systems;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Rules;
+using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Objectives;
 using Content.Shared._DV.FeedbackOverwatch;
 using Content.Shared.Mind;
 using Content.Shared.Random.Helpers;
+using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server._DV.Antag;
 
 public sealed class NukieOperationSystem : EntitySystem
 {
-    [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly SharedMindSystem _mind = default!;
-    [Dependency] private readonly ObjectivesSystem _objectives = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly NukeopsRuleSystem _nukeops = default!;
+    [Dependency] private readonly ObjectivesSystem _objectives = default!;
     [Dependency] private readonly SharedFeedbackOverwatchSystem _feedback = default!;
+    [Dependency] private readonly SharedMindSystem _mind = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<NukieOperationComponent, AfterAntagEntitySelectedEvent>(OnAntagSelected);
         SubscribeLocalEvent<GetNukeCodePaperWriting>(OnNukeCodePaperWritingEvent);
+    }
+    /// <summary>
+    /// This runs the automatic war declaration, distributes TC, and makes sure it only happens when it's not hostage ops.
+    /// </summary>
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<NukieAutoWarComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (_time.CurTime < comp.AutoWarCallTime)
+                continue;
+
+            RemCompDeferred<NukieAutoWarComponent>(uid);
+            var nukeops = Comp<NukeopsRuleComponent>(uid);
+            nukeops.WarDeclaredTime = _time.CurTime;
+            _nukeops.DistributeExtraTc((uid, nukeops));
+            _chat.DispatchGlobalAnnouncement(Loc.GetString("nuke-ops-auto-war-message"),
+                Loc.GetString("chat-manager-sender-announcement"),
+                true, new SoundPathSpecifier("/Audio/Announcements/war.ogg"), Color.DarkRed);
+        }
     }
 
     private void OnAntagSelected(Entity<NukieOperationComponent> ent, ref AfterAntagEntitySelectedEvent args)
@@ -53,6 +86,11 @@ public sealed class NukieOperationSystem : EntitySystem
             // TODO: Remove once enough feedback has been received!
             if (objectiveProto.Id == "KidnapHeadsObjective")
                 _feedback.SendPopupMind(mindId, "NukieHostageRoundStartPopup");
+        }
+        if (chosenOp.AutoWarAfter is { } duration)
+        {
+            var autoWar = EnsureComp<NukieAutoWarComponent>(ent);
+            autoWar.AutoWarCallTime = _time.CurTime + duration;
         }
     }
 

--- a/Content.Server/_DV/Antag/NukieOperationSystem.cs
+++ b/Content.Server/_DV/Antag/NukieOperationSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Antag;
 using Content.Server.Chat.Systems;
-using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Objectives;
@@ -17,7 +16,6 @@ namespace Content.Server._DV.Antag;
 public sealed class NukieOperationSystem : EntitySystem
 {
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly IGameTiming _time = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;

--- a/Content.Server/_DV/Antag/NukieOperationSystem.cs
+++ b/Content.Server/_DV/Antag/NukieOperationSystem.cs
@@ -31,6 +31,7 @@ public sealed class NukieOperationSystem : EntitySystem
         SubscribeLocalEvent<NukieOperationComponent, AfterAntagEntitySelectedEvent>(OnAntagSelected);
         SubscribeLocalEvent<GetNukeCodePaperWriting>(OnNukeCodePaperWritingEvent);
     }
+
     /// <summary>
     /// This runs the automatic war declaration, distributes TC, and makes sure it only happens when it's not hostage ops.
     /// </summary>

--- a/Content.Shared/_DV/Antag/NukieOperationPrototype.cs
+++ b/Content.Shared/_DV/Antag/NukieOperationPrototype.cs
@@ -17,4 +17,10 @@ public sealed partial class NukieOperationPrototype : IPrototype
 
     [DataField]
     public LocId? NukeCodePaperOverride;
+
+    /// <summary>
+    /// If non-null, calls war after the given duration
+    /// </summary>
+    [DataField]
+    public TimeSpan? AutoWarAfter;
 }

--- a/Resources/Locale/en-US/_DV/nukie-operations/autowar.ftl
+++ b/Resources/Locale/en-US/_DV/nukie-operations/autowar.ftl
@@ -1,0 +1,3 @@
+# Played when war is automatically called
+
+nuke-ops-auto-war-message = Our intelligence indicates that a hostile boarding party is enroute to your location.

--- a/Resources/Prototypes/_DV/Objectives/nukies.yml
+++ b/Resources/Prototypes/_DV/Objectives/nukies.yml
@@ -4,10 +4,17 @@
   id: NukieOperations
   weights:
     NukieOperationDestroyStation: 1
+    NukieOperationDestroyStationWar: 1
 #    NukieOperationKidnapHeads: 1
 
 - type: nukieOperation
   id: NukieOperationDestroyStation
+  operationObjectives:
+  - NukeStationObjective
+
+- type: nukieOperation
+  id: NukieOperationDestroyStationWar
+  autoWarAfter: 120
   operationObjectives:
   - NukeStationObjective
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->
to quote @Stop-Signs:

## About the PR
WOWZA ITS WAR TIME!!!!

If a nukie mode is not hostage ops it will AUTOMATICALLY call war after 2 minutes of the round starting. War still includes everything it did, as a reminder ill put what it does here

all nukies get 80TC (yes, still 80 without hardsuits)
nukies cannot depart until a certain period of time has passed to give station time to prepare
crew cannot call evac until 25 minutes

TO BE DONE AT A LATER DATE:
once ERT gamerules get added I will add those to automatically spawn, as well as force the shuttle to come with a timer that cannot be recalled.

## Why / Balance
Id love to do my nukie rant here, but ill try to keep it concise. Current nukies is 30 minutes of RP, and then instant round over with little involvement for crew. Warops is ~25 minutes of the station coming together to defend themselves and become victorious. so +RP, +comradery, +not having 30 minutes wasted.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
I will add if requested but its literally just a funny announcement

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
The announcement that happens is pending direction discussion and will be added later

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Non-hostage ops nukies will always be warops.

