### PR TITLE
SOP change - Make captain publicly announce when they alter SOP.

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -158,7 +158,7 @@ Captain’s Authority carries a responsibility, however; the CO must do everythi
 
 Additionally, the legally appointed Captain of a vessel is afforded two additional rights over that of a CO:
 
-* To temporarily modify SOP in times of emergency, at the risk of criminal penalties if misused or abused, and
+* To, as long as it's publicly announced to the crew, temporarily modify SOP in times of emergency, at the risk of criminal penalties if misused or abused, and
 * To deputize members of the crew to carry out law enforcement activity. These deputies are bound by Security Regulations and Space Law, and the Captain may suffer criminal penalties for any crime committed by them.
 
 ==Line of Succession==

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -158,7 +158,7 @@ Captain’s Authority carries a responsibility, however; the CO must do everythi
 
 Additionally, the legally appointed Captain of a vessel is afforded two additional rights over that of a CO:
 
-* To, as long as it's publicly announced to the crew, temporarily modify SOP in times of emergency, at the risk of criminal penalties if misused or abused, and
+* To, with public announcement to the crew, temporarily modify SOP in times of emergency, at the risk of criminal penalties if misused or abused, and
 * To deputize members of the crew to carry out law enforcement activity. These deputies are bound by Security Regulations and Space Law, and the Captain may suffer criminal penalties for any crime committed by them.
 
 ==Line of Succession==


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
Captain can make changes to SOP and never tell anyone but sec, which is a bad idea IMO. Crew should know to keep security and the captain accountable of the SOP changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Change to SOP, Captains now have to publicly announce the change they made to SOP for better accountability.
