### PR TITLE
Make survival epic again

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -424,11 +424,13 @@
   - type: NextEvent # DeltaV: Queue Event for precognition
   - type: RampingStationEventScheduler
     timeKeyPoints: # DeltaV
-    - 14, 16
-    - 32, 8
+    - 10, 12
+    - 32, 6
+    - 32, 3
+    - 12, 1
     - 32, 4
-    - 8, 2
-    - 32, 8
+    - 32, 2
+    - 32, 1.5
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
edited survival values to be evil

## Why / Balance
survival is either greenshift or greenshift + ninja, this should make survival actually difficult to _survive_

## Technical details
math

## Media
epic recreation of what it should now look like (red is current, black is 3 months ago survival, pink is now) (i have no graphing software)
![image](https://github.com/user-attachments/assets/f19d6025-d684-47f8-a077-580fba1d5527)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: survival values have been changed, and should make  the mode more exciting