### PR TITLE
Fix Listening Post crew monitoring console

### DIFF
--- a/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/ObjectsTab/ObjectsTab.xaml.cs
@@ -76,7 +76,11 @@ public sealed partial class ObjectsTab : Control
         switch (selection)
         {
             case ObjectsTabSelection.Stations:
-                entities.AddRange(_entityManager.EntitySysManager.GetEntitySystem<StationSystem>().Stations);
+                var a = _entityManager.EntitySysManager.GetEntitySystem<StationSystem>().Stations;
+                for (int i = 0; i < a.Count; i++)
+                {
+                    entities.Add(a[i]);
+                }
                 break;
             case ObjectsTabSelection.Grids:
             {

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -1,12 +1,8 @@
 using Content.Shared.Medical.CrewMonitoring;
 using Robust.Client.UserInterface;
 using Content.Client.Station;
-using System.Diagnostics;
 using System.Linq;
-using Content.Shared.Station.Components;
-using Robust.Shared.Log;
 using Content.Shared.Tag;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client.Medical.CrewMonitoring;
 

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -1,5 +1,10 @@
 using Content.Shared.Medical.CrewMonitoring;
 using Robust.Client.UserInterface;
+using Content.Client.Station;
+using System.Diagnostics;
+using System.Linq;
+using Content.Shared.Station.Components;
+using Robust.Shared.Log;
 
 namespace Content.Client.Medical.CrewMonitoring;
 
@@ -15,11 +20,18 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
     protected override void Open()
     {
         base.Open();
-
+        var debug = Logger.GetSawmill("crewmon-ui");
         EntityUid? gridUid = null;
         var stationName = string.Empty;
-
-        if (EntMan.TryGetComponent<TransformComponent>(Owner, out var xform))
+        // Delta-v start of crew monitor display correction
+        var station = EntMan.EntitySysManager.GetEntitySystem<StationSystem>().Stations;
+        var station0 = station.FirstOrDefault();
+        
+        debug.Debug($"Stations: {station.Count} Station 0 name: {station0.Name}");
+        var station0_uid = EntMan.GetEntity(station0.Entity);
+        debug.Debug($"Station 0 ENT-UID: {station0_uid}, station 0 netid: {station0.Entity.Id}");
+        
+        if (EntMan.TryGetComponent<TransformComponent>(station0_uid, out var xform))
         {
             gridUid = xform.GridUid;
 
@@ -28,6 +40,7 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
                 stationName = metaData.EntityName;
             }
         }
+        
 
         _menu = this.CreateWindow<CrewMonitoringWindow>();
         _menu.Set(stationName, gridUid);

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -22,7 +22,6 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
     protected override void Open()
     {
         base.Open();
-        var log = Logger.GetSawmill("crewmon-ui");
         EntityUid? gridUid = null;
         var stationName = string.Empty;
         // Delta-v start of crew monitor display correction
@@ -32,7 +31,6 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
         {
             var station = EntMan.EntitySysManager.GetEntitySystem<StationSystem>().Stations;
             var station0 = station.FirstOrDefault();
-            log.Debug($"Amount of grids {station0.StationGrids.Count}");
             var station0_grid0 = station0.StationGrids[0];
             mappedGrid = EntMan.GetEntity(station0_grid0);
         }
@@ -40,7 +38,7 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
         {
             mappedGrid = Owner;
         }
-        
+        // end delta-v
         if (EntMan.TryGetComponent<TransformComponent>(mappedGrid, out var xform))
         {
             gridUid = xform.GridUid;

--- a/Content.Client/Station/StationSystem.cs
+++ b/Content.Client/Station/StationSystem.cs
@@ -7,7 +7,7 @@ namespace Content.Client.Station;
 /// </summary>
 public sealed partial class StationSystem : SharedStationSystem
 {
-    private readonly List<(string Name, NetEntity Entity)> _stations = new();
+    private readonly List<StationRecord> _stations = new();
 
     /// <summary>
     /// All stations that currently exist.
@@ -16,7 +16,7 @@ public sealed partial class StationSystem : SharedStationSystem
     /// I'd have this just invoke an entity query, but we're on the client and the client barely knows about stations.
     /// </remarks>
     // TODO: Stations have a global PVS override now, this can probably be changed into a query.
-    public IReadOnlyList<(string Name, NetEntity Entity)> Stations => _stations;
+    public IReadOnlyList<StationRecord> Stations => _stations;
 
     /// <inheritdoc/>
     public override void Initialize()

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -528,7 +528,6 @@ public sealed partial class StationSystem : SharedStationSystem
         {
             var data_comp = EntityManager.GetComponent<StationDataComponent>(station);
             var list = data_comp.Grids.ToArray();
-            _sawmill.Debug($"Grids amount {list.Length}");
             var netgrids = new List<NetEntity>();
             for (int i = 0; i < list.Length; i++) {
                 netgrids.Add(GetNetEntity(list[i]));

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -518,14 +518,20 @@ public sealed partial class StationSystem : SharedStationSystem
         return stations;
     }
 
-    public List<(string Name, NetEntity Entity)> GetStationNames()
+    public List<StationRecord> GetStationNames()
     {
         var stations = GetStationsSet();
-        var stats = new List<(string Name, NetEntity Station)>();
+        var stats = new List<StationRecord>();
 
-        foreach (var weh in stations)
+        foreach (var station in stations)
         {
-            stats.Add((MetaData(weh).EntityName, GetNetEntity(weh)));
+            var data_comp = EntityManager.GetComponent<StationDataComponent>(station);
+            var list = data_comp.Grids.ToArray();
+            var netgrids = new List<NetEntity>();
+            for (int i = 0; i < list.Length; i++) {
+                netgrids.Add(GetNetEntity(list[i]));
+            }
+            stats.Add(new StationRecord(MetaData(station).EntityName, GetNetEntity(station), netgrids));
         }
 
         return stats;

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -182,6 +182,7 @@ public sealed partial class StationSystem : SharedStationSystem
     private void OnStationGridAdded(StationGridAddedEvent ev)
     {
         // When a grid is added to a station, update all trackers on that grid
+        RaiseNetworkEvent(new StationsUpdatedEvent(GetStationNames()), Filter.Broadcast());
         UpdateTrackersOnGrid(ev.GridId, ev.Station);
     }
 
@@ -527,6 +528,7 @@ public sealed partial class StationSystem : SharedStationSystem
         {
             var data_comp = EntityManager.GetComponent<StationDataComponent>(station);
             var list = data_comp.Grids.ToArray();
+            _sawmill.Debug($"Grids amount {list.Length}");
             var netgrids = new List<NetEntity>();
             for (int i = 0; i < list.Length; i++) {
                 netgrids.Add(GetNetEntity(list[i]));

--- a/Content.Shared/Station/StationsUpdatedEvent.cs
+++ b/Content.Shared/Station/StationsUpdatedEvent.cs
@@ -1,13 +1,26 @@
-﻿using Robust.Shared.Serialization;
+﻿using System.ComponentModel.DataAnnotations;
+using Content.Shared.Nutrition.EntitySystems;
+using Robust.Shared.Serialization;
 
 namespace Content.Shared.Station;
 
+// delta-v
+[NetSerializable, Serializable]
+public record struct StationRecord(string StationName, NetEntity StationEntity, List<NetEntity> StationGrids)
+{
+    public static implicit operator ValueTuple<string, NetEntity>(StationRecord record)
+    {
+        return (record.StationName, record.StationEntity);
+    }
+};
+
+// end delta-v
 [NetSerializable, Serializable]
 public sealed class StationsUpdatedEvent : EntityEventArgs
 {
-    public readonly List<(string Name, NetEntity Entity)> Stations;
+    public readonly List<StationRecord> Stations;
 
-    public StationsUpdatedEvent(List<(string Name, NetEntity Entity)> stations)
+    public StationsUpdatedEvent(List<StationRecord> stations)
     {
         Stations = stations;
     }

--- a/Resources/Maps/_DV/Nonstations/listening_post.yml
+++ b/Resources/Maps/_DV/Nonstations/listening_post.yml
@@ -4259,6 +4259,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 12.5,0.5
       parent: 1
+    - type: Tag
+      tags:
+      - Syndicate # Tag which essentially tells the crewmon to focus on the main station
 - proto: ComputerMassMedia
   entities:
   - uid: 311


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR fixes the previously broken crew monitoring console aboard the listening post. 

## Why / Balance
This change would allow listening post operative to actually know where the crew is aboard the station and allow them to have more accurate information which they could use to cause communication mayhem.

## Technical details
The code within the PR slightly modifies the station system, which now sends grids along with the station and name, as well as adds the "Syndicate" tag to the crew monitoring console to let the system know that the LPO console in particular has to search for the main station.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
https://github.com/user-attachments/assets/a8754aa5-969e-40d7-aeb5-0b2a1d577e49

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


## Breaking changes
The `StationsUpdatedEvent` tuple was turned into a `record struct`, however it can still be used as the original tuple as it contains an implicit conversion method.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this

 Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed Listening Post crew monitor not displaying station grid correctly.

