### PR TITLE
early merge teg nerf

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/teg.yml
@@ -62,6 +62,7 @@
     # It fires processing on behalf of its connected circulators.
     - type: AtmosDevice
     - type: TegGenerator
+      thermalEfficiency: 0.1
 
     - type: DeviceNetwork
       deviceNetId: AtmosDevices


### PR DESCRIPTION
## About the PR
garteg is kill, const temp setup max power is only like 60kw now
you have to use radiators now as god intended

arena and tortugas tegs will need updating to not be awful roundstart though

## Why / Balance
see gamers novel

**Changelog**
:cl: ArtisticRoomba
- tweak: The TEG's efficiency in extracting power from gasses has been tweaked to promote dual-loop designs that recycle the waste heat of gasses, and punish "meta" single loop designs.