### PR TITLE
Change plasteel and wood crates from cargo to come with 90 sheets instead of 30.

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -24,7 +24,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: plastic_3
   product: CrateMaterialPlastic
-  cost: 2000
+  cost: 1500 # Delta-V - was 2000
   category: cargoproduct-category-name-materials
   group: market
 
@@ -94,7 +94,7 @@
     sprite: Objects/Materials/Sheets/other.rsi
     state: generic_materials
   product: CrateMaterialBasicResource
-  cost: 1660
+  cost: 1500 # Delta-V - was 1660
   category: cargoproduct-category-name-materials
   group: market
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -52,6 +52,7 @@
   - type: StorageFill
     contents:
       - id: MaterialWoodPlank
+        amount: 3 # Delta-V
 
 - type: entity
   id: CrateMaterialBrass
@@ -68,11 +69,12 @@
   id: CrateMaterialPlasteel
   parent: CrateGenericSteel
   name: plasteel crate
-  description: 30 sheets of plasteel.
+  description: 90 sheets of plasteel. # Delta-V - was 90 sheets
   components:
   - type: StorageFill
     contents:
       - id: SheetPlasteel
+        amount: 3 # Delta-V
 
 - type: entity
   id: CrateMaterialPlasma


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Changed the plasteel and wood crates to contain 90 sheets. Also brough plastic and basic sheet prices in line with steel and glass crate prices.

## Why / Balance
Manufacturing plasteel is irreversible and requires an industrial ore processor. This is quite unfortunate, as it is essential for proper station repair. 30 sheets per crate is a bit silly - especially since the crate isn't that cheap. The other changes are made for cosistency.

## Technical details
It's YAML

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have tested all added content and changes. - it's YAML
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Changed plasteel and wood crates from cargo to come with 90 sheets instead of 30.
- tweak: Brough plastic and basic sheet prices in line with steel and glass crate prices - 1500 spesos.
