### PR TITLE
change ransom reputation to match teach a lesson

### DIFF
--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -23,9 +23,9 @@
   - type: TargetObjective
     title: objective-condition-ransom-title
   - type: ReputationCondition
-    reputation: 60
+    reputation: 30
   - type: ContractObjective
-    reputation: 10
+    reputation: 15
     payment: 4
   - type: StoreUnlocker
     listings:


### PR DESCRIPTION
## About the PR
reputation requirement and reward changed to match teach a lesson (30 and 15)

## Why / Balance
its wanted and ive never seen anyone do it yet so

**Changelog**
:cl:
- fix: Traitor ransom objectives can be picked earlier.
