### PR TITLE
Remove IPC Cold damage bloodloss

### DIFF
--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -77,6 +77,7 @@
     Piercing: 0.2
     Shock: 0.0
     Heat: -0.5 # heat damage cauterizes wounds, but will still hurt obviously.
+    Cold: 0.0
     Poison: 0.0
     Radiation: 0.0
     Asphyxiation: 0.0


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removes Cold damage form causing bleeding in IPCs

## Why / Balance
1. Play as crew IPC in coscult round
2. Urist McCult passes by, siphons you, then walks away
3. You start profusely bleeding off of 5 cold damage and need to drop whatever you're doing to find:
- A way to cauterize
- Cables to fix the damage
- Oil packs
4. Logi's out of plastic? Sucks to suck! Drop dead, or cauterize yourself and wait for it to happen again!

This is not challenging, fun, or interactive. IPC bloodstream already makes the species a living hell to play around any remotely sharp objects (yay I got accidentally wideswung I have to fix this within minutes or drop dead!!!), but as usual with me this is a separate topic. Cold damage causing bleeding makes coscult rounds a literal living hell for IPCs because you can't do shit except hide. You just have to sit and take it while you're forced to eat all of the station's plastic over and over and over and over and over and over

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: IPCs no longer bleed when taking Cold damage.
