### PR TITLE
Engiborg improvements

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/other.yml
@@ -12,6 +12,7 @@
   - type: Tag
     tags:
     - Sheet
+    - BorgMaterial # DeltaV
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -117,6 +118,7 @@
   - type: Tag
     tags:
     - Sheet
+    - BorgMaterial # DeltaV
 
 - type: entity
   parent: SheetPlasma

--- a/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ingots.yml
@@ -14,6 +14,7 @@
   - type: Tag
     tags:
     - Ingot
+    - BorgMaterial # DeltaV
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -134,6 +134,7 @@
       - ClothMade
       - Gauze
       - RawMaterial
+      - BorgMaterial # DeltaV
   - type: Construction
     graph: WebObjects # not sure if I should either keep this here or just make another prototype. Will keep it here just in case.
     node: cloth
@@ -199,6 +200,7 @@
     tags:
       - ClothMade
       - RawMaterial
+      - BorgMaterial # DeltaV
   - type: Item
     heldPrefix: durathread
 
@@ -248,6 +250,7 @@
     tags:
     - Wooden
     - RawMaterial
+    - BorgMaterial # DeltaV
   - type: Extractable
     grindableSolutionName: wood
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/machine_parts.yml
@@ -24,6 +24,7 @@
     - type: Tag
       tags:
         - CapacitorStockPart
+        - BorgStockPart # DeltaV - engiborgs can hold stock parts
     - type: Stack
       stackType: Capacitor
 
@@ -36,6 +37,9 @@
   components:
     - type: Sprite
       state: micro_mani
+    - type: Tag # DeltaV - engiborgs can hold stock parts
+      tags:
+      - BorgStockPart
     - type: Stack
       stackType: Manipulator
 
@@ -48,5 +52,8 @@
   components:
     - type: Sprite
       state: matter_bin
+    - type: Tag # DeltaV - engiborgs can hold stock parts
+      tags:
+      - BorgStockPart
     - type: Stack
       stackType: MatterBin

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -472,6 +472,7 @@
     - RemoteSignaller
     - GasAnalyzer
     - GeigerCounter
+    - HolofanProjector # DeltaV - borgs can have holofans
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: adv-tools-module }
 
@@ -513,6 +514,18 @@
       whitelist:
         components:
         - FloorTile
+    - id: CapacitorStockPart
+      whitelist:
+        tags:
+        - BorgStockPart
+    - id: MicroManipulatorStockPart
+      whitelist:
+        tags:
+        - BorgStockPart
+    - id: MatterBinStockPart
+      whitelist:
+        tags:
+        - BorgStockPart
     # End DeltaV Additions
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: construction-module }

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -43,6 +43,9 @@
   id: BorgMaterial # for materials that can be used in a borg construction module
 
 - type: Tag
+  id: BorgStockPart
+
+- type: Tag
   id: BulletBB
 
 - type: Tag


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- engiborg can how hold more construction materials
  - sheets: paper (construction material), wood, plasma, uranium
  - ingots: gold and silver
  - machine parts: capacitor/manipulator/matterbin
- engiborg now has a holofan in the advanced tools module

## Why / Balance
- this makes engiborg's construction module more capable of construction, especially of machines and of decorative structures
- there's no longer an issue with borgs having holofans due to the powercell-less rework

## Technical details
- new tag: BorgStockPart
- add more stuff to the modules

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![grafik](https://github.com/user-attachments/assets/ac2efae9-b1de-40d3-81f8-02dc2bf76ff4)
![grafik](https://github.com/user-attachments/assets/bcb8d097-223e-4cf7-8ecf-2c6e9102354c)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Engineering borgs have a holofan in the advanced tools module
- tweak: Engineering borgs hold more construction materials in their construction module: paper, wood, plasma, uranium, gold, silver, and stock machine parts.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
