### PR TITLE
Increase the ninja's stun cooldown to 6 seconds.

### DIFF
--- a/Content.Shared/Ninja/Components/StunProviderComponent.cs
+++ b/Content.Shared/Ninja/Components/StunProviderComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class StunProviderComponent : Component
     /// How long stunning is disabled after stunning something.
     /// </summary>
     [DataField]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(2);
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(6); // DeltaV - Was 2.
 
     /// <summary>
     /// ID of the cooldown use delay.

--- a/Content.Shared/Ninja/Components/StunProviderComponent.cs
+++ b/Content.Shared/Ninja/Components/StunProviderComponent.cs
@@ -55,7 +55,7 @@ public sealed partial class StunProviderComponent : Component
     /// How long stunning is disabled after stunning something.
     /// </summary>
     [DataField]
-    public TimeSpan Cooldown = TimeSpan.FromSeconds(6); // DeltaV - Was 2.
+    public TimeSpan Cooldown = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// ID of the cooldown use delay.

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -243,6 +243,7 @@
     - components:
       - type: BatteryDrainer
       - type: StunProvider
+        cooldown: 6 # DeltaV - Made it have a 6 seconds cooldown.
         noPowerPopup: ninja-no-power
         whitelist:
           components:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title.

## Why / Balance
Currently the ninja has an awfully OP stunlock, two seconds per stun and it's a 5 second stun. This should make it so ninjas use it in more interesting ways and not to just stun lock HOS/Cap or whatever.

## Technical details
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/d65baace-3ccf-4924-b1db-2846651633f7

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Increased the stun cooldown of the ninja's gloves to 6 seconds.
