### PR TITLE
give prisoners more rights

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -256,7 +256,10 @@ Prisoners have certain rights that must be upheld by law enforcement and Station
 
 * Adequate medical care and moral, spiritual, or legal counseling if it is requested and available.
 * Access to the Common and Prison radio channels only while serving their sentence. This right may be revoked should it be abused.
-* Clothing, food, and water on request.
+* Standard prisoner clothing must always be available for prisoners.
+* Confiscated clothing should be returned upon request, except in the case of Extended Confinement or if the clothing in question poses a clear risk to prisoner or crew safety.
+* Food and water for organic prisoners must be available and given on request.
+* Power for silicon prisoners such as IPCs and cyborgs, at minimum a cyborg recharging station must be provided.
 * Should the holding cells or Permabrig become uninhabitable, prisoners must be securely and safely relocated to another area for confinement, until the holding cells or Permabrig are returned to a serviceable state.
 * Prisoners should be granted freedom of movement within their holding area unless there is an undue risk to life and limb.
 


### PR DESCRIPTION
## About the PR
- you now have the unalienable right to prisoner clothes
- you have the right to your old clothes outside of perma if it doesnt threaten you or the crew (to have smartasses not say they must have their web vest back as its clothes)
- ipcs have the right to power
- food has to be available not just given on request, so sec cant just say food at centcom or take 20 minutes getting you something from another dimension

## Why / Balance
saul goodman gif

sec were fully within their rights to deprive ipcs of power i cant see how this would be bad :trollface:

shoe rights for life

**Changelog**
:cl:
- tweak: Update prisoner rights in SOP, notably sec is no longer allowed to deprive IPCs of power.