### PR TITLE
Bugfix: high damage sources do not sever limbs when they should

### DIFF
--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
@@ -233,12 +233,17 @@ public partial class SharedBodySystem
         var partIdSlot = GetParentPartAndSlotOrNull(partEnt)?.Slot;
         var delta = args.DamageDelta;
 
+        // DeltaV: Start of modification: fix delayed severing bug
+        bool wouldBecomeDisabledByThisDamage = partEnt.Comp.Enabled &&
+            damageable.TotalDamage >= partEnt.Comp.IntegrityThresholds[TargetIntegrity.CriticallyWounded];
+        // DeltaV: End of modification
+
         if (args.CanSever
             && partEnt.Comp.CanSever
             && partIdSlot is not null
             && delta != null
             && !HasComp<BodyPartReattachedComponent>(partEnt)
-            && !partEnt.Comp.Enabled
+            && (!partEnt.Comp.Enabled || wouldBecomeDisabledByThisDamage) // DeltaV: fix delayed severing bug
             && partEnt.Comp.SeverThresholds.Any(threshold => CheckDamageThreshold(threshold, damageable.Damage)))
             severed = true;
 

--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
@@ -233,10 +233,10 @@ public partial class SharedBodySystem
         var partIdSlot = GetParentPartAndSlotOrNull(partEnt)?.Slot;
         var delta = args.DamageDelta;
 
-        // DeltaV: Start of modification: fix delayed severing bug
+        // Begin DeltaV additions: fix delayed severing bug
         bool wouldBecomeDisabledByThisDamage = partEnt.Comp.Enabled &&
             damageable.TotalDamage >= partEnt.Comp.IntegrityThresholds[TargetIntegrity.CriticallyWounded];
-        // DeltaV: End of modification
+        // End DeltaV additions
 
         if (args.CanSever
             && partEnt.Comp.CanSever


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->
## The bug
1. Take an unarmored urist, and hit their right arm with a bat a few times until they have exactly 44.x damage on the limb.
2. Take an explosive grenade. It deals 50 damage to limbs point blank. Set it off on the urist.
3. The urist now has 94.x damage on their hands, more than the sever threshold, but the limb is not severed
4. Defib them. This deals shock damage, but more importantly, updates limb damages causing the limb to finally sever.

![image](https://github.com/user-attachments/assets/1f56e88b-431b-435c-b3ac-132ec4dd94c0)

This bug happens only when
- before the single damage event, the observed limb is not critically wounded
- the single damage event pushes the limb into critically wounded AND above the sever threshold
- only a subsequent damage event will sever the limb

This happens because when the damages are applied, the following happens in order:
1. The damage values are added to the limb
2. The sever check is ran. Only limbs that are disabled can be severed
3. The body part is checked and it's enabled / disabled status is updated


## Fix
The body part check cannot be cleanly placed above the sever check, as it takes in the result of the sever check.
My minimal fix adds a step before the sever check that checks if the body part will be disabled because of the damage, and also allows the sever check to pass based on that.


## Considerations
No more defib popping of limbs

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Nope

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed limbs not getting correctly severed when receiving high amounts of damage at once. Defibs will no longer pop limbs off.

