### PR TITLE
Oni buffs and Redux of nyano uplink items

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
@@ -37,6 +37,7 @@
     Telecrystal: 2
   categories:
   - UplinkWearables
+  conditions:
   - !type:BuyerWhitelistCondition
     blacklist:
       components:

--- a/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
@@ -10,10 +10,6 @@
     Telecrystal: 10
   categories:
   - UplinkWeaponry
-  conditions:
-  - !type:BuyerSpeciesCondition
-    whitelist:
-    - Oni
 
 - type: listing
   id: UplinkRickenbacker
@@ -22,9 +18,9 @@
   productEntity: Rickenbacker4001Instrument
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 2
   cost:
-    Telecrystal: 10
+    Telecrystal: 5
   categories:
   - UplinkJob
   conditions:
@@ -37,17 +33,10 @@
   name: uplink-samurai-crate-name
   description: uplink-samurai-crate-desc
   productEntity: CrateSyndicateSamurai
-  discountCategory: usualDiscounts
-  discountDownTo:
-    Telecrystal: 3
   cost:
-    Telecrystal: 6
+    Telecrystal: 2
   categories:
   - UplinkWearables
-  conditions:
-  - !type:BuyerSpeciesCondition
-    whitelist:
-    - Oni
   - !type:BuyerWhitelistCondition
     blacklist:
       components:

--- a/Resources/Prototypes/Nyanotrasen/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Nyanotrasen/Damage/modifier_sets.yml
@@ -1,11 +1,4 @@
 - type: damageModifierSet
-  id: Oni
-  coefficients:
-    Blunt: 0.85
-    Slash: 0.85
-    Piercing: 0.85
-
-- type: damageModifierSet
   id: Felinid
   coefficients:
     Blunt: 1.15

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -11,7 +11,7 @@
   - type: Sprite
     scale: 1.2, 1.2
   - type: PlayerToolModifier
-    pryTimeMultiplier: 0.6
+    pryTimeMultiplier: 0.4
   - type: PlayerAccuracyModifier
     spreadMultiplier: 15
     maxSpreadAngle: 180
@@ -21,8 +21,8 @@
     damageModifierSet:
       coefficients:
         Blunt: 1.35
-        Slash: 1.2
-        Piercing: 1.2
+        Slash: 1.3
+        Piercing: 1.3
         Asphyxiation: 1.35
   - type: Damageable
     damageModifierSet: Oni

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -11,7 +11,7 @@
   - type: Sprite
     scale: 1.2, 1.2
   - type: PlayerToolModifier
-    pryTimeMultiplier: 0.4
+    pryTimeMultiplier: 0.5
   - type: PlayerAccuracyModifier
     spreadMultiplier: 15
     maxSpreadAngle: 180

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -84,3 +84,10 @@
     Bloodloss: 0.0
     Cellular: 0.0
     Caustic: 0.0
+
+- type: damageModifierSet
+  id: Oni
+  coefficients:
+    Blunt: 0.75
+    Slash: 0.75
+    Piercing: 0.8

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -88,6 +88,6 @@
 - type: damageModifierSet
   id: Oni
   coefficients:
-    Blunt: 0.75
-    Slash: 0.75
+    Blunt: 0.85
+    Slash: 0.85
     Piercing: 0.8


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
made oni pry doors 60% faster, have more pierce res, and do more slash and pierce damage

removed species lock for kanabou and samurai armor

reduced price of rickenbacker and samurai armor

## Why / Balance
oni are kinda a yikes role right now, they were fine when they could reasonably use pistols but since that was taken away they've just been pretty bad. they still do more blunt than anything else since more force applied will benefit blunt force objects moreso than slash or pierce, but slash and pierce also benefit from these things. they pry doors faster because 40% faster was just marginally better.

direction feedback on #3557 lead me to remove the species lock on those 2 items

samurai armor is objectively worse than a web vest in every way so idk why it cost 2x as much. rickenbacker was just a 10TC tax for musicians who wanted the cool guitar, its still a decent weapon but its not in any way worth more than an esword

## Technical details
moved the damage set to dv files, ill move the nyano uplink shit to dv if requested
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: Removed the species lockout for kanabou and samurai armor.
- tweak: Oni's now hit harder with slash and pierce weapons (not bullets)
- tweak: Oni have slightly more resistance to brute damage
- tweak: Oni pry doors 60% faster than humans
- tweak: samurai armor is much cheaper now
- tweak: rickenbacker is much cheaper now