### PR TITLE
add disciplines to lathe/rnd computer prototypes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -510,6 +510,12 @@
     channels:
     - Science
   - type: TechnologyDatabase
+    supportedDisciplines: # DeltaV - don't change it in maps
+    - Industrial
+    - Biochemical
+    - Arsenal
+    - Experimental
+    - CivilianServices
   - type: ActivatableUI
     key: enum.ResearchConsoleUiKey.Key
   - type: UserInterface

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -49,6 +49,12 @@
     price: 800
   - type: ResearchClient
   - type: TechnologyDatabase
+    supportedDisciplines: # DeltaV - don't add it to every map
+    - Industrial
+    - Biochemical
+    - Arsenal
+    - Experimental
+    - CivilianServices
 
 # a lathe that can be sped up with space lube / slowed down with glue
 - type: entity


### PR DESCRIPTION
so they dont get saved by some bullshit and potentially break maps if a new discipline is added, similar to lathe recipes being locked on ancient maps