### PR TITLE
Wizard Clothes- Slowdown removed, hat lets you breathe

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -686,6 +686,7 @@
     lowPressureMultiplier: 1000
   - type: TemperatureProtection # DeltaV
     coolingCoefficient: 0.2
+  - type: BreathMask # DeltaV - No more masks needed
 
 - type: entity
   parent: ClothingHeadHatWizardBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -172,9 +172,6 @@
   id: ClothingOuterWizardBase
   components:
   - type: WizardClothes
-  - type: ClothingSpeedModifier # DeltaV - We made wizrobes spaceproof, this just makes them incur no slowdown
-    walkModifier: 1
-    sprintModifier: 1
 
 # Is this wizard wearing a fanny pack???
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/misc.yml
@@ -172,6 +172,9 @@
   id: ClothingOuterWizardBase
   components:
   - type: WizardClothes
+  - type: ClothingSpeedModifier # DeltaV - We made wizrobes spaceproof, this just makes them incur no slowdown
+    walkModifier: 1
+    sprintModifier: 1
 
 # Is this wizard wearing a fanny pack???
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removed the slowdown on this magical robes, and gave the hat the Breathmask Comp

## Why / Balance
While the wizard robe is an EVA suit, it is rare, and not exactly standard. So why does it slow as much as a standard EVA? This allows wizrobes to no longer slow you when worn, since they do not have NEARLY the bulk of an EVA suit. Also allows you ot breath in sapce with just the hat, an no mask. As its MAGIC

## Technical details
Light yaml work

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: EVA Safe wizard robes no longer slow you, and the hat allows you to breath