### PR TITLE
Re-add cosmicRadio after IPC pops lock

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
@@ -9,6 +9,7 @@ using Content.Server.Popups;
 using Content.Server.Station.Systems;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult;
+using Content.Server._EE.Radio;
 using Content.Shared.Alert;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
@@ -26,6 +27,8 @@ using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Shared.Popups;
+using Content.Shared.Radio;
+using Content.Server.Radio.Components;
 
 namespace Content.Server._DV.CosmicCult;
 
@@ -82,6 +85,8 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
         SubscribeLocalEvent<CosmicImposingComponent, RefreshMovementSpeedModifiersEvent>(OnImpositionMoveSpeed);
 
         SubscribeLocalEvent<CosmicCultExamineComponent, ExaminedEvent>(OnCosmicCultExamined);
+
+        SubscribeLocalEvent<CosmicCultComponent, EncryptionChannelsChangedEvent>(OnTransmitterChannelsChangedCult, after: new[] { typeof(IntrinsicRadioKeySystem) });
 
         SubscribeFinale(); //Hook up the cosmic cult finale system
     }
@@ -202,5 +207,17 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
         args.ModifySpeed(0.65f, 0.65f);
     }
     #endregion
+
+    private void OnTransmitterChannelsChangedCult(EntityUid uid, CosmicCultComponent component, EncryptionChannelsChangedEvent args) //Handles IPCs not regaining astral murmur after panel operations
+    {
+        if (TryComp<IntrinsicRadioTransmitterComponent>(uid, out var transmitterComponent) && TryComp<ActiveRadioComponent>(uid, out var activeRadioComponent))
+        {
+            if (!transmitterComponent.Channels.Contains("CosmicRadio") && !activeRadioComponent.Channels.Contains("CosmicRadio"))
+            {
+                transmitterComponent.Channels.Add("CosmicRadio");
+                activeRadioComponent.Channels.Add("CosmicRadio");
+            }
+        }
+    }
 
 }

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
@@ -61,6 +61,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
 
     private static readonly EntProtoId CosmicEchoVfx = "CosmicEchoVfx";
     private static readonly ProtoId<StatusEffectPrototype> EntropicDegen = "EntropicDegen";
+    private static readonly ProtoId<RadioChannelPrototype> CosmicRadio = "CosmicRadio";
 
     public override void Initialize()
     {
@@ -208,16 +209,21 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     }
     #endregion
 
-    private void OnTransmitterChannelsChangedCult(EntityUid uid, CosmicCultComponent component, EncryptionChannelsChangedEvent args) //Handles IPCs not regaining astral murmur after panel operations
+    /// <summary>
+    /// Edge Case to handle IPCs losing astral murmur after panel operations.
+    /// </summary>
+    private void OnTransmitterChannelsChangedCult(EntityUid uid, CosmicCultComponent component, EncryptionChannelsChangedEvent args)
     {
-        if (TryComp<IntrinsicRadioTransmitterComponent>(uid, out var transmitterComponent) && TryComp<ActiveRadioComponent>(uid, out var activeRadioComponent))
-        {
-            if (!transmitterComponent.Channels.Contains("CosmicRadio") && !activeRadioComponent.Channels.Contains("CosmicRadio"))
-            {
-                transmitterComponent.Channels.Add("CosmicRadio");
-                activeRadioComponent.Channels.Add("CosmicRadio");
-            }
-        }
+        if (!TryComp<IntrinsicRadioTransmitterComponent>(uid, out IntrinsicRadioTransmitterComponent? transmitter) || !TryComp<ActiveRadioComponent>(uid, out ActiveRadioComponent? activeRadio))
+            return;
+
+        if (transmitter.Channels.Contains(CosmicRadio) && activeRadio.Channels.Contains(CosmicRadio))
+            return;
+
+        transmitter.Channels.Add(CosmicRadio);
+        activeRadio.Channels.Add(CosmicRadio);
+
+
     }
 
 }

--- a/Content.Server/_EE/Radio/IntrinsicRadioKeySystem.cs
+++ b/Content.Server/_EE/Radio/IntrinsicRadioKeySystem.cs
@@ -1,4 +1,5 @@
 using Content.Server.Radio.Components;
+using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
 
@@ -28,5 +29,10 @@ public sealed class IntrinsicRadioKeySystem : EntitySystem
     {
         channels.Clear();
         channels.UnionWith(keyHolderComp.Channels);
-    }
+
+        if (TryComp<CosmicCultComponent>(_, out var cultComp)) //Begin Delta-V
+        {
+            channels.Add("CosmicRadio"); // Re add cosmic cult radio, fixes IPCs
+        }
+    } //End Delta-V
 }

--- a/Content.Server/_EE/Radio/IntrinsicRadioKeySystem.cs
+++ b/Content.Server/_EE/Radio/IntrinsicRadioKeySystem.cs
@@ -29,10 +29,5 @@ public sealed class IntrinsicRadioKeySystem : EntitySystem
     {
         channels.Clear();
         channels.UnionWith(keyHolderComp.Channels);
-
-        if (TryComp<CosmicCultComponent>(_, out var cultComp)) //Begin Delta-V
-        {
-            channels.Add("CosmicRadio"); // Re add cosmic cult radio, fixes IPCs
-        }
-    } //End Delta-V
+    }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
IPCs no longer lose Astral Murmur when unlocking and locking their panels.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
IPCs deserve to participate in Cult Comms

Fixes #4047 

## Technical details
<!-- Summary of code changes for easier review. -->
Previously when an IPC would lock and/or unlock their panel they would lose CosmicRadio as it has no formal encryption key.
This just re-adds it if they have CosmicCultComponent,

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: IPCs no longer lose Astral Murmur when unlocking and locking their panels.

