### PR TITLE
make gibbing/butchering yield filthy organs

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -357,6 +357,11 @@ public partial class SharedBodySystem
         var bodyTransform = Transform(bodyId);
         _audioSystem.PlayPredicted(gibSoundOverride, bodyTransform.Coordinates, null);
 
+        // Begin DeltaV Additions
+        var ev = new BodyGibbedEvent(gibs);
+        RaiseLocalEvent(bodyId, ref ev);
+        // End DeltaV Additions
+
         if (acidify)
             return gibs;
 

--- a/Content.Shared/Body/Systems/SharedBodySystem.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.cs
@@ -49,6 +49,7 @@ public abstract partial class SharedBodySystem : EntitySystem
         InitializeIntegrityQueue();
         InitializePartAppearances();
         // Shitmed Change End
+        InitializeGibDirtying(); // DeltaV
     }
 
     /// <summary>

--- a/Content.Shared/_DV/Body/Systems/SharedBodySystem.GibDirtying.cs
+++ b/Content.Shared/_DV/Body/Systems/SharedBodySystem.GibDirtying.cs
@@ -1,0 +1,41 @@
+using Content.Shared._DV.Surgery;
+using Content.Shared.Body.Components;
+using Content.Shared.FixedPoint;
+using Content.Shared.Forensics.Components;
+
+namespace Content.Shared.Body.Systems;
+
+/// <summary>
+/// Makes bodyparts and organs filthy and dna-contaminated when a body is gibbed or butchered.
+/// Adds some friction to organ harvesting -> free alien organs pipeline, you need to actually operate on the corpse.
+/// </summary>
+public abstract partial class SharedBodySystem
+{
+    [Dependency] private readonly SurgeryCleanSystem _clean = default!;
+
+    /// <summary>
+    /// Dirtiness to give giblets.
+    /// </summary>
+    public static readonly FixedPoint2 DirtAdded = FixedPoint2.New(100);
+
+    private void InitializeGibDirtying()
+    {
+        SubscribeLocalEvent<BodyComponent, BodyGibbedEvent>(OnGibbed);
+    }
+
+    private void OnGibbed(Entity<BodyComponent> ent, ref BodyGibbedEvent args)
+    {
+        var dna = CompOrNull<DnaComponent>(ent)?.DNA;
+        foreach (var giblet in args.Gibs)
+        {
+            _clean.AddDirt(giblet, DirtAdded);
+            _clean.AddDna(giblet, dna);
+        }
+    }
+}
+
+/// <summary>
+/// Raised by body system on the body entity after being gibbed.
+/// </summary>
+[ByRefEvent]
+public record struct BodyGibbedEvent(HashSet<EntityUid> Gibs);


### PR DESCRIPTION
## About the PR
gibbbing and by extension spiking/butchering make organs filthy and put their dna on them so if you use them without cleaning the patient gets giga sepsis

## Why / Balance
its common sense
if you want clean organs you have to take the slow methodical approach of gamer organ harvest speedrun from neurotrauma instead of just do the funny doafter on fish
slight nerf to "butcher fish in the middle of a hall then get it transplanted 5s later" ops

## Technical details
new event for specifically gibbing bodies because gibbing is supercode

## Media
![03:01:25](https://github.com/user-attachments/assets/0604fcbf-c3e9-49c2-b42d-d3e099c376ff)

![03:01:58](https://github.com/user-attachments/assets/aa71a2b0-9c47-49f7-9429-6f0f073b4adf)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Organs from gibbed/butchered mobs are now filthy and will require cleaning for transplant.
