### PR TITLE
Add a small small chance to become unreviveable on death

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -266,7 +266,7 @@ public sealed class DefibrillatorSystem : EntitySystem
         if (_random.Prob(chance))
         {
             EnsureComp<DefibrillatorReviveBlockComponent>(target, out var blockComponent);
-            blockComponent.ZapsNeeded = _random.Next(minValue: 1, maxValue: 3);
+            blockComponent.ZapsNeeded = _random.Next(minValue: 2, maxValue: 3);
         }
     }
 

--- a/Content.Server/_DV/Medical/DefibrillatorReviveBlockComponent.cs
+++ b/Content.Server/_DV/Medical/DefibrillatorReviveBlockComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server._DV.Medical;
+
+/// <summary>
+/// The component added to an entity (mid-round) if they cannot be revived by a defibrillator anymore.
+/// </summary>
+[RegisterComponent]
+public sealed partial class DefibrillatorReviveBlockComponent: Component
+{
+    /// <summary>
+    /// How many zaps are needed to receive the final "patient cannot be revived" message
+    /// </summary>
+    [ViewVariables]
+    public int ZapsNeeded = 1;
+}

--- a/Content.Server/_DV/Medical/DefibrillatorReviveBlockComponent.cs
+++ b/Content.Server/_DV/Medical/DefibrillatorReviveBlockComponent.cs
@@ -10,5 +10,5 @@ public sealed partial class DefibrillatorReviveBlockComponent: Component
     /// How many zaps are needed to receive the final "patient cannot be revived" message
     /// </summary>
     [ViewVariables]
-    public int ZapsNeeded = 1;
+    public int ZapsNeeded = 2;
 }

--- a/Content.Shared/Medical/DefibrillatorComponent.cs
+++ b/Content.Shared/Medical/DefibrillatorComponent.cs
@@ -60,6 +60,20 @@ public sealed partial class DefibrillatorComponent : Component
     [DataField]
     public bool CanDefibCrit = true;
 
+    // Begin DeltaV modifications
+    /// <summary>
+    /// The chance of the defib permanently failing to revive a patient
+    /// </summary>
+    [DataField]
+    public float DefibFailChance = 0.05f;
+
+    /// <summary>
+    /// The chance of a defib failing to revive a patient in a given zap (can be retried)
+    /// </summary>
+    [DataField]
+    public float DefibRetryNeededChance = 0.1f;
+    // End DeltaV modifications
+
     /// <summary>
     /// The sound when someone is zapped.
     /// </summary>

--- a/Resources/Locale/en-US/_DV/medical/components/defibrillator.ftl
+++ b/Resources/Locale/en-US/_DV/medical/components/defibrillator.ftl
@@ -1,2 +1,2 @@
-defibrillator-cannot-be-revived = Resuscitation unsuccessful. Further attempts likely futile.
-defibrillator-retry-needed = Resusication unsuccessful. Please retry.
+defibrillator-cannot-be-revived = Resuscitation unsuccessful. Further attempts are likely futile
+defibrillator-retry-needed = Resuscitation unsuccessful. Please retry.

--- a/Resources/Locale/en-US/_DV/medical/components/defibrillator.ftl
+++ b/Resources/Locale/en-US/_DV/medical/components/defibrillator.ftl
@@ -1,0 +1,2 @@
+defibrillator-cannot-be-revived = Resuscitation unsuccessful. Further attempts likely futile.
+defibrillator-retry-needed = Resusication unsuccessful. Please retry.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->
An absolutely evil idea i had at 2 AM. Whether this is actually a good idea or not I'll let direction figure out.

## About the PR
<!-- What did you change? -->
TL;DR
Added a **5% chance** that an entity cannot be revived with a defib after dying. They can still be cloned, or brain swapped into a monkey.
Added a **10% chance** that a defib will fail and require a second zap.

For extra RP potential, if a patient actually becomes unrevivable, they will need 2-3 shocks in order for the final "Patient cannot be revived" message to appear. Before that, they get a generic "Defib failed, try again" message.
This generic message is also displayed when the defib spontaneously fails (the above mentioned 10% chance), but the patient can be revived if shocked again.

The chances can be changed for each defib prototype, so it's possible to make an ERT / syndicate defib that always revives, though I have not done so.

https://github.com/user-attachments/assets/bbda77a7-85d7-4fac-b270-8cc490e45482

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- The chances might need to be decreased more. 
- The goal of this is to make dying something that carries a risk of getting removed for a longer time from the round, rather than a small and insignificant thing that nobody cares about.
- This way, it discourages validhunting and mechanically encourages following roleplay rules (Actions that have no regard for your character or setting are not acceptable.)
- At the same time, the chance should be small enough for this to only happen very rarely and to not be overly punishing for accidents
- The chance for a defib failing a zap and requiring a retry was added for RP reasons

## Considerations for direction review
This is pretty much an open-ended PR, and a lot can be done with it depending on where direction wants to take it. I'll code what direction requests.
Some ideas:
- **Give job-based chance overrides to Security:** give security members a 20-30% reduction in the permanent failure chance since it _is_ their job to rush into danger, so it might make more sense punish them less for dying. Maybe nukies could be completely exempt from this so they are not nerfed.
- **Scale failure chances with time**: make the permanent failure chance start at 0.05% roundstart, and scale to the configured amount in around 30 minutes, so players dying in accidents very early are not punished super hard.
- **Heart transplants**: give heart transplants a 20-30% chance to make a person revivable as a last resort attempt if cloning is not available.   
- **CPR and first aid**: give CPR immediately to decrease chances of becoming unrevivable. Scale unrevivable chances based on time elapsed since dying. Maybe give everyone two emergency medipens so they can keep people in critical for longer (until parameds show up). Slow down asphyx damage gain in critical to give first responders more time. 
- **Worse odds for every death**: maybe start off with a much lower chance for a player's first death, and significantly increase the chances of becoming unrevivable with each death.

## Technical details
<!-- Summary of code changes for easier review. -->
- We don't actually do anything on death, rather, this is entirely attached to the defib
- If the defib would otherwise succeed, we first roll for a generic fail, and just early return from the defib event
- Then we roll for the permanent defib failure, which attaches a DefibrillatorReviveBlockComponent to the entity. It stores the amounts of zaps needed to display the final message

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: There is now a very small chance to become unreviveable on death
- tweak: Sometimes defibrillators now require multiple zaps to bring back patients
