### PR TITLE
remove traits from med and secborgs

### DIFF
--- a/Resources/Prototypes/_DV/Roles/Jobs/Medical/medical_borg.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Medical/medical_borg.yml
@@ -13,3 +13,4 @@
   icon: JobIconMedicalBorg
   supervisors: job-supervisors-cmo
   jobEntity: PlayerBorgMedical
+  applyTraits: false

--- a/Resources/Prototypes/_DV/Roles/Jobs/Security/securityborg.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Security/securityborg.yml
@@ -13,3 +13,4 @@
   icon: JobIconSecurityBorg
   supervisors: job-supervisors-everyone
   jobEntity: PlayerBorgSecurity
+  applyTraits: false


### PR DESCRIPTION
fixes #3809

they were missing the bool borg and AI have

:cl:
- fix: Fixed medical and security cyborg jobs having traits like accents apply.