### PR TITLE
feat: Allow removing empty SmartFridge entries

### DIFF
--- a/Content.Client/_DV/SmartFridge/SmartFridgeBoundUserInterface.cs
+++ b/Content.Client/_DV/SmartFridge/SmartFridgeBoundUserInterface.cs
@@ -19,6 +19,7 @@ public sealed class SmartFridgeBoundUserInterface : BoundUserInterface
 
         _menu = this.CreateWindow<SmartFridgeMenu>();
         _menu.OnItemSelected += OnItemSelected;
+        _menu.OnRemoveButtonPressed += OnRemoveButtonPressed;
         Refresh();
     }
 
@@ -38,5 +39,10 @@ public sealed class SmartFridgeBoundUserInterface : BoundUserInterface
         if (data is not SmartFridgeListData entry)
             return;
         SendPredictedMessage(new SmartFridgeDispenseItemMessage(entry.Entry));
+    }
+
+    private void OnRemoveButtonPressed(SmartFridgeListData data)
+    {
+        SendPredictedMessage(new SmartFridgeRemoveEntryMessage(data.Entry));
     }
 }

--- a/Content.Client/_DV/SmartFridge/SmartFridgeItem.xaml
+++ b/Content.Client/_DV/SmartFridge/SmartFridgeItem.xaml
@@ -13,4 +13,10 @@
             SizeFlagsStretchRatio="3"
             HorizontalExpand="True"
             ClipText="True"/>
+    <TextureButton Name="RemoveButton"
+                   StyleClasses="CrossButtonRed"
+                   HorizontalAlignment="Right"
+                   VerticalAlignment="Center"
+                   Scale="0.75 0.75"
+                   Visible="True" />
 </BoxContainer>

--- a/Content.Client/_DV/SmartFridge/SmartFridgeItem.xaml.cs
+++ b/Content.Client/_DV/SmartFridge/SmartFridgeItem.xaml.cs
@@ -16,10 +16,7 @@ public sealed partial class SmartFridgeItem : BoxContainer
 
         EntityView.SetEntity(uid);
         NameLabel.Text = text;
-        RemoveButton.OnPressed += _ =>
-        {
-            RemoveButtonPressed?.Invoke();
-        };
+        RemoveButton.OnPressed += _ => RemoveButtonPressed?.Invoke();
 
         if (uid.IsValid())
             RemoveButton.Visible = false;

--- a/Content.Client/_DV/SmartFridge/SmartFridgeItem.xaml.cs
+++ b/Content.Client/_DV/SmartFridge/SmartFridgeItem.xaml.cs
@@ -8,11 +8,20 @@ namespace Content.Client._DV.SmartFridge;
 [GenerateTypedNameReferences]
 public sealed partial class SmartFridgeItem : BoxContainer
 {
+    public Action? RemoveButtonPressed;
+
     public SmartFridgeItem(EntityUid uid, string text)
     {
         RobustXamlLoader.Load(this);
 
         EntityView.SetEntity(uid);
         NameLabel.Text = text;
+        RemoveButton.OnPressed += _ =>
+        {
+            RemoveButtonPressed?.Invoke();
+        };
+
+        if (uid.IsValid())
+            RemoveButton.Visible = false;
     }
 }

--- a/Content.Client/_DV/SmartFridge/SmartFridgeMenu.xaml.cs
+++ b/Content.Client/_DV/SmartFridge/SmartFridgeMenu.xaml.cs
@@ -16,6 +16,7 @@ public sealed partial class SmartFridgeMenu : FancyWindow
     [Dependency] private readonly IEntityManager _entityManager = default!;
 
     public event Action<GUIBoundKeyEventArgs, ListData>? OnItemSelected;
+    public event Action<SmartFridgeListData>? OnRemoveButtonPressed;
 
     private readonly StyleBoxFlat _styleBox = new() { BackgroundColor = new Color(70, 73, 102) };
 
@@ -47,7 +48,9 @@ public sealed partial class SmartFridgeMenu : FancyWindow
             return;
 
         var label = Loc.GetString("smart-fridge-list-item", ("item", entry.Entry.Name), ("amount", entry.Amount));
-        button.AddChild(new SmartFridgeItem(entry.Representative, label));
+        var item = new SmartFridgeItem(entry.Representative, label);
+        item.RemoveButtonPressed += () => OnRemoveButtonPressed?.Invoke(entry);
+        button.AddChild(item);
 
         button.ToolTip = label;
         button.StyleBoxOverride = _styleBox;

--- a/Content.Shared/_DV/SmartFridge/SmartFridgeComponent.cs
+++ b/Content.Shared/_DV/SmartFridge/SmartFridgeComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.GameObjects;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._DV.SmartFridge;
 
@@ -35,7 +36,7 @@ public sealed partial class SmartFridgeComponent : Component
     [ViewVariables]
     public bool Ejecting => EjectEnd != null;
 
-    [DataField, AutoPausedField]
+    [DataField(customTypeSerializer:typeof(TimeOffsetSerializer)), AutoPausedField]
     public TimeSpan? EjectEnd;
 
     /// <summary>

--- a/Content.Shared/_DV/SmartFridge/SmartFridgeComponent.cs
+++ b/Content.Shared/_DV/SmartFridge/SmartFridgeComponent.cs
@@ -71,3 +71,9 @@ public sealed class SmartFridgeDispenseItemMessage(SmartFridgeEntry entry) : Bou
 {
     public SmartFridgeEntry Entry = entry;
 }
+
+[Serializable, NetSerializable]
+public sealed class SmartFridgeRemoveEntryMessage(SmartFridgeEntry entry) : BoundUserInterfaceMessage
+{
+    public SmartFridgeEntry Entry = entry;
+}

--- a/Content.Shared/_DV/SmartFridge/SmartFridgeComponent.cs
+++ b/Content.Shared/_DV/SmartFridge/SmartFridgeComponent.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared._DV.SmartFridge;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), AutoGenerateComponentPause]
 public sealed partial class SmartFridgeComponent : Component
 {
     [DataField]
@@ -28,6 +28,15 @@ public sealed partial class SmartFridgeComponent : Component
 
     [DataField, AutoNetworkedField]
     public Dictionary<SmartFridgeEntry, List<NetEntity>> ContainedEntries = new();
+
+    [DataField]
+    public TimeSpan EjectCooldown = TimeSpan.FromSeconds(1.2);
+
+    [ViewVariables]
+    public bool Ejecting => EjectEnd != null;
+
+    [DataField, AutoPausedField]
+    public TimeSpan? EjectEnd;
 
     /// <summary>
     ///     Sound that plays when ejecting an item


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
The Smartfridge currently doesn't have a way of clearing out-of-stock entries—once you insert a typo'd label into a smartfridge, it's there forever. This allows optionally removing those empty entries, as they are still useful for telling if an item is out of stock.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Typo gaming?

## Technical details
<!-- Summary of code changes for easier review. -->
There is an existing issue with the SmartFridge where it will mispredict the updated inventory count after dispensing an item, and this is now much more obvious with the flashing X that goes along with it. (See media.) I also am not really sure why this is happening, so I would appreciate someone who knows how BUI actually works taking a look at this before this is merged.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/1c4cc7e8-60ec-4070-bf0b-d4bd16b25284

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
