### PR TITLE
Cherrypick "Update locker storage to entity tables" from upstream + move our StorageFill to entityTables

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/biohazard.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/biohazard.yml
@@ -1,49 +1,84 @@
- - type: entity
-   id: ClosetL3Filled
-   suffix: Filled, Generic
-   parent: ClosetL3
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioGeneral
-       - id: ClothingHeadHatHoodBioGeneral
+- type: entity
+  id: ClosetL3Filled
+  suffix: Filled, Generic
+  parent: ClosetL3
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearGeneric
 
- - type: entity
-   id: ClosetL3VirologyFilled
-   suffix: Filled, Virology
-   parent: ClosetL3Virology
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioVirology
-       - id: ClothingHeadHatHoodBioVirology
+- type: entityTable
+  id: FillBiohazardGearGeneric
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioGeneral
+    - id: ClothingHeadHatHoodBioGeneral
 
- - type: entity
-   id: ClosetL3SecurityFilled
-   suffix: Filled, Security
-   parent: ClosetL3Security
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioSecurity
-       - id: ClothingHeadHatHoodBioSecurity
+- type: entity
+  id: ClosetL3VirologyFilled
+  suffix: Filled, Virology
+  parent: ClosetL3Virology
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearVirology
 
- - type: entity
-   id: ClosetL3JanitorFilled
-   suffix: Filled, Janitor
-   parent: ClosetL3Janitor
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioJanitor
-       - id: ClothingHeadHatHoodBioJanitor
+- type: entityTable
+  id: FillBiohazardGearVirology
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioVirology
+    - id: ClothingHeadHatHoodBioVirology
 
- - type: entity
-   id: ClosetL3ScienceFilled
-   suffix: Filled, Epistemics # DeltaV - Epistemics Department replacing Science
-   parent: ClosetL3Science
-   components:
-   - type: StorageFill
-     contents:
-       - id: ClothingOuterBioScientist
-       - id: ClothingHeadHatHoodBioScientist
+- type: entity
+  id: ClosetL3SecurityFilled
+  suffix: Filled, Security
+  parent: ClosetL3Security
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearSecurity
+
+- type: entityTable
+  id: FillBiohazardGearSecurity
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioSecurity
+    - id: ClothingHeadHatHoodBioSecurity
+
+- type: entity
+  id: ClosetL3JanitorFilled
+  suffix: Filled, Janitor
+  parent: ClosetL3Janitor
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearJanitor
+
+- type: entityTable
+  id: FillBiohazardGearJanitor
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioJanitor
+    - id: ClothingHeadHatHoodBioJanitor
+
+- type: entity
+  id: ClosetL3ScienceFilled
+  suffix: Filled, Epistemics # DeltaV - Epistemics Department replacing Science
+  parent: ClosetL3Science
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillBiohazardGearScience
+
+- type: entityTable
+  id: FillBiohazardGearScience
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterBioScientist
+    - id: ClothingHeadHatHoodBioScientist

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -6,10 +6,10 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillToolCloset
+        tableId: FillClosetTool
 
 - type: entityTable
-  id: FillToolCloset
+  id: FillClosetTool
   table: !type:AllSelector
     children:
     - id: ClothingOuterVestHazard
@@ -132,7 +132,7 @@
       entity_storage: !type:AllSelector
         children:
         - !type:NestedSelector
-          tableId: FillAtmosphericsLocker
+          tableId: FillLockerAtmospherics
         - !type:NestedSelector
           tableId: FillAtmosphericsHardsuit
 
@@ -144,10 +144,10 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillAtmosphericsLocker
+        tableId: FillLockerAtmospherics
 
 - type: entityTable
-  id: FillAtmosphericsLocker
+  id: FillLockerAtmospherics
   table: !type:AllSelector
     children:
     - id: ClothingMaskGasAtmos
@@ -178,7 +178,7 @@
       entity_storage: !type:AllSelector
         children:
         - !type:NestedSelector
-          tableId: FillEngineerLocker
+          tableId: FillLockerEngineer
         - !type:NestedSelector
           tableId: FillEngineerHardsuit
 
@@ -190,10 +190,10 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillEngineerLocker
+        tableId: FillLockerEngineer
 
 - type: entityTable
-  id: FillEngineerLocker
+  id: FillLockerEngineer
   table: !type:AllSelector
     children:
     - id: ClothingHandsGlovesColorYellow

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -150,6 +150,8 @@
   id: FillLockerAtmospherics
   table: !type:AllSelector
     children:
+    - !type:NestedSelector # DeltaV - Our additions
+      tableId: FillLockerAtmosphericsDeltaV
     - id: ClothingMaskGasAtmos
     - id: ClothingOuterSuitAtmosFire
     - id: ClothingHeadHelmetAtmosFire
@@ -164,6 +166,8 @@
   id: FillAtmosphericsHardsuit
   table: !type:AllSelector
     children:
+    - !type:NestedSelector # DeltaV - Our additions
+      tableId: FillAtmosphericsHardsuitDeltaV
     - id: ClothingOuterHardsuitAtmos
     - id: OxygenTankFilled
     - id: ClothingMaskBreath

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -3,60 +3,83 @@
   parent: ClosetTool
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterVestHazard
-        prob: 0.4
-      - id: FlashlightLantern
-        prob: 0.7
-      - id: Screwdriver
-        prob: 0.7
-      - id: Wrench
-        prob: 0.7
-      - id: Welder
-        prob: 0.7
-      - id: Crowbar
-        prob: 0.7
-      - id: Wirecutter
-        prob: 0.7
-      - id: Multitool
-        prob: 0.2
-      - id: trayScanner
-        prob: 0.7
-      - id: GasAnalyzer
-        prob: 0.7
-      - id: ClothingBeltUtility
-        prob: 0.2
-      - id: ClothingHandsGlovesColorYellow
-        prob: 0.05
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillToolCloset
+
+- type: entityTable
+  id: FillToolCloset
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterVestHazard
+      prob: 0.4
+    - id: FlashlightLantern
+      prob: 0.7
+    - id: Screwdriver
+      prob: 0.7
+    - id: Wrench
+      prob: 0.7
+    - id: Welder
+      prob: 0.7
+    - id: Crowbar
+      prob: 0.7
+    - id: Wirecutter
+      prob: 0.7
+    - id: Multitool
+      prob: 0.2
+    - id: trayScanner
+      prob: 0.7
+    - id: GasAnalyzer
+      prob: 0.7
+    - id: ClothingBeltUtility
+      prob: 0.2
+    - id: ClothingHandsGlovesColorYellow
+      prob: 0.05
+    - !type:GroupSelector
+      prob: 0.4
+      children:
       - id: ClothingHeadHatHardhatRed
-        prob: 0.4
-      - id: CableApcStack
-        prob: 0.3
-      - id: CableApcStack
-        prob: 0.3
-      - id: CableApcStack
-        prob: 0.3
-      - id: SprayPainter
-        prob: 0.7
+      - id: ClothingHeadHatHardhatBlue
+      - id: ClothingHeadHatHardhatOrange
+      - id: ClothingHeadHatHardhatWhite
+      - id: ClothingHeadHatHardhatYellow
+      - id: ClothingHeadHatHardhatYellowDark
+    - id: CableApcStack
+      prob: 0.3
+      rolls: !type:ConstantNumberSelector
+        value: 3
+    - id: SprayPainter
+      prob: 0.7
 
 - type: entity
   id: LockerElectricalSuppliesFilled
   suffix: Filled
   parent: LockerElectricalSupplies
   components:
-  - type: StorageFill
-    contents:
-      - id: ToolboxElectricalFilled
-        prob: 0.7
-      - id: FirelockElectronics
-        prob: 0.05
-      - id: APCElectronics
-        prob: 0.1
-      - id: CableMVStack
-        prob: 0.2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillElectricalSupplies
+
+- type: entityTable
+  id: FillElectricalSupplies
+  table: !type:AllSelector
+    children:
+    - id: ToolboxElectricalFilled
+      prob: 0.7
+    - id: FirelockElectronics
+      prob: 0.05
+    - id: APCElectronics
+      prob: 0.1
+    - !type:GroupSelector
+      prob: 0.5
+      children:
       - id: CableApcStack
-        prob: 0.3
+        weight: 5
+      - id: CableMVStack
+      - id: CableHVStack
+        weight: 0.5
 
 - type: entity
   id: LockerWeldingSuppliesFilled
@@ -104,86 +127,108 @@
   suffix: Filled, Hardsuit
   parent: LockerAtmospherics
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterHardsuitAtmos
-      - id: ClothingMaskGasAtmos
-      - id: ClothingShoesBootsMag # DeltaV - Give atmos techs boots and insuls
-      - id: ClothingOuterSuitAtmosFire
-      - id: ClothingHeadHelmetAtmosFire
-      - id: ClothingHandsGlovesColorYellow # DeltaV - Give atmos techs boots and insuls
-      - id: GasAnalyzer
-      - id: MedkitOxygenFilled
-      - id: HolofanProjector
-      - id: DoorRemoteFirefight # DeltaV - Re-added fire-fighting remote.
-      - id: RCD
-      - id: RCDAmmo
-      - id: LunchboxEngineeringFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
-      - id: AirGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillAtmosphericsLocker
+        - !type:NestedSelector
+          tableId: FillAtmosphericsHardsuit
 
 - type: entity
   id: LockerAtmosphericsFilled
   suffix: Filled
   parent: LockerAtmospherics
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingMaskGasAtmos
-      - id: ClothingOuterSuitAtmosFire
-      - id: ClothingHeadHelmetAtmosFire
-      - id: ClothingHandsGlovesColorYellow # DeltaV - Give atmos techs boots and insuls
-      - id: GasAnalyzer
-      - id: MedkitOxygenFilled
-      - id: HolofanProjector
-      - id: DoorRemoteFirefight # DeltaV - Re-added fire-fighting remote.
-      - id: RCD
-      - id: RCDAmmo
-      - id: LunchboxEngineeringFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
-      - id: AirGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillAtmosphericsLocker
+
+- type: entityTable
+  id: FillAtmosphericsLocker
+  table: !type:AllSelector
+    children:
+    - id: ClothingMaskGasAtmos
+    - id: ClothingOuterSuitAtmosFire
+    - id: ClothingHeadHelmetAtmosFire
+    - id: GasAnalyzer
+    - id: MedkitOxygenFilled
+    - id: HolofanProjector
+    - id: RCD
+    - id: RCDAmmo
+    - id: AirGrenade
+
+- type: entityTable
+  id: FillAtmosphericsHardsuit
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterHardsuitAtmos
+    - id: OxygenTankFilled
+    - id: ClothingMaskBreath
 
 - type: entity
   id: LockerEngineerFilledHardsuit
   suffix: Filled, Hardsuit
   parent: LockerEngineer
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterHardsuitEngineering
-      - id: ClothingHandsGlovesColorYellow
-      - id: ClothingMaskGas
-      - id: ClothingShoesBootsMag
-      - id: RCD
-      - id: RCDAmmo
-      - id: LunchboxEngineeringFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
-      - id: MetalFoamGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillEngineerLocker
+        - !type:NestedSelector
+          tableId: FillEngineerHardsuit
 
 - type: entity
   id: LockerEngineerFilled
   suffix: Filled
   parent: LockerEngineer
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingHandsGlovesColorYellow
-      - id: ClothingMaskGas
-      - id: trayScanner
-      - id: RCD
-      - id: RCDAmmo
-      - id: LunchboxEngineeringFilledRandom # DeltaV - Lunchboxes!
-        prob: 0.3
-      - id: MetalFoamGrenade
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillEngineerLocker
+
+- type: entityTable
+  id: FillEngineerLocker
+  table: !type:AllSelector
+    children:
+    - id: ClothingHandsGlovesColorYellow
+    - id: ClothingMaskGas
+    - id: trayScanner
+    - id: RCD
+    - id: RCDAmmo
+    - id: MetalFoamGrenade
+
+- type: entityTable
+  id: FillEngineerHardsuit
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterHardsuitEngineering
+    - id: OxygenTankFilled
+    - id: ClothingShoesBootsMag
+    - id: ClothingMaskBreath
 
 - type: entity
   id: ClosetRadiationSuitFilled
   parent: ClosetRadiationSuit
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingOuterSuitRad
-        amount: 2
-      - id: GeigerCounter
-        amount: 2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillRadiationSuit
+
+- type: entityTable
+  id: FillRadiationSuit
+  table: !type:AllSelector
+    children:
+    - id: ClothingOuterSuitRad
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: GeigerCounter
+      amount: !type:ConstantNumberSelector
+        value: 2

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -3,15 +3,20 @@
   suffix: Filled
   parent: LockerScientist
   components:
-  - type: StorageFill
-    contents:
-      - id: ClothingHandsGlovesLatex
-      - id: ClothingHeadsetScience
-      - id: ClothingMaskSterile
-      - id: ClothingOuterCoatRnd
-      - id: AnomalyScanner
-      - id: NodeScanner
-      - id: NetworkConfigurator
-        prob: 0.5
-      - id: LunchboxEpistemicsFilledRandom # Delta-V Lunchboxes!
-        prob: 0.3
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillScientistLocker
+
+- type: entityTable
+  id: FillScientistLocker
+  table: !type:AllSelector
+    children:
+    - id: ClothingHandsGlovesLatex
+    - id: ClothingHeadsetScience
+    - id: ClothingMaskSterile
+    - id: ClothingOuterCoatRnd
+    - id: AnomalyScanner
+    - id: NodeScanner
+    - id: NetworkConfigurator
+      prob: 0.5

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -12,6 +12,8 @@
   id: FillLockerScientist
   table: !type:AllSelector
     children:
+    - !type:NestedSelector # DeltaV - Our additions
+      tableId: FillLockerScientistDeltaV
     - id: ClothingHandsGlovesLatex
     - id: ClothingHeadsetScience
     - id: ClothingMaskSterile

--- a/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/science.yml
@@ -6,10 +6,10 @@
   - type: EntityTableContainerFill
     containers:
       entity_storage: !type:NestedSelector
-        tableId: FillScientistLocker
+        tableId: FillLockerScientist
 
 - type: entityTable
-  id: FillScientistLocker
+  id: FillLockerScientist
   table: !type:AllSelector
     children:
     - id: ClothingHandsGlovesLatex

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -97,10 +97,8 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:AllSelector
-        children:
-        - !type:NestedSelector
-          tableId: FillEngineerHardsuit
+      entity_storage: !type:NestedSelector
+        tableId: FillEngineerHardsuit
   - type: AccessReader
     access: [["Engineering"]]
 
@@ -112,10 +110,8 @@
   components:
   - type: EntityTableContainerFill
     containers:
-      entity_storage: !type:AllSelector
-        children:
-        - !type:NestedSelector
-          tableId: FillAtmosphericsHardsuit
+      entity_storage: !type:NestedSelector
+        tableId: FillAtmosphericsHardsuit
   - type: AccessReader
     access: [["Atmospherics"]]
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/suit_storage.yml
@@ -95,12 +95,12 @@
   parent: SuitStorageBase
   suffix: Station Engineer
   components:
-  - type: StorageFill
-    contents:
-        - id: OxygenTankFilled
-        - id: ClothingShoesBootsMag
-        - id: ClothingOuterHardsuitEngineering
-        - id: ClothingMaskBreath
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillEngineerHardsuit
   - type: AccessReader
     access: [["Engineering"]]
 
@@ -110,12 +110,12 @@
   parent: SuitStorageBase
   suffix: Atmospheric Technician
   components:
-  - type: StorageFill
-    contents:
-        - id: OxygenTankFilled
-        - id: ClothingShoesBootsMag
-        - id: ClothingOuterHardsuitAtmos
-        - id: ClothingMaskBreath
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - !type:NestedSelector
+          tableId: FillAtmosphericsHardsuit
   - type: AccessReader
     access: [["Atmospherics"]]
 

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/emergency.yml
@@ -1,3 +1,4 @@
+# TODO: Move to EntityStorageFill once upstream does too to avoid copy paste.
 - type: entity
   parent: BoxSurvival
   id: BoxSurvivalBrigmedic

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
@@ -1,21 +1,29 @@
+# This abstract should be killed and replaced for upstream's once they move to EntityTableContainerFill.
+- type: entity
+  abstract: true
+  parent: BoxCardboard
+  id: BoxEncryptionKeyDeltaV # Avoiding StorageFill
+  name: passenger encryption key box
+  description: A box of spare encryption keys.
+  components:
+  - type: Sprite
+    layers:
+    - state: box
+    - state: encryptokey
+  - type: Storage
+    whitelist:
+      components:
+      - EncryptionKey
+
 - type: entity
   name: Prisoner encryption key box
-  parent: BoxCardboard
+  parent: BoxEncryptionKeyDeltaV
   id: BoxEncryptionKeyPrisoner
-  description: A box of spare encryption keys.
   components:
   - type: EntityTableContainerFill
     containers:
       storagebase: !type:NestedSelector
         tableId: FillBoxEncryptionKeyPrisoner
-  - type: Sprite
-    layers:
-      - state: box
-      - state: encryptokey
-  - type: Storage
-    whitelist:
-      components:
-      - EncryptionKey
 
 - type: entityTable
   id: FillBoxEncryptionKeyPrisoner
@@ -26,10 +34,9 @@
         value: 4
 
 - type: entity
-  parent: BoxEncryptionKeyPassenger
+  parent: BoxEncryptionKeyDeltaV
   id: BoxEncryptionKeyTraffic
   name: traffic encryption key box
-  description: A box of spare encryption keys.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -46,9 +53,8 @@
 
 - type: entity
   name: justice encryption key box
-  parent: BoxEncryptionKeyPassenger
+  parent: BoxEncryptionKeyDeltaV
   id: BoxEncryptionKeyJustice
-  description: A box of spare encryption keys.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -67,7 +73,6 @@
   name: syndicate radio implanter box
   parent: BoxCardboard
   id: BoxSyndicateRadioImplanter
-  description: Contains cranial radio implants favored by Syndicate agents.
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/general.yml
@@ -4,10 +4,10 @@
   id: BoxEncryptionKeyPrisoner
   description: A box of spare encryption keys.
   components:
-  - type: StorageFill
-    contents:
-      - id: EncryptionKeyPrison
-        amount: 4
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxEncryptionKeyPrisoner
   - type: Sprite
     layers:
       - state: box
@@ -17,16 +17,32 @@
       components:
       - EncryptionKey
 
+- type: entityTable
+  id: FillBoxEncryptionKeyPrisoner
+  table: !type:AllSelector
+    children:
+    - id: EncryptionKeyPrison
+      amount: !type:ConstantNumberSelector
+        value: 4
+
 - type: entity
   parent: BoxEncryptionKeyPassenger
   id: BoxEncryptionKeyTraffic
   name: traffic encryption key box
   description: A box of spare encryption keys.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxEncryptionKeyTraffic
+
+- type: entityTable
+  id: FillBoxEncryptionKeyTraffic
+  table: !type:AllSelector
+    children:
     - id: EncryptionKeyTraffic
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   name: justice encryption key box
@@ -34,10 +50,18 @@
   id: BoxEncryptionKeyJustice
   description: A box of spare encryption keys.
   components:
-  - type: StorageFill
-    contents:
-      - id: EncryptionKeyJustice
-        amount: 4
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxEncryptionKeyJustice
+
+- type: entityTable
+  id: FillBoxEncryptionKeyJustice
+  table: !type:AllSelector
+    children:
+    - id: EncryptionKeyJustice
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   name: syndicate radio implanter box
@@ -49,10 +73,18 @@
     layers:
     - state: box_of_doom
     - state: implant
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxSyndicateRadioImplanter
+
+- type: entityTable
+  id: FillBoxSyndicateRadioImplanter
+  table: !type:AllSelector
+    children:
     - id: SyndicateRadioImplanter
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
 
 - type: entity
   name: syndicate hostage implanter box
@@ -71,10 +103,18 @@
     whitelist:
       components:
       - Implanter
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxSyndicateHostageImplanter
+
+- type: entityTable
+  id: FillBoxSyndicateHostageImplanter
+  table: !type:AllSelector
+    children:
     - id: HostageImplanter
-      amount: 6
+      amount: !type:ConstantNumberSelector
+        value: 6
 
 - type: entity
   name: syndicate handcuff box
@@ -93,10 +133,18 @@
     whitelist:
       components:
       - Handcuff
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxSyndicateHandcuffBundle
+
+- type: entityTable
+  id: FillBoxSyndicateHandcuffBundle
+  table: !type:AllSelector
+    children:
     - id: Handcuffs
-      amount: 10
+      amount: !type:ConstantNumberSelector
+        value: 10
 
 - type: entity
   parent: BoxCardboard
@@ -112,8 +160,15 @@
     maxItemSize: Normal
     grid:
     - 0,0,3,1
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxSyndicateStunBundle
+
+- type: entityTable
+  id: FillBoxSyndicateStunBundle
+  table: !type:AllSelector
+    children:
     - id: Stunbaton
     - id: WeaponDisabler
 
@@ -127,9 +182,18 @@
     layers:
     - state: box_of_doom
     - state: writing_of_doom
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxSyndicateFirebugsFestival
+
+- type: entityTable
+  id: FillBoxSyndicateFirebugsFestival
+  table: !type:AllSelector
+    children:
     - id: ChemistryBottleFirebugsFriend
-      amount: 8
+      amount: !type:ConstantNumberSelector
+        value: 8
     - id: SyndicateFlippo
-      amount: 1
+      amount: !type:ConstantNumberSelector
+        value: 1

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/medical.yml
@@ -4,8 +4,19 @@
   name: basic medicine bottle box
   description: A box full of bottles with medicine.
   components:
-  - type: StorageFill
-    contents:
+  - type: Sprite
+    layers:
+    - state: box
+    - state: bottle
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxBottleMedicineBasic
+
+- type: entityTable
+  id: FillBoxBottleMedicineBasic
+  table: !type:AllSelector
+    children:
     - id: ChemistryBottleBruizine
     - id: ChemistryBottleLacerinol
     - id: ChemistryBottlePuncturase
@@ -14,20 +25,26 @@
     - id: ChemistryBottleDiphenhydramine
     - id: ChemistryBottleOmnizine
     - id: ChemistryBottleEphedrine
-      amount: 2
-  - type: Sprite
-    layers:
-    - state: box
-    - state: bottle
+      amount: !type:ConstantNumberSelector
+        value: 2
 
 - type: entity
   parent: BoxBottleMedicineBasic
   id: BoxBottleMedicineAdvanced
   name: advanced medicine bottle box
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxBottleMedicineAdvanced
+
+- type: entityTable
+  id: FillBoxBottleMedicineAdvanced
+  table: !type:AllSelector
+    children:
     - id: ChemistryBottleOmnizine
-      amount: 7
+      amount: !type:ConstantNumberSelector
+        value: 7
     - id: ChemistryBottleEphedrine
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/pda.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/pda.yml
@@ -4,12 +4,19 @@
   id: BoxPDASecurity
   description: A box of spare PDA microcomputers for the security department.
   components:
-  - type: StorageFill
-    contents:
-      - id: SecurityPDA
-      - id: DetectivePDA
-      - id: WardenPDA
-      - id: SeniorOfficerPDA
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxPDASecurity
+
+- type: entityTable
+  id: FillBoxPDASecurity
+  table: !type:AllSelector
+    children:
+    - id: SecurityPDA
+    - id: DetectivePDA
+    - id: WardenPDA
+    - id: SeniorOfficerPDA
 
 - type: entity
   name: prisoner PDA box
@@ -17,10 +24,18 @@
   id: BoxPDAPrisoner
   description: A box of spare PDA microcomputers for the warden to use for prisoners.
   components:
-  - type: StorageFill
-    contents:
-      - id: PrisonerPDA
-        amount: 4
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxPDAPrisoner
+
+- type: entityTable
+  id: FillBoxPDAPrisoner
+  table: !type:AllSelector
+    children:
+    - id: PrisonerPDA
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   name: medical PDA box
@@ -28,12 +43,19 @@
   id: BoxPDAMedical
   description: A box of spare PDA microcomputers for the medical department.
   components:
-  - type: StorageFill
-    contents:
-      - id: MedicalPDA
-      - id: ChemistryPDA
-      - id: ParamedicPDA
-      - id: SeniorPhysicianPDA
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxPDAMedical
+
+- type: entityTable
+  id: FillBoxPDAMedical
+  table: !type:AllSelector
+    children:
+    - id: MedicalPDA
+    - id: ChemistryPDA
+    - id: ParamedicPDA
+    - id: SeniorPhysicianPDA
 
 - type: entity
   name: epistemics PDA box
@@ -41,12 +63,19 @@
   id: BoxPDAScience
   description: A box of spare PDA microcomputers for the epistemics department.
   components:
-  - type: StorageFill
-    contents:
-      - id: SciencePDA
-      - id: PsionicMantisPDA
-      - id: ChaplainPDA
-      - id: SeniorResearcherPDA
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxPDAScience
+
+- type: entityTable
+  id: FillBoxPDAScience
+  table: !type:AllSelector
+    children:
+    - id: SciencePDA
+    - id: PsionicMantisPDA
+    - id: ChaplainPDA
+    - id: SeniorResearcherPDA
 
 - type: entity
   name: engineering PDA box
@@ -54,12 +83,19 @@
   id: BoxPDAEngineering
   description: A box of spare PDA microcomputers for the engineering department.
   components:
-  - type: StorageFill
-    contents:
-      - id: EngineerPDA
-      - id: AtmosPDA
-      - id: SeniorEngineerPDA
-      - id: TechnicalAssistantPDA
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxPDAEngineering
+
+- type: entityTable
+  id: FillBoxPDAEngineering
+  table: !type:AllSelector
+    children:
+    - id: EngineerPDA
+    - id: AtmosPDA
+    - id: SeniorEngineerPDA
+    - id: TechnicalAssistantPDA
 
 - type: entity
   name: logistics PDA box
@@ -67,13 +103,22 @@
   id: BoxPDACargo
   description: A box of spare PDA microcomputers for the logistics department.
   components:
-  - type: StorageFill
-    contents:
-      - id: CargoPDA
-        amount: 2
-      - id: SalvagePDA
-      - id: MailCarrierPDA
-        amount: 1
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxPDACargo
+
+- type: entityTable
+  id: FillBoxPDACargo
+  table: !type:AllSelector
+    children:
+    - id: CargoPDA
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: SalvagePDA
+    - id: MailCarrierPDA
+      amount: !type:ConstantNumberSelector
+        value: 1
 
 - type: entity
   name: justice PDA box
@@ -81,9 +126,17 @@
   id: BoxPDAJustice
   description: A box of spare PDA microcomputers for the justice department.
   components:
-  - type: StorageFill
-    contents:
-      - id: LawyerPDA
-        amount: 2
-      - id: ProsecutorPDA
-      - id: ClerkPDA
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxPDAJustice
+
+- type: entityTable
+  id: FillBoxPDAJustice
+  table: !type:AllSelector
+    children:
+    - id: LawyerPDA
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: ProsecutorPDA
+    - id: ClerkPDA

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/pda.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/pda.yml
@@ -1,6 +1,17 @@
+# This abstract should be killed and replaced for upstream's once they move to EntityTableContainerFill.
+- type: entity
+  abstract: true
+  parent: BoxCardboard
+  id: BoxPDADeltaV # Avoiding StorageFill
+  components:
+  - type: Sprite
+    layers:
+    - state: box
+    - state: pda
+
 - type: entity
   name: security PDA box
-  parent: BoxPDA
+  parent: BoxPDADeltaV
   id: BoxPDASecurity
   description: A box of spare PDA microcomputers for the security department.
   components:
@@ -20,7 +31,7 @@
 
 - type: entity
   name: prisoner PDA box
-  parent: BoxPDA
+  parent: BoxPDADeltaV
   id: BoxPDAPrisoner
   description: A box of spare PDA microcomputers for the warden to use for prisoners.
   components:
@@ -39,7 +50,7 @@
 
 - type: entity
   name: medical PDA box
-  parent: BoxPDA
+  parent: BoxPDADeltaV
   id: BoxPDAMedical
   description: A box of spare PDA microcomputers for the medical department.
   components:
@@ -59,7 +70,7 @@
 
 - type: entity
   name: epistemics PDA box
-  parent: BoxPDA
+  parent: BoxPDADeltaV
   id: BoxPDAScience
   description: A box of spare PDA microcomputers for the epistemics department.
   components:
@@ -79,7 +90,7 @@
 
 - type: entity
   name: engineering PDA box
-  parent: BoxPDA
+  parent: BoxPDADeltaV
   id: BoxPDAEngineering
   description: A box of spare PDA microcomputers for the engineering department.
   components:
@@ -99,7 +110,7 @@
 
 - type: entity
   name: logistics PDA box
-  parent: BoxPDA
+  parent: BoxPDADeltaV
   id: BoxPDACargo
   description: A box of spare PDA microcomputers for the logistics department.
   components:
@@ -122,7 +133,7 @@
 
 - type: entity
   name: justice PDA box
-  parent: BoxPDA
+  parent: BoxPDADeltaV
   id: BoxPDAJustice
   description: A box of spare PDA microcomputers for the justice department.
   components:

--- a/Resources/Prototypes/_DV/Catalog/Fills/Boxes/security.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Boxes/security.yml
@@ -9,10 +9,18 @@
     - state: box_security
     - sprite: _DV/Objects/Storage/boxes.rsi
       state: recorder
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxTapeRecorder
+
+- type: entityTable
+  id: FillBoxTapeRecorder
+  table: !type:AllSelector
+    children:
     - id: CassetteTape
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
     - id: TapeRecorder
 
 - type: entity
@@ -21,10 +29,18 @@
   name: mindshield box
   description: A box filled with mindshield implants.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxMindshield
+
+- type: entityTable
+  id: FillBoxMindshield
+  table: !type:AllSelector
+    children:
     - id: MindShieldImplanter
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   parent: BoxCardboard
@@ -32,7 +48,15 @@
   name: c4 box
   description: A box filled with C4s.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBoxC4
+
+- type: entityTable
+  id: FillBoxC4
+  table: !type:AllSelector
+    children:
     - id: C4
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
@@ -2,61 +2,112 @@
   id: CrateArmoryGrand
   parent: CrateWeaponSecure
   components:
-  - type: StorageFill
-    contents:
-      - id: WeaponSniperGrand
-        amount: 2
-      - id: BoxSpeedLoaderLightRifle
-        amount: 1
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateArmoryGrand
+
+- type: entityTable
+  id: FillCrateArmoryGrand
+  table: !type:AllSelector
+    children:
+    - id: WeaponSniperGrand
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: BoxSpeedLoaderLightRifle
+      amount: !type:ConstantNumberSelector
+        value: 1
 
 - type: entity
   id: CrateArmoryUniversal
   parent: CrateWeaponSecure
   components:
-  - type: StorageFill
-    contents:
-      - id: WeaponPistolUniversal
-        amount: 2
-      - id: MagazineUniversalMagnum
-        amount: 4
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateArmoryUniversal
+
+- type: entityTable
+  id: FillCrateArmoryUniversal
+  table: !type:AllSelector
+    children:
+    - id: WeaponPistolUniversal
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: MagazineUniversalMagnum
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   id: CrateArmoryAdjutant
   parent: CrateWeaponSecure
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateArmoryAdjutant
+
+- type: entityTable
+  id: FillCrateArmoryAdjutant
+  table: !type:AllSelector
+    children:
     - id: WeaponShotgunAdjutant
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: BoxLethalshot
-      amount: 3
+      amount: !type:ConstantNumberSelector
+        value: 3
 
 - type: entity
   id: CrateArmoryEnergyGun
   parent: CrateWeaponSecure
   components:
-  - type: StorageFill
-    contents:
-      - id: WeaponEnergyGun
-        amount: 3
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateArmoryEnergyGun
+
+- type: entityTable
+  id: FillCrateArmoryEnergyGun
+  table: !type:AllSelector
+    children:
+    - id: WeaponEnergyGun
+      amount: !type:ConstantNumberSelector
+        value: 3
 
 - type: entity
   id: CrateArmoryEnergyGunMini
   parent: CrateWeaponSecure
   components:
-  - type: StorageFill
-    contents:
-      - id: WeaponEnergyGunMini
-        amount: 3
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateArmoryEnergyGunMini
+
+- type: entityTable
+  id: FillCrateArmoryEnergyGunMini
+  table: !type:AllSelector
+    children:
+    - id: WeaponEnergyGunMini
+      amount: !type:ConstantNumberSelector
+        value: 3
 
 - type: entity
   id: CrateArmoryArmingSword
   parent: CrateWeaponSecure
   components:
-  - type: StorageFill
-    contents:
-      - id: PlasteelArmingSword
-        amount: 2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateArmoryArmingSword
+
+- type: entityTable
+  id: FillCrateArmoryArmingSword
+  table: !type:AllSelector
+    children:
+    - id: PlasteelArmingSword
+      amount: !type:ConstantNumberSelector
+        value: 2
 
 - type: entity
   parent: CrateSecgear
@@ -64,7 +115,15 @@
   name: watchdog implant crate
   description: Crate with three Watchdog implanters.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateWatchdogImplants
+
+- type: entityTable
+  id: FillCrateWatchdogImplants
+  table: !type:AllSelector
+    children:
     - id: WatchdogImplanter
-      amount: 3
+      amount: !type:ConstantNumberSelector
+        value: 3

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/food.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/food.yml
@@ -2,33 +2,44 @@
   id: CrateFoodDonkpocketSavory
   parent: CratePlastic
   components:
-    - type: StorageFill
-      contents:
-        - id: FoodBoxDonkpocket
-          amount: 2
-        - id: FoodBoxDonkpocketPizza
-          amount: 1
-        - id: FoodBoxDonkpocketSpicy
-          amount: 1
-        - id: FoodBoxDonkpocketTeriyaki
-          amount: 1
-        - id: FoodBoxDonkpocketDink
-          prob: 0.1
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateFoodDonkpocketSavory
+
+- type: entityTable
+  id: FillCrateFoodDonkpocketSavory
+  table: !type:AllSelector
+    children:
+    - id: FoodBoxDonkpocket
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: FoodBoxDonkpocketPizza
+    - id: FoodBoxDonkpocketSpicy
+    - id: FoodBoxDonkpocketTeriyaki
+    - id: FoodBoxDonkpocketDink
+      prob: 0.1
 
 - type: entity
   id: CrateFoodDonkpocketSweet
   parent: CratePlastic
   components:
-    - type: StorageFill
-      contents:
-        - id: FoodBoxDonkpocket
-          amount: 2
-        - id: FoodBoxDonkpocketHonk
-          amount: 1
-        - id: FoodBoxDonkpocketBerry
-          amount: 1
-        - id: FoodBoxDonkpocketDink
-          prob: 0.1
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateFoodDonkpocketSweet
+
+- type: entityTable
+  id: FillCrateFoodDonkpocketSweet
+  table: !type:AllSelector
+    children:
+    - id: FoodBoxDonkpocket
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: FoodBoxDonkpocketHonk
+    - id: FoodBoxDonkpocketBerry
+    - id: FoodBoxDonkpocketDink
+      prob: 0.1
 
 - type: entity
   id: CrateFoodEmergencyPie
@@ -36,10 +47,18 @@
   name: emergency pie delivery
   description: '"Then let them eat pie."'
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateFoodEmergencyPie
+
+- type: entityTable
+  id: FillCrateFoodEmergencyPie
+  table: !type:AllSelector
+    children:
     - id: FoodPieBananaCream
-      amount: 13
+      amount: !type:ConstantNumberSelector
+        value: 13
 
 - type: entity
   parent: CratePlastic
@@ -47,15 +66,25 @@
   name: HydroCo Dairy crate
   description: A shipment of powdered dairy products from HydroCo. Contains powdered milk and soy milk.
   components:
-    - type: StorageFill
-      contents:
-        - id: PaperCrateHydroCoConsumption
-        - id: SpoonPlastic
-          amount: 2
-        - id: ReagentTinPowderedMilk
-          amount: 2
-        - id: ReagentTinPowderedMilkSoy
-          amount: 2
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateHydroCoDairy
+
+- type: entityTable
+  id: FillCrateHydroCoDairy
+  table: !type:AllSelector
+    children:
+    - id: PaperCrateHydroCoConsumption
+    - id: SpoonPlastic
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: ReagentTinPowderedMilk
+      amount: !type:ConstantNumberSelector
+        value: 2
+    - id: ReagentTinPowderedMilkSoy
+      amount: !type:ConstantNumberSelector
+        value: 2
 
 - type: entity
   parent: CratePlastic

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/fun.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/fun.yml
@@ -2,11 +2,19 @@
   parent: CrateGenericSteel
   id: CrateFunBBGun
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateFunBBGun
+
+- type: entityTable
+  id: FillCrateFunBBGun
+  table: !type:AllSelector
+    children:
     - id: WeaponRifleBB
     - id: BoxCartridgeBB
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
 
 - type: entity
   parent: CratePlastic
@@ -14,10 +22,19 @@
   name: cap gun box set
   description: A box filled with fun, harmless cap guns that are sure to keep security entertained and the air smelling of sulfur.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateCapGunSet
+
+- type: entityTable
+  id: FillCrateCapGunSet
+  table: !type:AllSelector
+    children:
     - id: RevolverCapGun
     - id: SpeedLoaderCap
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: BoxCartridgeCap
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/medical.yml
@@ -4,10 +4,18 @@
   name: radio implant crate
   description: Communicate without having a pesky headset on your ear.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateGenericRadioImplants
+
+- type: entityTable
+  id: FillCrateGenericRadioImplants
+  table: !type:AllSelector
+    children:
     - id: GenericRadioImplanter
-      amount: 3
+      amount: !type:ConstantNumberSelector
+        value: 3
 
 - type: entity
   id: CratePainkillerBottles
@@ -15,7 +23,15 @@
   name: painkiller crate
   description: Running out of these is not an option.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCratePainkillerBottles
+
+- type: entityTable
+  id: FillCratePainkillerBottles
+  table: !type:AllSelector
+    children:
     - id: PillCanisterStubantazine
-      amount: 3
+      amount: !type:ConstantNumberSelector
+        value: 3

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/npc.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/npc.yml
@@ -2,7 +2,13 @@
   id: CrateNPCSecDog
   parent: CrateLivestock
   components:
-  - type: StorageFill
-    contents:
-      - id: MobSecDog
-        amount: 1
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateNPCSecDog
+
+- type: entityTable
+  id: FillCrateNPCSecDog
+  table: !type:AllSelector
+    children:
+    - id: MobSecDog

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/science.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/science.yml
@@ -4,7 +4,15 @@
   name: oil pack crate
   description: Pristine oil bagged in bulk.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateOilPack
+
+- type: entityTable
+  id: FillCrateOilPack
+  table: !type:AllSelector
+    children:
     - id: Oilpack
-      amount: 5
+      amount: !type:ConstantNumberSelector
+        value: 5

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/shuttle.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/shuttle.yml
@@ -4,6 +4,13 @@
   name: traffic key crate
   description: Contains a box of traffic keys
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateTrafficKey
+
+- type: entityTable
+  id: FillCrateTrafficKey
+  table: !type:AllSelector
+    children:
     - id: BoxEncryptionKeyTraffic

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/vending.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/vending.yml
@@ -2,14 +2,28 @@
   id: CrateVendingMachineRestockPrideFilled
   parent: CratePlastic
   components:
-  - type: StorageFill
-    contents:
-      - id: VendingMachineRestockPride
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillCrateVendingMachineRestockPrideFilled
+
+- type: entityTable
+  id: FillCrateVendingMachineRestockPrideFilled
+  table: !type:AllSelector
+    children:
+    - id: VendingMachineRestockPride
 
 - type: entity
   id: CrateVendingMachineRestockSustenanceFilled
   parent: CratePlastic
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillVendingMachineRestockSustenanceFilled
+
+- type: entityTable
+  id: FillVendingMachineRestockSustenanceFilled
+  table: !type:AllSelector
+    children:
     - id: VendingMachineRestockSustenance

--- a/Resources/Prototypes/_DV/Catalog/Fills/Items/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Items/Backpacks/duffelbag.yml
@@ -4,8 +4,15 @@
   name: mining conscription kit
   description: A duffel bag containing everything a crewmember needs to support a shaft miner in the field.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillSalvageConscription
+
+- type: entityTable
+  id: FillSalvageConscription
+  table: !type:AllSelector
+    children:
     - id: ClothingEyesGlassesMeson
     - id: MineralScanner
     - id: OreBag
@@ -22,8 +29,15 @@
   name: syndicate autodoc bundle
   description: A large duffel bag containing parts for a sinister-looking Mk. XIV Autodoc.
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillSyndicateAutodoc
+
+- type: entityTable
+  id: FillSyndicateAutodoc
+  table: !type:AllSelector
+    children:
     - id: AutodocSyndieFlatpack
     - id: OperatingTableFlatpack
     - id: Multitool

--- a/Resources/Prototypes/_DV/Catalog/Fills/Items/Belts/belts.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Items/Belts/belts.yml
@@ -15,13 +15,20 @@
   parent: ClothingBeltCorpsmanWebbing
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
-      - id: MedicatedSuture
-      - id: RegenerativeMesh
-      - id: Bloodpack
-      - id: SyringeEphedrine
-      - id: EmergencyMedipen
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillCorpsmanWebbing
+
+- type: entityTable
+  id: FillCorpsmanWebbing
+  table: !type:AllSelector
+    children:
+    - id: MedicatedSuture
+    - id: RegenerativeMesh
+    - id: Bloodpack
+    - id: SyringeEphedrine
+    - id: EmergencyMedipen
 
 - type: entity
   id: ClothingBeltFoamSheathFilled
@@ -48,8 +55,15 @@
   id: ClothingBeltPaperworkFilled
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: BeltPaperwork
+
+- type: entityTable
+  id: BeltPaperwork
+  table: !type:AllSelector
+    children:
     - id: BoxFolderBase
     - id: BoxFolderBlack
     - id: BoxFolderClipboard
@@ -60,8 +74,15 @@
   id: ClothingBeltSurgeonFilled
   suffix: Filled, Surgical
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillBeltSurgeon
+
+- type: entityTable
+  id: FillBeltSurgeon
+  table: !type:AllSelector
+    children:
     - id: Cautery
     - id: ScalpelAdvanced
     - id: Retractor

--- a/Resources/Prototypes/_DV/Catalog/Fills/Items/toolboxes.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Items/toolboxes.yml
@@ -3,8 +3,15 @@
   id: ToolboxSyndicateFilledCoreExtraction
   suffix: Filled, Core Extraction
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:NestedSelector
+        tableId: FillCoreExtraction
+
+- type: entityTable
+  id: FillCoreExtraction
+  table: !type:AllSelector
+    children:
     - id: Crowbar
     - id: Welder
     - id: Wrench

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/chiefjustice.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/chiefjustice.yml
@@ -3,8 +3,15 @@
   id: LockerChiefJusticeFilled
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillLockerChiefJustice
+
+- type: entityTable
+  id: FillLockerChiefJustice
+  table: !type:AllSelector
+    children:
     - id: ClothingHeadsetAltJustice
     - id: ClothingNeckCloakCJ
     - id: ClothingNeckMantleCJ
@@ -13,7 +20,8 @@
     - id: ClothingUniformJumpskirtCJFormal
     - id: ClothingUniformJumpsuitChiefJusticeWhite
     - id: PaperStationWarrant
-      amount: 10
+      amount: !type:ConstantNumberSelector
+        value: 10
     - id: BoxPDAJustice
     - id: BoxEncryptionKeyJustice
     - id: ChiefJusticeIDCard
@@ -21,7 +29,7 @@
     - id: Gavel
     - id: RubberStampChiefJustice
     - id: CargoRequestJusticeComputerCircuitboard
-    - id: LunchboxCommandFilledRandom # Delta-V Lunchboxes!
+    - id: LunchboxCommandFilledRandom
       prob: 0.3
     - id: RubberStampApproved
     - id: RubberStampDenied

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/clerk.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/clerk.yml
@@ -3,8 +3,15 @@
   id: LockerClerkFilled
   suffix: Filled
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillLockerClerk
+
+- type: entityTable
+  id: FillLockerClerk
+  table: !type:AllSelector
+    children:
     - id: ClothingOuterClerkVest
     - id: PaperStationWarrant
       amount: 10

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/engineering.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/engineering.yml
@@ -1,0 +1,21 @@
+- type: entityTable
+  id: FillLockerEngineerDeltaV
+  table: !type:AllSelector
+    children:
+    - id: LunchboxEngineeringFilledRandom
+      prob: 0.3
+
+- type: entityTable
+  id: FillLockerAtmosphericsDeltaV
+  table: !type:AllSelector
+    children:
+    - id: ClothingHandsGlovesColorYellow
+    - id: DoorRemoteFirefight
+    - id: LunchboxEngineeringFilledRandom
+      prob: 0.3
+
+- type: entityTable
+  id: FillAtmosphericsHardsuitDeltaV
+  table: !type:AllSelector
+    children:
+    - id: ClothingShoesBootsMag

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
@@ -1,0 +1,6 @@
+- type: entityTable
+  id: FillLockerScientistDeltaV
+  table: !type:AllSelector
+    children:
+    - id: LunchboxEpistemicsFilledRandom
+      prob: 0.3

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
@@ -3,56 +3,99 @@
   id: GunSafePistolUniversal
   name: mk32 safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillGunSafePistolUniversal
+
+- type: entityTable
+  id: FillGunSafePistolUniversal
+  table: !type:AllSelector
+    children:
     - id: WeaponPistolUniversal
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: MagazineUniversalMagnum
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   parent: GunSafeBaseSecure
   id: GunSafeSniperGrand
   name: mark 1 rifle safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillGunSafeSniperGrand
+
+- type: entityTable
+  id: FillGunSafeSniperGrand
+  table: !type:AllSelector
+    children:
     - id: WeaponSniperGrand
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: SpeedLoaderLightRifle
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   parent: GunSafeBaseSecure
   id: GunSafeVulcanRifle
   name: vulcan safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillGunSafeVulcanRifle
+
+- type: entityTable
+  id: FillGunSafeVulcanRifle
+  table: !type:AllSelector
+    children:
     - id: WeaponRifleVulcan
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: MagazineLightRifle
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   parent: GunSafeBaseSecure
   id: GunSafeAdjutantShotgun
   name: adjutant safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillGunSafeAdjutantShotgun
+
+- type: entityTable
+  id: FillGunSafeAdjutantShotgun
+  table: !type:AllSelector
+    children:
     - id: WeaponShotgunAdjutant
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: MagazineShotgun
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   parent: GunSafeBaseSecure
   id: GunSafeEnergyGun
   name: energy gun safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillGunSafeEnergyGun
+
+- type: entityTable
+  id: FillGunSafeEnergyGun
+  table: !type:AllSelector
+    children:
     - id: WeaponEnergyGun
       amount: 3
 
@@ -61,8 +104,15 @@
   id: GunSafeEnergyGunMini
   name: miniature energy gun safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillGunSafeEnergyGunMini
+
+- type: entityTable
+  id: FillGunSafeEnergyGunMini
+  table: !type:AllSelector
+    children:
     - id: WeaponEnergyGunMini
       amount: 3
 
@@ -71,20 +121,36 @@
   id: GunSafeM90Rifle
   name: M-90 rifle safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillGunSafeM90Rifle
+
+- type: entityTable
+  id: FillGunSafeM90Rifle
+  table: !type:AllSelector
+    children:
     - id: WeaponRifleM90
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: MagazineRifle
-      amount: 4
+      amount: !type:ConstantNumberSelector
+        value: 4
 
 - type: entity
   parent: GunSafeBaseSecure
   id: GunSafeRocketLauncher
   name: RPG safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: RPGTable
+
+- type: entityTable
+  id: RPGTable
+  table: !type:AllSelector
+    children:
     - id: WeaponLauncherRocket
     - id: CartridgeRocket
       prob: 0.2
@@ -94,8 +160,15 @@
   id: GunSafeBeamDevastator
   name: Devastator safe
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: BeamDevastatorTable
+
+- type: entityTable
+  id: BeamDevastatorTable
+  table: !type:AllSelector
+    children:
     - id: WeaponBeamDevastator
 
 - type: entityTable
@@ -124,3 +197,12 @@
     containers:
       entity_storage: !type:NestedSelector
         tableId: GamblagatorTable
+
+- type: entityTable
+  id: GamblagatorTable
+  table: !type:AllSelector
+    children:
+    - id: WeaponSniperGamblagator
+    - id: GamblagatorCapacitor
+      amount: !type:ConstantNumberSelector
+        value: 4

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
@@ -3,18 +3,30 @@
   parent: SuitStorageSec
   suffix: Security, DeltaV
   components:
-  - type: StorageFill
-    contents:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:NestedSelector
+        tableId: FillSuitStorageSecDeltaV
+
+- type: entityTable
+  id: FillSuitStorageSecDeltaV # This should be properly added to upstream fill whenever they move to entity tables.
+  table: !type:AllSelector
+    children:
     - id: OxygenTankFilled
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: ClothingOuterHardsuitCombatOfficer
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: ClothingMaskGasSecurity
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: ClothingShoesBootsSecurityMagboots
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
     - id: JetpackSecurityFilled
-      amount: 2
+      amount: !type:ConstantNumberSelector
+        value: 2
 
 #Paramedic hardsuit
 - type: entityTable

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/security.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/security.yml
@@ -22,21 +22,5 @@
       tableId: RPGTable
     - !type:NestedSelector
       tableId: GamblagatorTable
-    - id: WeaponBeamDevastator
-
-- type: entityTable
-  id: RPGTable
-  table: !type:AllSelector
-    children:
-    - id: WeaponLauncherRocket
-    - id: CartridgeRocket
-      prob: 0.2
-
-- type: entityTable
-  id: GamblagatorTable
-  table: !type:AllSelector
-    children:
-    - id: WeaponSniperGamblagator
-    - id: GamblagatorCapacitor
-      amount: !type:ConstantNumberSelector
-        value: 4
+    - !type:NestedSelector
+      tableId: BeamDevastatorTable


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Moving our StorageFills to entityTables.

## Why / Balance
It needed updating, copy paste is bad and this makes it easier to add our stuff to upstream lockers.

## Technical details
Transformed all the `StorageFill` to a `EntityTableContainerFill`. Only file i didn't touch was the emergency boxes as those will be better be tackled after upstream moves theirs, for less copy paste.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
N/A