### PR TITLE
Remove the LO knuckledusters from the locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -20,7 +20,7 @@
     - id: RubberStampDenied
     - id: RubberStampQm
     - id: AstroNavCartridge
-    - id: ClothingHandsKnuckleDustersQM
+    #- id: ClothingHandsKnuckleDustersQM # DeltaV - No weaponry for LO.
     #- id: MailTeleporterMachineCircuitboard # DeltaV - upstream deliveries not ported yet
 
 - type: entity

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -238,16 +238,15 @@
     stealGroup: BoxFolderQmClipboard
     owner: job-name-qm
 
-# DeltaV - Removed the knuckledusters from the locker.
-#- type: entity
-#  parent: BaseTraitorStealObjective
-#  id: KnuckleDustersStealObjective
-#  components:
-#  - type: NotJobRequirement
-#    job: Quartermaster
-#  - type: StealCondition
-#    stealGroup: ClothingHandsKnuckleDustersQM
-#    owner: job-name-qm
+- type: entity
+  parent: BaseTraitorStealObjective
+  id: KnuckleDustersStealObjective
+  components:
+  - type: NotJobRequirement
+    job: Quartermaster
+  - type: StealCondition
+    stealGroup: ClothingHandsKnuckleDustersQM
+    owner: job-name-qm
 
 ## hop
 

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -238,15 +238,16 @@
     stealGroup: BoxFolderQmClipboard
     owner: job-name-qm
 
-- type: entity
-  parent: BaseTraitorStealObjective
-  id: KnuckleDustersStealObjective
-  components:
-  - type: NotJobRequirement
-    job: Quartermaster
-  - type: StealCondition
-    stealGroup: ClothingHandsKnuckleDustersQM
-    owner: job-name-qm
+# DeltaV - Removed the knuckledusters from the locker.
+#- type: entity
+#  parent: BaseTraitorStealObjective
+#  id: KnuckleDustersStealObjective
+#  components:
+#  - type: NotJobRequirement
+#    job: Quartermaster
+#  - type: StealCondition
+#    stealGroup: ClothingHandsKnuckleDustersQM
+#    owner: job-name-qm
 
 ## hop
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
Why would we give weaponry to the head of logistics. They shouldn't be carrying weapons unless there is a proper threat, which is security's duty to handle.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed LO's knuckledusters from their locker.
