### PR TITLE
Easy upgradeable solar panels

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
@@ -71,6 +71,19 @@
     - node: solarpanelplasma
       entity: SolarPanelPlasma
       edges:
+        # Begin DeltaV additions - Easy upgradeable solars
+        - to: solarpaneluranium
+          conditions:
+          - !type:EntityAnchored
+          completed:
+          - !type:SpawnPrototype
+            prototype: SheetPlasma1
+            amount: 2
+          steps:
+          - material: Uranium
+            amount: 2
+            doAfter: 0.5
+        # End DeltaV additions - Easy upgradeable solars
         - to: solarassembly
           completed:
             - !type:SnapToGrid
@@ -105,6 +118,22 @@
     - node: solarpanel
       entity: SolarPanel
       edges:
+        # Begin DeltaV additions - Easy upgradeable solars
+        - to: solarpaneluranium
+          conditions:
+          - !type:EntityAnchored
+          steps:
+          - material: Uranium
+            amount: 2
+            doAfter: 0.5
+        - to: solarpanelplasma
+          conditions:
+          - !type:EntityAnchored
+          steps:
+          - material: Plasma
+            amount: 2
+            doAfter: 0.5
+        # End DeltaV additions - Easy upgradeable solars
         - to: solarassembly
           completed:
             - !type:SnapToGrid

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
@@ -77,10 +77,21 @@
           - !type:EntityAnchored
           completed:
           - !type:SpawnPrototype
-            prototype: SheetPlasma1
+            prototype: SheetPGlass1
             amount: 2
           steps:
-          - material: Uranium
+          - material: UraniumGlass
+            amount: 2
+            doAfter: 1.5
+        - to: solarpanel
+          conditions:
+          - !type:EntityAnchored
+          completed:
+          - !type:SpawnPrototype
+            prototype: SheetPGlass1
+            amount: 2
+          steps:
+          - material: Glass
             amount: 2
             doAfter: 1.5
         # End DeltaV additions - Easy upgradeable solars
@@ -101,6 +112,30 @@
     - node: solarpaneluranium
       entity: SolarPanelUranium
       edges:
+        # Begin DeltaV additions - Easy upgradeable solars
+        - to: solarpanelplasma
+          conditions:
+          - !type:EntityAnchored
+          completed:
+          - !type:SpawnPrototype
+            prototype: SheetUGlass1
+            amount: 2
+          steps:
+          - material: PlasmaGlass
+            amount: 2
+            doAfter: 1.5
+        - to: solarpanel
+          conditions:
+          - !type:EntityAnchored
+          completed:
+          - !type:SpawnPrototype
+            prototype: SheetUGlass1
+            amount: 2
+          steps:
+          - material: Glass
+            amount: 2
+            doAfter: 1.5
+        # End DeltaV additions - Easy upgradeable solars
         - to: solarassembly
           completed:
             - !type:SnapToGrid
@@ -122,15 +157,23 @@
         - to: solarpaneluranium
           conditions:
           - !type:EntityAnchored
+          completed:
+          - !type:SpawnPrototype
+            prototype: SheetGlass1
+            amount: 2
           steps:
-          - material: Uranium
+          - material: UraniumGlass
             amount: 2
             doAfter: 1.5
         - to: solarpanelplasma
           conditions:
           - !type:EntityAnchored
+          completed:
+          - !type:SpawnPrototype
+            prototype: SheetGlass1
+            amount: 2
           steps:
-          - material: Plasma
+          - material: PlasmaGlass
             amount: 2
             doAfter: 1.5
         # End DeltaV additions - Easy upgradeable solars

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/solarpanel.yml
@@ -82,7 +82,7 @@
           steps:
           - material: Uranium
             amount: 2
-            doAfter: 0.5
+            doAfter: 1.5
         # End DeltaV additions - Easy upgradeable solars
         - to: solarassembly
           completed:
@@ -125,14 +125,14 @@
           steps:
           - material: Uranium
             amount: 2
-            doAfter: 0.5
+            doAfter: 1.5
         - to: solarpanelplasma
           conditions:
           - !type:EntityAnchored
           steps:
           - material: Plasma
             amount: 2
-            doAfter: 0.5
+            doAfter: 1.5
         # End DeltaV additions - Easy upgradeable solars
         - to: solarassembly
           completed:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR allows the player to upgrade the solar panels with the material glass directly. It also allows you to go back to previous states.

## Why / Balance
I always felt it was weird that you weren't able to upgrade solars this way like you could with windows.

## Technical details
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/d80a2568-a86e-42f0-99d7-d55ba0328d50


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Solar panels now can be upgraded by using the upgrade material glass directly on it. You can also go back to a previous state by applying a different glass on it.

