### PR TITLE
Fix harpy theobromine poisoning

### DIFF
--- a/Resources/Prototypes/_DV/Body/Prototypes/harpy.yml
+++ b/Resources/Prototypes/_DV/Body/Prototypes/harpy.yml
@@ -19,7 +19,7 @@
       - left leg
       - head # Shitmed Change
       organs:
-        heart: OrganHumanHeart
+        heart: OrganAnimalHeart
         lungs: OrganHarpyLungs
         stomach: OrganAnimalStomach
         liver:  OrganAnimalLiver


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Harpies are supposed to be poisoned by theobromine (and allicin) they now will be.

## Why / Balance
It seems the intention was for them to be this way..

## Technical details
Hearts are the organ that actually metabolizes all reagents (besides, food, drinks, and alcohol). So, it is the organ that is checked when determining if a reagent is poisonous to that type of organ. Theobromine is only poisonous if the metabolizing organ is an animal organ. 

Because I gave harpies the animal heart organ, they now get poisoned correctly. As far as I can tell that is the only difference between the animal and human hearts.

## Media
Attached image of poor Urist dying of theobromine.
![image](https://github.com/user-attachments/assets/5315df20-9a2e-4de8-b462-5efdcf4aa2bb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None that I am aware of.

**Changelog**

:cl:
- fix: Harpies now properly poisoned by theobromine and allicin

