### PR TITLE
Add Anodynafil as an alternative anesthetic option

### DIFF
--- a/Resources/Locale/en-US/_DV/guidebook/chemistry/statuseffects.ftl
+++ b/Resources/Locale/en-US/_DV/guidebook/chemistry/statuseffects.ftl
@@ -2,3 +2,4 @@ reagent-effect-status-effect-PsionicallyInsulated = psionic insulation
 reagent-effect-status-effect-PsionicsDisabled = inability to use psionic powers
 reagent-effect-status-effect-Anesthesia = surgical anesthesia
 reagent-effect-status-effect-SlurredSpeech = slurred speech
+reagent-effect-status-effect-PainNumbness = inability to sense pain

--- a/Resources/Locale/en-US/_DV/reagents/meta/medicine.ftl
+++ b/Resources/Locale/en-US/_DV/reagents/meta/medicine.ftl
@@ -14,3 +14,6 @@ reagent-desc-umbroxol = An ominous chemical. Used to treat holy damage from thos
 
 reagent-name-unholy-water = unholy water
 reagent-desc-unholy-water = Water treated with blood and sulfur. Just looking at it chills you to the bone.
+
+reagent-name-anodynafil = anodynafil
+reagent-desc-anodynafil = An effective short-lasting anesthetic that doesn't interfere with consciousness, but results in prolonged pain suppression.

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -145,6 +145,7 @@
     - InPain # DeltaV - Pain system
     - SuppressPain # DeltaV - Pain system
     - Anesthesia # DeltaV - Anesthesia
+    - PainNumbness # DeltaV - Pain numbness status effect
   - type: Body
     prototype: Human
     requiredLegs: 2

--- a/Resources/Prototypes/_DV/Reagents/medicine.yml
+++ b/Resources/Prototypes/_DV/Reagents/medicine.yml
@@ -140,3 +140,30 @@
         damage:
           types:
             Cold: 1 # plan to change this when holy counterpart damage exists
+
+- type: reagent
+  id: Anodynafil
+  name: reagent-name-anodynafil
+  desc: reagent-desc-anodynafil
+  flavor: tingly
+  color: "#8FABA3"
+  physicalDesc: reagent-physical-desc-sticky
+  group: Medicine
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:GenericStatusEffect
+        key: Anesthesia
+        component: Anesthesia
+        refresh: false
+        time: 4.0
+        type: Add
+      - !type:GenericStatusEffect
+        key: PainNumbness
+        component: PainNumbness
+        refresh: false
+        time: 8.0
+        type: Add
+      - !type:MovespeedModifier
+        walkSpeedModifier: 0.5
+        sprintSpeedModifier: 0.5

--- a/Resources/Prototypes/_DV/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_DV/Recipes/Reactions/medicine.yml
@@ -62,3 +62,16 @@
       amount: 1
   products:
     UnholyWater: 3
+
+- type: reaction
+  id: Anodynafil
+  minTemp: 400
+  reactants:
+    SalicylicAcid:
+      amount: 1
+    Ethanol:
+      amount: 1
+    Iodine:
+      amount: 1
+  products:
+    Anodynafil: 4

--- a/Resources/Prototypes/_DV/status_effects.yml
+++ b/Resources/Prototypes/_DV/status_effects.yml
@@ -12,3 +12,6 @@
 
 - type: statusEffect
   id: Anesthesia
+
+- type: statusEffect
+  id: PainNumbness

--- a/Resources/Prototypes/status_effects.yml
+++ b/Resources/Prototypes/status_effects.yml
@@ -73,6 +73,3 @@
 - type: statusEffect
   id: Adrenaline
   alert: Adrenaline
-
-- type: statusEffect
-  id: PainNumbness

--- a/Resources/Prototypes/status_effects.yml
+++ b/Resources/Prototypes/status_effects.yml
@@ -73,3 +73,6 @@
 - type: statusEffect
   id: Adrenaline
   alert: Adrenaline
+
+- type: statusEffect
+  id: PainNumbness


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- new anesthetic, Anodynafil

## Why / Balance
- offer an alternative to chloral hydrate that causes pain numbness rather than drowsiness

## Technical details
- new reagent, new reaction
- new status effect for PainNumbness

## Media
![grafik](https://github.com/user-attachments/assets/dc67c605-b167-4f2d-901a-2d4c736e7b6f)

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Anodynafil now exists, an anesthetic that doesn't interfere with consciousness but causes prolonged inability to sense pain
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
