### PR TITLE
add rep requirement for syndie lawset objective

### DIFF
--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -254,6 +254,11 @@
   - type: CodeCondition
   - type: AILawsUpdatedRequirement
     lawset: SyndicateLawset
+  - type: ReputationCondition
+    reputation: 80
+  - type: ContractObjective
+    reputation: 20 # bring you to 100
+    payment: 6
   - type: ObjectiveLimit
     limit: 1
 


### PR DESCRIPTION
ai public enemy #1

:cl:
- tweak: Fixed the subvert AI objective being available immediately and having no payment.