### PR TITLE
replace summary stasis with exfil

### DIFF
--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -187,7 +187,7 @@ Emergency alert status. ''Central Command has called the Gamma Alert; the Statio
 | style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection heavily advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for general orders. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Propose evacuation or scuttling if station cannot be retaken.
+| style="border: 1px solid #000000;" | Report to supervisor for general orders. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Propose evacuation or scuttling if station cannot be retaken.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
 | style="border: 1px solid #000000;" | All HSAs should remain locked and under guard. Secure areas unlocked unless affected by known threats.
@@ -217,7 +217,7 @@ Emergency alert status. ''The nuclear destruction mechanism has been engaged and
 | style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection heavily advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Emergency personnel must expend all efforts to prevent station destruction if engaged in error. Security and Command personnel are to oversee the evacuation of personnel and safe scuttling of the station. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats.
+| style="border: 1px solid #000000;" | Emergency personnel must expend all efforts to prevent station destruction if engaged in error. Security and Command personnel are to oversee the evacuation of personnel and safe scuttling of the station. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
 | style="border: 1px solid #000000;" | All secure areas and HSAs should remain locked.

--- a/.wiki/_DV/Laws/SpaceLaw.txt
+++ b/.wiki/_DV/Laws/SpaceLaw.txt
@@ -92,7 +92,6 @@ Capital Sentences are organized in order of severity, with the least severe last
 ** The convict may either face execution by firing squad, by lethal electrocution, by being ejected from the station via an airlock (being "spaced"), or by a method of their choosing, at the Judge's sole discretion.
 ** If recoverable, their remains must either be cremated, processed via the biomass reclaimer, or stored in the morgue.
 * '''Decorporealization:''' Stripping the convict's mind from their body into a more restrictive form, such as a cyborg or soul gem.
-* '''Preservative Stasis:''' Relocation of the convict into a morgue or similar controlled and regulated environment until one's sentence is concluded, or until the legal system can accomodate the convict.
 * '''Exfiltration:''' Immediate retrieval of the convict via a CentComm or GALPOL prison transport.
 ** The prisoner may be held within the permanent brig until the transport arrives.
 ** If transport cannot be arranged, default to other capital sentences.

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -269,7 +269,7 @@ Additionally, prisoners sentenced to Extended Confinement have certain rights bu
 * Prisoners may request retrial for capital crimes; these requests may be refused depending on the discretion and availability of the court clerk, chief justice, or at the discretion of the warden or head of station security.
 * Prisoners may request or may otherwise be given parole with a hearing by the Chief Justice, Court Clerk, or in their absence, the head of station security or commanding officer (see Paroles and Pardons).
 
-Should prisoners repeatedly and maliciously antagonize law enforcement, to an extent where continued extended confinement becomes infeasible, the warden is fully authorized and encouraged to temporarily upgrade the relevant prisoners’ sentences to Preservative Stasis summarily.
+Should prisoners repeatedly and maliciously antagonize law enforcement, to an extent where continued extended confinement becomes infeasible, the warden is fully authorized and encouraged to temporarily upgrade the relevant prisoners’ sentences to Exfiltration summarily.
 
 Moreover, prisoners are liable for any and all crimes that they commit while held either in the temporary holding cells or the Permanent Brig, and may receive trial for more restrictive punishments if their actions warrant a capital sentence.
 

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -269,7 +269,7 @@ Additionally, prisoners sentenced to Extended Confinement have certain rights bu
 * Prisoners may request retrial for capital crimes; these requests may be refused depending on the discretion and availability of the court clerk, chief justice, or at the discretion of the warden or head of station security.
 * Prisoners may request or may otherwise be given parole with a hearing by the Chief Justice, Court Clerk, or in their absence, the head of station security or commanding officer (see Paroles and Pardons).
 
-Should prisoners repeatedly and maliciously antagonize law enforcement, to an extent where continued extended confinement becomes infeasible, the warden is fully authorized and encouraged to temporarily upgrade the relevant prisoners’ sentences to Exfiltration summarily.
+Should prisoners repeatedly and maliciously antagonize law enforcement, to an extent where continued extended confinement becomes infeasible, the warden is fully authorized and encouraged to upgrade the relevant prisoners’ sentences to Exfiltration summarily.
 
 Moreover, prisoners are liable for any and all crimes that they commit while held either in the temporary holding cells or the Permanent Brig, and may receive trial for more restrictive punishments if their actions warrant a capital sentence.
 


### PR DESCRIPTION
removes stasis, replaces summary stasis with exfil


## About the PR
replaced summary stasis with summary exfil. removed all other mentions of stasis

## Why / Balance
exfil is stasis but with RP. Martial Law stasis is already covered by the rest of martial law.


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- remove: Stasis is no longer a valid sentence
- tweak: Summary Stasis has been replaced with summary Exfiltration

