### PR TITLE
Revert "Add minimum player count for thieves"

### DIFF
--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -2,8 +2,6 @@
   parent: BaseGameRule
   id: Thief
   components:
-  - type: GameRule # DeltaV - thieves need players to be fun against
-    minPlayers: 30
   - type: ThiefRule
   - type: AntagObjectives
     objectives:


### PR DESCRIPTION
Reverts DeltaV-Station/Delta-v#3731, because at the moment if 30 players aren't readied up it sets the game mode to extended, which is bad