### PR TITLE
Grabbag of coscult fixes

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
@@ -78,6 +78,7 @@ public sealed class CosmicBlankSystem : EntitySystem
                 mind.PreventGhosting = false;
                 _mind.TransferTo(mindEnt, comp.OriginalBody);
                 RemComp<CosmicBlankComponent>(comp.OriginalBody);
+                RemComp<CosmicCultExamineComponent>(comp.OriginalBody);
                 _popup.PopupEntity(Loc.GetString("cosmicability-blank-return"), comp.OriginalBody, comp.OriginalBody);
                 QueueDel(uid);
             }

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicConversionSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicConversionSystem.cs
@@ -30,7 +30,7 @@ public sealed class CosmicConversionSystem : EntitySystem
 
     private void OnConversionGlyph(Entity<CosmicGlyphConversionComponent> uid, ref TryActivateGlyphEvent args)
     {
-        var possibleTargets = _cosmicGlyph.GetTargetsNearGlyph(uid, uid.Comp.ConversionRange, entity => !_cosmicCult.EntityIsCultist(entity));
+        var possibleTargets = _cosmicGlyph.GetTargetsNearGlyph(uid, uid.Comp.ConversionRange, entity => _cosmicCult.EntityIsCultist(entity));
         if (possibleTargets.Count == 0)
         {
             _popup.PopupEntity(Loc.GetString("cult-glyph-conditions-not-met"), uid, args.User);

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicReturnSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicReturnSystem.cs
@@ -47,5 +47,6 @@ public sealed class CosmicReturnSystem : EntitySystem
         mind.PreventGhosting = false;
         QueueDel(uid);
         RemComp<CosmicBlankComponent>(uid.Comp.OriginalBody);
+        RemComp<CosmicCultExamineComponent>(uid.Comp.OriginalBody);
     }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -10,6 +10,7 @@
       - PsionicInvisibility
       - Ghost
       - Normal
+      - CosmicCultMonument # DeltaV - Cosmic Cult
   - type: ContentEye
     maxZoom: 8.916104, 8.916104
   - type: Tag

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -54,6 +54,7 @@
       - PsionicInvisibility
       - Ghost
       - Normal
+      - CosmicCultMonument # DeltaV - Cosmic Cult
   - type: Input
     context: "ghost"
   - type: Examiner


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
see changelog

## Technical details
- double negative from conversion glyph removed
- clean up CosmicExamineComponent as necessary
- ghosts get CosmicCultMonument now

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Cosmic cultist conversion now converts non-cultists instead of cultists
- fix: Cosmic cultist projection & blanking no longer leaves the examine text lingering
- tweak: Ghosts can now see The Monument
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
