### PR TITLE
revert limb integrity thresholds

### DIFF
--- a/Resources/Prototypes/_DV/Body/Parts/base.yml
+++ b/Resources/Prototypes/_DV/Body/Parts/base.yml
@@ -10,13 +10,6 @@
         Slash: 100
     - types:
         Blunt: 100
-    integrityThresholds:
-      CriticallyWounded: 90
-      HeavilyWounded: 75
-      ModeratelyWounded: 60
-      SomewhatWounded: 40
-      LightlyWounded: 20
-      Healthy: 10
 
 - type: entity
   abstract: true
@@ -30,13 +23,6 @@
         Slash: 55
     - types:
         Blunt: 90
-    integrityThresholds:
-      CriticallyWounded: 50
-      HeavilyWounded: 40
-      ModeratelyWounded: 30
-      SomewhatWounded: 20
-      LightlyWounded: 15
-      Healthy: 10
 
 - type: entity
   abstract: true
@@ -50,13 +36,6 @@
         Slash: 40
     - types:
         Blunt: 90
-    integrityThresholds:
-      CriticallyWounded: 35
-      HeavilyWounded: 30
-      ModeratelyWounded: 25
-      SomewhatWounded: 20
-      LightlyWounded: 15
-      Healthy: 10
 
 - type: entity
   abstract: true
@@ -70,13 +49,6 @@
         Slash: 80
     - types:
         Blunt: 90
-    integrityThresholds:
-      CriticallyWounded: 70
-      HeavilyWounded: 60
-      ModeratelyWounded: 50
-      SomewhatWounded: 40
-      LightlyWounded: 20
-      Healthy: 10
 
 - type: entity
   abstract: true
@@ -90,10 +62,3 @@
         Slash: 40
     - types:
         Blunt: 90
-    integrityThresholds:
-      CriticallyWounded: 35
-      HeavilyWounded: 30
-      ModeratelyWounded: 25
-      SomewhatWounded: 20
-      LightlyWounded: 15
-      Healthy: 10


### PR DESCRIPTION
## About the PR
its just severing now

## Why / Balance
25 poison disabling your hands is a meme, a single dart of amatoxin or even weaker poisons would disable all your limbs
zombie infection also did this in minutes (which in theory is good because sleeping to outheal a fucking zombie virus is awful but just outright crippling you is bad)

**Changelog**
:cl:
- tweak: Limbs are harder to get disabled by poisons, etc.
