### PR TITLE
Replaces wizard whitelist & Teleport scroll

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/ghost_roles.yml
@@ -254,6 +254,9 @@
     - MindRoleGhostRoleSoloAntagonist
     raffle:
       settings: default
+    requirements:
+    - !type:OverallPlaytimeRequirement # DeltaV - Playtime requirement
+      time: 90000 # DeltaV - 25 hours
   - type: Sprite
     sprite: Markers/jobs.rsi
     layers:

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -13,8 +13,7 @@
   objective: roles-antag-wizard-objective # TODO: maybe give random objs and stationary ones from AntagObjectives and AntagRandomObjectives
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
-  - !type:WhitelistRequirement # DeltaV - Whitelist requirement
+    time: 90000 # DeltaV - 25 hours, was #18000 # 5h
   guides: [ Wizard ]
 
 # See wizard_startinggear for wiz start gear options

--- a/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/wizard_startinggear.yml
@@ -10,7 +10,7 @@
     id: WizardPDA
     ears: ClothingHeadsetAltWizard
     belt: ClothingBeltWand
-    pocket1: WizardTeleportScroll
+    #pocket1: WizardTeleportScroll # DeltaV - commented out until someone makes this thing not let anyone who picks it up go to Central Command
     pocket2: WizardsGrimoire
 
 - type: startingGear


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
This is a hotfix PR for certain wizard-related nonsense. This PR replaces wizard whitelist requirement with a simple 25 hour playtime requirement, and removes the teleport scroll from wizard's pocket on spawn.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. Whitelist for wizard only affects the roundstart wizard role, and has no bearing on the midround wizard.
2. Teleport scroll at the moment allows the wiz to go to CC, and they'll do some dumb shit over there. Also, anyone can pick it up and do the same thing should the wizard lose it.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="802" height="61" alt="image" src="https://github.com/user-attachments/assets/a1f01f12-c891-4945-9dd4-3c555f1caefa" />
<img width="697" height="117" alt="image" src="https://github.com/user-attachments/assets/7f945784-faf7-4956-9d8d-fa9e30f23426" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
🤷 
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
2small
