### PR TITLE
Remove the stasis clause from SOP 

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -266,7 +266,6 @@ Additionally, prisoners sentenced to Extended Confinement have certain rights bu
 * Prisoners may request retrial for capital crimes; these requests may be refused depending on the discretion and availability of the court clerk, chief justice, or at the discretion of the warden or head of station security.
 * Prisoners may request or may otherwise be given parole with a hearing by the Chief Justice, Court Clerk, or in their absence, the head of station security or commanding officer (see Paroles and Pardons).
 
-Should prisoners repeatedly and maliciously antagonize law enforcement, to an extent where continued extended confinement becomes infeasible, the warden is fully authorized and encouraged to temporarily upgrade the relevant prisoners’ sentences to Preservative Stasis summarily.
 
 Moreover, prisoners are liable for any and all crimes that they commit while held either in the temporary holding cells or the Permanent Brig, and may receive trial for more restrictive punishments if their actions warrant a capital sentence.
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
Stasis is being missused constantly and the cases where it should be applied are rare enough to warrant it's removal. Give the person a trial if they tried to escape twice, remove the privileges from perma confinement if they tried to escape. Don't kill them just for trying to escape.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Preservative stasis can only be used on Gamma, Delta and Octarine now.
