### PR TITLE
Move the energy shotgun to the warden's locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -342,7 +342,7 @@
     - !type:NestedSelector # DeltaV
       tableId: LockerFillHeadOfSecurityDeltaV
     - id: BookSecretDocuments
-    - id: WeaponEnergyShotgun
+    #- id: WeaponEnergyShotgun # DeltaV - Moved to the ward's locker.
     - id: BookSpaceLaw
     - id: BoxEncryptionKeySecurity
     - id: CigarGoldCase

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -21,6 +21,7 @@
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
       # Begin DeltaV additions
+      - id: WeaponEnergyShotgun
       - id: BoxPDAPrisoner
       - id: BoxEncryptionKeyPrisoner
       - id: LunchboxSecurityFilledRandom
@@ -56,6 +57,7 @@
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
       # Begin DeltaV additions
+      - id: WeaponEnergyShotgun
       - id: BoxPDAPrisoner
       - id: BoxEncryptionKeyPrisoner
       - id: LunchboxSecurityFilledRandom

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -212,7 +212,7 @@
     job: HeadOfSecurity
   - type: StealCondition
     stealGroup: WeaponEnergyShotgun
-    owner: job-name-hos
+    owner: job-name-warden # DeltaV - was job-name-hos.
 
 ## ce
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR moves the energy shotgun to the warden's office.

## Why / Balance
Makes more sense that a crowd control gun goes to the person in charge of protecting security.

## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Moved the energy shotgun to the warden's locker.

