### PR TITLE
Crafting options for directional and directional reinforced uranium windows

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -687,6 +687,43 @@
   objectType: Structure
   placementMode: SnapgridCenter
 
+  # Delta-V - added recipe for uranium directional window  
+- type: construction
+  name: directional uranium window
+  id: UraniumWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: _DV/Structures/Windows/directional.rsi
+    state: uranium_window
+  objectType: Structure
+  placementMode: SnapgridCenter
+  # Delta-V - added recipe for uranium directional reinforced window  
+- type: construction
+  name: directional reinforced uranium window
+  id: UraniumReinforcedWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumReinforcedWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: _DV/Structures/Windows/directional.rsi
+    state: uranium_reinforced_window
+  objectType: Structure
+  placementMode: SnapgridCenter
+
 - type: construction
   name: uranium window
   id: UraniumWindow

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -687,44 +687,6 @@
   objectType: Structure
   placementMode: SnapgridCenter
 
-  # Delta-V - added recipe for uranium directional window  
-- type: construction
-  name: directional uranium window
-  id: UraniumWindowDirectional
-  graph: WindowDirectional
-  startNode: start
-  targetNode: uraniumWindowDirectional
-  category: construction-category-structures
-  canBuildInImpassable: true
-  description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
-  conditions:
-    - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
-  icon:
-    sprite: _DV/Structures/Windows/directional.rsi
-    state: uranium_window
-  objectType: Structure
-  placementMode: SnapgridCenter
-  
-  # Delta-V - added recipe for uranium directional reinforced window  
-- type: construction
-  name: directional reinforced uranium window
-  id: UraniumReinforcedWindowDirectional
-  graph: WindowDirectional
-  startNode: start
-  targetNode: uraniumReinforcedWindowDirectional
-  category: construction-category-structures
-  canBuildInImpassable: true
-  description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
-  conditions:
-    - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
-  icon:
-    sprite: _DV/Structures/Windows/directional.rsi
-    state: uranium_reinforced_window
-  objectType: Structure
-  placementMode: SnapgridCenter
-
 - type: construction
   name: uranium window
   id: UraniumWindow

--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -705,6 +705,7 @@
     state: uranium_window
   objectType: Structure
   placementMode: SnapgridCenter
+  
   # Delta-V - added recipe for uranium directional reinforced window  
 - type: construction
   name: directional reinforced uranium window

--- a/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
@@ -1,0 +1,37 @@
+# Delta-V - recipe for uranium directional window  
+- type: construction
+  name: directional uranium window
+  id: UraniumWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: _DV/Structures/Windows/directional.rsi
+    state: uranium_window
+  objectType: Structure
+  placementMode: SnapgridCenter
+  
+  # Delta-V - recipe for uranium directional reinforced window  
+- type: construction
+  name: directional reinforced uranium window
+  id: UraniumReinforcedWindowDirectional
+  graph: WindowDirectional
+  startNode: start
+  targetNode: uraniumReinforcedWindowDirectional
+  category: construction-category-structures
+  canBuildInImpassable: true
+  description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
+  conditions:
+    - !type:EmptyOrWindowValidInTile
+    - !type:NoWindowsInTile
+  icon:
+    sprite: _DV/Structures/Windows/directional.rsi
+    state: uranium_reinforced_window
+  objectType: Structure
+  placementMode: SnapgridCenter

--- a/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
@@ -1,4 +1,3 @@
-# DeltaV - recipe for uranium directional window
 - type: construction
   name: directional uranium window
   id: UraniumWindowDirectional
@@ -9,15 +8,14 @@
   canBuildInImpassable: true
   description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
   conditions:
-    - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
+  - !type:EmptyOrWindowValidInTile
+  - !type:NoWindowsInTile
   icon:
     sprite: _DV/Structures/Windows/directional.rsi
     state: uranium_window
   objectType: Structure
   placementMode: SnapgridCenter
 
-  # DeltaV - recipe for uranium directional reinforced window
 - type: construction
   name: directional reinforced uranium window
   id: UraniumReinforcedWindowDirectional
@@ -28,8 +26,8 @@
   canBuildInImpassable: true
   description: Clear and even tougher, with added RadAbsorb to protect you from deadly radiation.
   conditions:
-    - !type:EmptyOrWindowValidInTile
-    - !type:NoWindowsInTile
+  - !type:EmptyOrWindowValidInTile
+  - !type:NoWindowsInTile
   icon:
     sprite: _DV/Structures/Windows/directional.rsi
     state: uranium_reinforced_window

--- a/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
@@ -1,4 +1,4 @@
-# Delta-V - recipe for uranium directional window  
+# DeltaV - recipe for uranium directional window  
 - type: construction
   name: directional uranium window
   id: UraniumWindowDirectional
@@ -17,7 +17,7 @@
   objectType: Structure
   placementMode: SnapgridCenter
   
-  # Delta-V - recipe for uranium directional reinforced window  
+  # DeltaV - recipe for uranium directional reinforced window  
 - type: construction
   name: directional reinforced uranium window
   id: UraniumReinforcedWindowDirectional

--- a/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
@@ -1,4 +1,4 @@
-# DeltaV - recipe for uranium directional window  
+# DeltaV - recipe for uranium directional window
 - type: construction
   name: directional uranium window
   id: UraniumWindowDirectional
@@ -16,8 +16,8 @@
     state: uranium_window
   objectType: Structure
   placementMode: SnapgridCenter
-  
-  # DeltaV - recipe for uranium directional reinforced window  
+
+  # DeltaV - recipe for uranium directional reinforced window
 - type: construction
   name: directional reinforced uranium window
   id: UraniumReinforcedWindowDirectional

--- a/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/structures.yml
@@ -1,4 +1,4 @@
-# Delta-V - recipe for uranium directional window  
+# Delta-V - recipe for uranium directional window
 - type: construction
   name: directional uranium window
   id: UraniumWindowDirectional
@@ -16,8 +16,8 @@
     state: uranium_window
   objectType: Structure
   placementMode: SnapgridCenter
-  
-  # Delta-V - recipe for uranium directional reinforced window  
+
+  # Delta-V - recipe for uranium directional reinforced window
 - type: construction
   name: directional reinforced uranium window
   id: UraniumReinforcedWindowDirectional


### PR DESCRIPTION
## About the PR
Added the crafting options for directional and directional reinforced uranium windows in the crafting menu, including Delta-V specific sprites. PR was originally a part of PR #3564 but was moved to new branch as it fell outside the scope of those changes.

## Why / Balance
Despite having a graph, it was not possible to select and place directional plasma windows and directional reinforced plasma windows.

## Technical details
- Addition of the recipes to the structures.yml

## Media
![image](https://github.com/user-attachments/assets/346e8967-5914-449f-84bc-794e4bb28ef5)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None known.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added ability to build directional and directional reinforced uranium windows.

