### PR TITLE
Cosmic Cult | Finale emergency hotfix

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -54,7 +54,10 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     {
         uid.Comp.Occupied = false;
         if (args.Args.Target == null || args.Cancelled || args.Handled)
+        {
+            uid.Comp.Occupied = false;
             return;
+        }
 
         _popup.PopupEntity(Loc.GetString("cosmiccult-finale-beckon-success"), args.Args.User, args.Args.User);
         StartFinale(uid);
@@ -102,7 +105,10 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
         uid.Comp.Occupied = false;
         var comp = uid.Comp;
         if (args.Args.Target is not {} target || args.Cancelled || args.Handled)
+        {
+            uid.Comp.Occupied = false;
             return;
+        }
 
         var stationUid = _station.GetOwningStation(uid);
 

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -52,11 +52,9 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
 
     private void OnFinaleStartDoAfter(Entity<CosmicFinaleComponent> uid, ref StartFinaleDoAfterEvent args)
     {
+        uid.Comp.Occupied = false;
         if (args.Args.Target == null || args.Cancelled || args.Handled)
-        {
-            uid.Comp.Occupied = false;
             return;
-        }
 
         _popup.PopupEntity(Loc.GetString("cosmiccult-finale-beckon-success"), args.Args.User, args.Args.User);
         StartFinale(uid);
@@ -101,12 +99,10 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
 
     private void OnFinaleCancelDoAfter(Entity<CosmicFinaleComponent> uid, ref CancelFinaleDoAfterEvent args)
     {
+        uid.Comp.Occupied = false;
         var comp = uid.Comp;
         if (args.Args.Target is not {} target || args.Cancelled || args.Handled)
-        {
-            uid.Comp.Occupied = false;
             return;
-        }
 
         var stationUid = _station.GetOwningStation(uid);
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
FIXES A CRUCIAL BUG REGARDING THE COSMIC CULT'S FINALE.
REQUESTING SPEEDMERGE.

## Why / Balance
Makes the crew able to shut down the monument.
Y'know, as they SHOULD be able to.

## Technical details
Changes a few lines regarding the Monument being occupied or not in Cultsystem.finale.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- fix: Hotfixed a cosmic cult finale bug.
