### PR TITLE
Improve comic cult evac behavior

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -18,6 +18,7 @@ using Content.Server.Station.Components;
 using Content.Server.Station.Events;
 using Content.Server.Station.Systems;
 using Content.Shared._DV.CustomObjectiveSummary; // DeltaV
+using Content.Server._DV.Shuttles.Events; // DeltaV
 using Content.Shared.Access.Systems;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
@@ -440,6 +441,8 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
 
         _consoleAccumulator = _configManager.GetCVar(CCVars.EmergencyShuttleDockTime);
         EmergencyShuttleArrived = true;
+
+        RaiseLocalEvent(new EvacShuttleDockedEvent()); // DeltaV
 
         var query = AllEntityQuery<StationEmergencyShuttleComponent>();
 

--- a/Content.Server/_DV/CosmicCult/Components/CosmicFinaleComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicFinaleComponent.cs
@@ -87,4 +87,5 @@ public enum FinaleState : byte
     ReadyFinale,
     ActiveFinale,
     Victory,
+    Unreachable,
 }

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -1,4 +1,6 @@
 using Content.Server._DV.CosmicCult.Components;
+using Content.Server.RoundEnd;
+using Content.Server.Shuttles.Systems;
 using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.Audio;
@@ -15,6 +17,10 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     /// <summary>
     ///     Used to calculate when the finale song should start playing
     /// </summary>
+
+    [Dependency] private readonly RoundEndSystem _roundEnd = default!;
+    [Dependency] private readonly EmergencyShuttleSystem _evac = default!;
+
     public void SubscribeFinale()
     {
         SubscribeLocalEvent<CosmicFinaleComponent, InteractHandEvent>(OnInteract);
@@ -98,6 +104,8 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
 
         Dirty(uid, monument);
         _ui.SetUiState(uid.Owner, MonumentKey.Key, new MonumentBuiState(monument));
+
+        if (!_evac.EmergencyShuttleArrived && _roundEnd.IsRoundEndRequested()) _roundEnd.CancelRoundEndCountdown(checkCooldown: false);
     }
 
     private void OnFinaleCancelDoAfter(Entity<CosmicFinaleComponent> uid, ref CancelFinaleDoAfterEvent args)

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -43,7 +43,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
             _doAfter.TryStartDoAfter(doargs);
             args.Handled = true;
         }
-        else if (EntityIsCultist(args.User) && !args.Handled && !ent.Comp.Occupied && !ent.Comp.FinaleActive && ent.Comp.CurrentState != FinaleState.Unavailable)
+        else if (EntityIsCultist(args.User) && !args.Handled && !ent.Comp.Occupied && !ent.Comp.FinaleActive && ent.Comp.CurrentState == FinaleState.ReadyFinale)
         {
             ent.Comp.Occupied = true;
             var doargs = new DoAfterArgs(EntityManager, args.User, ent.Comp.InteractionTime, new StartFinaleDoAfterEvent(), ent, ent)

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -14,13 +14,12 @@ namespace Content.Server._DV.CosmicCult;
 
 public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
 {
+    [Dependency] private readonly RoundEndSystem _roundEnd = default!;
+    [Dependency] private readonly EmergencyShuttleSystem _evac = default!;
+    
     /// <summary>
     ///     Used to calculate when the finale song should start playing
     /// </summary>
-
-    [Dependency] private readonly RoundEndSystem _roundEnd = default!;
-    [Dependency] private readonly EmergencyShuttleSystem _evac = default!;
-
     public void SubscribeFinale()
     {
         SubscribeLocalEvent<CosmicFinaleComponent, InteractHandEvent>(OnInteract);

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -16,7 +16,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
 {
     [Dependency] private readonly RoundEndSystem _roundEnd = default!;
     [Dependency] private readonly EmergencyShuttleSystem _evac = default!;
-    
+
     /// <summary>
     ///     Used to calculate when the finale song should start playing
     /// </summary>

--- a/Content.Server/_DV/CosmicCult/MonumentSystem.cs
+++ b/Content.Server/_DV/CosmicCult/MonumentSystem.cs
@@ -130,7 +130,7 @@ public sealed class MonumentSystem : SharedMonumentSystem
         var evacQuery = EntityQueryEnumerator<MonumentComponent, CosmicFinaleComponent>();
         while (evacQuery.MoveNext(out var ent, out var monuComp, out var finaleComp))
         {
-            finaleComp.CurrentState = FinaleState.Unavailable;
+            finaleComp.CurrentState = FinaleState.Unreachable;
         }
 
     }

--- a/Content.Server/_DV/Shuttles/Events/EvacShuttleDockedEvent.cs
+++ b/Content.Server/_DV/Shuttles/Events/EvacShuttleDockedEvent.cs
@@ -1,0 +1,7 @@
+namespace Content.Server._DV.Shuttles.Events;
+
+/// <summary>
+///     DeltaV event for when the evac shuttle docks with the station.
+/// </summary>
+[Serializable]
+public sealed class EvacShuttleDockedEvent : EventArgs;


### PR DESCRIPTION
## About the PR
1. If evac is on it's way to the station when finale begins, evac is automaticaly recalled.
2. The monument shuts down the moment evac docks to the station, instead of when evac leaves.
3. Monument still works normaly when it shuts down, but the finale can no longer be activated.

## Why / Balance
It kinda sucks when evac arrives during the finale, since you now have to sacrifice your end-of-round RP and instead go fight the cultists. The previous system didn't fully prevent that kind of situation, so I adjusted it a bit. Now you either activate the finale before the evac docks, which would recall it, or you don't and get a minor win at best.
Also, evac now simply makes finale unavailable instead of completely bricking the monument, so any cultists that are left behind at least get to have some fun in the end.

## Technical details
I have probably just merge conflict'd my other PR by doing this.

## Media
You won't believe me but it works as intended (it doesn't actually get recalled twice that's me fucking around)
<img width="472" height="465" alt="изображение" src="https://github.com/user-attachments/assets/0a6bc922-9ae8-4349-919d-f6b868b16712" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Monument no longer gets bricked when evac departs.
- tweak: Cosmic cult's finale can no longer be triggered when evac docks to the station.
- tweak: If evac was on it's way to the station when cosmic cult's finale is activated, it gets automatically recalled.
