### PR TITLE
Cultists (tiles) cant kill artists (work)

### DIFF
--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -13,9 +13,10 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.GameStates;
+using Robust.Shared.Map; // Delta-V
+using Robust.Shared.Map.Components; // Delta-V
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Map;
-using Robust.Shared.Map.Components;
 
 namespace Content.Server.Crayon;
 

--- a/Content.Server/Crayon/CrayonSystem.cs
+++ b/Content.Server/Crayon/CrayonSystem.cs
@@ -13,7 +13,6 @@ using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.GameStates;
-using Robust.Shared.Map; // Delta-V
 using Robust.Shared.Map.Components; // Delta-V
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -25,13 +24,10 @@ public sealed class CrayonSystem : SharedCrayonSystem
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly DecalSystem _decals = default!;
+    [Dependency] private readonly MapSystem _map = default!; // Delta-V
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
-    [Dependency] private readonly MapSystem _map = default!;
-    [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
-    [Dependency] private readonly IMapManager _mapManager = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
@@ -105,17 +105,16 @@ public sealed class CosmicCorruptingSystem : EntitySystem
 
             if (_rand.Prob(ent.Comp.CorruptionChance)) //if it rolls good
             {
-
-                var coordinates = _maps.GridTileToLocal(tileRef.GridUid, mapGrid, tileRef.GridIndices); // Grab Coords of tile
-                var decals = _decal.GetDecalsInRange(tileRef.GridUid, coordinates.SnapToGrid(EntityManager, _mapManager).Position, 0.5f); //Get Decal HashSet
+                var decals = _decal.GetDecalsInRange(tileRef.GridUid, tileRef.GridIndices, 1f); //Get Decal HashSet
 
                 //replace & variantise the tile
                 _tile.ReplaceTile(tileRef, convertTile);
                 _tile.PickVariant(convertTile);
 
-                foreach (var singleDecal in decals) //For each decal in the HashSet, reapply the decal after replacement
+                foreach (var decalSet in decals) //For each decal in the HashSet, reapply the decal after replacement
                 {
-                    _decalSystem.TryAddDecal(singleDecal.Decal.Id, coordinates.SnapToGrid(EntityManager, _mapManager), out _, singleDecal.Decal.Color, singleDecal.Decal.Angle, singleDecal.Decal.ZIndex, singleDecal.Decal.Cleanable);
+                    var coords = decalSet.Decal.Coordinates;
+                    _decalSystem.TryAddDecal(decalSet.Decal.Id, new EntityCoordinates(tileRef.GridUid, coords), out _, decalSet.Decal.Color, decalSet.Decal.Angle, decalSet.Decal.ZIndex, decalSet.Decal.Cleanable); // Reapply decal
                 }
 
                 //then add the new neighbours as targets as long as they're not already corrupted

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
@@ -105,7 +105,7 @@ public sealed class CosmicCorruptingSystem : EntitySystem
 
             if (_rand.Prob(ent.Comp.CorruptionChance)) //if it rolls good
             {
-                var decals = _decal.GetDecalsInRange(tileRef.GridUid, tileRef.GridIndices, 1f); //Get Decal HashSet
+                var decals = _decal.GetDecalsInRange(tileRef.GridUid, tileRef.GridIndices, 1.5f); //Get Decal HashSet
 
                 //replace & variantise the tile
                 _tile.ReplaceTile(tileRef, convertTile);

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
@@ -1,8 +1,6 @@
 using System.Linq;
-using Content.Server.Decals;
 using Content.Server._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult.Components;
-using Content.Shared.Decals;
 using Content.Shared.Maps;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
@@ -27,7 +27,6 @@ public sealed class CosmicCorruptingSystem : EntitySystem
         new(1, -1),
     ];
 
-
     [Dependency] private readonly IRobustRandom _rand = default!;
     [Dependency] private readonly TileSystem _tile = default!;
     [Dependency] private readonly ITileDefinitionManager _tileDefinition = default!;

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
@@ -3,7 +3,6 @@ using Content.Server.Decals;
 using Content.Server._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.Decals;
-using Content.Shared.Coordinates.Helpers;
 using Content.Shared.Maps;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
@@ -30,13 +29,10 @@ public sealed class CosmicCorruptingSystem : EntitySystem
         new(1, -1),
     ];
 
-    [Dependency] private readonly IMapManager _mapManager = default!;
+
     [Dependency] private readonly IRobustRandom _rand = default!;
     [Dependency] private readonly TileSystem _tile = default!;
     [Dependency] private readonly ITileDefinitionManager _tileDefinition = default!;
-    [Dependency] private readonly DecalSystem _decalSystem = default!;
-    [Dependency] private readonly SharedDecalSystem _decal = default!;
-    [Dependency] private readonly SharedMapSystem _maps = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly TurfSystem _turfs = default!;
 
@@ -105,7 +101,6 @@ public sealed class CosmicCorruptingSystem : EntitySystem
 
             if (_rand.Prob(ent.Comp.CorruptionChance)) //if it rolls good
             {
-
                 //replace & variantise the tile
                 _map.SetTile(gridUid, mapGrid, pos, new Tile(convertTile.TileId, variant: _tile.PickVariant(convertTile)));
 

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicCorruptingSystem.cs
@@ -105,17 +105,9 @@ public sealed class CosmicCorruptingSystem : EntitySystem
 
             if (_rand.Prob(ent.Comp.CorruptionChance)) //if it rolls good
             {
-                var decals = _decal.GetDecalsInRange(tileRef.GridUid, tileRef.GridIndices, 1.5f); //Get Decal HashSet
 
                 //replace & variantise the tile
-                _tile.ReplaceTile(tileRef, convertTile);
-                _tile.PickVariant(convertTile);
-
-                foreach (var decalSet in decals) //For each decal in the HashSet, reapply the decal after replacement
-                {
-                    var coords = decalSet.Decal.Coordinates;
-                    _decalSystem.TryAddDecal(decalSet.Decal.Id, new EntityCoordinates(tileRef.GridUid, coords), out _, decalSet.Decal.Color, decalSet.Decal.Angle, decalSet.Decal.ZIndex, decalSet.Decal.Cleanable); // Reapply decal
-                }
+                _map.SetTile(gridUid, mapGrid, pos, new Tile(convertTile.TileId, variant: _tile.PickVariant(convertTile)));
 
                 //then add the new neighbours as targets as long as they're not already corrupted
                 foreach (var neighbourPos in _neighbourPositions)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Tiles converting to their malign variants no longer remove applied decals

## Why / Balance
Spend time on masterpiece -> cult -> art gone

## Technical details
Decals are reapplied after the tile is replaced

## Media
![image](https://github.com/user-attachments/assets/af583352-3dd5-44b9-879b-d0e3c2d8d09e)
![image](https://github.com/user-attachments/assets/ffd1013e-78ee-49c2-883f-4116c615d979)




## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Cult tile conversion no longer removes artwork

