### PR TITLE
Fix Race Condition Leading to the Round Removal of Kitsune

### DIFF
--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Actions;
 using Content.Server.Polymorph.Systems;
 using Content.Server.Popups;
 using Content.Shared._DV.Abilities.Kitsune;
+using Content.Shared.Damage.Components;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.NPC.Components;
@@ -75,6 +76,12 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
 
     private void OnMorphIntoKitsune(Entity<KitsuneComponent> ent, ref MorphIntoKitsune args)
     {
+        // Ensure the fox form isn't going to be instantly stunned and reverted, causing RR
+        if (TryComp<StaminaComponent>(ent, out var stamina) && stamina.Critical)
+        {
+            _popup.PopupEntity(Loc.GetString("kitsune-popup-cant-morph-stamina"), ent, ent);
+            return;
+        }
         if (_polymorph.PolymorphEntity(ent, ent.Comp.KitsunePolymorphId) == null)
             return;
         args.Handled = true;

--- a/Resources/Locale/en-US/_DV/actions/kitsune.ftl
+++ b/Resources/Locale/en-US/_DV/actions/kitsune.ftl
@@ -1,4 +1,5 @@
 petting-success-soft-floofy-kitsune = You gently pat {THE($target)}
 kitsune-popup-morph-message-other = {$target} shifts their form
 kitsune-popup-morph-message-user = You shift your form
+kitsune-popup-cant-morph-stamina = You are too exhausted!
 fox-no-hands = You can't make a wisp without a hand


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
This PR seeks to fix a race condition that results in Kitsune being round removed if they attempt to shapeshift into their fox form while their stamina is critical.

This is done with a simple check that now prohibits the usage of the polymorph ability when your stamina is critical.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Round removal,

 is bad.
## Technical details
<!-- Summary of code changes for easier review. -->
First things first, allow me to explain what exactly is the race condition here. And correct me if I am wrong on anything, I am not infallible. And since I'm a little bit of a novice myself, I write this for others to learn about this sort of thing. I apologize in advance if I happen to be a big idiot.

Let us assume you are Urist McKitsune. You just got stun batoned by a overly eager cadet wanting to prove himself to the Head of Security. But the rookie makes a rookie mistake, forgetting to cuff you, and so you make a run for it...

As soon as you get up from your electricity induced stupor, you attempt to shapeshift into your fox form for a faster getaway. But alas, all of a sudden, your form vanishes. There is no Urist McKitsune anymore. Just the spiritual remnant of what once was.

**So, what happened? Lets dig into the details.**

We all know that when stamina damage reaches 100, it will throw that `Critical` = true. This then triggers the stamina crit stun all of us are very familiar with. Recall that one of the Kitsune's main primary balancing features is the fact the fox form will instantly revert back into the regular form if they are stunned.

With this in mind, and if we recall #3528 and the addition of another balancing feature: The fact that your stamina damage is transferred between polymorphs. Or at least the *attempt* of it. You see where I am going with this, right?

So, Urist McKitsune's stamina is still critical for a short period after recovering from the stamina stun. They attempt to shapeshift into the fox form. Once the fox entity comes into existence, two things are happening in parallel: The normal process for the Kitsune polymorph, and the stamina damage transfer. Let us assume that Urist McKitsune's uid is `2048` and the new fox entity's uid is `2077`.  We know that at this point, the parameters for `PolymorphedEvent` is as follows;
```
OldEntity = 2048
NewEntity = 2077
IsRevert  = false
```
Right now, `2048` has been sent to nullspace for safe-keeping, intended to be kept so you can revert back. Right?....

Since `PolymorphedEvent` is raised, the stamina damage transfer code is activated, transferring the current stamina damage of `2048` to `2077`. and because a `100` stamina damage is inflicted on `2077`, it instantly puts it into stamina crit, which in turn invokes both the paralyze mechanic, and the stun status effect. And because the stun status effect is inflicted, it instantly attempts to `Revert` the polymorph as shown in this snippet from `KitsuneFoxSystem.cs`:

```
    private void OnStunned(Entity<KitsuneFoxComponent> ent, ref StunnedEvent args)
    {
        if (!TryComp<PolymorphedEntityComponent>(ent, out var polymorph))
            return;

        _polymorph.Revert(ent.Owner);
    }
```
At this point, the parameters for `PolymorphedEvent` has changed. It is now:
```
OldEntity = 2077
NewEntity = 2048
IsRevert = true
```
**All done, before the fox, `2077`, even had a chance to come into proper existence**, let alone be seen on your screen. As a matter of fact, this all occurs before the polymorph execution even reaches `KitsuneSystem.cs` which performs the final checks and corrections on the fox.

And because this fox never had a chance to even exist on your screen, the end result is `2048`, without a mind, stuck in nullspace, and Urist McKitsune, now a ghost to forever roam the station. Without a clue of how they got snapped out of existence.

Of course, there is much more to it, but that is what I managed to garner after my hours of running a debugger to figure out what is going on with the technical intuition I had.

To remediate this in the least disruptive way, a check has been put into the `OnMorphIntoKitsune` method to ensure that players do not accidentally shapeshift themselves into oblivion. It will check the boolean value of `stamina.Critical` in the `StaminaComponent`. If `stamina.Critical == true`, it will throw a message saying the player is too tired, and the action stops there.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Not Applicable.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None that I know of.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: M3739
- fix: Kitsune can no longer shapeshift themselves out of existence right after getting up from a stamina crit stun.

