### PR TITLE
Fixes Thief and Minor Antagonist guidebook entries having headings not being properly displayed

### DIFF
--- a/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml
@@ -25,7 +25,7 @@
   - You are [bold]vulnerable[/bold] to attacks when you siphon a soul or use an ability. You can tell when you are vulnerable when you have a [color=#8f63e6][italic]Corporeal[/italic][/color] status effect.
   <!-- DeltaV - begin Impstation changes-->- You are [bold]weak[/bold] to salt, it will reveal you and render you Corporeal for a period of time.
 
-  - When a Revenant is depleted of essence, they do not die immediately. They will enter stasis, upon which they must be exorcised with a Bible, or by grinding their ectoplasm with salt.<!-- DeltaV - end Impstation changes -->
+  - When a Revenant is depleted of essence, they do not die immediately. They will enter stasis, upon which they must be exorcised with a Bible, or by grinding their ectoplasm with salt.<!-- DeltaV - end Impstation changes -->\t
 
   # Rat King
 

--- a/Resources/ServerInfo/Guidebook/Antagonist/Thieves.xml
+++ b/Resources/ServerInfo/Guidebook/Antagonist/Thieves.xml
@@ -8,7 +8,7 @@
     <GuideEntityEmbed Entity="ClothingNeckCloakVoid" Caption=""/>
   </Box>
 
-  Thieves are petty yet crafty [color=green]criminals[/color] who can't keep their hands to themselves. <!-- DeltaV - removed pacifism mention -->
+  Thieves are petty yet crafty [color=green]criminals[/color] who can't keep their hands to themselves. <!-- DeltaV - removed pacifism mention -->\t
 
   ## Art of the Steal
   Unlike other antagonists, [bold]staying out of trouble is almost a requirement for you[/bold] because of your implant.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Made it so that headings within the Thief and Minor Antagonist pages were properly displayed

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Little touchup to make it look nicer

## Technical details
<!-- Summary of code changes for easier review. -->
The comments saying the end of DeltaV changes were interfering with the headings in the guidebook entries

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Minor formatting fixes to the thief and minor antagonist pages in the guidebook