### PR TITLE
limit nukies to 3 max [mald pr]

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -161,7 +161,7 @@
     - prefRoles: [ Nukeops ]
       fallbackRoles: [ NukeopsCommander, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsOperative
-      max: 3
+      max: 1 # DeltaV
       playerRatio: 12 # DeltaV
       startingGear: SyndicateOperativeGearFull
       roleLoadout:


### PR DESCRIPTION
## About the PR
its just commander agent and operator now

## Why / Balance
5 nukies vs 2 sec #3460 guys cant wait to see what happens

until its made to scale with online secmains this will have to do

nukies can still do well with good tactics, their gear is op as shit anyway not even including lubeops etc

**Changelog**
:cl:
- remove: Nukies now only get 3 players max, instead of 5.