### PR TITLE
Change SOP to permit issuing of controlled item and armament licenses based on item/armament category or type.

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -37,7 +37,7 @@ Controlled Items include any item that is restricted from general possession and
 * Teleportation and portal technology.
 * Hydraulic or powered equipment designed for the electronic or mechanical bypass of secure-access systems.
 
-Any individual requiring any above item in the course of their job, or for regular function, may request a document of authorization from the relevant departmental head. Such a document must have an itemized list of the approved Controlled Items, the name and position of the holder, and a signed and stamped statement by the authorizing party.
+Any individual requiring any above item in the course of their job, or for regular function, may request a document of authorization from the relevant departmental head. Such a document must have either an itemized list of the approved Controlled Items or a description of approved Controlled Items on the basis of category and type, the name and position of the holder, and a signed and stamped statement by the authorizing party.
 
 Should the holder commit crimes through the use of such authorized items, the authorizing party may be found guilty of Accessory to said crimes, in addition to Endangerment and Abuse of Power where applicable. The Commanding Officer is also authorized to supervise the approval and revocation of documentation as they see fit.
 
@@ -91,7 +91,7 @@ Controlled Armaments are grouped into categories of increasing severity.
 * Any object or instrument specifically designed or adapted to launch large-calibre explosives or projectiles for offensive or defensive purposes
 * Any object or instrument specifically designed or adapted to employ chemical, biological, esoteric, radiological, or nuclear hazards for offensive or defensive purposes
 
-Armaments licenses may be issued by the Commanding Officer, Warden, or Head of Security. The license must include the name of the holder, a list of allowed armaments, and a stamped signature from the issuer.
+Armaments licenses may be issued by the Commanding Officer, Warden, or Head of Security. The license must include the name of the holder, a list of allowed armaments or a list of allowed categories of armaments, and a stamped signature from the issuer.
 
 If the holder uses their armaments in the commission of a crime, the issuer may be held liable for accessory to the crimes committed, along with Endangerment and Abuse of Power where applicable.
 

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -91,7 +91,7 @@ Controlled Armaments are grouped into categories of increasing severity.
 * Any object or instrument specifically designed or adapted to launch large-calibre explosives or projectiles for offensive or defensive purposes
 * Any object or instrument specifically designed or adapted to employ chemical, biological, esoteric, radiological, or nuclear hazards for offensive or defensive purposes
 
-Armaments licenses may be issued by the Commanding Officer, Warden, or Head of Security. The license must include the name of the holder, a list of allowed armaments or a list of allowed categories of armaments, and a stamped signature from the issuer.
+Armaments licenses may be issued by the Commanding Officer, Warden, or Head of Security. The license must include the name of the holder, a list of allowed armaments or a list of allowed categories or types of armaments, and a stamped signature from the issuer.
 
 If the holder uses their armaments in the commission of a crime, the issuer may be held liable for accessory to the crimes committed, along with Endangerment and Abuse of Power where applicable.
 


### PR DESCRIPTION

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Rewords the SOP to permit issuing of controlled item and armament licenses based on item/armament category or type, not only via an itemized list of every single permitted item.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Currently licenses may only be issued with an _itemized list of permitted items_. This is needlessly tedious and absurd - it requires the issuer or requester to memorize item names, and if a license is being issued for a category of items (for example if you want to authorize someone to wear hardsuits), becomes completely unrealistic.

The practical end result of the current SOP is that:

- In practical use licenses are very rarely in accordance with SOP, instead being "bluespace permits", "weapon category permits" or similar. The only regularly processed license that meets the requirements is a jaws-of-life permit.
- If a HoS or Warden chooses to follow SOP to the letter, most players will just not ask for a license anyway. Most prominantly this applies to Salvage, who already are iffy about asking for licenses even barring denials.

I should note that even I was not until recently aware of this _specificity_ - as can be evidenced by the "Salvage Armaments License" form on the wiki, a license I had multiple times had gotten approved in the past, and only recently it was denied by a HoS on the basis of SOP-as-written.

This does not "give" any license, nor does it impose any risk - permitted categories and types _are still at the discression of the issuer_. The change is further worded to permit issues by type - so you may issue a "hardsuit license" without issuing a full Category D license, or permit non-lethal firearms without issuing a full Category C license which would permit 

## Technical details
<!-- Summary of code changes for easier review. -->
N/A

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [] I have tested all added content and changes. - N/A
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed the SOP to permit issuing of controlled item and armament licenses based on item/armament category and/or type.


