### PR TITLE
Corruptible figurines

### DIFF
--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
@@ -28,6 +28,8 @@ public sealed class CosmicCorruptingSystem : EntitySystem
         new(1, -1),
     ];
 
+    private HashSet<EntityUid> _entsOnTile = new();
+
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
     [Dependency] private readonly IRobustRandom _rand = default!;
     [Dependency] private readonly TileSystem _tile = default!;
@@ -118,7 +120,9 @@ public sealed class CosmicCorruptingSystem : EntitySystem
 
                 //corrupt all entities on tile
                 var coords = new EntityCoordinates(gridUid, pos + new Vector2(0.5f, 0.5f));
-                foreach (var convertedEnt in _lookup.GetEntitiesInRange(coords, .49f).ToList())
+                _entsOnTile.Clear();
+                _entsOnTile = _lookup.GetEntitiesInRange(coords, .49f).ToHashSet();
+                foreach (var convertedEnt in _entsOnTile)
                 {
                     ConvertEntity(convertedEnt, ent);
                 }

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
@@ -93,7 +93,6 @@
       rarePrototypes:
       - ToyFigurineNukieElite
       - ToyFigurineNukieCommander
-      - ToyFigurineCosmicCultist # DeltaV Figurine, see Resources/Prototypes/_DV/Entities/Objects/Fun/toys.yml
       rareChance: 0.05
       prototypes:
       - ToyFigurinePassenger

--- a/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurine_boxes.yml
@@ -166,7 +166,4 @@
       - id: ToyFigurineNeuroticist
         orGroup: SpacemenFig
         prob: 0.10
-      - id: ToyFigurineCosmicCultist
-        prob: 0.50
-        orGroup: SpacemenFig
         # End DeltaV Additions

--- a/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/figurines.yml
@@ -17,6 +17,8 @@
   - type: Tag
     tags:
     - Figurine
+  - type: CosmicCorruptible # DeltaV - corrupt figurines
+    convertTo: ToyFigurineCosmicCultist
   - type: UseDelay
     delay: 5
   - type: TriggerOnActivate


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Tweaked CosmicCorruptingSystem to allow any entities on a tile be corrupted. Figurines get corrupted into cosmic cultist figurines.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
sauce

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
![image](https://github.com/user-attachments/assets/46f028fa-d4da-4b43-902e-bfd20017ae84)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Figurines now can be corrupted to the cult too!
