### PR TITLE
Censer needs people to be not-incapacitated for deconversion

### DIFF
--- a/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
+++ b/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
@@ -63,7 +63,7 @@ public sealed class DeconversionSystem : EntitySystem
 
     private void OnAfterInteract(Entity<CosmicCenserComponent> ent, ref AfterInteractEvent args)
     {
-        if (args.Handled || args.Target is not {} target || !HasComp<CosmicCenserTargetComponent>(target) || _mobState.IsDead(target))
+        if (args.Handled || args.Target is not {} target || !HasComp<CosmicCenserTargetComponent>(target) || _mobState.IsIncapacitated(target))
             return;
 
         args.Handled = _tools.UseTool(
@@ -79,7 +79,7 @@ public sealed class DeconversionSystem : EntitySystem
     private void OnDoAfter(Entity<CosmicCenserTargetComponent> uid, ref CleanseOnDoAfterEvent args)
     {
         var target = args.Args.Target;
-        if (args.Cancelled || args.Handled || target == null || _mobState.IsDead(target.Value))
+        if (args.Cancelled || args.Handled || target == null || _mobState.IsIncapacitated(target.Value))
             return;
 
         if (args.Args.Used is not {} used || !TryComp<CosmicCenserComponent>(used, out var censer))


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- censer now requires not incapacitated instead of just not dead

## Why / Balance
- security gamers aren't getting the "stop executing cuffed cultists" memo

## Technical details
- _mobState.IsIncapacitated

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Deconverting cultists requires that they aren't critical or dead
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
