### PR TITLE
Give everybody the same TC - Again

### DIFF
--- a/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/TraitorRuleSystem.cs
@@ -109,13 +109,14 @@ public sealed class TraitorRuleSystem : GameRuleSystem<TraitorRuleComponent>
             Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Uplink start");
             // Calculate the amount of currency on the uplink.
             var startingBalance = component.StartingBalance;
+            /* DeltaV - everyone gets the same amount of TC
             if (_jobs.MindTryGetJob(mindId, out var prototype))
             {
                 if (startingBalance < prototype.AntagAdvantage) // Can't use Math functions on FixedPoint2
                     startingBalance = 0;
                 else
                     startingBalance = startingBalance - prototype.AntagAdvantage;
-            }
+            }*/
 
             // Choose and generate an Uplink, and return the uplink code if applicable
             Log.Debug($"MakeTraitor {ToPrettyString(traitor)} - Uplink request start");

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -12,7 +12,7 @@
   startingGear: ForensicMantisGear
   icon: "JobIconForensicMantis"
   supervisors: job-supervisors-rd
-  antagAdvantage: 4 # DeltaV - Protolathe, Psionics, Has an objective item, anomaly stuff, glimmer factor
+  antagAdvantage: 2 # DeltaV - Psionics, Has an objective item
   canBeAntag: true # DeltaV - Mantis is no longer a Detective
   access:
   - Research

--- a/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/chaplain.yml
@@ -3,7 +3,7 @@
   name: job-name-chaplain
   description: job-description-chaplain
   playTimeTracker: JobChaplain
-  antagAdvantage: 4 # DeltaV - Protolathe, Increased Psionics, Gib machine, anomaly access, glimmer factor
+  antagAdvantage: 2 # DeltaV - Increased Psionics, Gib machine
   startingGear: ChaplainGear
   icon: "JobIconChaplain"
   supervisors: job-supervisors-rd # DeltaV - Change supervisor to mystagogue

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -3,7 +3,6 @@
   name: job-name-research-assistant
   description: job-description-research-assistant
   playTimeTracker: JobResearchAssistant
-  antagAdvantage: 2 # DeltaV - Protolathe, anomaly stuff, glimmer factor
   requirements:
     - !type:DepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics replacing Science

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -3,7 +3,6 @@
   name: job-name-scientist
   description: job-description-scientist
   playTimeTracker: JobScientist
-  antagAdvantage: 2 # DeltaV - Protolathe, anomaly stuff, glimmer factor.
   requirements:
     - !type:DepartmentTimeRequirement
       department: Epistemics # DeltaV - Epistemics replacing Science

--- a/Resources/Prototypes/_DV/Roles/Jobs/Epistemics/roboticist.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Epistemics/roboticist.yml
@@ -3,7 +3,7 @@
   name: job-name-roboticist
   description: job-description-roboticist
   playTimeTracker: JobRoboticist
-  antagAdvantage: 6 # The shadow factory + scientist advantage
+  antagAdvantage: 4 # The shadow factory
   requirements:
   - !type:DepartmentTimeRequirement
     department: Epistemics


### PR DESCRIPTION
## About the PR
~~Scientists no longer have their -2 TC penalty, and all other Epistemics roles have had their TC penalty lowered by 2.~~ That, but also, all roles now get the same TC.

## Why / Balance
~~The reason for the penalty in the first place was `Protolathe, anomaly stuff, glimmer factor`. However:~~
- ~~Protolathe no longer exists~~
- ~~Anomalies don't provide any meaningful advantage to a traitor~~
- ~~Glimmer isn't an objective anymore, and similarly, provides little advantage~~
direction said so :)

## Technical details
certified yaml soldier

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: All jobs, again, now get the same starting TC.
