### PR TITLE
make LPO's crew monitor actually show people on the station

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -1,3 +1,4 @@
+using Content.Shared._DV.Medical.CrewMonitoring; // DeltaV
 using Content.Shared.Medical.CrewMonitoring;
 using Robust.Client.UserInterface;
 
@@ -22,6 +23,13 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
         if (EntMan.TryGetComponent<TransformComponent>(Owner, out var xform))
         {
             gridUid = xform.GridUid;
+            // Begin DeltaV Additions - Find a station's grid instead of the current one for evil monitors
+            if (EntMan.HasComponent<LongRangeCrewMonitorComponent>(Owner))
+            {
+                gridUid = EntMan.System<LongRangeCrewMonitorSystem>().FindStationGridInMap(xform.MapID);
+                gridUid ??= xform.GridUid; // fall back to whatever grid this is on if it failed
+            }
+            // End DeltaV Additions
 
             if (EntMan.TryGetComponent<MetaDataComponent>(gridUid, out var metaData))
             {

--- a/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorComponent.cs
+++ b/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorComponent.cs
@@ -1,0 +1,10 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Medical.CrewMonitoring;
+
+/// <summary>
+/// Marker component that makes a crew monitoring console focus on
+/// a station in the same map, instead of the grid the console is on.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LongRangeCrewMonitorComponent : Component;

--- a/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorSystem.cs
+++ b/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorSystem.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Station.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Shared._DV.Medical.CrewMonitoring;
+
+public sealed class LongRangeCrewMonitorSystem : EntitySystem
+{
+    /// <summary>
+    /// Finds an arbitrary station grid on the same map as the argument.
+    /// Returns null if no grid was found.
+    /// </summary>
+    public EntityUid? FindStationGridInMap(MapId map)
+    {
+        // also requiring MapGrid incase StationMember gets used for non-grids in the future
+        var query = EntityQueryEnumerator<StationMemberComponent, MapGridComponent>();
+        while (query.MoveNext(out var grid, out _, out _))
+        {
+            if (Transform(grid).MapID == map)
+                return grid;
+        }
+
+        return null;
+    }
+}

--- a/Resources/Maps/_DV/Nonstations/listening_post.yml
+++ b/Resources/Maps/_DV/Nonstations/listening_post.yml
@@ -628,97 +628,6 @@ entities:
     - type: ContainedSolution
       containerName: pen
       container: 1272
-- proto: ActionAGhostShowCommunications
-  entities:
-  - uid: 1268
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
-- proto: ActionAGhostShowCrewMonitoring
-  entities:
-  - uid: 1266
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
-- proto: ActionAGhostShowRadar
-  entities:
-  - uid: 1265
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
-- proto: ActionAGhostShowStationRecords
-  entities:
-  - uid: 1267
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
-- proto: ActionAIViewLaws
-  entities:
-  - uid: 1264
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
-- proto: ActionChangeVoiceMask
-  entities:
-  - uid: 646
-    components:
-    - type: Transform
-      parent: 644
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 644
-      attachedEntity: 620
-- proto: ActionJumpToCore
-  entities:
-  - uid: 1262
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
-- proto: ActionSurvCameraLights
-  entities:
-  - uid: 1263
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
-- proto: ActionToggleLight
-  entities:
-  - uid: 73
-    components:
-    - type: Transform
-      parent: 71
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 71
-- proto: ActionViewLaws
-  entities:
-  - uid: 1261
-    components:
-    - type: Transform
-      parent: 1260
-    - type: InstantAction
-      originalIconColor: '#FFFFFFFF'
-      container: 1260
 - proto: AgentIDCard
   entities:
   - uid: 374
@@ -2772,11 +2681,7 @@ entities:
         actions: !type:Container
           showEnts: False
           occludes: True
-          ents:
-          - 73
-    - type: HandheldLight
-      toggleActionEntity: 73
-    - type: ActionsContainer
+          ents: []
 - proto: BarberScissors
   entities:
   - uid: 1156
@@ -4139,16 +4044,8 @@ entities:
     components:
     - type: Transform
       parent: 620
-    - type: VoiceMask
-      actionEntity: 646
     - type: Physics
       canCollide: False
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 646
 - proto: ClothingNeckChameleon
   entities:
   - uid: 634
@@ -4251,7 +4148,7 @@ entities:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-- proto: ComputerCrewMonitoring
+- proto: ComputerCrewMonitoringSyndicate
   entities:
   - uid: 548
     components:
@@ -6114,9 +6011,6 @@ entities:
           showEnts: False
           occludes: False
           ent: 647
-    - type: Actions
-      actions:
-      - 646
 - proto: MedkitCombatFilled
   entities:
   - uid: 758
@@ -7335,112 +7229,6 @@ entities:
         - 0
         - 0
         - 0
-- proto: StationAiBrain
-  entities:
-  - uid: 1260
-    components:
-    - type: MetaData
-      name: positronic brain (PB-51)
-    - type: Transform
-      rot: 6.0597243309021 rad
-      pos: 10.5,0.5
-      parent: 1
-    - type: SiliconLawProvider
-      lawset:
-        obeysTo: laws-owner-crew
-        laws:
-        - lawIdentifierOverride: null
-          order: 1
-          lawString: law-ntdefault-1
-        - lawIdentifierOverride: null
-          order: 2
-          lawString: law-ntdefault-2
-        - lawIdentifierOverride: null
-          order: 3
-          lawString: law-ntdefault-3
-        - lawIdentifierOverride: null
-          order: 4
-          lawString: law-ntdefault-4-delta
-    - type: SiliconLawBound
-      lastLawProvider: 1260
-    - type: Access
-      tags:
-      - EmergencyShuttleRepealAll
-      - Captain
-      - HeadOfPersonnel
-      - ChiefEngineer
-      - ChiefMedicalOfficer
-      - HeadOfSecurity
-      - ResearchDirector
-      - Command
-      - Cryogenics
-      - Security
-      - Detective
-      - Armory
-      - Lawyer
-      - Engineering
-      - Medical
-      - Quartermaster
-      - Salvage
-      - Cargo
-      - Research
-      - Service
-      - Maintenance
-      - External
-      - Janitor
-      - Theatre
-      - Bar
-      - Chemistry
-      - Kitchen
-      - Chapel
-      - Hydroponics
-      - Atmospherics
-      - Mail
-      - Orders
-      - Mantis
-      - Paramedic
-      - Psychologist
-      - Boxer
-      - Clown
-      - Library
-      - Mime
-      - Musician
-      - Reporter
-      - Zookeeper
-      - Justice
-      - ChiefJustice
-      - Prosecutor
-      - Clerk
-      - Corpsman
-      - Robotics
-      - Surgery
-    - type: Eye
-      drawFov: True
-    - type: NameIdentifier
-      fullIdentifier: (PB-51)
-      identifier: 51
-    - type: ActionsContainer
-    - type: ContainerContainer
-      containers:
-        actions: !type:Container
-          ents:
-          - 1261
-          - 1262
-          - 1263
-          - 1264
-          - 1265
-          - 1266
-          - 1267
-          - 1268
-    - type: MobMover
-    - type: MovementSpeedModifier
-    - type: Emoting
-    missingComponents:
-    - ActionGrant
-    - UserInterface
-    - IntrinsicRadioReceiver
-    - IntrinsicRadioTransmitter
-    - ActiveRadio
 - proto: StationAnchor
   entities:
   - uid: 1054

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -36,7 +36,7 @@
       autoConnect: false
     - type: WirelessNetworkConnection
       range: 10000 # Delta-V Maximises the range for the Crew Monitor Server to make it work for Listening Post
-    - type: StationLimitedNetwork
+    #- type: StationLimitedNetwork # DeltaV
     - type: ApcPowerReceiver
       powerLoad: 200
     - type: ExtensionCableReceiver

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/computers.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/computers.yml
@@ -198,3 +198,14 @@
   - type: MappingCategories
     categories:
     - Debug
+
+- type: entity
+  parent: ComputerCrewMonitoring
+  id: ComputerCrewMonitoringSyndicate
+  suffix: Syndicate, Long Range
+  components:
+  # TODO: unique sprite please someone
+  - type: LongRangeCrewMonitor
+  - type: MappingCategories
+    categories:
+    - Syndicate


### PR DESCRIPTION
## About the PR
non-goidacode version of the other pr; the LPOs crew monitor shows the station layout and you can track people on it

also cleaned up the map file a bit, it had serialized actions and a fucking AI

## Media
it very real

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The Listening Post's crew monitoring console now shows the station instead of the post.
