### PR TITLE
Add an antag immune implant for CC trialmins

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
@@ -27,7 +27,7 @@
     ClothingBackpackCentcom: 3 # DeltaV - Centcomm Drip
     ClothingBackpackDuffelCentcom: 3 # DeltaV - Centcomm Drip
     ClothingBackpackSatchelCentcom: 3 # DeltaV - Centcomm Drip
-    AntagImmuneImplanter: 3 # DeltaV - For trialmins
+    CentCommImplanter: 3 # DeltaV - For trialmins
   contrabandInventory:
     ToyFigurineCaptain: 1
     ToyFigurineHeadOfPersonnel: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
@@ -27,7 +27,7 @@
     ClothingBackpackCentcom: 3 # DeltaV - Centcomm Drip
     ClothingBackpackDuffelCentcom: 3 # DeltaV - Centcomm Drip
     ClothingBackpackSatchelCentcom: 3 # DeltaV - Centcomm Drip
-    AntagImmuneImplanter: 3 # DeltaV- For trialmins
+    AntagImmuneImplanter: 3 # DeltaV - For trialmins
   contrabandInventory:
     ToyFigurineCaptain: 1
     ToyFigurineHeadOfPersonnel: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/centdrobe.yml
@@ -27,6 +27,7 @@
     ClothingBackpackCentcom: 3 # DeltaV - Centcomm Drip
     ClothingBackpackDuffelCentcom: 3 # DeltaV - Centcomm Drip
     ClothingBackpackSatchelCentcom: 3 # DeltaV - Centcomm Drip
+    AntagImmuneImplanter: 3 # DeltaV- For trialmins
   contrabandInventory:
     ToyFigurineCaptain: 1
     ToyFigurineHeadOfPersonnel: 1

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
@@ -48,11 +48,11 @@
 
 - type: entity
   parent: BaseImplantOnlyImplanter
-  id: AntagImmuneImplanter
-  name: antag immune implanter
+  id: CentCommImplanter
+  name: centcomm implanter
   components:
   - type: Implanter
-    implant: AntagImmuneImplant
+    implant: CentCommImplant
 
 # Nukie implants
 

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
@@ -46,6 +46,15 @@
   - type: Implanter
     implant: WatchdogImplant
 
+- type: entity
+  parent: BaseImplantOnlyImplanter
+  id: AntagImmuneImplanter
+  name: antag immune implanter
+  suffix: antag immune
+  components:
+  - type: Implanter
+    implant: AntagImmuneImplant
+
 # Nukie implants
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/implanters.yml
@@ -50,7 +50,6 @@
   parent: BaseImplantOnlyImplanter
   id: AntagImmuneImplanter
   name: antag immune implanter
-  suffix: antag immune
   components:
   - type: Implanter
     implant: AntagImmuneImplant

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
@@ -93,7 +93,7 @@
   components:
   - type: SubdermalImplant
     addedComponents:
-     - type: AntagImmune
+    - type: AntagImmune
 
 # Nukie implants
 

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
@@ -84,6 +84,17 @@
   - type: Rattle
     radioChannel: Security
 
+- type: entity
+  parent: BaseSubdermalImplant
+  id: AntagImmuneImplant
+  name: antag immune implant
+  description: This implant makes you immune to any evil thoughts!
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    addedComponents:
+     - type: AntagImmune
+
 # Nukie implants
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
@@ -86,14 +86,15 @@
 
 - type: entity
   parent: BaseSubdermalImplant
-  id: AntagImmuneImplant
-  name: antag immune implant
-  description: This implant makes you immune to any evil thoughts!
+  id: CentCommImplant
+  name: centcomm implant
+  description: This implant includes a MindShield and something labeled as "antag immune"? Whatever that is.
   categories: [ HideSpawnMenu ]
   components:
   - type: SubdermalImplant
     addedComponents:
     - type: AntagImmune
+    - type: MindShield
 
 # Nukie implants
 

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/subdermal_implants.yml
@@ -91,8 +91,8 @@
   description: This implant includes a MindShield and something labeled as "antag immune"? Whatever that is.
   categories: [ HideSpawnMenu ]
   components:
-  - type: SubdermalImplant
-    addedComponents:
+  - type: AddComponentsImplant
+    componentsToAdd:
     - type: AntagImmune
     - type: MindShield
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
Facilitates RP at shuttle arrival + makes answering faxes easier with an in-game character, this should allow trialmins.

## Technical details
N/A

## Media

https://github.com/user-attachments/assets/8ae1a4ac-7c07-4f4e-ad3f-5734e8b8afc0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
DELTAVADMIN:
- add: CentDrobe now has implanters to make your CC characters antag immune.
