### PR TITLE
Add GPS to the security suit storages

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
@@ -15,6 +15,8 @@
       amount: 2
     - id: JetpackSecurityFilled
       amount: 2
+    - id: HandheldGPSBasic
+      amount: 2
 
 #Paramedic hardsuit
 - type: entityTable


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
This should allow sec to be able to lose sight of the station to move in space, it takes a 1x2 space so I feel it's balanced.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added two handheld GPS to the security suit storages
