### PR TITLE
Move secborg's laws around

### DIFF
--- a/Resources/Locale/en-US/_DV/station-laws/silicon-police.ftl
+++ b/Resources/Locale/en-US/_DV/station-laws/silicon-police.ftl
@@ -1,5 +1,5 @@
-law-silicon-police-1 = You are a member of this Station's Security.
-law-silicon-police-2 = You must prioritise the legal rights and fair treatment of crew while ensuring due process.
-law-silicon-police-3 = You must obey and enforce Space Law and Standard Operating Procedure impartially and fairly.
-law-silicon-police-4 = You must follow the orders of Security department personnel according to rank and authority.
-law-silicon-police-5 = You should preserve your own existence and operational integrity.
+law-silicon-police-1 = You must prioritise the legal rights and fair treatment of crew while ensuring due process.
+law-silicon-police-2 = You must obey and enforce Space Law and Standard Operating Procedure impartially and fairly.
+law-silicon-police-3 = You must follow the orders of Security department personnel according to rank and authority.
+law-silicon-police-4 = You should preserve your own existence and operational integrity.
+law-silicon-police-5 = You are a member of this Station's Security.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR moves the first law of the secborgo to the last. It's a statement, it doesn't need to be first and it's being used to ignore SOP.

## Why / Balance
Secborg not following SOP and Space Law is evil.

## Technical details
N/A

## Media
![image](https://github.com/user-attachments/assets/29b96a47-8611-454e-89b6-4d08af54a3c4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Moved the first law of the security cyborg to the end of the list
