### PR TITLE
make esword/edagger no longer perma-able

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -81,7 +81,7 @@ Controlled Armaments are grouped into categories of increasing severity.
 
 * Any semi-automatic ballistic arms that are easily concealable
 * Any fully-automatic ballistic arms
-* Any laser, plasma, or energy based arms, including ones designed, intended, or used for melee combat.
+* Any laser, plasma, or energy based ranged weaponry
 * Any object or device specifically designed or adapted to cause physical harm through detonation of an explosive charge
 * Any object or equipment specifically designed or adapted to protect against both a space environment and physical harm caused by weapons, projectiles, or other forms of direct assault
 


### PR DESCRIPTION
## About the PR
made the energy arms clause specific to range again so you cant perma someone just for having a funny pen

now its only 5 minutes for knife

## Why / Balance
being able to perma someone just for having a pen is insane
if they stab someone thats assault with a deadly weapon + possession, you can still perma for that
if you want to perma people left and right do a *little* bit of thinking at least

arguable viper perma should be axed too because permaing people over tiny shit causes 2 things:
- try to do a cool rp with a pistol and get permad, traitor becomes greenshift
- know you will get permad anyway and go full rambo, noooo you cant do that so evil

you might say "but erm it says UP TO", except nobody EVER gives lenient sentences nor are they incentivised to. that's not a suggestion it's practically a requirement
if you can perma a syndie why *wouldnt* you, a functioning member of sec who isn't against nanotrasen?

**Changelog**
:cl:
- tweak: Adjusted SOP's controlled armaments, energy melee weapons are no longer Cat D.