### PR TITLE
Lower xeno ghostrole raffle timer

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -44,7 +44,7 @@
     description: ghost-role-information-xeno-description
     rules: ghost-role-information-xeno-rules
     raffle:
-      settings: default
+      settings: short # DeltaV - lower xeno raffle time - formerly default
   - type: GhostTakeoverAvailable
 
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Xenomorph raffle timer is now 10 seconds instead of 30.

## Why / Balance
With the old timer, it would take about 40-50 seconds on average for somebody to claim a xeno, at which point they're probably already dead. This change brings xenomorphs more in line with other ghostrole critters like slimes. 

## Technical details
single line ops

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Xenomorph raffle timer is now 10 seconds, down from 30.

