### PR TITLE
Adds Experiment Plushie and Bee Plushie to Trinkets

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -10,6 +10,10 @@
   - Headphones
   - PlushieLizard
   - PlushieSpaceLizard
+  # Begin DeltaV Additions
+  - PlushieExperiment
+  - PlushieBee
+  # End DeltaV Additions
   - ThreeCandles
   - Lighter
   - CigPackGreen

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
@@ -45,3 +45,15 @@
   storage:
     back:
     - Wristwatch
+
+- type: loadout
+  id: PlushieExperiment
+  storage:
+    back:
+    - PlushieExperiment
+
+- type: loadout
+  id: PlushieBee
+  storage:
+    back:
+    - PlushieBee


### PR DESCRIPTION
## About the PR
Adds two wearable plushies to trinkets in the loadout. Have fun with new silly friends on your head!
## Why / Balance
I am definitely not biased towards the experiment plushie and not being able to start with them roundstart like the existing lizard plushie.
## Technical details
Adds the Experiment Plushie and the Bee Plushie to loadout_groups.yml and DV's trinkets.yml
## Media
![image](https://github.com/user-attachments/assets/89371897-8cbd-4dbb-b486-f8b1b0e77a53)
## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added Experiment Plushie and Bee Plushie to Trinkets