### PR TITLE
Make standard airlocks paintable for med

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Doors/airlock_groups.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Doors/airlock_groups.yml
@@ -12,6 +12,7 @@
     freezer:     _DV/Structures/Doors/Airlocks/Standard/freezer.rsi
     hydroponics: _DV/Structures/Doors/Airlocks/Standard/hydroponics.rsi
     maintenance: _DV/Structures/Doors/Airlocks/Standard/maint.rsi
+    medical:     _DV/Structures/Doors/Airlocks/Standard/medical.rsi
     science:     _DV/Structures/Doors/Airlocks/Standard/science.rsi
     security:    _DV/Structures/Doors/Airlocks/Standard/security.rsi
     virology:    _DV/Structures/Doors/Airlocks/Standard/virology.rsi


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixed the ability to paint standard airlocks medical colors, whereas before you could only paint glass airlocks that theme.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Seems like just an oversight

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/7404845a-d5d6-473d-bdd1-8ceb7ef33f24)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Standard airlocks can now be painted medical colors.