### PR TITLE
Remove references to enforced loyalty from mindshield descriptions

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/subdermal_implants.yml
@@ -335,7 +335,7 @@
   parent: BaseSubdermalImplant
   id: MindShieldImplant
   name: mindshield implant
-  description: This implant will ensure loyalty to Nanotrasen and prevent mind control devices.
+  description: This implant will shield the brain from external influences and prevent mind control devices. # DeltaV - mindshield does not enforce loyalty
   categories: [ HideSpawnMenu ]
   components:
    - type: SubdermalImplant


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Changed mindshield description from: `This implant will ensure loyalty to Nanotrasen and prevent mind control devices.`
To: `This implant will shield the brain from external influences and prevent mind control devices.`

<img width="538" alt="image" src="https://github.com/user-attachments/assets/d144fc1a-6ba7-478e-ba5f-4ee2574dd435" />


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
[discord link](https://discord.com/channels/968983104247185448/1355855015058739200/1379260724349505657)
Direction does not want mindshields to have loyalty implications

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Nope!

Normally this wouldn't need a changelog but let's give this one because half the playebase thinks mindshields affect loyalty which is not the case
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed the description of mindshields to reflect they do not enforce loyalty to Nanotrasen in any form.
