### PR TITLE
Alert Procedure update

### DIFF
--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -186,7 +186,7 @@ Emergency alert status. ''Central Command has called the Gamma Alert; the Statio
 | style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel. EVA protection heavily advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for general orders. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Propose evacuation or scuttling if station cannot be retaken. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced.
+| style="border: 1px solid #000000;" | Report to supervisor for general orders. Martial law is in effect.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
 | style="border: 1px solid #000000;" | All [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] recommended to be bolted and under guard. Secure areas unbolted.
@@ -216,7 +216,7 @@ Emergency alert status. ''The nuclear destruction mechanism has been engaged and
 | style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel. EVA protection heavily advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Security and Command must expend all efforts to prevent station destruction if engaged in error.  Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced.
+| style="border: 1px solid #000000;" | Security and Command must expend all efforts to prevent station destruction if engaged in error.  Martial law is in effect.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
 | style="border: 1px solid #000000;" | All secure areas and [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] should remain unbolted.
@@ -245,7 +245,7 @@ Emergency alert status''. The station's deep-spectrum sensors have identified cr
 | style="border: 1px solid #000000;" |  Issuing of lethal weapons recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection strongly advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" |  Emergency personnel must expend all efforts to prevent station destruction. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Where possible, threats should be subdued and brought to the Chaplain or Mystagogue for processing. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced.
+| style="border: 1px solid #000000;" |  Emergency personnel must expend all efforts to prevent station destruction. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Where possible, threats should be subdued and brought to the Chaplain or Mystagogue for processing.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
 | style="border: 1px solid #000000;" |  All secure areas and [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] should remain unbolted.

--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -169,7 +169,7 @@ Elevated alert status. ''The station is suffering dangerously high levels of gli
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew. Prepare for detonation of [[Glimmer#Probers|probers]].
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
-| style="border: 1px solid #000000;" | Engage with minimal force required; ROE on mindbreaking is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
+| style="border: 1px solid #000000;" | Engage with minimal force required; ROE on mindwiping is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
 |}
 
 == <span style="color:#36717d;>Gamma Alert</span> ==
@@ -257,7 +257,7 @@ Emergency alert status''. The station's deep-spectrum sensors have identified cr
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew.
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
-| style="border: 1px solid #000000;" |  Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests. ROE on mindbreaking is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
+| style="border: 1px solid #000000;" |  Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests. ROE on mindwiping is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
 |}
 
 {{Guides Menu}}

--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -222,7 +222,7 @@ Emergency alert status. ''The nuclear destruction mechanism has been engaged and
 | style="border: 1px solid #000000;" | All secure areas and [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] should remain unbolted.
 |-
 | style="border: 1px solid #000000;" | Medical
-| style="border: 1px solid #000000;" | Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
+| style="border: 1px solid #000000;" | Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
 |-
 | style="border: 1px solid #000000;" | Engineering
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew.
@@ -251,7 +251,7 @@ Emergency alert status''. The station's deep-spectrum sensors have identified cr
 | style="border: 1px solid #000000;" |  All secure areas and [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] should remain unbolted.
 |-
 | style="border: 1px solid #000000;" | Medical
-| style="border: 1px solid #000000;" |  Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
+| style="border: 1px solid #000000;" |  Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
 |-
 | style="border: 1px solid #000000;" | Engineering
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew.

--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -108,7 +108,7 @@ Elevated alert status. ''There is a serious viral outbreak, ongoing major death 
 | style="border: 1px solid #000000;" | Report to supervisor for orders. Full suit sensors heavily advised. EVA suits recommended for emergency responders, functioning internals and PPE heavily advised.
 |-
 | style="border: 1px solid #000000;" | Engineering
-| style="border: 1px solid #000000;" | Report to supervisor for orders.
+| style="border: 1px solid #000000;" | Report to supervisor for general orders.
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
 | style="border: 1px solid #000000;" | Engage with minimal force required; prioritize de-escalation whenever possible.
@@ -131,7 +131,7 @@ Elevated alert status. ''There is a major issue with the atmospheric system, the
 | style="border: 1px solid #000000;" | Report to supervisor for orders. Non-engineering personnel advised to evacuate affected areas. Security should seek to aid engineering staff where possible.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | Secure areas unbolted. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
+| style="border: 1px solid #000000;" | Secure areas unbolted. [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Full suit sensors heavily advised. EVA suits and functioning internals recommended for emergency responders.
@@ -160,7 +160,7 @@ Elevated alert status. ''The station is suffering dangerously high levels of gli
 | style="border: 1px solid #000000;" | Report to supervisor for orders. Security and Engineering should seek to aid epistemics staff where possible. Propose evacuation if glimmer spiral is unrecoverable.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | Secure areas unbolted. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
+| style="border: 1px solid #000000;" | Secure areas unbolted. [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Full suit sensors heavily advised. Prepare for increased incidents of burn and brain damage.
@@ -169,7 +169,7 @@ Elevated alert status. ''The station is suffering dangerously high levels of gli
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew. Prepare for detonation of [[Glimmer#Probers|probers]].
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
-| style="border: 1px solid #000000;" | Engage with minimal force required; ROE on mindwiping is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
+| style="border: 1px solid #000000;" | Engage with minimal force required; ROE on mindwiping is lifted and may be performed by the Psionic Mantis, Chaplain or Mystagogue at their discretion.
 |}
 
 == <span style="color:#36717d;>Gamma Alert</span> ==
@@ -198,7 +198,7 @@ Emergency alert status. ''Central Command has called the Gamma Alert; the Statio
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew.
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
-| style="border: 1px solid #000000;" | Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests.
+| style="border: 1px solid #000000;" | Martial law is in effect.
 |}
 
 == <span style="color:#996633;>Delta Alert</span> ==
@@ -228,7 +228,7 @@ Emergency alert status. ''The nuclear destruction mechanism has been engaged and
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew.
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
-| style="border: 1px solid #000000;" | Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests.
+| style="border: 1px solid #000000;" | Martial law is in effect.
 |}
 
 == <span style="color:#cae8e8;>Code Octarine</span> ==

--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -9,16 +9,16 @@ The normal operating procedure. ''There is no currently known threat to the ship
 | style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > Department Heads > Supervisory Roles
 |-
 | style="border: 1px solid #000000;" | Armoury Policy
-| style="border: 1px solid #000000;" | Open carrying of long arms disallowed. Standard stab-and bullet-resistant equipment recommended for Security personnel.
+| style="border: 1px solid #000000;" | Open carrying of long arms disallowed for Security personnel. Standard stab-and bullet-resistant equipment recommended for Security personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
 | style="border: 1px solid #000000;" | Report to supervisor for general orders.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | Secure areas unbolted and accessible to all authorized personnel. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
+| style="border: 1px solid #000000;" | Secure areas unbolted and accessible to all authorized personnel. HSAs and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 |-
 | style="border: 1px solid #000000;" | Medical
-| style="border: 1px solid #000000;" | Report to supervisor for general orders.
+| style="border: 1px solid #000000;" | Binary suit sensors recommended at a minimum.
 |-
 | style="border: 1px solid #000000;" | Engineering
 | style="border: 1px solid #000000;" | Report to supervisor for general orders.
@@ -38,20 +38,19 @@ Elevated alert status. ''There is an ongoing, known, or suspected security threa
 | style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > [[Head of Security|Head of Station Security]] > Department Heads > Supervisory Roles
 |-
 | style="border: 1px solid #000000;" | Armoury Policy
-| style="border: 1px solid #000000;" | Open carry of weaponry permitted for authorised entities. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel.
+| style="border: 1px solid #000000;" | Open carry of weaponry permitted for all authorised entities. Body armour mandatory for Security personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for general orders. Searching individuals suspected of committing a crime is encouraged. Open carry disallowed for non-security personnel.
+| style="border: 1px solid #000000;" | Report to supervisor for general orders. Searching individuals suspected of committing a crime is encouraged.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | Secure areas unlocked unless affected by known threats. Access to [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] locked.
-
+| style="border: 1px solid #000000;" | Secure areas unbolted unless affected by known threats. Bolting [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] recommended.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Binary suit sensors recommended at a minimum. EVA suits recommended for emergency responders, functioning internals and PPE heavily advised.
 |-
 | style="border: 1px solid #000000;" | Engineering
-| style="border: 1px solid #000000;" | EVA suits recommended for engineers. Make emergency internals easily accessible.
+| style="border: 1px solid #000000;" | EVA suits recommended for engineers.
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
 | style="border: 1px solid #000000;" | Engage with minimal force required; non-lethal weapons may be used freely based on threat and compliance.
@@ -68,19 +67,19 @@ Emergency alert status. ''There are multiple major emergency situations ongoing,
 | style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > Security Personnel > Department Heads > Supervisory Roles
 |-
 | style="border: 1px solid #000000;" | Armoury Policy
-| style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel.
+| style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for general orders. Protection of personnel prioritized over body and department searches. Open carry disallowed for non-security personnel.
+| style="border: 1px solid #000000;" | Report to supervisor for general orders. Protection of personnel prioritized over body and department searches.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | All HSAs should remain locked and under guard. Secure areas unlocked unless affected by known threats.
+| style="border: 1px solid #000000;" | All [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] recommended to be bolted and under guard. Secure areas unbolted unless affected by known threats.
 |-
 | style="border: 1px solid #000000;" | Medical
-| style="border: 1px solid #000000;" | Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
+| style="border: 1px solid #000000;" | Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
 |-
 | style="border: 1px solid #000000;" | Engineering
-| style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew.
+| style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Make emergency internals easily accessible.
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
 | style="border: 1px solid #000000;" | Engage with adequate force to safely subdue suspects, dependent on threat and compliance. Lethal force is permitted to effect arrests against evasive targets.
@@ -97,19 +96,19 @@ Elevated alert status. ''There is a serious viral outbreak, ongoing major death 
 | style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > [[Chief Medical Officer]] > Medical Personnel > Department Heads > Supervisory Roles
 |-
 | style="border: 1px solid #000000;" | Armoury Policy
-| style="border: 1px solid #000000;" | Issuing of lethal weapons disadvised. Standard stab-and bullet-resistant equipment recommended for Security personnel. Basic PPE highly recommended for all personnel, L3 biohazard gear advised.
+| style="border: 1px solid #000000;" | Issuing of lethal weapons disadvised. Standard stab-and bullet-resistant equipment recommended for Security personnel. Biohazard gear advised.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for orders. Non-medical personnel should ensure they do not interfere with medical staff, may assist where applicable, obey all applicable orders from medical personnel. Security should seek to aid medical staff in enforcement of quarantine procedures or medical treatment as necessary.
+| style="border: 1px solid #000000;" | Report to supervisor for orders. Non-medical personnel should ensure they do not interfere with medical staff. Security should seek to aid medical staff where possible.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | Secure areas unlocked and accessible to all authorized personnel. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
+| style="border: 1px solid #000000;" | Secure areas unbolted. [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Report to supervisor for orders. Full suit sensors heavily advised. EVA suits recommended for emergency responders, functioning internals and PPE heavily advised.
 |-
 | style="border: 1px solid #000000;" | Engineering
-| style="border: 1px solid #000000;" | Standard practice.
+| style="border: 1px solid #000000;" | Report to supervisor for orders.
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
 | style="border: 1px solid #000000;" | Engage with minimal force required; prioritize de-escalation whenever possible.
@@ -129,10 +128,10 @@ Elevated alert status. ''There is a major issue with the atmospheric system, the
 | style="border: 1px solid #000000;" | Issuing of lethal weapons disadvised. EVA protection heavily advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for orders. Non-engineering personnel advised to evacuate affected areas and obey any relevant instructions from engineering personnel. Security should seek to aid engineering staff where possible.
+| style="border: 1px solid #000000;" | Report to supervisor for orders. Non-engineering personnel advised to evacuate affected areas. Security should seek to aid engineering staff where possible.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | Secure areas unlocked and accessible to all authorized personnel. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
+| style="border: 1px solid #000000;" | Secure areas unbolted. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Full suit sensors heavily advised. EVA suits and functioning internals recommended for emergency responders.
@@ -155,13 +154,13 @@ Elevated alert status. ''The station is suffering dangerously high levels of gli
 | style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > [[Mystagogue]] > Epistemics Personnel > Department Heads > Supervisory Roles
 |-
 | style="border: 1px solid #000000;" | Armoury Policy
-| style="border: 1px solid #000000;" | Open carry of weaponry permitted for authorised entities. Standard stab- and bullet-resistant equipment recommended for Security personnel. Psionic insulation recommended for all personnel.
+| style="border: 1px solid #000000;" | Psionic insulation recommended for all personnel. Open carry of weaponry permitted for authorised entities. Standard stab- and bullet-resistant equipment recommended for Security personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for orders. Security and engineering should seek to aid epistemics staff in shutting off glimmer probers, and propose evacuation if glimmer spiral is unrecoverable.
+| style="border: 1px solid #000000;" | Report to supervisor for orders. Security and Engineering should seek to aid epistemics staff where possible. Propose evacuation if glimmer spiral is unrecoverable.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | Secure areas unlocked and accessible to all authorized personnel, unless affected by a known threat. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
+| style="border: 1px solid #000000;" | Secure areas unbolted. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Full suit sensors heavily advised. Prepare for increased incidents of burn and brain damage.
@@ -184,13 +183,13 @@ Emergency alert status. ''Central Command has called the Gamma Alert; the Statio
 | style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > Security Personnel > Department Heads > Supervisory Roles
 |-
 | style="border: 1px solid #000000;" | Armoury Policy
-| style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection heavily advised for all personnel.
+| style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel. EVA protection heavily advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Report to supervisor for general orders. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Propose evacuation or scuttling if station cannot be retaken.
+| style="border: 1px solid #000000;" | Report to supervisor for general orders. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Propose evacuation or scuttling if station cannot be retaken. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | All HSAs should remain locked and under guard. Secure areas unlocked unless affected by known threats.
+| style="border: 1px solid #000000;" | All [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] recommended to be bolted and under guard. Secure areas unbolted.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
@@ -214,13 +213,13 @@ Emergency alert status. ''The nuclear destruction mechanism has been engaged and
 | style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > Security Personnel > Department Heads > Supervisory Roles
 |-
 | style="border: 1px solid #000000;" | Armoury Policy
-| style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection heavily advised for all personnel.
+| style="border: 1px solid #000000;" | Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel. EVA protection heavily advised for all personnel.
 |-
 | style="border: 1px solid #000000;" | Discipline
-| style="border: 1px solid #000000;" | Emergency personnel must expend all efforts to prevent station destruction if engaged in error. Security and Command personnel are to oversee the evacuation of personnel and safe scuttling of the station. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats.
+| style="border: 1px solid #000000;" | Security and Command must expend all efforts to prevent station destruction if engaged in error.  Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced.
 |-
 | style="border: 1px solid #000000;" | Secure Areas
-| style="border: 1px solid #000000;" | All secure areas and HSAs should remain locked.
+| style="border: 1px solid #000000;" | All secure areas and [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] should remain unbolted.
 |-
 | style="border: 1px solid #000000;" | Medical
 | style="border: 1px solid #000000;" | Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
@@ -230,6 +229,35 @@ Emergency alert status. ''The nuclear destruction mechanism has been engaged and
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
 | style="border: 1px solid #000000;" | Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests.
+|}
+
+== <span style="color:#cae8e8;>Code Octarine</span> ==
+Emergency alert status''. The station's deep-spectrum sensors have identified critical Λ-CDM levels. The station and all surrounding space is under threat of an impending existential noospheric-to-real threat.''
+
+{| class="wikitable" style="width: 80%; border: 1px solid #000000;"
+!style="text-align:left; width:25%; padding:5px; padding-left:10px; background-color:#583ca2BF; border: 1px solid #000000;" | '''Condition'''
+!style="text-align:left; width:75%; padding:5px; padding-left:10px; background-color:#583ca2BF; border: 1px solid #000000;" | '''Description'''
+|-
+| style="border: 1px solid #000000;" | Chain of Command
+| style="border: 1px solid #000000;" | [[Standard_Operating_Procedure#Captain’s_Authority|CO]] > [[Mystagogue]] > Security Personnel > Department Heads > Supervisory Roles >
+|-
+| style="border: 1px solid #000000;" | Armoury Policy
+| style="border: 1px solid #000000;" |  Issuing of lethal weapons recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection strongly advised for all personnel.
+|-
+| style="border: 1px solid #000000;" | Discipline
+| style="border: 1px solid #000000;" |  Emergency personnel must expend all efforts to prevent station destruction. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Where possible, threats should be subdued and brought to the Chaplain or Mystagogue for processing. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced.
+|-
+| style="border: 1px solid #000000;" | Secure Areas
+| style="border: 1px solid #000000;" |  All secure areas and [[Standard_Operating_Procedure#High_Security_Areas|HSAs]] should remain unbolted.
+|-
+| style="border: 1px solid #000000;" | Medical
+| style="border: 1px solid #000000;" |  Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
+|-
+| style="border: 1px solid #000000;" | Engineering
+| style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew.
+|-
+| style="border: 1px solid #000000;" | Rules of Engagement
+| style="border: 1px solid #000000;" |  Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests. ROE on mindbreaking is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
 |}
 
 {{Guides Menu}}

--- a/.wiki/_DV/Laws/SpaceLaw.txt
+++ b/.wiki/_DV/Laws/SpaceLaw.txt
@@ -88,7 +88,7 @@ For example, an attack upon a sophont which causes them to die of their injuries
 Capital Sentences are organized in order of severity, with the least severe last. Execution should be utilized as an '''absolute last resort,'''  for criminals whose crimes are extraordinarily cruel, or who prove impossible to confine through less restrictive means.
 
 * '''Execution:''' Termination of the convict's life.
-** Whenever any execution is performed, for any reason, a general announcement must be made stating who was executed, and for what reason.
+** Whenever any execution is performed, outside of Martial Law, a general announcement must be made stating who was executed, and for what reason.
 ** The convict may either face execution by firing squad, by lethal electrocution, by being ejected from the station via an airlock (being "spaced"), or by a method of their choosing, at the Judge's sole discretion.
 ** If recoverable, their remains must either be cremated, processed via the biomass reclaimer, or stored in the morgue.
 * '''Decorporealization:''' Stripping the convict's mind from their body into a more restrictive form, such as a cyborg or soul gem.

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -245,6 +245,14 @@ Law enforcement personnel hold a Category D Armaments License, and are authorize
 
 Despite their allowance of lethal force, Security is required to follow the Rules of Engagement of the current Alert Level, as outlined within [[Alert Procedure]].
 
+== Martial Law ==
+Martial Law may only be declared by Central Command. Under Martial Law:
+* Arrests, searches, and departmental raids may be performed at the discretion of security personnel and without a warrant.
+* Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats.
+* Security is authorized to summarily execute station threats.
+* Security is no longer bound to the Rules of Engagement.
+* Security is not obligated to provide any medical care to prisoners and detainees, including revival.
+
 == Armory Procedure ==
 The armory and its usage are governed by the Warden. The Warden is responsible for stocking, distributing, and recording the collection of weapons used by the station during the shift. They are also afforded the authority to arm security at their discretion, so long as the weaponry distributed is in appropriate response to [[Alert Procedure]].
 

--- a/Resources/ServerInfo/Guidebook/_DV/AlertProcedure.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/AlertProcedure.xml
@@ -10,49 +10,49 @@ On Delta-V, there are some restrictions on when certain alert levels can be used
 ## Code Green
 [color=#7cfc00]The normal operating procedure. There is no currently known threat to the ship, nor crew.[/color]
 - [color=#a4885c]Chain of Command (COC)[/color]: Commanding Officer (CO), Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Open carrying of long arms disallowed. Standard stab-and bullet-resistant equipment recommended for Security personnel.
+- [color=#a4885c]Armory Policy[/color]: Open carrying of long arms disallowed for Security personnel. Standard stab-and bullet-resistant equipment recommended for Security personnel.
 - [color=#a4885c]Discipline[/color]: Report to supervisor for general orders.
-- [color=#a4885c]Secure Areas[/color]: Secure areas unlocked and accessible to all authorized personnel. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
-- [color=#a4885c]Medical[/color]: Report to supervisor for general orders.
+- [color=#a4885c]Secure Areas[/color]: Secure areas unbolted and accessible to all authorized personnel. HSAs and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
+- [color=#a4885c]Medical[/color]: Binary suit sensors recommended at a minimum.
 - [color=#a4885c]Engineering[/color]: Report to supervisor for general orders.
 - [color=#a4885c]Rules of Engagement (ROE)[/color]: Engage with minimal force required; prioritize de-escalation whenever possible.
 
 ## Code Blue
 [color=#0000FF]Elevated alert status. There is an ongoing, known, or suspected security threat to the NanoTrasen vessel or its crew.[/color]
 - [color=#a4885c]COC[/color]: CO, Head of Security, Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Open carry of weaponry permitted for authorised entities. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel.
-- [color=#a4885c]Discipline[/color]: Report to supervisor for general orders. Searching individuals suspected of committing a crime is encouraged. Open carry disallowed for non-security personnel.
-- [color=#a4885c]Secure Areas[/color]: Secure areas unlocked unless affected by known threats. Access to HSAs locked.
+- [color=#a4885c]Armory Policy[/color]: Open carry of weaponry permitted for all authorised entities. Body armour mandatory for Security personnel.
+- [color=#a4885c]Discipline[/color]: Report to supervisor for general orders. Searching individuals suspected of committing a crime is encouraged.
+- [color=#a4885c]Secure Areas[/color]: Secure areas unbolted unless affected by known threats. Bolting HSAs recommended.
 - [color=#a4885c]Medical[/color]: Binary suit sensors recommended at a minimum. EVA suits recommended for emergency responders, functioning internals and PPE heavily advised.
-- [color=#a4885c]Engineering[/color]: EVA suits recommended for engineers. Make emergency internals easily accessible.
+- [color=#a4885c]Engineering[/color]: EVA suits recommended for engineers.
 - [color=#a4885c]ROE[/color]: Engage with minimal force; non-lethal weapons may be used freely based on threat and compliance.
 
 ## Code Red
 [color=#ff0000]Emergency alert status. There are multiple major emergency situations ongoing, or a major security emergency affecting the station.[/color]
 - [color=#a4885c]COC[/color]: CO, Security Personnel, Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel.
-- [color=#a4885c]Discipline[/color]: Report to supervisor for general orders. Protection of personnel prioritized over body and department searches. Open carry disallowed for non-security personnel.
-- [color=#a4885c]Secure Areas[/color]: All HSAs should remain locked and under guard. Secure areas unlocked unless affected by known threats.
-- [color=#a4885c]Medical[/color]: Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
-- [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Distribute emergency internals to crew.
+- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel.
+- [color=#a4885c]Discipline[/color]: Report to supervisor for general orders. Protection of personnel prioritized over body and department searches.
+- [color=#a4885c]Secure Areas[/color]: All HSAs recommended to be bolted and under guard. Secure areas unbolted unless affected by known threats.
+- [color=#a4885c]Medical[/color]: Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
+- [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Make emergency internals easily accessible.
 - [color=#a4885c]ROE[/color]: Engage with adequate force to safely subdue suspects, dependent on threat and compliance. Lethal force is permitted to effect arrests against evasive targets.
 
 ## Code Violet
 [color=#7f00ff]Elevated alert status. There is a serious viral outbreak, ongoing major death event, or there is another significant medical emergency.[/color]
 - [color=#a4885c]COC[/color]: CO, Chief Medical Officer, Medical Personnel, Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons disadvised. Standard stab-and bullet-resistant equipment recommended for Security personnel. Basic PPE highly recommended for all personnel, L3 biohazard gear advised.
-- [color=#a4885c]Discipline[/color]: Report to supervisor for orders. Non-medical personnel should ensure they do not interfere with medical staff, may assist where applicable, obey all applicable orders from medical personnel. Security should seek to aid medical staff in enforcement of quarantine procedures or medical treatment as necessary.
-- [color=#a4885c]Secure Areas[/color]: Secure areas unlocked and accessible to all authorized personnel. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
+- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons disadvised. Standard stab-and bullet-resistant equipment recommended for Security personnel. Biohazard gear advised.
+- [color=#a4885c]Discipline[/color]: Report to supervisor for orders. Non-medical personnel should ensure they do not interfere with medical staff. Security should seek to aid medical staff where possible.
+- [color=#a4885c]Secure Areas[/color]: Secure areas unbolted. HSAs and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 - [color=#a4885c]Medical[/color]: Report to supervisor for orders. Full suit sensors heavily advised. EVA suits recommended for emergency responders, functioning internals and PPE heavily advised.
-- [color=#a4885c]Engineering[/color]: Standard practice.
+- [color=#a4885c]Engineering[/color]: Report to supervisor for general orders.
 - [color=#a4885c]ROE[/color]: Engage with minimal force; prioritize de-escalation whenever possible.
 
 ## Code Yellow
 [color=#ffff00]Elevated alert status. There is a major issue with the atmospheric system, the station has suffered/is about to suffer significant damage, or there is another significant engineering emergency.[/color]
 - [color=#a4885c]COC[/color]: CO, Chief Engineer, Engineering Personnel, Department Heads, Supervisory Roles
 - [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons disadvised. EVA protection heavily advised for all personnel.
-- [color=#a4885c]Discipline[/color]: Report to supervisor for orders. Non-engineering personnel advised to evacuate affected areas and obey any relevant instructions from engineering personnel. Security should seek to aid engineering staff where possible.
-- [color=#a4885c]Secure Areas[/color]: Secure areas unlocked and accessible to all authorized personnel. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
+- [color=#a4885c]Discipline[/color]: Report to supervisor for orders. Non-engineering personnel advised to evacuate affected areas. Security should seek to aid engineering staff where possible.
+- [color=#a4885c]Secure Areas[/color]: Secure areas unbolted. HSAs and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 - [color=#a4885c]Medical[/color]: Full suit sensors heavily advised. EVA suits and functioning internals recommended for emergency responders.
 - [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Distribute emergency internals to crew. Propose evacuation if damage is irreparable or sufficiently hazardous.
 - [color=#a4885c]ROE[/color]: Engage with minimal force; prioritize de-escalation whenever possible.
@@ -60,40 +60,40 @@ On Delta-V, there are some restrictions on when certain alert levels can be used
 ## Code White
 [color=#f6ccf6]Elevated alert status. The station is suffering dangerously high levels of glimmer, there are several active psionic threats, or there is another significant epistemic emergency.[/color]
 - [color=#a4885c]COC[/color]: CO, Mystagogue, Epistemics Personnel, Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Open carry of weaponry permitted for authorised entities. Standard stab- and bullet-resistant equipment recommended for Security personnel. Psionic insulation recommended for all personnel.
-- [color=#a4885c]Discipline[/color]: Report to supervisor for orders. Security and engineering should seek to aid epistemics staff in shutting off glimmer probers, and propose evacuation if glimmer spiral is unrecoverable.
-- [color=#a4885c]Secure Areas[/color]: Secure areas unlocked and accessible to all authorized personnel, unless affected by a known threat. High Security Areas and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be locked as needed.
+- [color=#a4885c]Armory Policy[/color]: Psionic insulation recommended for all personnel. Open carry of weaponry permitted for authorised entities. Standard stab- and bullet-resistant equipment recommended for Security personnel.
+- [color=#a4885c]Discipline[/color]: Report to supervisor for orders. Security and Engineering should seek to aid epistemics staff where possible. Propose evacuation if glimmer spiral is unrecoverable.
+- [color=#a4885c]Secure Areas[/color]: Secure areas unbolted. HSAs and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 - [color=#a4885c]Medical[/color]: Full suit sensors heavily advised. Prepare for increased incidents of burn and brain damage.
 - [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Distribute emergency internals to crew. Prepare for detonation of probers.
-- [color=#a4885c]ROE[/color]: Engage with minimal force required; ROE on mindbreaking is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
+- [color=#a4885c]ROE[/color]: Engage with minimal force required; ROE on mindwiping is lifted and may be performed by the Psionic Mantis, Chaplain or Mystagogue at their discretion.
 
 ## Code Gamma
 [color=#db7093]Emergency alert status. Central Command has called the Gamma Alert; the Station is on its last legs, almost everyone is dead, or there is another existential crisis affecting the station.[/color]
 - [color=#a4885c]COC[/color]: CO, Security Personnel, Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection heavily advised for all personnel.
-- [color=#a4885c]Discipline[/color]: Report to supervisor for general orders. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats. Propose evacuation or scuttling if station cannot be retaken.
-- [color=#a4885c]Secure Areas[/color]: All HSAs should remain locked and under guard. Secure areas unlocked unless affected by known threats.
+- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel. EVA protection heavily advised for all personnel.
+- [color=#a4885c]Discipline[/color]: Report to supervisor for general orders. Martial law is in effect.
+- [color=#a4885c]Secure Areas[/color]: All HSAs recommended to be bolted and under guard. Secure areas unbolted.
 - [color=#a4885c]Medical[/color]: Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
 - [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Distribute emergency internals to crew.
-- [color=#a4885c]ROE[/color]: Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests.
+- [color=#a4885c]ROE[/color]: Martial law is in effect.
 
 ## Code Delta
 [color=#8b0000]Emergency alert status. The nuclear destruction mechanism has been engaged and station destruction is imminent. All crew aboard the station must attempt to reverse the self-destruct mechanism, if engaged in error. Should reversal prove impossible, evacuate as applicable.[/color]
 - [color=#a4885c]COC[/color]: CO, Security Personnel, Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection heavily advised for all personnel.
-- [color=#a4885c]Discipline[/color]: Emergency personnel must expend all efforts to prevent station destruction if engaged in error. Security and Command personnel are to oversee the evacuation of personnel and safe scuttling of the station. Martial law is in effect. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced. Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats.
-- [color=#a4885c]Secure Areas[/color]: All secure areas and HSAs should remain locked.
-- [color=#a4885c]Medical[/color]: Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
+- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons heavily recommended. Body armour and helmets mandatory for Security personnel. EVA protection heavily advised for all personnel.
+- [color=#a4885c]Discipline[/color]: Security and Command must expend all efforts to prevent station destruction if engaged in error.  Martial law is in effect.
+- [color=#a4885c]Secure Areas[/color]: All secure areas and HSAs should remain unbolted.
+- [color=#a4885c]Medical[/color]: Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
 - [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Distribute emergency internals to crew.
-- [color=#a4885c]ROE[/color]: Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests.
+- [color=#a4885c]ROE[/color]: Martial law is in effect.
 
 ## Code Octarine
 [color=#cae8e8]Emergency alert status. The station's deep-spectrum sensors have identified critical Λ-CDM levels. The station and all surrounding space is under threat of an impending existential noospheric-to-real threat.[/color]
 - [color=#a4885c]COC[/color]: CO, Mystagogue, Security Personnel, Department Heads, Supervisory Roles
-- [color=#a4885c]Armory Policy[/color]: Issuing of nonlethal crowd control gear mandatory, lethal weapons permitted for self-defense. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection strongly advised for all personnel.
-- [color=#a4885c]Discipline[/color]: Emergency personnel must expend all efforts to prevent station destruction. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Where possible, threats should be subdued nonlethally and brought to the Chaplain or Mystagogue for processing. Threats neutralised by lethal force may be placed in Preservative Stasis until the station alert level is reduced.
-- [color=#a4885c]Secure Areas[/color]: All secure areas and HSAs should remain locked.
-- [color=#a4885c]Medical[/color]: Full suit sensors heavily advised. EVA suits and functioning internals heavily advised for emergency responders.
+- [color=#a4885c]Armory Policy[/color]: Issuing of lethal weapons recommended. Body armour and helmets mandatory for Security personnel, permitted for distribution to authorised personnel. EVA protection strongly advised for all personnel.
+- [color=#a4885c]Discipline[/color]: Emergency personnel must expend all efforts to prevent station destruction. Arrests, searches, and raids may be performed at the discretion of security personnel and without a warrant. Where possible, threats should be subdued and brought to the Chaplain or Mystagogue for processing.
+- [color=#a4885c]Secure Areas[/color]: All secure areas and HSAs should remain unbolted.
+- [color=#a4885c]Medical[/color]:Full suit sensors mandatory for observation and safety. EVA suits and functioning internals heavily advised for emergency responders.
 - [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Distribute emergency internals to crew.
-- [color=#a4885c]ROE[/color]: Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests.
+- [color=#a4885c]ROE[/color]: Engage with adequate force to neutralise threats. Lethal force authorised at the discretion of Security personnel, in self-defence, or to effect arrests. ROE on mindwiping is lifted and may be performed by the Psionic Mantis or Mystagogue at their discretion.
 </Document>


### PR DESCRIPTION
## About the PR
Updates Alert Procedure
adds code octarine cause noone added it, woops

## Why / Balance
AP was insanely outdated and impractical
kills ambiguity of 'locked/unlocked/bolted/unbolted'


**Changelog**
- bartenders can now open carry
- suit sensors are always recommended but only mandatory on gamma and up
- helmets are no longer mandatory on blue
- HSAs no longer need to be bolted on blue and up
- HSAs no longer need to be guarded on red and up
- sec can now explicitly stasis people who got shot during martial law
- ROE on mindbreaking is lifted on octarine
- removed some things that do not need to be spelled out (sec can hand out guns, listen to people above you in CoC)
- standardised language 
- removed summary stasis from octarine
- added a 'Martial Law' section to SoP

:cl:
- tweak: Updated Alert Procedure, go read it again.
- add: SoP now explains what Martial Law is.
-->
