### PR TITLE
fix energy katana inhand sprite

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -153,6 +153,7 @@
       types:
         Slash: 30
   - type: Item
+    sprite: Objects/Weapons/Melee/energykatana.rsi # DeltaV - don't use the regular katana inhands
     storedSprite:
       state: storage
       sprite: Objects/Weapons/Melee/energykatana_storage_64x.rsi #Done in 64x64 because it looks way too puny in 32x32


### PR DESCRIPTION
## About the PR
title

## Why / Balance
evil katana sprite was overriding it due to inheritance

## Media
![01:18:15](https://github.com/user-attachments/assets/f7595c9c-e6ae-486f-9943-64d7877a8058)

**Changelog**
:cl:
- fix: Fixed energy katana's held sprite.