### PR TITLE
add crit anomaly objective

### DIFF
--- a/Content.Server/_DV/Objectives/Components/CritAnomalyConditionComponent.cs
+++ b/Content.Server/_DV/Objectives/Components/CritAnomalyConditionComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._DV.Objectives.Components;
+
+/// <summary>
+/// Triggers <c>CodeConditionComponent</c> when an anomaly goes supercritical.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CritAnomalyConditionComponent : Component;

--- a/Content.Server/_DV/Objectives/Components/CritAnomalyConditionComponent.cs
+++ b/Content.Server/_DV/Objectives/Components/CritAnomalyConditionComponent.cs
@@ -1,7 +1,7 @@
 namespace Content.Server._DV.Objectives.Components;
 
 /// <summary>
-/// Triggers <c>CodeConditionComponent</c> when an anomaly goes supercritical.
+/// Triggers <see cref="Server.Objectives.Components.CodeConditionComponent" /> when an anomaly goes supercritical.
 /// </summary>
 [RegisterComponent]
 public sealed partial class CritAnomalyConditionComponent : Component;

--- a/Content.Server/_DV/Objectives/Systems/CritAnomalyConditionSystem.cs
+++ b/Content.Server/_DV/Objectives/Systems/CritAnomalyConditionSystem.cs
@@ -1,7 +1,6 @@
 using Content.Server._DV.Objectives.Components;
 using Content.Server.Objectives.Systems;
 using Content.Shared.Anomaly.Components;
-using Content.Shared.Objectives.Components;
 
 namespace Content.Server._DV.Objectives.Systems;
 

--- a/Content.Server/_DV/Objectives/Systems/CritAnomalyConditionSystem.cs
+++ b/Content.Server/_DV/Objectives/Systems/CritAnomalyConditionSystem.cs
@@ -1,0 +1,33 @@
+using Content.Server._DV.Objectives.Components;
+using Content.Server.Objectives.Systems;
+using Content.Shared.Anomaly.Components;
+using Content.Shared.Objectives.Components;
+
+namespace Content.Server._DV.Objectives.Systems;
+
+public sealed class CritAnomalyConditionSystem : EntitySystem
+{
+    [Dependency] private readonly CodeConditionSystem _codeCondition = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AnomalyShutdownEvent>(OnAnomalyShutdown);
+    }
+
+    private void OnAnomalyShutdown(ref AnomalyShutdownEvent args)
+    {
+        // don't care about decaying
+        if (!args.Supercritical)
+            return;
+
+        // everyone with the objective succeeds because you could trick someone to crit it for you
+        // without ever touching an ape yourself
+        var query = EntityQueryEnumerator<CritAnomalyConditionComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            _codeCondition.SetCompleted(uid);
+        }
+    }
+}

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -60,9 +60,9 @@
     Telecrystal: 1
   categories:
   - UplinkWeaponry
-  conditions: # DeltaV - its a mosin bro
+  conditions: # DeltaV - Long arm reputation
   - !type:ReputationCondition
-    reputation: 1
+    reputation: 60
 
 - type: listing
   id: UplinkEsword

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -60,9 +60,9 @@
     Telecrystal: 1
   categories:
   - UplinkWeaponry
-  conditions: # DeltaV - Long arm reputation
+  conditions: # DeltaV - its a mosin bro
   - !type:ReputationCondition
-    reputation: 60
+    reputation: 1
 
 - type: listing
   id: UplinkEsword

--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -6,6 +6,7 @@
     TraitorObjectiveGroupKill: 1
     TraitorObjectiveGroupState: 1 #As in, something about your character. Alive, dead, arrested, gained an ability...
     TraitorObjectiveGroupSocial: 0.5 # DeltaV #Involves helping/harming others without killing them or stealing their stuff
+    TraitorObjectiveGroupSabotage: 1 # DeltaV
     TraitorObjectiveGroupSpecial: .2 # DeltaV
 
 - type: weightedRandom

--- a/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
@@ -22,6 +22,12 @@
   weights:
     RandomTraitorAssistObjective: 1
 
+# Sabotage
+- type: weightedRandom
+  id: TraitorObjectiveGroupSabotage
+  weights:
+    TraitorCritAnomalyObjective: 1
+
 ## Ninja
 # Hacking things
 - type: weightedRandom

--- a/Resources/Prototypes/_DV/Objectives/reputation_offerings.yml
+++ b/Resources/Prototypes/_DV/Objectives/reputation_offerings.yml
@@ -6,5 +6,6 @@
     TraitorObjectiveGroupKill: 1
     # no state as taking a contract to escape is basically paid eorg
     TraitorObjectiveGroupAssist: 0.5
+    TraitorObjectiveGroupSabotage: 1
     TraitorObjectiveGroupSpecial: 0.2
     TraitorObjectiveGroupRansom: 1

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -156,7 +156,7 @@
   parent: BaseTraitorObjective
   id: TraitorCritAnomalyObjective
   name: Force an anomaly to go super-critical
-  description: Hijack Epistemics's equipment to overload an anomaly and make it explode.
+  description: Hijack Epistemics' equipment to overload an anomaly and make it explode.
   components:
   - type: Objective
     difficulty: 1.5

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -152,6 +152,27 @@
     stealGroup: BibleMystagogue
     owner: job-name-rd
 
+- type: entity
+  parent: BaseTraitorObjective
+  id: TraitorCritAnomalyObjective
+  name: Force an anomaly to go super-critical
+  description: Hijack Epistemics's equipment to overload an anomaly and make it explode.
+  components:
+  - type: Objective
+    difficulty: 1.5
+    icon:
+      sprite: Structures/Specific/anomaly.rsi
+      state: anom2-pulse
+  - type: NotDepartmentRequirement
+    department: Epistemics
+  - type: CodeCondition
+  - type: CritAnomalyCondition
+  - type: ReputationCondition
+    reputation: 30 # its not that hard but don't want it happening IMMEDIATELY
+  - type: ContractObjective
+    reputation: 10
+    payment: 4
+
 # Assist traitor
 
 - type: entity


### PR DESCRIPTION
## About the PR
add objective to crit an anomaly, if any anomaly goes crit it gets completed

30 rep required so epi has some breathing room to get points going

## Why / Balance
we like things going boom
sabotage the ape, lie to an intern about what particle containment is, make rogue anomalies, whatever you want

## Media
![04:10:10](https://github.com/user-attachments/assets/73d2b168-67ac-490c-af20-20327aaa56ce)

its real
![04:11:22](https://github.com/user-attachments/assets/de7edb78-81f6-4178-9c00-423c2f80a7ee)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
no

**Changelog**
:cl:
- add: Added an objective to make an anomaly go super-critical.
