### PR TITLE
Allow CTs to wear the default Cargo gear

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -728,11 +728,11 @@
   id: CargoTechnicianJumpsuit
   name: loadout-group-cargo-technician-jumpsuit
   loadouts:
- #- CargoTechnicianJumpsuit
- #- CargoTechnicianJumpskirt
   - ClothingUniformJumpsuitCargoTechPants # DeltaV
   - ClothingUniformJumpsuitCargoTechOveralls # DeltaV
   - ClothingUniformJumpskirtCargoTechRomper # DeltaV
+  - CargoTechnicianJumpsuit
+  - CargoTechnicianJumpskirt
 
 - type: loadoutGroup
   id: CargoTechnicianBackpack


### PR DESCRIPTION
## About the PR

Also reorder loadout so the unique stuff is the defaulut and the other two are explicit opt-in, so the identification thing doesn't immediately go out the window completely.

## Why / Balance
I miss my jumpskirt :pensive:

## Technical details
Un-commented the original values in loadout `CargoTechnicianJumpsuit` and moved them to the end of the list.

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Re-added the jumpskirt and jumpsuit as an option to the Cargo Technician's loadout
