### PR TITLE
Sex applies correctly to kitsune fox form

### DIFF
--- a/Content.Server/Speech/EntitySystems/VocalSystem.cs
+++ b/Content.Server/Speech/EntitySystems/VocalSystem.cs
@@ -49,7 +49,7 @@ public sealed class VocalSystem : EntitySystem
 
     private void OnSexChanged(EntityUid uid, VocalComponent component, SexChangedEvent args)
     {
-        LoadSounds(uid, component);
+        LoadSounds(uid, component, args.NewSex);
     }
 
     private void OnEmote(EntityUid uid, VocalComponent component, ref EmoteEvent args)

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -6,9 +6,11 @@ using Content.Shared._DV.Abilities.Kitsune;
 using Content.Shared.Damage.Components;
 using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
+using Content.Shared.Humanoid;
 using Content.Shared.NPC.Components;
 using Content.Shared.NPC.Systems;
 using Content.Shared.Polymorph;
+using Content.Shared.Speech.Components;
 using Robust.Shared.Player;
 
 namespace Content.Server._DV.Abilities.Kitsune;
@@ -52,6 +54,9 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             foxfire.Kitsune = newEntity;
             Dirty(fireUid, foxfire);
         }
+
+        if (TryComp<HumanoidAppearanceComponent>(oldEntity, out var humanoidAppearance))
+            RaiseLocalEvent(newEntity, new SexChangedEvent(Sex.Unsexed, humanoidAppearance.Sex));
 
         // Code after this point will not run when reverting to human form.
         if (HasComp<KitsuneFoxComponent>(oldEntity))


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Includes early merge of https://github.com/space-wizards/space-station-14/pull/37405

## Why / Balance
Fixes #3648

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Kitsune now use correct emote sounds in fox form.
