### PR TITLE
Accidental Discharges

### DIFF
--- a/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
@@ -8,5 +8,5 @@ public sealed partial class FireOnLandComponent : Component
     /// </summary>
     [DataField("Probability")]
     [ViewVariables(VVAccess.ReadWrite)]
-    public float Probability = 0.125f;
+    public float Probability = 0.1f;
 }

--- a/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
@@ -6,7 +6,6 @@ public sealed partial class FireOnLandComponent : Component
     /// <summary>
     /// Chance to trigger.
     /// </summary>
-    [DataField("Probability")]
-    [ViewVariables(VVAccess.ReadWrite)]
+    [DataField]
     public float Probability = 0.1f;
 }

--- a/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Server._DV.Weapons.Ranged.Components;
+
+[RegisterComponent]
+public sealed partial class FireOnLandComponent : Component
+{
+    /// <summary>
+    /// Chance to trigger.
+    /// </summary>
+    // [DataField("Chance", required: true)]
+    // [ViewVariables(VVAccess.ReadWrite)]
+    // public float Chance = 0.1f;
+}

--- a/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Components/FireOnLandComponent.cs
@@ -6,7 +6,7 @@ public sealed partial class FireOnLandComponent : Component
     /// <summary>
     /// Chance to trigger.
     /// </summary>
-    // [DataField("Chance", required: true)]
-    // [ViewVariables(VVAccess.ReadWrite)]
-    // public float Chance = 0.1f;
+    [DataField("Probability")]
+    [ViewVariables(VVAccess.ReadWrite)]
+    public float Probability = 0.125f;
 }

--- a/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
@@ -1,0 +1,26 @@
+using Content.Server._DV.Weapons.Ranged.Components;
+using Content.Server.Weapons.Ranged.Systems;
+using Content.Shared.Throwing;
+using Content.Shared.Verbs;
+using Content.Shared.Weapons.Ranged.Components;
+
+namespace Content.Server._DV.Weapons.Ranged.Systems;
+
+public sealed class FireOnLandSystem : EntitySystem
+{
+    [Dependency] private readonly GunSystem _gunSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<FireOnLandComponent, LandEvent>(FireOnLand);
+    }
+
+    private void FireOnLand(Entity<FireOnLandComponent> ent, ref LandEvent args)
+    {
+        if (TryComp(ent, out GunComponent? gc))
+        {
+            _gunSystem.AttemptShoot(ent, gc);
+        }
+    }
+}

--- a/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
@@ -12,6 +12,7 @@ public sealed class FireOnLandSystem : EntitySystem
 {
     [Dependency] private readonly GunSystem _gunSystem = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -20,11 +21,11 @@ public sealed class FireOnLandSystem : EntitySystem
 
     private void FireOnLand(Entity<FireOnLandComponent> ent, ref LandEvent args)
     {
-        if (_random.Prob(ent.Comp.Probability) && TryComp(ent, out GunComponent? gc))
-        {
-            var dir = gc.DefaultDirection;
-            dir = new Vector2(-dir.Y, dir.X); // 90 degrees counter-clockwise, guns shoot down by default
-            _gunSystem.AttemptShoot(ent, ent, gc, new EntityCoordinates(ent, dir));
-        }
+        if (!_random.Prob(ent.Comp.Probability) || !TryComp(ent, out GunComponent? gc))
+            return;
+
+        var dir = gc.DefaultDirection;
+        dir = new Vector2(-dir.Y, dir.X); // 90 degrees counter-clockwise, guns shoot down by default
+        _gunSystem.AttemptShoot(ent, ent, gc, new EntityCoordinates(ent, dir));
     }
 }

--- a/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
@@ -2,7 +2,6 @@ using System.Numerics;
 using Content.Server._DV.Weapons.Ranged.Components;
 using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.Throwing;
-using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.Map;
 using Robust.Shared.Random;

--- a/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Systems/FireOnLandSystem.cs
@@ -1,15 +1,18 @@
+using System.Numerics;
 using Content.Server._DV.Weapons.Ranged.Components;
 using Content.Server.Weapons.Ranged.Systems;
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
 
 namespace Content.Server._DV.Weapons.Ranged.Systems;
 
 public sealed class FireOnLandSystem : EntitySystem
 {
     [Dependency] private readonly GunSystem _gunSystem = default!;
-
+    [Dependency] private readonly IRobustRandom _random = default!;
     public override void Initialize()
     {
         base.Initialize();
@@ -18,9 +21,11 @@ public sealed class FireOnLandSystem : EntitySystem
 
     private void FireOnLand(Entity<FireOnLandComponent> ent, ref LandEvent args)
     {
-        if (TryComp(ent, out GunComponent? gc))
+        if (_random.Prob(ent.Comp.Probability) && TryComp(ent, out GunComponent? gc))
         {
-            _gunSystem.AttemptShoot(ent, gc);
+            var dir = gc.DefaultDirection;
+            dir = new Vector2(-dir.Y, dir.X); // 90 degrees counter-clockwise, guns shoot down by default
+            _gunSystem.AttemptShoot(ent, ent, gc, new EntityCoordinates(ent, dir));
         }
     }
 }

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -68,7 +68,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
-  - type: FireOnLand # DeltaV
+  - type: FireOnLand # DeltaV - gun safety
 
 - type: entity
   name: viper

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -68,6 +68,7 @@
   - type: Appearance
   - type: StaticPrice
     price: 500
+  - type: FireOnLand # DeltaV
 
 - type: entity
   name: viper


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Whenever a pistol hits the ground (via throwing, tripping, or any physics-based method) there is a small chance for it to fire.

## Why / Balance
[relevant wyci thread](https://discord.com/channels/968983104247185448/1377275359598215209)
It's funny, and also slightly discourages secoffs from open-carrying their pistol 24/7.
This currently applies only to ballistic, magazine-fed pistols- no revolvers or energy weapons. The chance of it happening is 10%, which felt pretty reasonable in testing, but might be worth adjusting.

## Technical details
Adds a `FireOnLandComponent` which does about what it says on the tin. Any gun inheriting from `BaseWeaponPistol` gets the component.

## Media
(probability adjusted for comedic effect)

https://github.com/user-attachments/assets/b2db57ca-cf72-4224-adce-a337b9f886b1



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

## Licensing
I am sublicensing this PR under MIT, seeing as there is evidently some interest in porting this places

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Pistols now have a small chance to fire upon hitting the ground.
