### PR TITLE
Stingers - No more blunt, all stamina

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/grenade.yml
@@ -5,13 +5,16 @@
   parent: BaseBullet
   components:
   - type: Sprite
-    sprite: Objects/Weapons/Guns/Projectiles/projectiles2.rsi
-    state: buckshot
+    sprite: _Impstation/Objects/Weapons/Guns/Projectiles/energybolts.rsi # DeltaV - Swappign sprites, removing blunt part
+    layers:
+    - state: lightstun # DeltaV
+      shaders: unshaded
   - type: Projectile
     deleteOnCollide: false
     damage:
       types:
-        Blunt: 4
+        Blunt: 0
+    impactEffect: BulletImpactEffectDisabler # DeltaV - Pretty impacts
   - type: StaminaDamageOnCollide
     damage: 55
   - type: TimedDespawn


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Stingers no longer do any blutn damage, and isntead do purely stamina. I have changed the projectile sprites to match this

## Why / Balance
Issues w/ limb damage causing people to gib when stingers hit them

## Technical details
Light yaml changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Stinger grenades have been modified to purely stun, and do minimal damage to flesh