### PR TITLE
Make butter extractable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -637,6 +637,8 @@
   - type: SliceableFood
     count: 3
     slice: FoodButterSlice
+  - type: Extractable # DeltaV - Makes butter extractable
+    grindableSolutionName: food
 
 - type: entity
   name: butter slice
@@ -656,6 +658,8 @@
   - type: Tag
     tags:
     - Slice
+  - type: Extractable # DeltaV - Makes butter extractable
+    grindableSolutionName: food
 
 - type: entity
   name: stick of cannabis butter


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Made butter and butter slices extractable
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Cannabis butter is already extractable and it is the only way to obtain liquid butter. This change allows you to directly grind butter sticks and butter slices to get liquid butter for use in deep frying, creation of ghee, seasoning, and future cooking recipes that may want to use liquid butter
## Technical details
<!-- Summary of code changes for easier review. -->
The Extractable type was added to both butter sticks and butter slices, the same as with cannabis butter.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Sticks of butter and butter slices are now grindable

