### PR TITLE
AI no longer destroys small light bulbs when using Light Synthesizer.

### DIFF
--- a/Content.Server/_DV/Silicons/StationAiShopSystem.cs
+++ b/Content.Server/_DV/Silicons/StationAiShopSystem.cs
@@ -1,10 +1,12 @@
 using Content.Server.Fluids.EntitySystems;
 using Content.Server.Light.EntitySystems;
+using Content.Server.Light.Components;
 using Content.Server.Spreader;
 using Content.Server.Store.Systems;
 using Content.Shared._DV.Silicons;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Coordinates.Helpers;
+using Content.Shared.Light.Components;
 using Content.Shared.Maps;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
@@ -37,10 +39,20 @@ public sealed class StationAiShopSystem : SharedStationAiShopSystem
 
     private void OnLightSynthesizer(Entity<StationAiShopComponent> ent, ref StationAiLightSynthesizerActionEvent args)
     {
+        // Grab what light exists on the fixture, delete it. Then add light with respect to fixture.
+        var fixture = CompOrNull<PoweredLightComponent>(args.Target);
+        if (fixture is null) return;
+
+        var lightProto = fixture.BulbType switch
+        {
+            LightBulbType.Bulb => args.BulbPrototype,
+            LightBulbType.Tube => args.TubePrototype,
+            _ => args.BulbPrototype
+        };
+
         if (_poweredLight.EjectBulb(args.Target) is { } oldBulb)
             Del(oldBulb);
-
-        var bulb = Spawn(args.BulbPrototype);
+        var bulb = Spawn(lightProto);
         if (!_poweredLight.InsertBulb(args.Target, bulb))
         {
             Del(bulb);

--- a/Content.Shared/_DV/Silicons/StationAiShopComponent.cs
+++ b/Content.Shared/_DV/Silicons/StationAiShopComponent.cs
@@ -31,6 +31,8 @@ public sealed partial class StationAiLightSynthesizerActionEvent : EntityTargetA
 {
     [DataField(required: true)]
     public EntProtoId BulbPrototype;
+    [DataField(required: true)]
+    public EntProtoId TubePrototype;
 }
 
 /// <summary>

--- a/Resources/Prototypes/_DV/Actions/station_ai.yml
+++ b/Resources/Prototypes/_DV/Actions/station_ai.yml
@@ -46,9 +46,10 @@
     range: -1
     checkCanAccess: false
     checkCanInteract: false
-    useDelay: 300
+    useDelay: 0
     event: !type:StationAiLightSynthesizerActionEvent
-      bulbPrototype: LightTube
+      bulbPrototype: LightBulb
+      tubePrototype: LightTube
 
 - type: entity
   id: ActionStationAiBikeHorn

--- a/Resources/Prototypes/_DV/Actions/station_ai.yml
+++ b/Resources/Prototypes/_DV/Actions/station_ai.yml
@@ -46,7 +46,7 @@
     range: -1
     checkCanAccess: false
     checkCanInteract: false
-    useDelay: 0
+    useDelay: 300
     event: !type:StationAiLightSynthesizerActionEvent
       bulbPrototype: LightBulb
       tubePrototype: LightTube


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
title


## Why / Balance
Fixes #4026 

## Technical details
Light bulbs have a different prototype than light tubes, old code did not check for that so it would:

delete old bulb -> spawn LightTube -> attempt to insert light into fixture (failure on small lights!)

I added the other prototype and added logic to determine which type of light the AI is replacing. Otherwise I did not change much to the logic overall.

## Media

https://github.com/user-attachments/assets/4a597e26-eed9-43c9-a7f0-b1852eb9a47c



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Light Synthesizer properly replaces small lights.

