### PR TITLE
Cyborg Adjustments - Healing + Armor

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -103,13 +103,9 @@
     - Common
     - Science
   - type: ZombieImmune
-  # Begin DeltaV Changes - use IPC healing instead of 1 weld to heal everything
-  #- type: Repairable
-  #  doAfterDelay: 10
-  #  allowSelfRepair: false
-  - type: WeldingHealable
-    allowSelfHeal: false
-  # End DeltaV Changes
+  - type: Repairable
+    doAfterDelay: 30 # Delta V - Bring back 1 weld  heal, but makes it take 3x Longer
+    allowSelfRepair: false
   - type: BorgChassis
   - type: SurgerySelfDirty # DeltaV: borgs get dirty from doing surgery
   - type: Fiber # DeltaV - borgs leave metal fibers

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -40,6 +40,8 @@
   components:
   - type: BorgSwitchableType
     selectedBorgType: generic
+  - type: Damageable # DeltaV
+    damageModifierSet: NTBorgLight
 
 - type: entity
   id: BorgChassisMining
@@ -48,6 +50,8 @@
   components:
   - type: BorgSwitchableType
     selectedBorgType: mining
+  - type: Damageable # DeltaV
+    damageModifierSet: NTBorgMedium
 
 - type: entity
   id: BorgChassisEngineer
@@ -56,6 +60,10 @@
   components:
   - type: BorgSwitchableType
     selectedBorgType: engineering
+  - type: Damageable # DeltaV
+    damageModifierSet: NTBorgMedium
+  - type: ExplosionResistance # DeltaV - Most likely to encounter mines+Gibtonite
+    damageCoefficient: .60
 
 - type: entity
   id: BorgChassisJanitor
@@ -64,6 +72,8 @@
   components:
   - type: BorgSwitchableType
     selectedBorgType: janitor
+  - type: Damageable # DeltaV
+    damageModifierSet: NTBorgMedium
 
 - type: entity
   id: BorgChassisMedical
@@ -72,6 +82,8 @@
   components:
   - type: BorgSwitchableType
     selectedBorgType: medical
+  - type: Damageable # DeltaV
+    damageModifierSet: NTBorgLight
 
 - type: entity
   id: BorgChassisService
@@ -80,6 +92,8 @@
   components:
   - type: BorgSwitchableType
     selectedBorgType: service
+  - type: Damageable # DeltaV
+    damageModifierSet: NTBorgLight
 
 - type: entity
   id: BorgChassisSyndicateAssault
@@ -112,6 +126,10 @@
       interactFailureString: petting-failure-syndicate-cyborg
       interactSuccessSound:
         path: /Audio/Ambience/Objects/periodic_beep.ogg
+    - type: Damageable # DeltaV
+      damageModifierSet: SyndicateBorgHeavy
+    - type: ExplosionResistance # DeltaV - Might be saved from the RPG
+      damageCoefficent: .5
 
 - type: entity
   id: BorgChassisSyndicateMedical
@@ -151,6 +169,8 @@
         collection: FootstepHoverBorg
         params:
           volume: -6
+    - type: Damageable # DeltaV
+      damageModifierSet: SyndicateBorgLight
 
 - type: entity
   id: BorgChassisSyndicateSaboteur
@@ -187,6 +207,8 @@
       interactFailureString: petting-failure-syndicate-cyborg
       interactSuccessSound:
         path: /Audio/Ambience/Objects/periodic_beep.ogg
+    - type: Damageable # DeltaV
+      damageModifierSet: SyndicateBorgMedium
 
 - type: entity
   id: BorgChassisDerelict
@@ -219,3 +241,5 @@
     interactFailureString: petting-failure-derelict-cyborg
     interactSuccessSound:
       path: /Audio/Ambience/Objects/periodic_beep.ogg
+  - type: Damageable # DeltaV
+    damageModifierSet: NTBorgLight

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -129,7 +129,7 @@
     - type: Damageable # DeltaV
       damageModifierSet: SyndicateBorgHeavy
     - type: ExplosionResistance # DeltaV - Might be saved from the RPG
-      damageCoefficent: .5
+      damageCoefficient: .5
 
 - type: entity
   id: BorgChassisSyndicateMedical

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -84,3 +84,59 @@
     Bloodloss: 0.0
     Cellular: 0.0
     Caustic: 0.0
+
+# Cyborg Damage Modifier Sets
+
+- type: damageModifierSet
+  id: NTBorgLight
+  coefficients:
+    Blunt: .8
+    Slash: .8
+    Piercing: .75
+    Shock: 1.5
+    Heat: .80
+
+- type: damageModifierSet
+  id: NTBorgMedium
+  coefficients:
+    Blunt: .7
+    Slash: .7
+    Piercing: .6
+    Shock: 1.5
+    Heat: .70
+
+- type: damageModifierSet
+  id: NTBorgHeavy
+  coefficients:
+    Blunt: .5
+    Slash: .5
+    Piercing: .5
+    Shock: 1.5
+    Heat: .5
+
+- type: damageModifierSet
+  id: SyndicateBorgLight
+  coefficients:
+    Blunt: .75
+    Slash: .75
+    Piercing: .70
+    Shock: 1.5
+    Heat: .75
+
+- type: damageModifierSet
+  id: SyndicateBorgMedium
+  coefficients:
+    Blunt: .65
+    Slash: .65
+    Piercing: .55
+    Shock: 1.5
+    Heat: .60
+
+- type: damageModifierSet
+  id: SyndicateBorgHeavy
+  coefficients:
+    Blunt: .40
+    Slash: .40
+    Piercing: .40
+    Shock: 1.5
+    Heat: .40

--- a/Resources/Prototypes/_DV/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -5,3 +5,5 @@
   components:
   - type: BorgSwitchableType
     selectedBorgType: security
+  - type: Damageable
+    damageModifierSet: NTBorgHeavy


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR buffs Cyborgs across the board, giving them all armor values that class as Light, Medium, or Heavy. NT and Syndicate Aligned Versions as well. This also returns them to their Repairable state, BUT, Extends the repair do-after to 30 seconds instead of its old 10 seconds

## Why / Balance
Cyborgs are pitifully squishy, and annoying to repair. So, this restores their old healing while also up-armoring their chassis in general

## Technical details
Just a ton of yaml

## Media
For testing purposes, all Borgs will be shot with Captain's laser Twice, to demonstrate each armor class

NT Borg Light Class (Generic, Service, Medical)
![image](https://github.com/user-attachments/assets/d0528e4d-de14-407f-bfb3-bede812f21de)

NT Borg Medium (Janitor, Engineer, Salvage)
![image](https://github.com/user-attachments/assets/49b62fa7-67f1-4b04-9137-3e081526781c)

NT Borg Heavy (Security)
![image](https://github.com/user-attachments/assets/86010991-9e4e-4802-b9be-0ca31fa2dae4)

Syndie Borg Light (Medical)
![image](https://github.com/user-attachments/assets/217325b9-a9f7-403e-b7d0-2dfbf4d3d49e)

Syndie Borg Medium (Saboteur)
![image](https://github.com/user-attachments/assets/385a9589-522e-4ec1-91c5-1ca296506383)

Syndie Borg Heavy (Assault)
![image](https://github.com/user-attachments/assets/8336e060-3480-4838-94d9-93e2f14c2a2c)

In Addition, Salvage and Syndie Assault Borgs have gained blast resistance, due to the fact Salvage borgs often encounter landmines+Gibtonite, and the SAB because it is a heavy combat borg and should be blast shielded
1 RPG Shot landed between the borgs
![image](https://github.com/user-attachments/assets/1d9641d6-902d-4143-9852-90906dd106c8)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Cyborgs across the system have had repair manuals updated and chassis reinforced. All borgs are now a bit tougher
- tweak: Syndicate agents rejoice, all syndicate borgs have been uparmored for your devious schemes