### PR TITLE
Fix sugar cig and cleanup the file.

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -35,3 +35,8 @@
         reagents:
         - ReagentId: Sugar
           Quantity: 10
+      food:
+        maxVol: 10
+        reagents:
+        - ReagentId: Sugar
+          Quantity: 10

--- a/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -1,8 +1,7 @@
 - type: entity
+  parent: Cigarette
   id: CigaretteOlive
   suffix: olive
-  parent: Cigarette
-  name: cigarette
   description: A roll of tobacco and nicotine soaked in some chemical, smells like olives.
   components:
   - type: SolutionContainerManager
@@ -16,30 +15,23 @@
             Quantity: 5
 
 - type: entity
+  parent: [Cigarette, FoodBase]
   id: CigaretteCandy
   suffix: candy
-  parent: [Cigarette, FoodBase]
-  name: cigarette
   description: Sugar sticks designed to look like a roll of nicotine and tobacco.
   components:
-  - type: Appearance
-  - type: Food
   - type: Tag
     tags:
-      - FoodSnack
+    - FoodSnack
+    - Cigarette
+    - Trash
   - type: FlavorProfile
     flavors:
-      - sweet
-  - type: Sprite
-    sprite: Objects/Consumable/Smokeables/Cigarettes/cigarette.rsi
-    state: unlit-icon
-  - type: Clothing
-    sprite: Objects/Consumable/Smokeables/Cigarettes/cigarette.rsi
-    slots: [ mask ]
+    - sweet
   - type: SolutionContainerManager
     solutions:
-      food:
+      smokable:
         maxVol: 10
         reagents:
-          - ReagentId: Sugar
-            Quantity: 10
+        - ReagentId: Sugar
+          Quantity: 10


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixed the sprite issue of the sugar cigarette and made a general cleanup.

## Why / Balance
Bug fix and less copy paste. Fixes #3665

## Technical details
N/A

## Media
![image](https://github.com/user-attachments/assets/7429e0db-7855-4685-ac90-bdd2ddf1bb9c)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Sugar Rush candy cigarettes showing an error sprite.
