### PR TITLE
Use DV locker sprites for chef/jani

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -21,7 +21,7 @@
         amount: 2
       - id: RagItem
         amount: 2
-      - id: LunchboxServiceFilledRandom # Delta-V Lunchboxes!
+      - id: LunchboxServiceFilledRandom # DeltaV Lunchboxes!
         prob: 0.3
 
 #- type: entity
@@ -32,7 +32,7 @@
 - type: entity
   id: ClosetChefFilled
   suffix: Filled
-  parent: LockerKitchen # Delta V - Use DV secure lockers/sprites
+  parent: LockerKitchen # DeltaV - Use DV secure lockers/sprites
   components:
   - type: StorageFill
     contents:
@@ -56,13 +56,13 @@
       - id: DrinkMilkCarton
         amount: 2
       - id: DrinkSoyMilkCarton
-      - id: LunchboxServiceFilledRandom # Delta-V Lunchboxes!
+      - id: LunchboxServiceFilledRandom # DeltaV Lunchboxes!
         prob: 0.3
 
 - type: entity
   id: ClosetJanitorFilled
   suffix: Filled
-  parent: LockerJanitor # Delta V - Use DV secure lockers/sprites
+  parent: LockerJanitor # DeltaV - Use DV secure lockers/sprites
   components:
   - type: StorageFill
     contents:
@@ -83,7 +83,7 @@
         amount: 2
       - id: Plunger
         amount: 2
-      - id: LunchboxServiceFilledRandom # Delta-V Lunchboxes!
+      - id: LunchboxServiceFilledRandom # DeltaV Lunchboxes!
         prob: 0.3
 
 - type: entity
@@ -117,7 +117,7 @@
       - id: ClothingUniformOveralls
       - id: ClothingHeadHatTrucker
         prob: 0.1
-      - id: LunchboxServiceFilledRandom # Delta-V Lunchboxes!
+      - id: LunchboxServiceFilledRandom # DeltaV Lunchboxes!
         prob: 0.3
 
 - type: entity

--- a/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/service.yml
@@ -32,7 +32,7 @@
 - type: entity
   id: ClosetChefFilled
   suffix: Filled
-  parent: ClosetChef
+  parent: LockerKitchen # Delta V - Use DV secure lockers/sprites
   components:
   - type: StorageFill
     contents:
@@ -62,7 +62,7 @@
 - type: entity
   id: ClosetJanitorFilled
   suffix: Filled
-  parent: ClosetJanitor
+  parent: LockerJanitor # Delta V - Use DV secure lockers/sprites
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
## About the PR
Swaps the basic wardrobe lockers that chef/jani closets use for access locked, unique sprite lockers. 

## Why / Balance
We have these nice locker sprites just laying around in our folders feeling neglected. Time to give them some love.

## Technical details
n/a

## Media
![image](https://github.com/user-attachments/assets/5fb319ad-4efc-450e-add9-26aa0f78eae8)

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
