### PR TITLE
Make the natural shuttle call an OOC vote

### DIFF
--- a/Content.Server/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/RoundEnd/RoundEndSystem.cs
@@ -28,7 +28,7 @@ namespace Content.Server.RoundEnd
     /// Handles ending rounds normally and also via requesting it (e.g. via comms console)
     /// If you request a round end then an escape shuttle will be used.
     /// </summary>
-    public sealed class RoundEndSystem : EntitySystem
+    public sealed partial class RoundEndSystem : EntitySystem // DeltaV - Partial class
     {
         [Dependency] private readonly IAdminLogManager _adminLogger = default!;
         [Dependency] private readonly IConfigurationManager _cfg = default!;
@@ -357,7 +357,7 @@ namespace Content.Server.RoundEnd
             {
                 if (!_shuttle.EmergencyShuttleArrived && ExpectedCountdownEnd is null)
                 {
-                    RequestRoundEnd(null, false, "round-end-system-shuttle-auto-called-announcement");
+                    CallEvacuationVote(); // DeltaV - players vote on ending the round
                     _autoCalledBefore = true;
                 }
 

--- a/Content.Server/_DV/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/_DV/RoundEnd/RoundEndSystem.cs
@@ -1,0 +1,32 @@
+using Content.Server.Voting.Managers;
+using Content.Server.Voting;
+using Content.Shared._DV.CCVars;
+
+namespace Content.Server.RoundEnd;
+
+public sealed partial class RoundEndSystem : EntitySystem
+{
+    [Dependency] IVoteManager _vote = default!;
+
+    public void CallEvacuationVote()
+    {
+        var options = new VoteOptions
+        {
+            DisplayVotes = false,
+            Title = Loc.GetString("round-end-system-vote-title"),
+            Duration = _cfg.GetCVar(DCCVars.EmergencyShuttleVoteTime),
+            InitiatorText = Loc.GetString("vote-options-server-initiator-text")
+        };
+
+        options.Options.Add((Loc.GetString("round-end-system-vote-end"), true));
+        options.Options.Add((Loc.GetString("round-end-system-vote-continue"), false));
+
+        var vote = _vote.CreateVote(options);
+
+        vote.OnFinished += (_, args) =>
+        {
+            if (args.Winner == null || (bool)args.Winner)
+                RequestRoundEnd(null, false, "round-end-system-vote-shuttle-called-announcement");
+        };
+    }
+}

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -226,6 +226,14 @@ public sealed class DCCVars
     public static readonly CVarDef<int> MaxObjectiveSummaryLength =
         CVarDef.Create("game.max_objective_summary_length", 256, CVar.SERVER | CVar.REPLICATED);
 
+    /* OOC shuttle vote */
+
+    /// <summary>
+    /// How long players should have to vote on the round end shuttle being sent
+    /// </summary>
+    public static readonly CVarDef<TimeSpan> EmergencyShuttleVoteTime =
+        CVarDef.Create("shuttle.vote_time", TimeSpan.FromMinutes(1), CVar.SERVER);
+
     /*
      * Cosmic Cult
      */

--- a/Resources/Locale/en-US/_DV/roundend/round-end-system.ftl
+++ b/Resources/Locale/en-US/_DV/roundend/round-end-system.ftl
@@ -1,0 +1,4 @@
+round-end-system-vote-title = Should the shift end?
+round-end-system-vote-end = Initiate Crew Transfer
+round-end-system-vote-continue = Continue Round
+round-end-system-vote-shuttle-called-announcement = An automatic crew shift change shuttle has been sent. ETA: {$time} {$units}.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- shuttle call is now an OOC vote

## Why / Balance
- how long people want to play is primarily an OOC thing as opposed to IC reasons for calling the shuttle if something's going to shit
- not all people in the round are crew or alive to vote IC

## Technical details
- replace auto-call with call-vote behaviour

## Media
![grafik](https://github.com/user-attachments/assets/f4f0577a-d891-41d3-b33b-f5a2f4c74d7d)
![grafik](https://github.com/user-attachments/assets/3ff02717-97bb-4b89-9cd7-ce6b6da0c59b)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The server now calls an OOC vote for the routine crew change shuttle
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
