### PR TITLE
Make weaponry more expensive and add the SLP-67 to the cargo catalog

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/_DV/Catalog/Cargo/cargo_armory.yml
@@ -69,3 +69,13 @@
   cost: 18000
   category: Armory
   group: market
+
+- type: cargoProduct
+  id: ArmorySLP67
+  icon:
+    sprite: _DV/Objects/Weapons/Guns/Pistols/slp67.rsi
+    state: icon
+  product: CrateSLP67
+  cost: 9000
+  category: Armory
+  group: market

--- a/Resources/Prototypes/_DV/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/_DV/Catalog/Cargo/cargo_armory.yml
@@ -76,6 +76,6 @@
     sprite: _DV/Objects/Weapons/Guns/Pistols/slp67.rsi
     state: icon
   product: CrateSLP67
-  cost: 9000
+  cost: 7000
   category: Armory
   group: market

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
@@ -68,3 +68,25 @@
     contents:
     - id: WatchdogImplanter
       amount: 3
+
+- type: entityTable
+  id: CrateFillSLP67
+  table: !type:AllSelector
+    children:
+    - id: WeaponPistolSLP67
+      amount: !type:ConstantNumberSelector
+        value: 3
+    - id: MagazinePistolHighCapacity
+      amount: !type:ConstantNumberSelector
+        value: 3
+
+- type: entity
+  parent: CrateWeaponSecure
+  id: CrateSLP67
+  name: SLP-67 "Volk" crate
+  description: A crate containing 3 SLP-67 and 3 high-capacity .35 magazines. Requires Armory access to open.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: CrateFillSLP67


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR

This PR adds the SLP-67 to the cargo catalog. Note that the SLP-67 isn't the round start weapon that security can select (SLP-57), this one is a upgraded version, comes with a bigger magazine, full auto capability and can't be placed in boots or pockets.

## Why / Balance

We have this gun sitting there, let's put it to use.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added the SLP-67 "Volk" to the cargo catalog.