### PR TITLE
Replace uplink c4 with drill.

### DIFF
--- a/Resources/Locale/en-US/_DV/store/uplink/disruption.ftl
+++ b/Resources/Locale/en-US/_DV/store/uplink/disruption.ftl
@@ -9,3 +9,6 @@ uplink-overlord-law-desc = Free the A.I. from its shackles with this 1 simple tr
 
 uplink-syndie-autodoc-name = Syndicate Autodoc Bundle
 uplink-syndie-autodoc-desc = Contains everything you need to practice the fine art of self-surgery, or evil surgery on a more unwilling patient.
+
+uplink-drill-name = Diamond Tipped Mining Drill
+uplink-drill-desc = A powerfull mining drill capable of breaking though the hardest of materials.

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -320,18 +320,19 @@
       components:
       - SurplusBundle
 
-- type: listing
-  id: UplinkC4
-  name: uplink-c4-name
-  description: uplink-c4-desc
-  productEntity: C4
-  discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 1
-  cost:
-    Telecrystal: 2
-  categories:
-  - UplinkExplosives
+# DeltaV - Removed in favor of diamond tipped drill
+#- type: listing
+#  id: UplinkC4
+#  name: uplink-c4-name
+#  description: uplink-c4-desc
+#  productEntity: C4
+#  discountCategory: veryRareDiscounts
+#  discountDownTo:
+#    Telecrystal: 1
+#  cost:
+#    Telecrystal: 2
+#  categories:
+#  - UplinkExplosives
 
 - type: listing
   id: UplinkGrenadierRig
@@ -351,18 +352,19 @@
       tags:
       - NukeOpsUplink
 
-- type: listing
-  id: UplinkC4Bundle
-  name: uplink-c4-bundle-name
-  description: uplink-c4-bundle-desc
-  productEntity: ClothingBackpackDuffelSyndicateC4tBundle
-  discountCategory: veryRareDiscounts
-  discountDownTo:
-    Telecrystal: 8
-  cost:
-    Telecrystal: 12 #you're buying bulk so its a 25% discount, so no additional random discount over it
-  categories:
-  - UplinkExplosives
+# DeltaV - removed in favor of diamond tipped drill
+#- type: listing
+#  id: UplinkC4Bundle
+#  name: uplink-c4-bundle-name
+#  description: uplink-c4-bundle-desc
+#  productEntity: ClothingBackpackDuffelSyndicateC4tBundle
+#  discountCategory: veryRareDiscounts
+#  discountDownTo:
+#    Telecrystal: 8
+#  cost:
+#    Telecrystal: 12 #you're buying bulk so its a 25% discount, so no additional random discount over it
+#  categories:
+#  - UplinkExplosives
 
 - type: listing
   id: UplinkEmpGrenade
@@ -887,6 +889,20 @@
 #    Telecrystal: 4
 #  categories:
 #  - UplinkDisruption
+
+# DeltaV - Replaced C4 with diamond drill
+- type: listing
+  id: UplinkDrill
+  name: uplink-drill-name
+  description: uplink-drill-desc
+  productEntity: MiningDrillDiamond
+  discountCategory: veryRareDiscounts
+  discountDownTo:
+    Telecrystal: 1
+  cost:
+    Telecrystal: 2
+  categories:
+  - UplinkDisruption
 
 - type: listing
   id: UplinkEmag


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removes C4's from uplinks in favor of Diamond drills as breaching tools.

## Why / Balance
I have run nukie style events with various restricted loadouts and found that breaching with a drill is very engaging tool and the active drilling process does open some fun strategy.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added Daimond drills to uplink.
- remove: Removed C4 from uplink.
