### PR TITLE
Replace Mindbreaking with Noöspheric Tampering

### DIFF
--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -170,7 +170,7 @@ Elevated alert status. ''The station is suffering dangerously high levels of gli
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew. Prepare for detonation of [[Glimmer#Probers|probers]].
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
-| style="border: 1px solid #000000;" | Engage with minimal force required; ROE on mindbreaking is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
+| style="border: 1px solid #000000;" | Engage with minimal force required; ROE on [mindbreaking] is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
 |}
 
 == <span style="color:#36717d;>Gamma Alert</span> ==

--- a/.wiki/_DV/Laws/SpaceLaw.txt
+++ b/.wiki/_DV/Laws/SpaceLaw.txt
@@ -109,7 +109,7 @@ Capital Sentences are organized in order of severity, with the least severe last
 <!--                      -->
 :*'''Licence restriction''': Downgrading or suspending the convict’s armament licence and confiscating possessions accordingly. May be applied when the convict is guilty of possession or a crime involving a weapon they were lawfully permitted to carry.
 <!--                      -->
-:*'''Mindbreaking''': Removal of the convict’s psionic power by use of mindbreaker toxin or any other means. May be applied when the convict is guilty of a crime in which they use psionics.
+:*'''[Mindbreaking]''': Removal of the convict’s psionic power by use of mindbreaker toxin or any other means. May be applied when the convict is guilty of a crime in which they use psionics.
 
 == Crime Modifiers ==
 Sentencing modifiers are to be applied by the sentencing officer, judge, or arbiter. Aggravating modifiers may not extend a sentence beyond the specified limit, while extenuating modifiers may not reduce a sentence below the specified limit.
@@ -216,9 +216,9 @@ Sentencing modifiers are to be applied by the sentencing officer, judge, or arbi
 |-
 | style="border:1px solid black;" | 304
 | style="border:1px solid black;" | [[File:SL_Mindbreaking.png]]
-| style="border:1px solid black;" | Mindbreaking
+| style="border:1px solid black;" | Noöspheric Tampering
 | style="border:1px solid black;" | 14 minutes
-| style="border:1px solid black;" | To unlawfully and maliciously rid a psionic of their powers
+| style="border:1px solid black;" | To maliciously tamper with or create noöspheric anomalies, entities, aberrations, or other elements; Or to otherwise deliberately perform actions that would raise Glimmer or other anomalous reading levels in a way that threatens normative reality.
 |-
 | style="border:1px solid black;" | 305
 | style="border:1px solid black;" | [[File:SL_Sabotage.png]]


### PR DESCRIPTION
Replaces 304 Grand Felony Mindbreaking with 304 Grand Felony Noöspheric Tampering, renames mindbreaking to something else



## Why / Balance
'being a cultist' or 'doing cult stuff' isnt illegal and sec has no right to arrest you for absorbing a rift. this fixes this. also lets you sue epi for makin an anomaly on 400 glimmer which is nice

## Technical details
need a better term for 'mindbreaking' as something that describes removing both cult affiliation and psyonic powers. In general the term is pretty eh.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**

:cl:
- tweak: Replaced 304: Mindbreaking with 304: Noöspheric Tampering

