### PR TITLE
Make IDs work inside chest cavity

### DIFF
--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.Access.Components;
-using Content.Shared.Body.Components;
-using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Body.Components; // DeltaV
+using Content.Shared.Containers.ItemSlots; // DeltaV
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Hands.EntitySystems;
@@ -25,6 +25,7 @@ public sealed class AccessReaderSystem : EntitySystem
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly InventorySystem _inventorySystem = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!; // DeltaV
     [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly EmagSystem _emag = default!;
     [Dependency] private readonly TagSystem _tag = default!;
@@ -364,13 +365,9 @@ public sealed class AccessReaderSystem : EntitySystem
         // Begin DeltaV - check chest cavity
         if (TryComp(uid, out BodyComponent? body) && body.RootContainer.ContainedEntity is { } root)
         {
-            if (TryComp(root, out ItemSlotsComponent? itemSlots))
+            if (_itemSlotsSystem.GetItemOrNull(root, "torso_slot") is { } chestItem)
             {
-                foreach (var slot in itemSlots.Slots.Values)
-                {
-                    if (slot.ContainerSlot?.ContainedEntity is { } item)
-                        items.Add(item);
-                }
+                items.Add(chestItem);
             }
         }
         // End DeltaV - check chest cavity

--- a/Content.Shared/Access/Systems/AccessReaderSystem.cs
+++ b/Content.Shared/Access/Systems/AccessReaderSystem.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Content.Shared.Access.Components;
+using Content.Shared.Body.Components;
+using Content.Shared.Containers.ItemSlots;
 using Content.Shared.DeviceLinking.Events;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Hands.EntitySystems;
@@ -358,6 +360,20 @@ public sealed class AccessReaderSystem : EntitySystem
         {
             items.Add(idUid.Value);
         }
+
+        // Begin DeltaV - check chest cavity
+        if (TryComp(uid, out BodyComponent? body) && body.RootContainer.ContainedEntity is { } root)
+        {
+            if (TryComp(root, out ItemSlotsComponent? itemSlots))
+            {
+                foreach (var slot in itemSlots.Slots.Values)
+                {
+                    if (slot.ContainerSlot?.ContainedEntity is { } item)
+                        items.Add(item);
+                }
+            }
+        }
+        // End DeltaV - check chest cavity
 
         return items.Any();
     }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
IDs/PDAs/items with access will now be able to interface with access-locked things if stored inside one's chest via surgery.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
[relevant wyci](https://discord.com/channels/968983104247185448/1384089337112694804)
Adds a nice practical use for surgery, and also encourages silly ghetto surgery. Implanted ID icons will appear on sechuds, so unless you're very sneaky with an agent ID, it'll probably be pretty easy to sec to figure out what you've done if they confiscate your PDA. 

## Technical details
shitmed is shitmed so the code to check the chest cavity, unfortunately, may be a little bit shit. i have made it as pretty as i know how

## Media

https://github.com/user-attachments/assets/e6d1061c-c22b-4f69-bd1e-d587402aa4df

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: IDs now work when implanted inside of chest cavities.

