### PR TITLE
Service access added to service jobs

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -15,6 +15,7 @@
   - Service
   - Maintenance
   - Bar
+  - Service # DeltaV - They work for HoP, therefore service.
   extendedAccess:
   - Kitchen
   - Hydroponics

--- a/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/bartender.yml
@@ -15,7 +15,6 @@
   - Service
   - Maintenance
   - Bar
-  - Service # DeltaV - They work for HoP, therefore service.
   extendedAccess:
   - Kitchen
   - Hydroponics

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -5,11 +5,12 @@
   playTimeTracker: JobMusician
   startingGear: MusicianGear
   icon: "JobIconMusician"
-  supervisors: job-supervisors-hire
+  supervisors: job-supervisors-hop # DeltaV - was job-supervisors-hire
   access:
   - Maintenance # TODO Remove maint access for all gimmick jobs once access work is completed
   - Theatre
   - Musician # DeltaV - Add Musician access
+  - Service # DeltaV - They work for HoP, therefore service.
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: MikuDay

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/boxer.yml
@@ -7,7 +7,7 @@
   icon: "JobIconBoxer"
   supervisors: job-supervisors-hop
   access:
-  #- Service # DeltaV
+  - Service
   - Maintenance
   # Begin DeltaV Additions
   - Theatre # Boxer is vaguely a theatre role


### PR DESCRIPTION
## About the PR
Adds service access to service roles.

## Why / Balance
Seems dumb that they don't have the baseline access for service.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added service access to the Boxer and Musician.
