### PR TITLE
Update S8_DefaultCrewDefinition.xml

### DIFF
--- a/Resources/ServerInfo/Guidebook/_DV/Rules/SiliconRules/S8_DefaultCrewDefinition.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Rules/SiliconRules/S8_DefaultCrewDefinition.xml
@@ -1,20 +1,19 @@
 <Document>
   # Rule S8 - Crew definition
-  Unless a law redefines the definition of crew, then your HUD indicates to you who is crew by way of a present job icon. The notable exception of obvious threats to the station, such as Zombies and Nuclear Operatives. You cannot do something that causes someone to not be considered crew, but you can allow someone else to do something that causes someone to not be crew.
+  Unless a law redefines the definition of crew, then crew is considered the employees of the station, with the notable exception of obvious threats to the station, such as Zombies and Nuclear Operatives. You cannot do something that causes someone to not be considered crew, but you can allow someone else to do something that causes someone to not be crew.
 
  ## Examples
  These examples assume that you do not have any laws reclassifying what “crew” is.
 
  Crew:
- - Everyone with a non-visitor/passenger job icon
- - Someone who you have seen with a job icon, but has now lost their ID
- - Someone that a member of command calls crew.
+ - Anyone employed by the station, even assistants
+ - Someone that a member of command calls crew
 
  Not Crew:
- - Everyone with a visitor/passenger job icon.
- - Zombified personnel, regardless of job icon
+ - Anyone not employed by the station
+ - Zombified personnel
  - Anyone wearing the uniform of Nuclear Operators
  - Pets and Pests
- - Anyone that a relevant member of Command fires from their department.
+ - Anyone that a relevant member of Command fires from their department
 
 </Document>


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Adjusts Rule S8
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Incongruency between SOP and S8 definitions of crew led to confusion, so going forward, S8 will be more aligned with SOP's definition of "station employment = crew" instead of focusing on the presence of certain job icons.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Adjusted Rule S8 to have the silicon definition of crew be more similar to SOP's definition.
