### PR TITLE
Port ion damage but good

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/damage/damage-groups.ftl
+++ b/Resources/Locale/en-US/_Goobstation/damage/damage-groups.ftl
@@ -1,0 +1,1 @@
+damage-group-electronic = Electronic

--- a/Resources/Locale/en-US/_Goobstation/damage/damage-types.ftl
+++ b/Resources/Locale/en-US/_Goobstation/damage/damage-types.ftl
@@ -1,0 +1,1 @@
+damage-type-ion = Ion

--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -28,6 +28,7 @@
   id: Silicon
   supportedGroups:
     - Brute
+    - Electronic #Goobstation
   supportedTypes:
     - Heat
     - Shock

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -43,6 +43,7 @@
         Heat: -1.66
         Shock: -1.66
         Cold: -1.66 # DeltaV
+        Ion: -1.66 #Goobstation
   # EE Change End
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -203,6 +203,7 @@
       types:
         Blunt: 25
         Asphyxiation: 5
+        Ion: 5
         Cold: 5
         Structural: 60
     soundHit:

--- a/Resources/Prototypes/_DV/CosmicCult/Objects/cosmicweapons.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Objects/cosmicweapons.yml
@@ -21,6 +21,7 @@
       types:
         Slash: 11
         Asphyxiation: 12
+        Ion: 12
         Cold: 12
         Structural: 15
     soundHit:
@@ -97,6 +98,7 @@
       types:
         Piercing: 12
         Asphyxiation: 10
+        Ion: 10
         Cold: 10
     soundHit:
       path: /Audio/_DV/CosmicCult/cosmiclance_hit.ogg
@@ -213,6 +215,7 @@
         Slash: 3
         Piercing: 3
         Asphyxiation: 6
+        Ion: 6
         Cold: 6
         Structural: 15
     soundHit:

--- a/Resources/Prototypes/_DV/Damage/containers.yml
+++ b/Resources/Prototypes/_DV/Damage/containers.yml
@@ -3,5 +3,6 @@
   supportedGroups:
   - Brute
   - Burn
+  - Electronic
   supportedTypes:
   - Radiation

--- a/Resources/Prototypes/_Goobstation/Damage/groups.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/groups.yml
@@ -1,0 +1,5 @@
+- type: damageGroup
+  id: Electronic
+  name: damage-group-electronic
+  damageTypes:
+    - Ion

--- a/Resources/Prototypes/_Goobstation/Damage/types.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/types.yml
@@ -1,0 +1,5 @@
+- type: damageType
+  id: Ion
+  name: damage-type-ion
+  armorCoefficientPrice: 1
+  armorFlatPrice: 1


### PR DESCRIPTION
## About the PR
Revival of #2899, but without giving the new damage type to disablers. Instead, cult weapons now deal the same amount of ion damage as they do asphyxiation damage (because silicons can't asphyxiate).
Cult things that should probably also do ion damage:
- Being hit by astral nova
- Activating glyphs

## Why / Balance
Mostly fixes #3988. Cult weapons were much weaker against IPCs than other humanoids, now the damage is identical.
Also can be useful in the future? Maybe?

## Technical details
Just some YAML, nothing crazy. New damage group and damage type. Added said damage to cult weapons.

## Media
The sword
![изображение](https://github.com/user-attachments/assets/c1b969d6-e1b9-4b12-8cfc-c01b61f324e6)
Organics don't take ion damage
![изображение](https://github.com/user-attachments/assets/58234bae-c531-46cf-968d-dc7ec3eb3b58)
Silicons do take ion damage
![изображение](https://github.com/user-attachments/assets/e384821f-0705-4096-9d30-7293539c0a6d)


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Cosmic cult's weapons now deal ion damage, to compensate for silicon's inability to asphyxiate.
