### PR TITLE
Add a materials magnet to the logistics techfab

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -135,9 +135,9 @@
     board: LogisticsTechFabCircuitboard
   - type: StealTarget
     stealGroup: LogisticsTechFabCircuitboard
-  - type: MaterialStorageMagnetPickup # DeltaV - Adds magnet pull from Frontier
+  - type: MaterialStorageMagnetPickup
     magnetEnabled: True
-    range: 0.30 # DeltaV - End Magnet Pull
+    range: 0.30
   - type: LatheAnnouncing
     channels: [Supply]
 

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -135,6 +135,9 @@
     board: LogisticsTechFabCircuitboard
   - type: StealTarget
     stealGroup: LogisticsTechFabCircuitboard
+  - type: MaterialStorageMagnetPickup # DeltaV - Adds magnet pull from Frontier
+    magnetEnabled: True
+    range: 0.30 # DeltaV - End Magnet Pull
   - type: LatheAnnouncing
     channels: [Supply]
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds the ported-from-Frontier lathe magnet (previously used for the ore processor) to the logistics techfab

## Why / Balance
Logistics typically stores materials in their lathe. When a particularly large load of materials come in, inserting it all into the lathe is frankly miserable. This allows automation of that using conveyors.

## Technical details
It's just YAML, I just ported the lines from the ore processor and it just works like that, taking only mats, not ores. 

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
:cl:
- add: Added a short range materials magnet to the logistics techlathe. Cargo Technicians rejoice! WARNING: This does not fix the existing bug with diamonds being stuck in lathes. Use with caution.

