### PR TITLE
Mail access for skeleton crew Cargo Technicians

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -13,6 +13,7 @@
   - Orders # DeltaV - Add Orders access to cargo techs.
   extendedAccess:
   - Salvage
+  - Mail # DeltaV - It'd be a little silly to penalize Logistics for timed mail they may not have access to.
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: BoxingDay


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
This PR gives the Cargo Technician extended access to open Mail doors when they are working as part of a skeleton crew.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As someone who mainly plays on Periapsis, I've noticed that sometimes the population may be low enough that the Logistics crew do not have a Courier. This can be somewhat annoying as the Logistics department will still receive penalties for timed mail not being delivered.

Currently, when playing as a Logistics role in a skeleton crew, if you do not have a designated Courier, your best bet at avoiding these penalties is to ask a member of the Command department to assign you access to the Mail room manually. However, there is no guarantee that such a person will be available to fulfill your request in these scenarios, thus leaving the Logistics team to suffer penalties that are through no fault of their own and completely unavoidable. Additionally, if you're going to end up having someone from Logistics request Mail access to workaround this anyway, we might as well just do it for them so that they can avoid the hassle and have a more enjoyable experience.

Although the penalties are not too impactful on their own, it is also worth considering that delivering Mail can be a much needed source of income for a short-staffed Logistics department, especially early-round where less resources are available, and the crew may not have a designated Salvage Specialist to help recoup losses. In general, I feel that it would be rather demoralizing as an employee for your department to get penalized for something that is entirely out of your teams' control.

Finally, I will note that I thought about also giving this extended access to the Cargo Assistant too, however I decided against it as they do not already have extended access to anything, and as the role is intended for learning purposes, it would be better for them to wait for someone to be able to teach them how to deliver mail instead. 

## Technical details
<!-- Summary of code changes for easier review. -->
- Added `Mail` to the `extendedAccess` section of `Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml`

Patch diff:
```diff
diff --git a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
index 5e0f9248bd..940555f404 100644
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -13,6 +13,7 @@
   - Orders # DeltaV - Add Orders access to cargo techs.
   extendedAccess:
   - Salvage
+  - Mail # DeltaV - It'd be a little silly to penalize Logistics for timed mail they may not have access to.
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: BoxingDay
```

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/119fd06d-56b0-4c5a-8357-a98402979ae6


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
There are no breaking changes to my knowledge.

**Changelog**
:cl: 
- add: Cargo Technicians can now access the Mail room when working as part of a skeleton crew.

