### PR TITLE
Fix kitsune fox fires being too dark.

### DIFF
--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneSystem.cs
@@ -37,6 +37,7 @@ public sealed class KitsuneSystem : SharedKitsuneSystem
             return;
 
         newKitsune.Color = oldKitsune.Color;
+        newKitsune.ColorLight = oldKitsune.ColorLight;
         _appearance.SetData(newEntity, KitsuneColorVisuals.Color, newKitsune.Color ?? Color.Orange);
 
         // Ensure that the fox fire action state is transferred properly.

--- a/Content.Shared/_DV/Abilities/Kitsune/KitsuneComponent.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/KitsuneComponent.cs
@@ -30,6 +30,12 @@ public sealed partial class KitsuneComponent : Component
     [DataField, AutoNetworkedField] public List<EntityUid> ActiveFoxFires = [];
 
     [DataField, AutoNetworkedField] public Color? Color;
+
+    /// <summary>
+    /// Represents a light coming from a light source.
+    /// As such it has its value maximised while not touching hue or saturation.
+    /// </summary>
+    [DataField, AutoNetworkedField] public Color? ColorLight;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -31,6 +31,22 @@ public abstract class SharedKitsuneSystem : EntitySystem
         if (TryComp<HumanoidAppearanceComponent>(ent, out var humanComp))
         {
             ent.Comp.Color = humanComp.EyeColor;
+
+            var lightColor = ent.Comp.Color.Value;
+            var max = MathF.Max(lightColor.R, MathF.Max(lightColor.G, lightColor.B));
+            // Don't let it divide by 0
+            if (max == 0)
+            {
+                lightColor = new Color(1, 1, 1, lightColor.A);
+            }
+            else
+            {
+                var factor = 1 / max;
+                lightColor.R *= factor;
+                lightColor.G *= factor;
+                lightColor.B *= factor;
+            }
+            ent.Comp.ColorLight = lightColor;
         }
     }
 
@@ -71,7 +87,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         Dirty(fireEnt, fireComp);
         Dirty(ent);
 
-        _light.SetColor(fireEnt, ent.Comp.Color ?? Color.Purple);
+        _light.SetColor(fireEnt, ent.Comp.ColorLight ?? Color.Purple);
     }
 
     private void OnFoxfireShutdown(Entity<FoxfireComponent> ent, ref ComponentShutdown args)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fox fires now use a new field on the component which holds the color after it is scaled up to maximum brightness.

## Why / Balance
A light source should emit a "pure" light that only is affected by the relative proportions of the color.
Fixes #3695 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/43e57376-a341-4556-b2a2-ff63b5176b31)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fox fires now have the same brightness regardless of eye color.
