### PR TITLE
Remove advanced energy guns research

### DIFF
--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
@@ -75,13 +75,13 @@
   id: SecurityWeaponsDeltaV
   recipes:
   - WeaponEnergyGun
-  - WeaponEnergyGunMini
+ # - WeaponEnergyGunMini
   - WeaponEnergyGunPistol
   - WeaponRifleLaser
   - AdvancedTruncheon
   - WeaponColdCannon
   - WeaponBeamCannon
-  - WeaponEnergyGunAdvanced
+ # - WeaponEnergyGunAdvanced
   - WeaponImmolator
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
@@ -26,7 +26,6 @@
   - BoxBeanbag
   - BoxShellTranquilizer
   - MagazineShotgunBeanbag
-  - MagazineLaser
 
 - type: latheRecipePack
   id: SecurityRubberAmmoStatic
@@ -75,13 +74,11 @@
   id: SecurityWeaponsDeltaV
   recipes:
   - WeaponEnergyGun
- # - WeaponEnergyGunMini
-  - WeaponEnergyGunPistol
+  - WeaponEnergyGunMini
   - WeaponRifleLaser
   - AdvancedTruncheon
   - WeaponColdCannon
   - WeaponBeamCannon
- # - WeaponEnergyGunAdvanced
   - WeaponImmolator
 
 - type: latheRecipePack

--- a/Resources/Prototypes/_DV/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/security.yml
@@ -244,16 +244,6 @@
     Plastic: 250
 
 - type: latheRecipe
-  parent: BaseWeaponRecipeLong
-  id: WeaponEnergyGunPistol
-  result: WeaponEnergyGunPistol
-  materials:
-    Steel: 1500
-    Glass: 600
-    Plastic: 400
-    Gold: 150
-
-- type: latheRecipe
   parent: ClothingShoesBootsMagSci
   id: ClothingShoesBootsSecurityMagboots
   result: ClothingShoesBootsSecurityMagboots
@@ -301,14 +291,6 @@
     Bluespace: 100
 
 - type: latheRecipe
-  parent: BaseAmmoRecipe
-  id: MagazineLaser
-  result: MagazineLaser
-  materials:
-    Steel: 300
-    Plasma: 200
-
-- type: latheRecipe
   parent: BaseWeaponRecipeLong
   id: WeaponImmolator
   result: WeaponImmolator
@@ -317,16 +299,6 @@
     Glass: 500
     Plastic: 250
     Gold: 300
-
-- type: latheRecipe
-  parent: BaseWeaponRecipeLong
-  id: WeaponEnergyGunAdvanced
-  result: WeaponEnergyGunAdvanced
-  materials:
-    Steel: 1500
-    Glass: 1200
-    Gold: 500
-    Silver: 500
 
 - type: latheRecipe
   parent: BaseWeaponRecipeLong

--- a/Resources/Prototypes/_DV/Research/arsenal.yml
+++ b/Resources/Prototypes/_DV/Research/arsenal.yml
@@ -110,18 +110,18 @@
   - BorgModuleFauna
   - ShuttleGunKineticCircuitboard
 
-- type: technology
-  id: EnergyGunsAdvanced
-  name: research-technology-energy-gun-advance
-  icon:
-    sprite: _DV/Objects/Weapons/Guns/Battery/energygun_carbine.rsi
-    state: icon
-  discipline: Arsenal
-  tier: 2
-  cost: 12500
-  recipeUnlocks:
-  - WeaponEnergyGunPistol
-  - WeaponRifleLaser
+#- type: technology
+#  id: EnergyGunsAdvanced
+#  name: research-technology-energy-gun-advance
+#  icon:
+#    sprite: _DV/Objects/Weapons/Guns/Battery/energygun_carbine.rsi
+#    state: icon
+#  discipline: Arsenal
+#  tier: 2
+#  cost: 12500
+#  recipeUnlocks:
+#  - WeaponEnergyGunPistol
+#  - WeaponRifleLaser
 
 - type: technology
   id: IncendiaryLaserWeapons

--- a/Resources/Prototypes/_DV/Research/arsenal.yml
+++ b/Resources/Prototypes/_DV/Research/arsenal.yml
@@ -110,19 +110,6 @@
   - BorgModuleFauna
   - ShuttleGunKineticCircuitboard
 
-#- type: technology
-#  id: EnergyGunsAdvanced
-#  name: research-technology-energy-gun-advance
-#  icon:
-#    sprite: _DV/Objects/Weapons/Guns/Battery/energygun_carbine.rsi
-#    state: icon
-#  discipline: Arsenal
-#  tier: 2
-#  cost: 12500
-#  recipeUnlocks:
-#  - WeaponEnergyGunPistol
-#  - WeaponRifleLaser
-
 - type: technology
   id: IncendiaryLaserWeapons
   name: research-technology-incendiary-laser-weapons


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
removed advanced energy guns research, which includes the ik30, PDW9, and laser magazine

## Why / Balance
ridiculously OP in its current state, unfun and unfair to fight. the PDW doesn't have a place without this pairing so its going too.

## Technical details


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: IK30, PDW-9, and laser magazines are no longer available to crew.


