### PR TITLE
Fix tinted windows not inheriting tags

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Windows/tinted_windows.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Windows/tinted_windows.yml
@@ -11,6 +11,8 @@
     state: tinted_window
   - type: Tag
     tags:
+      - Window
+      - Directional
       - ForceNoFixRotations
   - type: Occluder
     boundingBox: "-0.5,-0.5,0.5,-0.3"
@@ -28,6 +30,8 @@
     state: tinted_reinforced_window
   - type: Tag
     tags:
+      - Window
+      - Directional
       - ForceNoFixRotations
   - type: Occluder
     boundingBox: "-0.5,-0.5,0.5,-0.3"


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
They weren't showing up in station maps

## Technical details
n/a

## Media
![image](https://github.com/user-attachments/assets/12b61bc9-728f-44c9-9990-b23a79e47aac)

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
