### PR TITLE
fix ransom buyback not working

### DIFF
--- a/Content.Server/_DV/Cargo/Systems/CargoSystem.Ransom.cs
+++ b/Content.Server/_DV/Cargo/Systems/CargoSystem.Ransom.cs
@@ -66,8 +66,8 @@ public sealed partial class CargoSystem
         if (GetEntity(args.Entity) is not { Valid: true } uid ||
             // got released already
             !TryComp<RansomComponent>(uid, out var ransom) ||
-            // not on a station
-            _station.GetOwningStation(uid) is not {} station ||
+            // console is not on a station
+            _station.GetOwningStation(ent.Owner) is not {} station ||
             !TryComp<StationBankAccountComponent>(station, out var bank) ||
             !TryComp<StationDataComponent>(station, out var stationData))
         {


### PR DESCRIPTION
it was checking ransomed mob not the computer and StationMember doesnt work when teleporting now or something

fixes #3804

:cl:
- fix: Fixed not being able to buy ransomed crewmembers.