### PR TITLE
Automatic ACO for apoapsis

### DIFF
--- a/Resources/ConfigPresets/DeltaV/apoapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/apoapsis.toml
@@ -2,8 +2,5 @@
 hostname         = "[EN][MRP] Delta-v (Ψ) | Apoapsis [US East 1]"
 soft_max_players = 80
 
-[game.spare_id]
-auto_unlock = false # Disabled for apo until if/when command whitelist
-
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"


### PR DESCRIPTION
## About the PR
Automatic ACO procedure is now enabled on apoapsis

## Why / Balance
Command whitelist is already there! Like for real this time!

## Technical details
Remove 2 lines

## Media
No

## Requirements
- [X] I have not tested all added content and changes.
- [X] I have realized that nobody ever reads those anyway so I'll just change the text for lulz.

**Changelog**
:cl:
- tweak: ACO procedure is now automatic on apoapsis.