### PR TITLE
reimplement assist contract traitor picking

### DIFF
--- a/Content.Server/_DV/Objectives/Components/PickRandomTraitorComponent.cs
+++ b/Content.Server/_DV/Objectives/Components/PickRandomTraitorComponent.cs
@@ -13,11 +13,4 @@ public sealed partial class PickRandomTraitorComponent : Component
     /// </summary>
     [DataField]
     public int MinReputation;
-
-    /// <summary>
-    /// Minimum number of active contracts a traitor needs to have.
-    /// By necessity requires a traitor to have a PDA that isn't deleted.
-    /// </summary>
-    [DataField]
-    public int MinContracts;
 }

--- a/Content.Server/_DV/Objectives/Systems/AssistRandomContractSystem.cs
+++ b/Content.Server/_DV/Objectives/Systems/AssistRandomContractSystem.cs
@@ -1,7 +1,9 @@
 using Content.Server._DV.Objectives.Components;
 using Content.Server.Objectives.Systems;
+using Content.Server.Roles;
 using Content.Shared._DV.Reputation;
 using Content.Shared.Objectives.Components;
+using Content.Shared.Roles;
 using Content.Shared.Whitelist;
 using Robust.Shared.Random;
 
@@ -14,7 +16,9 @@ public sealed class AssistRandomContractSystem : EntitySystem
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MetaDataSystem _meta = default!;
+    [Dependency] private readonly PickObjectiveTargetSystem _pickTarget = default!;
     [Dependency] private readonly ReputationSystem _reputation = default!;
+    [Dependency] private readonly SharedRoleSystem _role = default!;
     [Dependency] private readonly TargetObjectiveSystem _target = default!;
 
     private List<EntityUid> _available = new();
@@ -23,11 +27,35 @@ public sealed class AssistRandomContractSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<AssistRandomContractComponent, ObjectiveAssignedEvent>(OnAssigned);
         SubscribeLocalEvent<AssistRandomContractComponent, ObjectiveAfterAssignEvent>(OnAfterAssign);
         SubscribeLocalEvent<AssistRandomContractComponent, ComponentShutdown>(OnShutdown);
 
         SubscribeLocalEvent<AssistedContractComponent, ContractCompletedEvent>(OnCompleted);
         SubscribeLocalEvent<AssistedContractComponent, ContractFailedEvent>(OnFailed);
+    }
+
+    private void OnAssigned(Entity<AssistRandomContractComponent> ent, ref ObjectiveAssignedEvent args)
+    {
+        // have to check contracts against the blacklist
+        _pickTarget.AssignRandomTarget(ent, ref args, mindId =>
+        {
+            // only assist traitor contracts
+            if (!_role.MindHasRole<TraitorRoleComponent>(mindId))
+                return false;
+
+            // only assist traitors that use contracts
+            if (_reputation.GetContracts(mindId) is not {} contracts)
+                return false;
+
+            foreach (var obj in contracts.Comp.Objectives)
+            {
+                if (obj is {} uid && _whitelist.IsBlacklistFailOrNull(ent.Comp.Blacklist, uid))
+                    return true; // has at least 1 objective to pick
+            }
+
+            return false; // no objectives...
+        }, fallbackToAny: false); // don't fallback to non traitors obviously
     }
 
     private void OnAfterAssign(Entity<AssistRandomContractComponent> ent, ref ObjectiveAfterAssignEvent args)
@@ -43,6 +71,13 @@ public sealed class AssistRandomContractSystem : EntitySystem
         {
             if (obj is {} uid && _whitelist.IsBlacklistFailOrNull(ent.Comp.Blacklist, uid))
                 _available.Add(uid);
+        }
+
+        // just incase the target selection fails
+        if (_available.Count == 0)
+        {
+            Log.Error($"Objective {ToPrettyString(ent)} had no available contracts to pick from for {ToPrettyString(target)}!");
+            return;
         }
 
         var contract = _random.Pick(_available);

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -23,9 +23,9 @@
   - type: TargetObjective
     title: objective-condition-ransom-title
   - type: ReputationCondition
-    reputation: 60
+    reputation: 30
   - type: ContractObjective
-    reputation: 10
+    reputation: 15
     payment: 4
   - type: StoreUnlocker
     listings:
@@ -151,6 +151,27 @@
   - type: ExtractCondition
     stealGroup: BibleMystagogue
     owner: job-name-rd
+
+- type: entity
+  parent: BaseTraitorObjective
+  id: TraitorCritAnomalyObjective
+  name: Force an anomaly to go super-critical
+  description: Hijack Epistemics' equipment to overload an anomaly and make it explode.
+  components:
+  - type: Objective
+    difficulty: 1.5
+    icon:
+      sprite: Structures/Specific/anomaly.rsi
+      state: anom2-pulse
+  - type: NotDepartmentRequirement
+    department: Epistemics
+  - type: CodeCondition
+  - type: CritAnomalyCondition
+  - type: ReputationCondition
+    reputation: 30 # its not that hard but don't want it happening IMMEDIATELY
+  - type: ContractObjective
+    reputation: 10
+    payment: 4
 
 # Assist traitor
 

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -23,9 +23,9 @@
   - type: TargetObjective
     title: objective-condition-ransom-title
   - type: ReputationCondition
-    reputation: 30
+    reputation: 60
   - type: ContractObjective
-    reputation: 15
+    reputation: 10
     payment: 4
   - type: StoreUnlocker
     listings:
@@ -152,27 +152,6 @@
     stealGroup: BibleMystagogue
     owner: job-name-rd
 
-- type: entity
-  parent: BaseTraitorObjective
-  id: TraitorCritAnomalyObjective
-  name: Force an anomaly to go super-critical
-  description: Hijack Epistemics' equipment to overload an anomaly and make it explode.
-  components:
-  - type: Objective
-    difficulty: 1.5
-    icon:
-      sprite: Structures/Specific/anomaly.rsi
-      state: anom2-pulse
-  - type: NotDepartmentRequirement
-    department: Epistemics
-  - type: CodeCondition
-  - type: CritAnomalyCondition
-  - type: ReputationCondition
-    reputation: 30 # its not that hard but don't want it happening IMMEDIATELY
-  - type: ContractObjective
-    reputation: 10
-    payment: 4
-
 # Assist traitor
 
 - type: entity
@@ -183,8 +162,6 @@
     difficulty: 2.5
   - type: TargetObjective
     title: objective-condition-assist-traitor-title
-  - type: PickRandomTraitor
-    minContracts: 1
   - type: CodeCondition
   - type: SocialObjective # actually need this
   - type: AssistRandomContract


### PR DESCRIPTION
## About the PR
assist objective now only looks for traitors that have allowed objectives to assist

## Why / Balance
john crash bad, fixes #3737

## Technical details
MinContracts wasnt even used and couldnt know about blacklist
this just implements it

**Changelog**
:cl:
- fix: Fixed traitors randomly not being able to do anything.
