### PR TITLE
Re-add LO knuckledusters for flair but nerf them

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -20,7 +20,7 @@
     - id: RubberStampDenied
     - id: RubberStampQm
     - id: AstroNavCartridge
-    #- id: ClothingHandsKnuckleDustersQM # DeltaV - No weaponry for LO.
+    - id: ClothingHandsKnuckleDustersQM
     #- id: MailTeleporterMachineCircuitboard # DeltaV - upstream deliveries not ported yet
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -511,10 +511,10 @@
   - type: Fiber
     fiberColor: fibers-gold
   - type: MeleeWeapon
-    attackRate: 1.5
+    attackRate: 1.2
     damage:
       types:
-        Blunt: 14
+        Blunt: 9
     soundHit:
       collection: Punch
     animation: WeaponArcFist


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Reverts #3871
Nerfs speed to 1.2 and damage to 9 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
![image](https://github.com/user-attachments/assets/fafd9d13-c73e-416f-9cfa-cc38e7a792fd)

The weapon itself is as powerful as a toolbox or an oxygen tank now, it's mostly there to add flair to the role rather than to enable validhunting.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added LO's knuckledusters back to their locker
- tweak: LO's knuckledusters deal less damage now, and attack slightly slower
