### PR TITLE
prevent thieves from using long arms

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -27,6 +27,7 @@
     - suitStorage
     - Belt
   - type: Gun
+    clumsyProof: true # DeltaV - let clowns and thieves shoot pistols for self defence (not long arms though)
     fireRate: 6
     selectedMode: SemiAuto
     availableModes:

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -27,8 +27,12 @@
       allowNonHumans: true
       multiAntagSetting: NotExclusive
       startingGear: ThiefGear
-      #components: # DeltaV - forced pacifism is lame
-      #- type: Pacified
+      components:
+      - type: Clumsy # DeltaV - replaced pacifism with guns exploding in your face
+        clumsyDefaultCheck: 0.8
+        clumsyHypo: false
+        clumsyDefib: false
+        clumsyVaulting: false
       mindRoles:
       - MindRoleThief
       briefing:


### PR DESCRIPTION
## About the PR
thieves shooting guns will blow up in their face, like for clowns
clowns and thieves are now allowed to use pistols for self defence, but still not long arms or rpgs etc

## Why / Balance
thieves going too hard
long overdue clown buff

## Media
pistol ok
![07:18:13](https://github.com/user-attachments/assets/c16b3408-1ed6-4562-b2c6-c5637c437574)

big gun not ok
![07:17:32](https://github.com/user-attachments/assets/f66c0b80-cf67-4c21-aeac-2dea2ac6b317)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- tweak: Thives can only shoot pistols now.
- add: Clowns are now trained to use pistols without exploding. Beware the honk.
