### PR TITLE
Cosmic Cult | Disable entropic decay popup (Hotfix)

### DIFF
--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicEntropyDegenSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicEntropyDegenSystem.cs
@@ -39,8 +39,6 @@ public sealed partial class CosmicEntropyDegenSystem : EntitySystem
                 continue;
             component.CheckTimer = _timing.CurTime + component.CheckWait;
             _damageable.TryChangeDamage(uid, component.Degen, true, false);
-            if (_random.Prob(component.PopupChance))
-                _popup.PopupEntity(Loc.GetString("entropy-effect-numb"), uid, uid, PopupType.SmallCaution);
         }
     }
 }

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicEntropyDebuffComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicEntropyDebuffComponent.cs
@@ -19,12 +19,6 @@ public sealed partial class CosmicEntropyDebuffComponent : Component
     public TimeSpan CheckWait = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// The chance to recieve a message popup while under the effects of Entropic Degen.
-    /// </summary>
-    [DataField]
-    public float PopupChance = 0.05f;
-
-    /// <summary>
     /// The debuff applied while the component is present.
     /// </summary>
     [DataField]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removes the rare popup ocurrence from players affected by Entropic Decay.

## Why / Balance
Per internal (direction) request, meta concerns.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- remove: the Entropic Decay status effect no longer has an indicator popup.
