### PR TITLE
Make Null Glare an actually useful influence

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -117,16 +117,17 @@ namespace Content.Server.Flash
             float slowTo,
             bool displayPopup = true,
             bool melee = false,
-            TimeSpan? stunDuration = null)
+            TimeSpan? stunDuration = null,
+            bool ignoreProtection = false) //DeltaV: allow flashing to ignore flash protection
         {
-            var attempt = new FlashAttemptEvent(target, user, used);
+            var attempt = new FlashAttemptEvent(target, user, used, ignoreProtection); //DeltaV: allow flashing to ignore flash protection
             RaiseLocalEvent(target, attempt, true);
 
             if (attempt.Cancelled)
                 return;
 
             // don't paralyze, slowdown or convert to rev if the target is immune to flashes
-            if (!_statusEffectsSystem.TryAddStatusEffect<FlashedComponent>(target, FlashedKey, TimeSpan.FromSeconds(flashDuration / 1000f), true))
+            if (!_statusEffectsSystem.TryAddStatusEffect<FlashedComponent>(target, FlashedKey, TimeSpan.FromSeconds(flashDuration / 1000f), true) && !ignoreProtection) //DeltaV: allow flashing to ignore flash protection
                 return;
 
             if (stunDuration != null)
@@ -196,7 +197,7 @@ namespace Content.Server.Flash
 
         private void OnFlashImmunityFlashAttempt(EntityUid uid, FlashImmunityComponent component, FlashAttemptEvent args)
         {
-            if (component.Enabled)
+            if (component.Enabled && !args.IgnoreProtection) //DeltaV: allow flashing to ignore flash protection
                 args.Cancel();
         }
 
@@ -222,12 +223,14 @@ namespace Content.Server.Flash
         public readonly EntityUid Target;
         public readonly EntityUid? User;
         public readonly EntityUid? Used;
+        public readonly bool IgnoreProtection; //DeltaV: allow flashing to ignore flash protection
 
-        public FlashAttemptEvent(EntityUid target, EntityUid? user, EntityUid? used)
+        public FlashAttemptEvent(EntityUid target, EntityUid? user, EntityUid? used, bool ignoreProtection) //DeltaV: allow flashing to ignore flash protection
         {
             Target = target;
             User = user;
             Used = used;
+            IgnoreProtection = ignoreProtection; //DeltaV: allow flashing to ignore flash protection
         }
     }
     /// <summary>

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicGlareSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicGlareSystem.cs
@@ -68,7 +68,7 @@ public sealed class CosmicGlareSystem : EntitySystem
         {
             var targetEnt = GetEntity(target);
 
-            _flash.Flash(targetEnt, uid, args.Action, (float)uid.Comp.CosmicGlareDuration.TotalMilliseconds, uid.Comp.CosmicGlarePenalty, false, false, uid.Comp.CosmicGlareStun);
+            _flash.Flash(targetEnt, uid, args.Action, (float)uid.Comp.CosmicGlareDuration.TotalMilliseconds, uid.Comp.CosmicGlarePenalty, false, false, uid.Comp.CosmicGlareStun, uid.Comp.CosmicEmpowered);
 
             if (HasComp<BorgChassisComponent>(targetEnt) || HasComp<SiliconComponent>(targetEnt)) //For paralyzing borgs and IPCs specifically.
             {

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicGlareSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicGlareSystem.cs
@@ -68,7 +68,7 @@ public sealed class CosmicGlareSystem : EntitySystem
         {
             var targetEnt = GetEntity(target);
 
-            _flash.Flash(targetEnt, uid, args.Action, (float)uid.Comp.CosmicGlareDuration.TotalMilliseconds, uid.Comp.CosmicGlarePenalty, false, false, uid.Comp.CosmicGlareStun, uid.Comp.CosmicEmpowered);
+            _flash.Flash(targetEnt, uid, args.Action, (float)uid.Comp.CosmicGlareDuration.TotalMilliseconds, uid.Comp.CosmicGlarePenalty, false, false, uid.Comp.CosmicGlareStun, ignoreProtection: uid.Comp.CosmicEmpowered);
 
             if (HasComp<BorgChassisComponent>(targetEnt) || HasComp<SiliconComponent>(targetEnt)) //For paralyzing borgs and IPCs specifically.
             {

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -139,7 +139,7 @@ public sealed class CosmicRiftSystem : EntitySystem
         comp.CosmicEmpowered = true;
         comp.CosmicSiphonQuantity = 2;
         comp.CosmicGlareRange = 10;
-        comp.CosmicGlareDuration = TimeSpan.FromSeconds(10);
+        comp.CosmicGlareDuration = TimeSpan.FromSeconds(6);
         comp.CosmicGlareStun = TimeSpan.FromSeconds(1);
         comp.CosmicImpositionDuration = TimeSpan.FromSeconds(7.4);
         comp.CosmicBlankDuration = TimeSpan.FromSeconds(26);


### PR DESCRIPTION
## About the PR
If an empowered cosmic cultist uses Null Glare, it now flashes the target even if they have flash protection. Empowered duration was reduced from 10 to 6 seconds to compensate.

## Why / Balance
Null Glare is a pretty useless ability. Flash protection is very easy to get and almost completely negates it's effects. Breaking lights in an area is more of a cool visual than actual gameplay effect, and stunning borgs/IPCs is highly situational. Now it's actually useful in combat, since it would also affect security and random tiders with welding masks... if you are empowered, that is.

## Technical details
Some minor tweaks to FlashSystem.

## Media
My PC was begging for mercy, but I managed to record this anyway. Laggy as hell, but at least it does showcase the changes. 
Kinda.
It is physically painful to watch, but it's the best i can do.
https://github.com/user-attachments/assets/529a42ad-96c7-44f0-b606-51ad05dbc818


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Null Glare now ignores flash protection if the user is empowered.
- tweak: Null glare duration while empowered 10 -> 6 seconds.
