### PR TITLE
Recolor Salbutamol to be different from Diph

### DIFF
--- a/Resources/Prototypes/_Funkystation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/medicine.yml
@@ -93,7 +93,7 @@
   desc: reagent-desc-salbutamol
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
-  color: "#639cc7"
+  color: "#639cc7" # DeltaV - was #99ffff
   metabolisms:
     Medicine:
       metabolismRate: 0.2

--- a/Resources/Prototypes/_Funkystation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/medicine.yml
@@ -93,7 +93,7 @@
   desc: reagent-desc-salbutamol
   physicalDesc: reagent-physical-desc-cloudy
   flavor: medicine
-  color: "#99ffff"
+  color: "#639cc7"
   metabolisms:
     Medicine:
       metabolismRate: 0.2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Changed the color of Salbutamol so it's easier to distinguish from Diph.

**Before**:
![image](https://github.com/user-attachments/assets/95db6d3c-df71-498d-a305-68b1eb015dbc)
![image](https://github.com/user-attachments/assets/48889cb1-ac3a-48b4-8182-e15cabb9a0fe)

**After**:
![image](https://github.com/user-attachments/assets/c3072b60-2eeb-418e-9583-94a4b9f60b8d)
Left is Diph, center is Salb, the bottles on the right are various other commonly carried chems + ambuzol

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Salb and Diph are commonly carried and it's a QoL to make them different colored. Also, salb has the "cloudy" visual description so it makes sense for it to be a bit darker.

## Technical details
<!-- Summary of code changes for easier review. -->
one line yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Salbutamol is slightly darker now
