### PR TITLE
fix some contract issues

### DIFF
--- a/Content.Server/_DV/Objectives/Systems/PickRandomTraitorSystem.cs
+++ b/Content.Server/_DV/Objectives/Systems/PickRandomTraitorSystem.cs
@@ -25,6 +25,7 @@ public sealed class PickRandomTraitorSystem : EntitySystem
     private void OnRandomTraitorAssigned(Entity<PickRandomTraitorComponent> ent, ref ObjectiveAssignedEvent args)
     {
         _pickTarget.AssignRandomTarget(ent, ref args, mindId =>
-            _role.MindHasRole<TraitorRoleComponent>(mindId));
+            _role.MindHasRole<TraitorRoleComponent>(mindId),
+            fallbackToAny: false); // bruh
     }
 }

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -165,6 +165,7 @@
   - type: PickRandomTraitor
     minContracts: 1
   - type: CodeCondition
+  - type: SocialObjective # actually need this
   - type: AssistRandomContract
     blacklist:
       components:


### PR DESCRIPTION
## About the PR
fixes it picking non-traitors if there were no traitors... fallback to any was true by default for some reason
also fixes assisting assist contracts because SocialObjective was removed from the prototype to not break different objectives
might prevent having 2 assist objectives in 1 round but thats better than the spidermen pointing meme

## Why / Balance
fixes #3734 
fixes #3733

**Changelog**
:cl:
- fix: Fixed getting objectives to assist non-traitors...
- fix: Fixed getting an objective to assist someone with assisting someone else.
