### PR TITLE
Replace explosive foam grenade with a shrapnel foam grenade

### DIFF
--- a/Resources/Locale/en-US/_DV/store/uplink/explosives.ftl
+++ b/Resources/Locale/en-US/_DV/store/uplink/explosives.ftl
@@ -1,5 +1,5 @@
-uplink-explosive-foam-grenade-name = Explosive Foam Grenade
-uplink-explosive-foam-grenade-desc = An explosive grenade disguised as a regular foam toy grenade.
+uplink-explosive-foam-grenade-name = Shrapnel Foam Grenade
+uplink-explosive-foam-grenade-desc = A shrapnel grenade disguised as a regular foam toy grenade.
 
 uplink-supermatter-grenade-name = Supermatter Grenade
 uplink-supermatter-grenade-desc = Grenade that simulates delamination of a suppermatter engine, generates powerful gravity well. Explosion comparable to a Mini Bomb.

--- a/Resources/Prototypes/_DV/Catalog/Uplink/explosives.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/explosives.yml
@@ -1,12 +1,12 @@
 - type: listing
-  id: UplinkExGrenadeFoam
+  id: UplinkGrenadeShrapnelFoam
   name: uplink-explosive-foam-grenade-name
   description: uplink-explosive-foam-grenade-desc
-  productEntity: ExGrenadeFoam
+  productEntity: GrenadeShrapnelFoam
   discountCategory: usualDiscounts
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 3 # 1 TC more expensive than regular due to disguise.
+    Telecrystal: 4 # 1 TC more expensive than regular due to disguise.
   categories:
   - UplinkExplosives

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -7,13 +7,3 @@
     totalIntensity: 1
     canCreateVacuum: false
     deleteAfterExplosion: false # prevent borg having an empty hand
-
-- type: entity
-  parent: ExGrenade
-  id: ExGrenadeFoam
-  name: foam dart grenade
-  suffix: Explosive
-  description: Releases a bothersome spray of foam darts that cause severe welching.
-  components:
-  - type: Sprite
-    sprite: Objects/Weapons/Grenades/foamdart.rsi

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -1,0 +1,9 @@
+- type: entity
+  parent: GrenadeShrapnel
+  id: GrenadeShrapnelFoam
+  name: foam dart grenade
+  suffix: Shrapnel
+  description: Releases a bothersome spray of foam darts that cause severe welching.
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Grenades/foamdart.rsi


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Changes the sneaky grenade from boom to pew pew.

## Why / Balance
Shitters were leaving them for people to trigger them at evac shuttles. Shrapnel, at least, won't space the shuttle.

## Technical details
Changed parenting, upped price to mimic sharpnel price + 1, moved to another file.

## Media

https://github.com/user-attachments/assets/f4ebfea1-cf05-4db1-b297-59dae25c8733


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Syndicate foam grenades are now a shrapnel grenade instead of explosive one.