### PR TITLE
Add petting to scrimpering whimperlets

### DIFF
--- a/Resources/Locale/en-US/_DV/interaction/interaction-popup-component.ftl
+++ b/Resources/Locale/en-US/_DV/interaction/interaction-popup-component.ftl
@@ -10,3 +10,6 @@ petting-failure-security-cyborg = You reach out to pet {THE($target)}, but {POSS
 
 petting-success-supplybot = You pet {THE($target)} on {POSS-ADJ($target)} smooth metal head.
 petting-failure-supplybot = You reach out to pet {THE($target)}, but {SUBJECT($target)} doesn't seem to notice.
+
+petting-success-whimperlet = You pet {THE($target)} on {POSS-ADJ($target)} pathetic little head.
+petting-failure-whimperlet = You reach out to pet {THE($target)}, but {SUBJECT($target)} shrinks back from you.

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/animals.yml
@@ -241,6 +241,13 @@
     spawned:
     - id: FoodMeat
       amount: 1
+  - type: InteractionPopup
+    successChance: 0.5
+    interactSuccessString: petting-success-whimperlet
+    interactFailureString: petting-failure-whimperlet
+    interactSuccessSpawn: EffectHearts
+    interactSuccessSound:
+      path: /Audio/_DV/Voice/Kitsune/fox_squeal1.ogg
   - type: SolutionContainerManager # Ready for implementing planned desired behaviour
     solutions:
       tearducts:


### PR DESCRIPTION
## About the PR
Adds petting functionality to the whimperlet

## Why / Balance
When the wimperlet spawned in a round, people were surprised it couldn't be pet. This PR rectifies this oversight.

## Technical details
- Added petting component to the YAML
- Added success and failure lines to the _DV namespace .ftl file that handles petting lines.

## Media
![image](https://github.com/user-attachments/assets/4aa95a84-0308-4b20-9881-a3846330e278)
![image](https://github.com/user-attachments/assets/b6023fd6-2711-4b5c-b068-f1aeb985e937)

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Whimperlets are now very slightly harder to pick up, as petting is now the default action.

**Changelog**

:cl:
- :hammer_pick: You can now pet Scrimpering Whimperlets.
