### PR TITLE
Reintro StationLimitedNetwork component on crew_monitor_server

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -36,7 +36,7 @@
       autoConnect: false
     - type: WirelessNetworkConnection
       range: 10000 # Delta-V Maximises the range for the Crew Monitor Server to make it work for Listening Post
-    - type: StationLimitedNetwork # DeltaV
+    - type: StationLimitedNetwork
     - type: ApcPowerReceiver
       powerLoad: 200
     - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -34,10 +34,9 @@
       transmitFrequencyId: CrewMonitor
       receiveFrequencyId: SuitSensor
       autoConnect: false
-    - type: StationLimitedNetwork
     - type: WirelessNetworkConnection
       range: 10000 # Delta-V Maximises the range for the Crew Monitor Server to make it work for Listening Post
-    #- type: StationLimitedNetwork # DeltaV
+    - type: StationLimitedNetwork # DeltaV
     - type: ApcPowerReceiver
       powerLoad: 200
     - type: ExtensionCableReceiver

--- a/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/crew_monitor_server.yml
@@ -34,6 +34,7 @@
       transmitFrequencyId: CrewMonitor
       receiveFrequencyId: SuitSensor
       autoConnect: false
+    - type: StationLimitedNetwork
     - type: WirelessNetworkConnection
       range: 10000 # Delta-V Maximises the range for the Crew Monitor Server to make it work for Listening Post
     #- type: StationLimitedNetwork # DeltaV


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixes the admin ghost crew monitor not working

## Why / Balance
👁️ 
Fixes #4062 
Fixes #4071 
## Technical details
Removal of the component caused the aghost to not find a server

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Admin Ghosts can see the crew monitor again.

