### PR TITLE
Bring back Epistemics T3 Tech Lockout

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/duffel.yml
@@ -170,12 +170,6 @@
   - type: Storage
     grid:
     - 0,0,8,4
-  - type: ReverseEngineering # DeltaV: can RE any valid bag for BoH
-    difficulty: 4
-    recipes:
-    - ClothingBackpackHolding
-    - ClothingBackpackDuffelHolding
-    - ClothingBackpackSatchelHolding
 
 - type: entity
   parent: ClothingBackpackDuffelSyndicate

--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -188,7 +188,3 @@
     price: 75
   - type: Tag
     tags: [ ]
-  - type: ReverseEngineering # DeltaV: upgrade moonboots T1 to speedboots T3
-    difficulty: 5
-    recipes:
-    - ClothingShoesBootsSpeed

--- a/Resources/Prototypes/Entities/Objects/Power/powercells.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/powercells.yml
@@ -155,10 +155,6 @@
   - type: Battery
     maxCharge: 1080
     startingCharge: 1080
-  - type: ReverseEngineering # DeltaV: Upgrade line of high -> hyper -> microreactor
-    difficulty: 3
-    recipes:
-    - PowerCellHyper
 
 - type: entity
   id: PowerCellHighPrinted
@@ -194,10 +190,6 @@
   - type: Battery
     maxCharge: 1800
     startingCharge: 1800
-  - type: ReverseEngineering # DeltaV
-    difficulty: 4
-    recipes:
-    - PowerCellMicroreactor
 
 - type: entity
   id: PowerCellHyperPrinted
@@ -236,6 +228,10 @@
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 12 # takes 1 minute to charge itself back to full
+  - type: ReverseEngineering # DeltaV
+    difficulty: 3
+    recipes:
+    - PowerCellHyper
 
 - type: entity
   parent: PowerCellMicroreactor

--- a/Resources/Prototypes/Research/disciplines.yml
+++ b/Resources/Prototypes/Research/disciplines.yml
@@ -5,11 +5,11 @@
   icon:
     sprite: Interface/Misc/research_disciplines.rsi
     state: industrial
-  lockoutTier: 4 # DeltaV: Lockout occurs at t4
+  lockoutTier: 3
   tierPrerequisites:
     1: 0
-    2: 1 # DeltaV: raised to 1
-    3: 1 # DeltaV: raised to 1
+    2: 0.75
+    3: 0.75
 
 - type: techDiscipline
   id: Arsenal
@@ -18,11 +18,11 @@
   icon:
     sprite: Interface/Misc/research_disciplines.rsi
     state: arsenal
-  lockoutTier: 4 # DeltaV: Lockout occurs at t4
+  lockoutTier: 3
   tierPrerequisites:
     1: 0
-    2: 1 # DeltaV: raised to 1
-    3: 1 # DeltaV: raised to 1
+    2: 0.75
+    3: 0.75
 
 - type: techDiscipline
   id: Experimental
@@ -31,11 +31,11 @@
   icon:
     sprite: Interface/Misc/research_disciplines.rsi
     state: experimental
-  lockoutTier: 4 # DeltaV: Lockout occurs at t4
+  lockoutTier: 3
   tierPrerequisites:
     1: 0
-    2: 1 # DeltaV: raised to 1
-    3: 1 # DeltaV: raised to 1
+    2: 0.75
+    3: 0.75
 
 - type: techDiscipline
   id: CivilianServices
@@ -44,8 +44,8 @@
   icon:
     sprite: Interface/Misc/research_disciplines.rsi
     state: civilianservices
-  lockoutTier: 4 # DeltaV: Lockout occurs at t4
+  lockoutTier: 3
   tierPrerequisites:
     1: 0
-    2: 1 # DeltaV: raised to 1
-    3: 1 # DeltaV: raised to 1
+    2: 0.75
+    3: 0.75

--- a/Resources/Prototypes/_DV/Research/disciplines.yml
+++ b/Resources/Prototypes/_DV/Research/disciplines.yml
@@ -5,7 +5,8 @@
   icon:
     sprite: Interface/Misc/research_disciplines.rsi
     state: biochemical
+  lockoutTier: 3
   tierPrerequisites:
     1: 0
-    2: 1
-    3: 1
+    2: 0.75
+    3: 0.75


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removes the RE recipes that caused the T3 Research lockout removal in the first place, and returns the T3 lockout. 

## Why / Balance
The RE machine generally should not take something and make "the same thing but it's 100 times better," which is what the T3 RE recipes were. Regardless of whether we have a T3 lockout or not, it just doesn't make much sense.

For the past half year, every Epistemics shift has had the same cookie-cutter monotonous gameplay purely because of the lack of a T3 tech lockout. Epistemics researches within glimmer (RAs permitting), then gets every single overpowered toy and tech that were brought into this game and designed to be mutually exclusive. The MG runs around with their designer bag, $500 shoes, and bluespace everything-under-the-sun. Many mechanics of Epistemics are made nearly or entirely obsolete due to these previous changes. The tech disk terminal literally only exists for a cargo bounty that happens once a shift every 4 shifts, and getting extra servers has 0 meaning or practical purpose. The game was not balanced around this freedom of research, and it shows in many different facets of gameplay. Security can get a printable Captain's Laser nearly every shift because the T3 arsenal tech, which was only "balanced" purely because of its rarity, is now not rare at all.

I know that Direction is likely to be against this change, as I have spent a long time debating and trying to get my point across in the discord's #community-feedback channel, or other forms. Regardless of this, I implore direction to take the following into consideration:
As I have been told, and as the original lockout removal PR states, the main purpose behind the removal of the lockout was due to Epistemics choosing the same discipline each shift. I already personally disagreed with the statement before, but many things have changed in the last few months that bring new incentives for Epistemics to rotate/alternate their discipline pick.

Departmental Lathes
- Now that Epistemics has much more limited access to technology, the department is much more used to researching things they cannot use, and I think that this will make players more likely to apply the same experience to their T3 pick.

Lack of extra RE recipes
- The T3 lockout was removed a month after the T3 tech RE recipes were added. I firmly believe that one of the largest influences for Epistemics to get T3 Industrial most shifts was because getting speed boots and micros were both free from the RE machine, meaning that the overpowered combination that was meant to be rare could now EASILY happen every shift. It's totally understandable that Epi would pick this every shift- it took barely any effort and was intentionally unbalanced, since it's supposed to be rare.

Speed Boots nerf
- With the speed boots recipe becoming more expensive and it's power drain increased, the combo is now much more balanced and much less enticing for Epistemics. The boots are now difficult to mass produce because of the bluespace requirement, and they're also controlled items with the current version of SoP. I also believe that having the lockout will mean that Epi can make bluespace tech less often, and it will be easier for the Mystagogue to ensure that bluespace tech is printed with the proper authority and permission.

Overall, I do understand why the lockout was removed from an administrative standpoint. The issue is that the lockout was removed to combat a perceived problem which had a much simpler solution: reverting what was causing the original problem, i.e the extra RE recipes that incentivized and allowed for Epi to be more selfish. The lockout removal does not fix the problem it was originally intending to solve, and merely acts as a band-aid fix that only half works. Epistemics is still fairly selfish with research picks, typically prioritizing what they need to get points better/easier (which logically makes complete sense, especially for the person who was and/or is working to make the points).
The obvious fix to this is to either balance T3 techs accordingly to not having a lockout, or to change what the techs actually unlock so that Epistemics is naturally interested in more than two of the five trees. Until this is done, the T3 lockout removal is much more of a detriment to the department, and arguably the game, as a whole. The change instead causes more problems than it intended to solve, and is simply counterintuitive.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Brought back the T3 tech lockout. Epistemics can once again only choose one branch of technology to have at T3 per R&D server. Speak to your local Mystagogue about gambling or getting a new server!
- remove: Removed Tier 3 Tech Reverse Engineering recipes (Speed Boots, Bluespace Bags, Microreactors).
