### PR TITLE
Kitsune fixes 2

### DIFF
--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -77,31 +77,6 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             _faction.AddFactions(newEntity, factions.Factions);
         }
 
-        // Transfer equipped item speed modifiers
-        var movementComp = EnsureComp<MovementSpeedModifierComponent>(newEntity);
-        var slots = _inventory.GetSlotEnumerator(oldEntity.Owner);
-        while (slots.MoveNext(out var slot))
-        {
-            if (TryComp<ClothingSpeedModifierComponent>(slot.ContainedEntity, out var clothingComp))
-            {
-                _speed.ChangeBaseSpeed(newEntity,
-                    movementComp.BaseWalkSpeed * clothingComp.WalkModifier,
-                    movementComp.BaseSprintSpeed * clothingComp.SprintModifier,
-                    movementComp.Acceleration);
-            }
-        }
-
-        foreach (var held in _hands.EnumerateHeld(oldEntity))
-        {
-            if (TryComp<HeldSpeedModifierComponent>(held, out var heldComp))
-            {
-                _speed.ChangeBaseSpeed(newEntity,
-                    movementComp.BaseWalkSpeed * heldComp.WalkModifier,
-                    movementComp.BaseSprintSpeed * heldComp.SprintModifier,
-                    movementComp.Acceleration);
-            }
-        }
-
         _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-others", ("entity", args.NewEntity)), args.NewEntity, Filter.PvsExcept(args.NewEntity), true);
         _popup.PopupEntity(Loc.GetString("kitsune-popup-morph-message-user"), args.NewEntity, args.NewEntity);
     }

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -41,13 +41,14 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
     private void OnPolymorphed(Entity<KitsuneComponent> oldEntity, ref PolymorphedEvent args)
     {
         var newEntity = args.NewEntity;
-
-        _appearance.SetData(newEntity, KitsuneColorVisuals.Color, oldEntity.Comp.Color ?? Color.Orange);
-
-        // Ensure that the fox fire action state is transferred properly.
         if (!TryComp<KitsuneComponent>(newEntity, out var newKitsune)
             || !TryComp<KitsuneComponent>(oldEntity, out var oldKitsune))
             return;
+
+        newKitsune.Color = oldKitsune.Color;
+        _appearance.SetData(newEntity, KitsuneColorVisuals.Color, newKitsune.Color ?? Color.Orange);
+
+        // Ensure that the fox fire action state is transferred properly.
         newKitsune.ActiveFoxFires = oldKitsune.ActiveFoxFires;
 
         _actions.SetCharges(newKitsune.FoxfireAction, _actions.GetCharges(oldKitsune.FoxfireAction));

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -1,16 +1,10 @@
 using Content.Server.Access.Systems;
 using Content.Server.Actions;
-using Content.Server.Hands.Systems;
 using Content.Server.Polymorph.Systems;
 using Content.Server.Popups;
 using Content.Shared._DV.Abilities.Kitsune;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
-using Content.Shared.Clothing;
-using Content.Shared.Inventory;
-using Content.Shared.Item;
-using Content.Shared.Movement.Components;
-using Content.Shared.Movement.Systems;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Polymorph;
@@ -23,9 +17,6 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
     [Dependency] private readonly AccessReaderSystem _reader = default!;
     [Dependency] private readonly AccessSystem _access = default!;
     [Dependency] private readonly ActionsSystem _actions = default!;
-    [Dependency] private readonly HandsSystem _hands = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
-    [Dependency] private readonly MovementSpeedModifierSystem _speed = default!;
     [Dependency] private readonly NpcFactionSystem _faction = default!;
     [Dependency] private readonly PolymorphSystem _polymorph = default!;
     [Dependency] private readonly PopupSystem _popup = default!;


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Revert the equipment speed modifierers transferring to fox form.
Fox fire color uses fox color when in fox form.

## Why / Balance
Resolves #3560 Kitsune moving with heavy equipment found to be of little consequence in real testing. Not having the benefits from the armor while in fox form is enough of a negation of the bonuses for carrying heavy equipment at high speeds.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: SolStar
- remove: Equipment slowdown penalties no longer apply to Kitsune's polymorph.
- fix: Fox fire color now uses the correct color when in fox form.