### PR TITLE
fix malign wall being rcdable

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/walls.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/walls.yml
@@ -13,7 +13,6 @@
     sprite: _DV/CosmicCult/Tileset/cosmicwall.rsi
   - type: Icon
     sprite: _DV/CosmicCult/Tileset/cosmicwall.rsi
-  - type: RCDDeconstructable
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
## About the PR
title

## Why / Balance
wall being rcdable in literally 1 second is bullshit and basically solod the first coscult playtest, engis just dug into the base in seconds
**especially* bad when you can just replace it with any window and suddenly it goes from 1 second to impossible to rcd

## Media
![11:05:36](https://github.com/user-attachments/assets/96bed441-a076-4bbe-956c-7c4178dbd4e7)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed being able to instantly deconstruct malign walls with an RCD.