### PR TITLE
Fix admins reciving chelps when deadmined

### DIFF
--- a/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
+++ b/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
@@ -180,7 +180,7 @@ public sealed partial class CwoinkSystem : SharedCwoinkSystem
 
     private void OnAdminPermsChanged(AdminPermsChangedEventArgs args)
     {
-        if ((args.Flags & AdminFlags.CuratorHelp) != 0)
+        if ((args.Flags ?? 0 & AdminFlags.CuratorHelp) != 0)
             _activeCurators.Add(args.Player.Channel);
         else
         {

--- a/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
+++ b/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
@@ -180,7 +180,7 @@ public sealed partial class CwoinkSystem : SharedCwoinkSystem
 
     private void OnAdminPermsChanged(AdminPermsChangedEventArgs args)
     {
-        if ((args.Flags ?? 0 & AdminFlags.CuratorHelp) != 0)
+        if (((args.Flags ?? 0) & AdminFlags.CuratorHelp) != 0)
             _activeCurators.Add(args.Player.Channel);
         else
         {


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixes a case where admins were sent chelps while deadmined

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
args.Flags passes null when someone deadmins which when masked gave null instead of 0. this caused null != 0 which evaluates true. this was fixed by coalescing the null value with 0 returning it to intended behavior.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
