### PR TITLE
Nymph forces ghost return

### DIFF
--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -42,7 +42,7 @@ public sealed partial class NymphSystem : EntitySystem
 
         // Move the mind if there is one and it's supposed to be transferred
         if (comp.TransferMind == true && _mindSystem.TryGetMind(args.OldBody, out var mindId, out var mind))
-            _mindSystem.TransferTo(mindId, nymph, mind: mind);
+            _mindSystem.TransferTo(mindId, nymph, true, mind: mind); // force ghost into nymph body and transfers mind to nymph
 
         // Delete the old organ
         QueueDel(uid);

--- a/Content.Server/Species/Systems/NymphSystem.cs
+++ b/Content.Server/Species/Systems/NymphSystem.cs
@@ -42,7 +42,7 @@ public sealed partial class NymphSystem : EntitySystem
 
         // Move the mind if there is one and it's supposed to be transferred
         if (comp.TransferMind == true && _mindSystem.TryGetMind(args.OldBody, out var mindId, out var mind))
-            _mindSystem.TransferTo(mindId, nymph, true, mind: mind); // force ghost into nymph body and transfers mind to nymph
+            _mindSystem.TransferTo(mindId, nymph, true, mind: mind); // DeltaV - force ghost into nymph body and transfers mind to nymph
 
         // Delete the old organ
         QueueDel(uid);


### PR DESCRIPTION

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Forces the player ghost into the body of the brain nymph when it is spawned.

## Why / Balance
If a diona is gibbed / ashed nymphs for whatever reason, they would be unaware and completely miss their one chance for revival / escape, and the simplemob AI could run off and hide under a piece of garbage and be lost forever, without the player even knowing that they nymphed at all.
Previously when a diona was gibbed while ghosted it would force the ghost into the body, but this was changed or edited at some point.
## Technical details
Set ghostcheckoverride = true in the transfermind() call sent by nymphing 

fixes #3966

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have tested all added content and changes.
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: A diona corpse nymphing while they are ghosted once again returns them to their new body!

