### PR TITLE
Re-enables Prisoner Role on Arena/Roundstart Reporter on Shoukou

### DIFF
--- a/Resources/Prototypes/Maps/arena.yml
+++ b/Resources/Prototypes/Maps/arena.yml
@@ -48,7 +48,7 @@
             Detective: [ 1, 1 ]
             Gladiator: [ 2, 2 ]
             HeadOfSecurity: [ 1, 1 ]
-            #Prisoner: [ 2, 2 ] temporary test
+            Prisoner: [ 2, 2 ]
             PrisonGuard: [ 1, 1 ]
             SecurityOfficer: [ 5, 7 ]
             SecurityCadet: [ 2, 2 ]

--- a/Resources/Prototypes/Maps/shoukou.yml
+++ b/Resources/Prototypes/Maps/shoukou.yml
@@ -23,7 +23,7 @@
             HeadOfPersonnel: [ 1, 1 ]
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 1, 2 ]
-            Reporter: [ 0, 1 ]
+            Reporter: [ 1, 1 ]
             Bartender: [ 1, 2 ]
             Botanist: [ 1, 2 ]
             MartialArtist: [ 2, 3 ]


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
The world demands it

**Changelog**
:cl: Velcroboy
MAPS:
- tweak: Arena: Prisoner has been re-enabled.  
- tweak: Shoukou: Reporter can be selected roundstart.