### PR TITLE
add min pressure for pka damage modifier

### DIFF
--- a/Content.Server/_DV/Projectiles/PressureProjectileSystem.cs
+++ b/Content.Server/_DV/Projectiles/PressureProjectileSystem.cs
@@ -7,8 +7,8 @@ public sealed class PressureProjectileSystem : SharedPressureProjectileSystem
 {
     [Dependency] private readonly AtmosphereSystem _atmos = default!;
 
-    protected override float GetPressure(EntityUid uid)
+    protected override float GetPressure(Entity<PressureProjectileComponent> ent)
     {
-        return _atmos.GetContainingMixture(uid)?.Pressure ?? 0f;
+        return _atmos.GetContainingMixture(ent.Owner)?.Pressure ?? 0f;
     }
 }

--- a/Content.Shared/_DV/Projectiles/PressureProjectileComponent.cs
+++ b/Content.Shared/_DV/Projectiles/PressureProjectileComponent.cs
@@ -25,7 +25,7 @@ public sealed partial class PressureProjectileComponent : Component
     public float MaxPressure = Atmospherics.OneAtmosphere * 0.5f;
 
     /// <summary>
-    /// Multiplies projectile damage by this modifier when above <see cref="MinPressure"/> or below <see cref="MaxPressure"/>.
+    /// Multiplies projectile damage by this modifier when below <see cref="MinPressure"/> or above <see cref="MaxPressure"/>.
     /// </summary>
     [DataField]
     public float Modifier = 0.25f;

--- a/Content.Shared/_DV/Projectiles/PressureProjectileComponent.cs
+++ b/Content.Shared/_DV/Projectiles/PressureProjectileComponent.cs
@@ -11,6 +11,13 @@ namespace Content.Shared._DV.Projectiles;
 public sealed partial class PressureProjectileComponent : Component
 {
     /// <summary>
+    /// Min pressure to allow full damage at.
+    /// If it is below this at point of impact, damage gets modified by <see cref="Modifier"/>.
+    /// </summary>
+    [DataField]
+    public float MinPressure = Atmospherics.OneAtmosphere * 0.2f;
+
+    /// <summary>
     /// Max pressure to allow full damage at.
     /// If it exceeds this at point of impact, damage gets modified by <see cref="Modifier"/>.
     /// </summary>
@@ -18,7 +25,7 @@ public sealed partial class PressureProjectileComponent : Component
     public float MaxPressure = Atmospherics.OneAtmosphere * 0.5f;
 
     /// <summary>
-    /// Multiplies projectile damage by this modifier when below <see cref="MaxPressure"/>.
+    /// Multiplies projectile damage by this modifier when above <see cref="MinPressure"/> or below <see cref="MaxPressure"/>.
     /// </summary>
     [DataField]
     public float Modifier = 0.25f;

--- a/Content.Shared/_DV/Projectiles/SharedPressureProjectileSystem.cs
+++ b/Content.Shared/_DV/Projectiles/SharedPressureProjectileSystem.cs
@@ -13,7 +13,8 @@ public abstract class SharedPressureProjectileSystem : EntitySystem
 
     private void OnProjectileHit(Entity<PressureProjectileComponent> ent, ref ProjectileHitEvent args)
     {
-        if (GetPressure(ent) > ent.Comp.MaxPressure)
+        float pressure = GetPressure(ent);
+        if (pressure < ent.Comp.MinPressure || pressure > ent.Comp.MaxPressure)
             args.Damage *= ent.Comp.Modifier;
     }
 
@@ -30,7 +31,7 @@ public abstract class SharedPressureProjectileSystem : EntitySystem
         // (and projectile hit event isnt predicted anyway)
     }
 
-    // client assumes it to be in a vacuum to correctly predict for the intended use case of lavaland/space.
+    // client assumes it to always be at minimum allowed pressure to correctly predict for the intended use case of lavaland.
     // it also means it would mispredict targets staying alive rather than falsely falling over which is far more annoying.
-    protected virtual float GetPressure(EntityUid uid) => 0f;
+    protected virtual float GetPressure(Entity<PressureProjectileComponent> ent) => ent.Comp.MinPressure;
 }

--- a/Resources/Locale/en-US/_DV/prototypes/entities/objects/weapons/pka.ftl
+++ b/Resources/Locale/en-US/_DV/prototypes/entities/objects/weapons/pka.ftl
@@ -1,0 +1,3 @@
+# numbers have to be kept in sync manually if you change them :)
+ent-WeaponProtoKineticAccelerator = proto-kinetic accelerator
+    .desc = Fires low-damage kinetic bolts at a short range. Full damage can only be done between 20 and 50 kPa, like on lavaland.

--- a/Resources/Prototypes/_DV/planets.yml
+++ b/Resources/Prototypes/_DV/planets.yml
@@ -60,9 +60,9 @@
   atmosphere:
     volume: 2500
     temperature: 180 # -93, extreme cold
-    moles: # 119kPa, 21% O2
-    - 42
-    - 158
+    moles: # 43kPa, equivalent O2 of 21% at STP
+    - 21.8249
+    - 50
   biomeMarkerLayers:
   - OreIron
   - OreQuartz


### PR DESCRIPTION
## About the PR
pka now has a minimum pressure of 20kpa for doing damage meaning it no longer does damage in space

if you want to use it on station without buying the evil modkit you have to carefully control atmos instead of just smashing windows

crushers are unaffected

## Why / Balance
salv fucking nukies sideways is bad so this hard counters it
closes #3740

for wreck mobs they can go use gamer loot lasers or buy real guns or troll the very stupid AI to walk off the wreck. or they can do something that actually benefits the station and not just them idk

also makes it less of a skeleton key for breaking open crates instantly

will only really matter for actual salv doing their job when lavaland has mobs/ruins

## Media
![06:55:32](https://github.com/user-attachments/assets/99557abd-f874-480d-b428-0d377ff27f35)
![06:56:14](https://github.com/user-attachments/assets/8bac5317-a3f7-447f-88a6-1184ae44548a)

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: PKAs now have a minimum pressure for full damage, use them on lavaland.