### PR TITLE
Modifies Probers to be more dynamic

### DIFF
--- a/Content.Server/_DV/StationEvents/Components/LockProbersRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/LockProbersRuleComponent.cs
@@ -1,0 +1,11 @@
+using Content.Server._DV.StationEvents.Events;
+using Content.Shared.Psionics.Glimmer;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.StationEvents.Components;
+
+/// <summary>
+/// Locks all the probers on the station and turns them into bombs.
+/// </summary>
+[RegisterComponent, Access(typeof(GlimmerMobRule))]
+public sealed partial class LockProbersRuleComponent : Component { }

--- a/Content.Server/_DV/StationEvents/Events/LockProbersRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/LockProbersRule.cs
@@ -1,4 +1,5 @@
-using System.Linq;
+using Content.Server._DV.StationEvents.Components;
+using Content.Server.Power.Components;
 using Content.Server.Psionics.Glimmer;
 using Content.Server.Station.Systems;
 using Content.Server.StationEvents;
@@ -8,10 +9,9 @@ using Content.Shared.Abilities.Psionics;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.NPC.Components;
 using Content.Shared.Psionics.Glimmer;
-using Robust.Shared.Random;
 using Robust.Shared.Map;
-using Content.Server._DV.StationEvents.Components;
-using Content.Server.Power.Components;
+using Robust.Shared.Random;
+using System.Linq;
 
 namespace Content.Server._DV.StationEvents.Events;
 

--- a/Content.Server/_DV/StationEvents/Events/LockProbersRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/LockProbersRule.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using Content.Server.Psionics.Glimmer;
+using Content.Server.Station.Systems;
+using Content.Server.StationEvents;
+using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.NPC.Components;
+using Content.Shared.Psionics.Glimmer;
+using Robust.Shared.Random;
+using Robust.Shared.Map;
+using Content.Server._DV.StationEvents.Components;
+using Content.Server.Power.Components;
+
+namespace Content.Server._DV.StationEvents.Events;
+
+public sealed class LockProbersRule : StationEventSystem<LockProbersRuleComponent>
+{
+    [Dependency] private readonly GlimmerSystem _glimmer = default!;
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly GlimmerReactiveSystem _glimmerReactiveSystem = default!;
+
+    protected override void Started(EntityUid uid, LockProbersRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        if (!TryGetRandomStation(out var station))
+            return;
+
+        var probers = GetProbers(station.Value);
+        if (probers.Count == 0)
+        {
+            Log.Info($"{ToPrettyString(uid):rule} found no probers on station {station}!");
+            ForceEndSelf(uid, gameRule);
+            return;
+        }
+        RobustRandom.Shuffle(probers);
+        int probersToLock = RobustRandom.Next(1, probers.Count); // Lock a random number of probers, at least one
+        foreach (var prober in probers.Take(probersToLock))
+        {
+            _glimmerReactiveSystem.LockProber(prober);
+        }
+    }
+
+    private List<EntityUid> GetProbers(EntityUid station)
+    {
+        var probers = new List<EntityUid>();
+        var query = AllEntityQuery<SharedGlimmerReactiveComponent>();
+        while (query.MoveNext(out var uid, out var _))
+        {
+            var xform = Transform(uid);
+            if (xform.GridUid == null)
+                continue;
+
+            if (_stationSystem.GetOwningStation(xform.GridUid.Value) == station)
+                probers.Add(uid);
+        }
+        return probers;
+    }
+}

--- a/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerReactiveComponent.cs
+++ b/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerReactiveComponent.cs
@@ -32,25 +32,28 @@ namespace Content.Shared.Psionics.Glimmer
         [DataField("glimmerToLightRadiusFactor")]
         public float GlimmerToLightRadiusFactor = 1.0f;
 
-        [DataField("locked")]
-        public bool Locked = false; // Delta-V
+        /// <summary>
+        /// If this is true, this device has been locked by an event, is will not turn off until it is destroyed.
+        /// </summary>
+        [DataField]
+        public bool Locked = false;
 
         /// <summary>
         /// If true, this component will scale its research generation based on the glimmer tier, as well as its glimmer generation.
         /// </summary>
-        [DataField("scaleResearchGeneration")]
+        [DataField]
         public bool ScaleResearchGeneration = true;
         /// <summary>
         /// For each tier of glimmer, take the maximum possible glimmer value and multiply it by this factor to get the research generation factor.
         /// This is the research per second of this machine
         /// </summary>
-        [DataField("researchGenerationFactor")]
+        [DataField]
         public float ResearchGenerationFactor = 0.2f;
         /// <summary>
         /// For each tier of glimmer, take the maximum possible glimmer value and multiply it
         /// by this factor to get the glimmer generation per second.
         /// </summary>
-        [DataField("glimmerGenerationFactor")]
+        [DataField]
         public float GlimmerGenerationFactor = 0.001f;
 
         /// <summary>

--- a/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerReactiveComponent.cs
+++ b/Content.Shared/Nyanotrasen/Psionics/Glimmer/SharedGlimmerReactiveComponent.cs
@@ -32,6 +32,27 @@ namespace Content.Shared.Psionics.Glimmer
         [DataField("glimmerToLightRadiusFactor")]
         public float GlimmerToLightRadiusFactor = 1.0f;
 
+        [DataField("locked")]
+        public bool Locked = false; // Delta-V
+
+        /// <summary>
+        /// If true, this component will scale its research generation based on the glimmer tier, as well as its glimmer generation.
+        /// </summary>
+        [DataField("scaleResearchGeneration")]
+        public bool ScaleResearchGeneration = true;
+        /// <summary>
+        /// For each tier of glimmer, take the maximum possible glimmer value and multiply it by this factor to get the research generation factor.
+        /// This is the research per second of this machine
+        /// </summary>
+        [DataField("researchGenerationFactor")]
+        public float ResearchGenerationFactor = 0.2f;
+        /// <summary>
+        /// For each tier of glimmer, take the maximum possible glimmer value and multiply it
+        /// by this factor to get the glimmer generation per second.
+        /// </summary>
+        [DataField("glimmerGenerationFactor")]
+        public float GlimmerGenerationFactor = 0.001f;
+
         /// <summary>
         /// Noises to play on failed turn off.
         /// </summary>

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -13,6 +13,7 @@
     - id: GlimmerMiteSpawn
     - id: GlimmerRandomSentience
     - id: ThavenMoodUpset
+    - id: LockProbers
 
 - type: entity
   parent: BaseGameRule
@@ -158,3 +159,11 @@
     glimmerBurnLower: 30
     glimmerBurnUpper: 70
   - type: ThavenMoodUpsetRule
+
+- type: entity
+  parent: BaseGlimmerEvent
+  id: LockProbers
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 500
+  - type: LockProbersRule


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Modified Prober behaviour to be more dynamic, both to interact with and interacting with Glimmer / Research.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As it stands, Glimmer Probes are un-interesting to work with. Turn on, gain research, turn off before it gets to 500, destroy it if it does.
The proposed changes stop the instant lockout at 500 and improves effectiveness of the machine at higher glimmer, promoting more risk-reward play relating to glimmer probing.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a LockProbes Glimmer Event, which causes a random number (at least 1) of probes to Lock per former 500+ glimmer Locking Behaviour. These cannot be unlocked, though are only a risk when attempting to remove them.
Probes no-longer generate a flat number of Glimmer and Research, instead they scale roughly with the current glimmer value. With current implementation, they are identical to their previous implementation at 100 glimmer. Of course, the increased glimmer generation means they can quickly run-away.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Modified Glimmer Probers, they now generate more Glimmer and Research based on the current Glimmer.
- tweak: Glimmer Probers no-longer automatically lock themselves at 500 glimmer.
- add: Added a new Glimmer Event which locks some Glimmer Probes.
