### PR TITLE
CosmicCult  -  Equipment Crashfix

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
@@ -148,7 +148,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     private void OnGotEquipped(Entity<CosmicEquipmentComponent> ent, ref GotEquippedEvent args)
     {
         if (!EntityIsCultist(args.Equipee))
-            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.MaxValue, true);
+            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true);
     }
 
     private void OnGotUnequipped(Entity<CosmicEquipmentComponent> ent, ref GotUnequippedEvent args)
@@ -159,7 +159,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     private void OnGotHeld(Entity<CosmicEquipmentComponent> ent, ref GotEquippedHandEvent args)
     {
         if (!EntityIsCultist(args.User))
-            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.User, EntropicDegen, TimeSpan.MaxValue, true);
+            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.User, EntropicDegen, TimeSpan.FromDays(1), true);
     }
 
     private void OnGotUnheld(Entity<CosmicEquipmentComponent> ent, ref GotUnequippedHandEvent args)

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
@@ -148,7 +148,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     private void OnGotEquipped(Entity<CosmicEquipmentComponent> ent, ref GotEquippedEvent args)
     {
         if (!EntityIsCultist(args.Equipee))
-            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true);
+            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true); // TimeSpan.MaxValue causes a crash here, so we use FromDays(1) instead.
     }
 
     private void OnGotUnequipped(Entity<CosmicEquipmentComponent> ent, ref GotUnequippedEvent args)


### PR DESCRIPTION
## About the PR
Patches a crash caused by TimeSpan.Maxvalue in StatusEffectSystem when trying to apply EntropicDegen to a non-cult user picking up and holding on to Cosmic Cult equipment marked with the CosmicEquipmentComponent.

This is a 2-line change in a single file.

## Why / Balance
It's a fix.

## Technical details
Changes TimeSpan.MaxValue to TimeSpan.FromDays(1).

## Media
N/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Another cosmic cult fix
