### PR TITLE
Make eshield slightly cheaper

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -147,9 +147,9 @@
   productEntity: EnergyShield
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 12 # DeltaV - was 4
+    Telecrystal: 8 # DeltaV - was 4
   cost:
-    Telecrystal: 16 # DeltaV - Was 8
+    Telecrystal: 12 # DeltaV - Was 8
   categories:
   - UplinkWeaponry
   conditions:


### PR DESCRIPTION
## About the PR
Title. It's now worth 12 TC instead of 16.

## Why / Balance
It's not **that** good to be worth 16 TC. Yes, it makes you very tanky, but you have to sacrifice one hand for it, which basically means that you're locked to using pistols or melee weapons, which, in most cases, are significantly worse than the alternatives.

## Technical details
2 lines of YAML. I don't know why did it even have a discount, since nukie uplinks just don't give them, but I lowered taht too in case we ever add discounts to nukie uplinks.

## Media
It's literally 1 number, nothing to look at.

## Requirements
- [X] I have not tested any of the added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Energy shield price reduced from 16 to 12 telecrystals.
