### PR TITLE
Kill explosives payloads from crafting

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -97,7 +97,7 @@
   - ScienceExplosives # sec gets everything for modular grenade making that sci does
   id: SecurityExplosives
   recipes:
-  - ExplosivePayload
+  #- ExplosivePayload # DeltaV - Removed
   - GrenadeBlast
   - GrenadeEMP
   - GrenadeFlash

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -92,7 +92,7 @@
   name: research-technology-explosive-technology
   icon:
     sprite: Objects/Devices/payload.rsi
-    state: payload-explosive-armed
+    state: payload-flash-armed # DeltaV - was payload-explosive-armed
   discipline: Arsenal
   tier: 1
   cost: 10000
@@ -102,7 +102,7 @@
   - VoiceTrigger
   - TimerTrigger
   - FlashPayload
-  - ExplosivePayload
+  #- ExplosivePayload # DeltaV - Removed
   - ChemicalPayload
   - SignallerDeadMans # DeltaV - Dead Man's Signaller
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR removes the explosive payloads from any form of crafting. They can still be obtainable by salvaging.

## Why / Balance
Mass production, inconspicuous syndie bomb in a duffelbag is bad. It shut downs any counterplay.

## Technical details
N/A

## Media
![image](https://github.com/user-attachments/assets/dbed174e-31e2-46c8-9456-1803f7add270)

![image](https://github.com/user-attachments/assets/f576980b-49a4-415b-aa09-4e32e10847b7)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed explosive payloads from crafting.