### PR TITLE
Move energy shotgun to the warden's locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -342,7 +342,7 @@
     - !type:NestedSelector # DeltaV
       tableId: LockerFillHeadOfSecurityDeltaV
     - id: BookSecretDocuments
-    - id: WeaponEnergyShotgun
+    # - id: WeaponEnergyShotgun # DeltaV - Moved to warden locker
     - id: BookSpaceLaw
     - id: BoxEncryptionKeySecurity
     - id: CigarGoldCase

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -21,6 +21,7 @@
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
       # Begin DeltaV additions
+      - id: WeaponEnergyShotgun
       - id: BoxPDAPrisoner
       - id: BoxEncryptionKeyPrisoner
       - id: LunchboxSecurityFilledRandom
@@ -56,6 +57,7 @@
       - id: HoloprojectorSecurity
       - id: BookSpaceLaw
       # Begin DeltaV additions
+      - id: WeaponEnergyShotgun
       - id: BoxPDAPrisoner
       - id: BoxEncryptionKeyPrisoner
       - id: LunchboxSecurityFilledRandom

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -212,7 +212,7 @@
     job: HeadOfSecurity
   - type: StealCondition
     stealGroup: WeaponEnergyShotgun
-    owner: job-name-hos
+    owner: job-name-warden # DeltaV - was job-name-hos
 
 ## ce
 


### PR DESCRIPTION
literal word for word recreation of #3972 , no i dont know how to reopen other prs.

## About the PR
This PR moves the energy shotgun to the warden's office.

## Why / Balance
Makes more sense that a crowd control gun goes to the person in charge of protecting security.

N/A
:cl: Radezolid
- tweak: Moved the energy shotgun to the warden's locker.

