### PR TITLE
make licensing information more clear

### DIFF
--- a/LEGAL.md
+++ b/LEGAL.md
@@ -4,7 +4,7 @@
 
 Namespace refers to a subdirectory beginning with `_` indicating the authorship of its contents.
 
-Code refers to any C# source code files, YML files in `Resources` and any scripts these require such as `Tools`.
+Code refers to any C# source code files and compiled assemblies, YML files in `Resources` and any scripts these may require such as the `Tools` subdirectory.
 
 ## Copyright
 
@@ -18,7 +18,7 @@ The project as a whole is licensed under the terms of the [AGPLv3](/LICENSE-AGPL
 
 Where code from other authors is used, you must follow the terms of both the AGPLv3 *and* their license.
 
-> For MIT this means you **must not** remove the copy of the MIT license from any distribution.
+For MIT this means you **must not** remove the copy of the MIT license from any distribution.
 
 - Code created by Delta-V contributors is found in `_DV` Namespaces.
 

--- a/LEGAL.md
+++ b/LEGAL.md
@@ -1,16 +1,33 @@
-﻿# Legal Info
+# Legal Info
+
+## Definitions
+
+Namespace refers to a subdirectory beginning with `_` indicating the authorship of its contents.
+
+Code refers to any C# source code files, YML files in `Resources` and any scripts these require such as `Tools`.
 
 ## Copyright
 
 The Authors retain all copyright to their respective work here submitted.
 
+This means they remain at liberty to contribute their work anywhere they please.
+
 ## Code license
 
-Content contributed to this repository after commit 87c70a89a67d0521a56388e6b1c3f2cb947943e4 is licensed under the GNU Affero General Public License version 3.0, unless otherwise stated. See `LICENSE-AGPLv3.txt`.
+The project as a whole is licensed under the terms of the [AGPLv3](/LICENSE-AGPLv3.txt) and must be followed regardless of parent licenses.
 
-Content contributed to this repository before commit 87c70a89a67d0521a56388e6b1c3f2cb947943e4 is licensed under the MIT license, unless otherwise stated. See `LICENSE-MIT.txt`.
+Where code from other authors is used, you must follow the terms of both the AGPLv3 *and* their license.
 
-[87c70a89a67d0521a56388e6b1c3f2cb947943e4](https://github.com/DeltaV-Station/Delta-v/commit/87c70a89a67d0521a56388e6b1c3f2cb947943e4) was pushed on February 17th 2024 at 21:48 UTC
+> For MIT this means you **must not** remove the copy of the MIT license from any distribution.
+
+- Code created by Delta-V contributors is found in `_DV` Namespaces.
+
+- Upstream code from [Space Station 14](https://github.com/space-wizards/space-station-14) was taken under [the MIT license](/LICENSE-MIT.txt).
+  Any code not in a specific Namespace, excluding `Nyanotrasen` subdirectories, is sublicensed as MIT plus AGPLv3 from the Space Wizards Federation.
+
+- Code taken from [the Starlight project](https://github.com/ss14Starlight/space-station-14) in the `_Starlight` namespace was taken under [their custom MIT-like license](/LICENSE-Starlight.txt) and sublicensed to AGPLv3.
+
+Assets have distinct licenses in `attributions.yml` and `meta.json` files which must be followed individually.
 
 ## Warranty
 
@@ -20,3 +37,7 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Legacy code
+
+If you do not agree to the terms of these software licenses you may use legacy code from before [this commit](https://github.com/DeltaV-Station/Delta-v/commit/87c70a89a67d0521a56388e6b1c3f2cb947943e4) or the [legacy repository](https://github.com/DeltaV-Station/Delta-v-Legacy) which may be used under the MIT license.

--- a/README.md
+++ b/README.md
@@ -55,12 +55,7 @@ Build the server using `dotnet build`.
 
 ## License
 
-Content contributed to this repository after commit 87c70a89a67d0521a56388e6b1c3f2cb947943e4 is licensed under the GNU Affero General Public License version 3.0, unless otherwise stated. See `LICENSE-AGPLv3.txt`.
-Content contributed to this repository before commit 87c70a89a67d0521a56388e6b1c3f2cb947943e4 is licensed under the MIT license, unless otherwise stated. See `LICENSE-MIT.txt`.
-
-To be more specific, code in `Content.*/_DV`, `Resources/*/_DV` and any Delta-V specific scripts in `Tools` are licensed under AGPLv3. Other files are originally from other codebases and are not owned by Delta-V, though any code must be relicensable to AGPLv3. SS14 is MIT licensed so this forking is possible.
-
-[87c70a89a67d0521a56388e6b1c3f2cb947943e4](https://github.com/DeltaV-Station/Delta-v/commit/87c70a89a67d0521a56388e6b1c3f2cb947943e4) was pushed on February 17th 2024 at 21:48 UTC
+Read [LEGAL.md](/LEGAL.md) for legal information regarding the code licensing.
 
 Most assets are licensed under [CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/) unless stated otherwise. Assets have their license and the copyright in the metadata file. [Example](https://github.com/DeltaV-Station/Delta-v/blob/master/Resources/Textures/Objects/Tools/crowbar.rsi/meta.json).
 


### PR DESCRIPTION
## About the PR
- make it much clearer that the commit thing is for legacy use only.
  you cant retroactively relicense code from the past so it had no legal use to begin with
- list the sources of code with different licenses and explain that theyre sublicenses, both must be followed

fixes #3982