### PR TITLE
Make cosmic cult progression smother

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -552,11 +552,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                 var cultistQuery = EntityQueryEnumerator<CosmicCultComponent>();
                 while (cultistQuery.MoveNext(out var cultist, out var cultistComp))
                 {
-                    var mins = timer.Minutes;
-                    var secs = timer.Seconds;
                     _antag.SendBriefing(cultist,
-                        Loc.GetString("cosmiccult-finale-autocall-briefing",
-                            ("minutesandseconds", $"{mins} minutes and {secs} seconds")),
+                        Loc.GetString("cosmiccult-finale-autocall-briefing"),
                         Color.FromHex("#4cabb3"),
                         _monumentAlert);
                 }

--- a/Content.Server/_DV/CosmicCult/MonumentSystem.cs
+++ b/Content.Server/_DV/CosmicCult/MonumentSystem.cs
@@ -280,10 +280,10 @@ public sealed class MonumentSystem : SharedMonumentSystem
             _appearance.SetData(ent, MonumentVisuals.FinaleReached, true);
     }
 
-    //note - these ar the thresholds for moving to the next tier
-    //so t1 -> 2 needs 20% of the crew
-    //t2 -> 3 needs 40%
-    //and t3 -> finale needs an extra 20 entropy
+    //note - these are the thresholds for moving to the next tier
+    //so t1 -> 2 needs 1/3 of CosmicCultTargetConversionPercent
+    //t2 -> 3 needs 2/3 of CosmicCultTargetConversionPercent
+    //and t3 -> finale needs full CosmicCultTargetConversionPercent
     public void UpdateMonumentReqsForTier(Entity<MonumentComponent> monument, int tier)
     {
         if (_cosmicRule.AssociatedGamerule(monument) is not { } cult)
@@ -295,15 +295,15 @@ public sealed class MonumentSystem : SharedMonumentSystem
         {
             case 1:
                 monument.Comp.ProgressOffset = 0;
-                monument.Comp.TargetProgress = (int)(numberOfCrewForTier3 / 2 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue));
+                monument.Comp.TargetProgress = (int)(numberOfCrewForTier3 / 3 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue));
                 break;
             case 2:
-                monument.Comp.ProgressOffset = (int)(numberOfCrewForTier3 / 2 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue)); //reset the progress offset
-                monument.Comp.TargetProgress = (int)(numberOfCrewForTier3 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue));
+                monument.Comp.ProgressOffset = (int)(numberOfCrewForTier3 / 3 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue)); //reset the progress offset
+                monument.Comp.TargetProgress = (int)(numberOfCrewForTier3 / 3 * 2 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue));
                 break;
             case 3:
-                monument.Comp.ProgressOffset = (int)(numberOfCrewForTier3 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue));
-                monument.Comp.TargetProgress = (int)(numberOfCrewForTier3 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue)); //removed offset; replaced with timer
+                monument.Comp.ProgressOffset = (int)(numberOfCrewForTier3 / 3 * 2 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue));
+                monument.Comp.TargetProgress = (int)(numberOfCrewForTier3 * _config.GetCVar(DCCVars.CosmicCultistEntropyValue));
                 break;
         }
     }

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -248,5 +248,5 @@ public sealed partial class DCCVars
     /// The delay between the monument getting upgraded to tier 3 and the finale starting.
     /// </summary>
     public static readonly CVarDef<int> CosmicCultFinaleDelaySeconds =
-        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 110, CVar.SERVER);
+        CVarDef.Create("cosmiccult.extra_entropy_for_finale", 1, CVar.SERVER);
 }

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -104,9 +104,8 @@ cosmiccult-monument-stage2-briefing =
     Its influence will affect realspace in {$time} seconds.
 
 cosmiccult-monument-stage3-briefing =
-    The Monument has been completed!
+    The Monument grows in power!
     Its influence will begin to overlap with realspace in {$time} seconds.
-    This is the final stretch! Amass as much entropy as you can muster.
 
 
 ## MALIGN RIFTS

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -18,7 +18,7 @@ cosmiccult-vote-steward-briefing =
     Ensure that The Monument is placed in a secure location, and organize the cult to ensure your collective victory.
     You are not permitted to instruct cultists on how to use or spend their Entropy.
 
-cosmiccult-finale-autocall-briefing = The Monument activates in {$minutesandseconds}! Gather yourselves, and prepare for the end.
+cosmiccult-finale-autocall-briefing = The Monument has been completed! Gather yourselves, activate it, and prepare for the end.
 cosmiccult-finale-ready = A terrifying light surges forth from The Monument!
 cosmiccult-finale-speedup = The beckoning quickens! Energy surges through the surroundings...
 


### PR DESCRIPTION
## About the PR
Adjusted cosmic cult's entropy requirements for each stage to make the overall round flow smoother.
Previously, advancing from stage 1 to stage 2, and from stage 2 to stage 3 both required 1/2 of CosmicCultTargetConversionPercent, while advancing from stage 3 to the finale was a 2 minute timer, which made stage 3 basically non-existient.
Now, all the progression points (1 -> 2, 2 -> 3, 3 -> finale) require 1/3 of CosmicCultTargetConversionPercent.
The total amount of entropy that cult needs to collect remains unchanged, which means that stages 1 and 2 are slightly shorter than before (they are kinda boring anyway).

## Why / Balance
Stage 3 is now an actual progression stage for the round that lasts a significant amount of time. Theoreticaly, it should work as a middle ground between stage 2 (cult presence is known, but they mostly remain hidden) and the finale (team deathmatch between sec and the cult), which, according to feedback in the DeltaV discord server, is a much needed addition.
Additionaly, it makes vacuous spires actually useful, since now you still entropy in stage 3, where said spires are unlocked.

## Technical details
Minor tweaks to the MonumentSystem.

## Media
Beginning of stage 3.
<img width="1271" height="970" alt="изображение" src="https://github.com/user-attachments/assets/70aacc88-b9b0-4b08-93a0-2168e60e1d74" />
After inserting enough entropy. At this point the monument can be beckoned as usual, starting the finale.
<img width="1290" height="953" alt="изображение" src="https://github.com/user-attachments/assets/adb08bf8-e92c-42a8-aed3-2227501be077" />
(Ignore the fact that I became a steward after the monument reached stage 2, that's just debug speedrunning)


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cosmic cult's progression throughout the round should now feel much smoother.
