### PR TITLE
Reduce damage of c4 and breaching charges

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -67,9 +67,9 @@
     - Trigger # DeltaV: replace Timer with Trigger for TriggerOnSignal
   - type: Explosive # Powerful explosion in a very small radius. Doesn't break underplating.
     explosionType: DemolitionCharge
-    totalIntensity: 60
+    totalIntensity: 30 # DeltaV: down from 60
     intensitySlope: 5
-    maxIntensity: 30
+    maxIntensity: 10 # DeltaV: down from 30 just enough to punch though a plastitanium wall but not the girder
     canCreateVacuum: false
   - type: ExplodeOnTrigger
   - type: HolidayVisuals

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -22,7 +22,7 @@
     canToggleStartOnStick: true
   - type: Explosive
     explosionType: DemolitionCharge
-    totalIntensity: 10
+    totalIntensity: 5 # Enough to get though a reinforced wall but not the girder
     intensitySlope: 10
-    maxIntensity: 10
+    maxIntensity: 5
     canCreateVacuum: false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
c4 damage reduced to destroy single layer of plastitanium wall (no girder) or 2 layers of reinforced + girders
breaching charge reduced to destroy single layer of reinforced wall (no girder) or half a plastitianum wall

## Why / Balance
High health walls pose very little opposition to breaching charges to a comical level. While breaching are still able to effectively breach, they have been tuned down so that high health walls can pose some resistance.

This is a step towards mitigating armory rushes by enabling areas designed to be structurally secure to pose some level or resistance to breaching explosives whereas before any level of defense could be trivialized.

C4 and breaching charges are still strong enough to punch through any defenses that are not especially secure.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reduced structural damage of C4 so that they can only destroy 2 layers of reinforced walls or 1 layer of plastitianum wall.
