### PR TITLE
Robotech Surgical Tools

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -11,7 +11,12 @@
     HandheldHealthAnalyzer: 3
     Scalpel: 2
     SawElectric: 2
-    #Bonesetter: 2 add when robotics
+    # Begin DeltaV additions
+    Retractor: 2
+    Hemostat: 2
+    Cautery: 2
+    BoneGel: 2
+    # End DeltaV additions
     NitrousOxideTankFilled: 2
     ClothingMaskBreathMedical: 5
     ClothingHeadHatWeldingMaskFlame: 2 # DeltaV - Changed from 1 to 2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds the rest of the necessary surgical tools to the Robotech Deluxe.

## Why / Balance
Roboticists already get about half of the tools they need, and most maps don't have them, well, mapped. This is just a nice QoL so that roboticists don't need to beg Med or use their tools when they already should have the tools.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Robotech Deluxe now has a full set of surgical tools for Roboticists to use.
