### PR TITLE
Telegnosis Suffocation Nerf

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/TelegnosisPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/TelegnosisPowerSystem.cs
@@ -1,23 +1,30 @@
-using Content.Shared.Actions;
-using Content.Shared.StatusEffect;
+using Content.Server.Atmos.EntitySystems;
+using Content.Server.Body.Systems;
+using Content.Server.Disposal.Unit;
 using Content.Shared.Abilities.Psionics;
-using Content.Shared.Mind.Components;
-using Robust.Shared.Prototypes;
-using Robust.Shared.Timing;
-using Content.Server.Mind;
+using Content.Shared.Actions;
 using Content.Shared.Actions.Events;
+using Content.Shared.Atmos;
+using Content.Shared.Body.Components;
+using Content.Shared.Examine;
+using Content.Shared.Mech.Components;
+using Content.Shared.Medical.Cryogenics;
+using Content.Shared.Mind;
+using Content.Shared.Mind.Components;
+using Content.Shared.Storage.Components;
+using Robust.Server.GameObjects;
+using System.Numerics;
 
 namespace Content.Server.Abilities.Psionics
 {
     public sealed class TelegnosisPowerSystem : SharedTelegnosisPowerSystem
     {
-        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
-        [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
         [Dependency] private readonly SharedActionsSystem _actions = default!;
         [Dependency] private readonly MindSwapPowerSystem _mindSwap = default!;
         [Dependency] private readonly SharedPsionicAbilitiesSystem _psionics = default!;
-        [Dependency] private readonly IGameTiming _gameTiming = default!;
-        [Dependency] private readonly MindSystem _mindSystem = default!;
+        [Dependency] private readonly AtmosphereSystem _atmosSys = default!;
+        [Dependency] private readonly TransformSystem _transform = default!;
+        [Dependency] private readonly SharedMindSystem _mind = default!;
 
         public override void Initialize()
         {
@@ -26,6 +33,8 @@ namespace Content.Server.Abilities.Psionics
             SubscribeLocalEvent<TelegnosisPowerComponent, ComponentShutdown>(OnShutdown);
             SubscribeLocalEvent<TelegnosisPowerComponent, TelegnosisPowerActionEvent>(OnPowerUsed);
             SubscribeLocalEvent<TelegnosticProjectionComponent, MindRemovedMessage>(OnMindRemoved);
+            SubscribeLocalEvent<TelegnosisPowerComponent, InhaleLocationEvent>(OnInhaleLocation, after: [typeof(InsideCryoPodComponent), typeof(InternalsComponent), typeof(BeingDisposedComponent), typeof(InsideEntityStorageComponent), typeof(MechPilotComponent)]);
+            SubscribeLocalEvent<TelegnosisPowerComponent, ExaminedEvent>(OnExamine);
         }
 
         private void OnInit(EntityUid uid, TelegnosisPowerComponent component, ComponentInit args)
@@ -53,7 +62,10 @@ namespace Content.Server.Abilities.Psionics
         private void OnPowerUsed(EntityUid uid, TelegnosisPowerComponent component, TelegnosisPowerActionEvent args)
         {
             var projection = Spawn(component.Prototype, Transform(uid).Coordinates);
-            Transform(projection).AttachToGridOrMap();
+
+            _mind.ShowExamineInfo(uid, false); // Hide SSD indicator
+
+            _transform.AttachToGridOrMap(projection);
             _mindSwap.Swap(uid, projection);
 
             _psionics.LogPowerUsed(uid, "telegnosis");
@@ -61,7 +73,46 @@ namespace Content.Server.Abilities.Psionics
         }
         private void OnMindRemoved(EntityUid uid, TelegnosticProjectionComponent component, MindRemovedMessage args)
         {
+            // This is called during transfer to, so the MindSwappedComponent is still present.
+            if (TryComp<MindSwappedComponent>(uid, out var mindSwapped)){
+                _mind.ShowExamineInfo(mindSwapped.OriginalEntity, true);
+            }
             QueueDel(uid);
+        }
+
+        public (EntityUid uid, TelegnosticProjectionComponent? comp) GetCasterProjection(EntityUid uid)
+        {
+            if (!TryComp<MindSwappedComponent>(uid, out var mindSwapped) ||
+                !TryComp<TelegnosticProjectionComponent>(mindSwapped.OriginalEntity, out var projection))
+            {
+                return (default, null);
+            }
+            return (mindSwapped.OriginalEntity, projection);
+        }
+
+        private void OnInhaleLocation(EntityUid uid, TelegnosisPowerComponent component, ref InhaleLocationEvent args)
+        {
+            var (sensorUid, projection) = GetCasterProjection(uid);
+            if (projection == null)
+                return;
+            // Determine the distance to the sensor, this will be used to dilute the amount of air we take in.
+            var sensorPosition = _transform.GetWorldPosition(sensorUid);
+            var projectionPosition = _transform.GetWorldPosition(uid);
+            // A linear curve from 1.0 at 7 tiles away, to 0 at 57 tiles away
+            var distance = Vector2.Distance(sensorPosition, projectionPosition);
+            float gasMult = Math.Clamp(1f - (distance - 7f) / 50f, 0f, 1f);
+            args.Gas = (args.Gas ?? _atmosSys.GetContainingMixture(uid, excite: true))?.RemoveVolume(Atmospherics.BreathVolume * gasMult);
+            if (args.Gas == null)
+                return;
+            args.Gas.Volume = Math.Min(args.Gas.Volume, Atmospherics.BreathVolume);
+        }
+
+        private void OnExamine(EntityUid uid, TelegnosisPowerComponent entity, ref ExaminedEvent args)
+        {
+            if (GetCasterProjection(uid).comp == null)
+                return;
+
+            args.PushMarkup($"[color=yellow]{Loc.GetString("telegnosis-power-ssd", ("ent", uid))}[/color]");
         }
     }
 }

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -652,23 +652,6 @@ public abstract partial class SharedMindSystem : EntitySystem
 
         return allHumans;
     }
-
-    // Begin Delta-V Changes
-
-    /// <summary>
-    /// Set whether or not to show examine information about the mind. Used to obscure if a mind is SSD or not.
-    /// </summary>
-    /// <param name="uid">Entity to set the mind examine info for.</param>
-    /// <param name="showExamineInfo">True to show examine information, false to hide it.</param>
-    public void ShowExamineInfo(EntityUid uid, bool showExamineInfo)
-    {
-        if (!TryComp<MindContainerComponent>(uid, out var mindContainer))
-            return;
-
-        mindContainer.ShowExamineInfo = showExamineInfo;
-        Dirty(uid, mindContainer);
-    }
-    // End Delta-V Changes
 }
 
 /// <summary>

--- a/Content.Shared/Mind/SharedMindSystem.cs
+++ b/Content.Shared/Mind/SharedMindSystem.cs
@@ -652,6 +652,23 @@ public abstract partial class SharedMindSystem : EntitySystem
 
         return allHumans;
     }
+
+    // Begin Delta-V Changes
+
+    /// <summary>
+    /// Set whether or not to show examine information about the mind. Used to obscure if a mind is SSD or not.
+    /// </summary>
+    /// <param name="uid">Entity to set the mind examine info for.</param>
+    /// <param name="showExamineInfo">True to show examine information, false to hide it.</param>
+    public void ShowExamineInfo(EntityUid uid, bool showExamineInfo)
+    {
+        if (!TryComp<MindContainerComponent>(uid, out var mindContainer))
+            return;
+
+        mindContainer.ShowExamineInfo = showExamineInfo;
+        Dirty(uid, mindContainer);
+    }
+    // End Delta-V Changes
 }
 
 /// <summary>

--- a/Content.Shared/_DV/Mind/SharedMindSystem.cs
+++ b/Content.Shared/_DV/Mind/SharedMindSystem.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Mind.Components;
+
+namespace Content.Shared.Mind;
+
+public partial class SharedMindSystem
+{
+    /// <summary>
+    /// Set whether or not to show examine information about the mind. Used to obscure if a mind is SSD or not.
+    /// </summary>
+    /// <param name="uid">Entity to set the mind examine info for.</param>
+    /// <param name="showExamineInfo">True to show examine information, false to hide it.</param>
+    public void ShowExamineInfo(EntityUid uid, bool showExamineInfo)
+    {
+        if (!TryComp<MindContainerComponent>(uid, out var mindContainer))
+            return;
+
+        mindContainer.ShowExamineInfo = showExamineInfo;
+        Dirty(uid, mindContainer);
+    }
+}

--- a/Resources/Locale/en-US/_DV/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/_DV/abilities/psionic.ftl
@@ -45,3 +45,5 @@ psionic-power-precognition-random-sentience-result-message = Something bright an
 psionic-power-precognition-unknown-shuttle-cargo-lost-result-message = You see a vision of a simple ship of old Terra, adrift of the sea, far away from home.
 psionic-power-precognition-unknown-shuttle-traveling-cuisine-result-message = You see a vision of peace, a cozy meal sizzling on a warm stove. A delicious smells wafts through the air.
 psionic-power-precognition-unknown-shuttle-disaster-evac-pod-result-message = You see a vision of death and blood, of a destruction so complete only few survive, drifting through the coldness of space.
+
+telegnosis-power-ssd = { CAPITALIZE(POSS-ADJ($ent)) } eyes are unfocused and darting around, as if trying to see something that isn't there.

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/special.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/special.yml
@@ -15,8 +15,8 @@
   - type: Physics
     fixedRotation: true
   - type: MovementSpeedModifier
-    baseSprintSpeed: 8
-    baseWalkSpeed: 5
+    baseSprintSpeed: 6
+    baseWalkSpeed: 4
   #- type: PsionicallyInvisible
   - type: Eye
     drawFov: false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Telegnosis has been nerfed, causing damage if used too long and too far away. Additionally, Telegnosis users no-longer appear SSD.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Telegnosis in its current state has a dominant effect on any rounds in which its Psions are present, being able to frequently immediately spot and track antagonists that would otherwise have the advantage of surprise or stealth. This change is designed to punish players who hide away and use Telegnosis all round, whilst still keeping Telegnosis as a powerful information gathering tool.

This should _only_ have any considerable impact on Telegnosis users who refuse to leave their projection, as even distant use shouldn't be very harmful if done in moderation.

Making Telegnosis users no-longer appear SSD has two intentions
 * Users are no-longer accidently cryo'd.
 * Users are no-longer incorrectly assumed to be "untouchable" by other players.

## Technical details
<!-- Summary of code changes for easier review. -->
 Using Telegnosis now makes breathing harder.
 - If the Projection is less than 7 tiles away, there is no effect.
 - Between 7 and 57 tiles, there is a linear drop-off in how much air is taken in with each breath.
 - Past 57 tiles, no air is taken in with each breath.

This slowly causes suffocation damage with prolonged use but can be prevented by regularly returning to your body.

Telegnosis's sensor has been slowed down slightly to make the threat of distance more present. This should still be faster than most humans.

Telegnosis users no-longer appear SSD and instead have examine text showing that they are not present. (See media)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="565" height="261" alt="image" src="https://github.com/user-attachments/assets/326afa27-7b05-42b8-a965-7347835dc597" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: TehFlaminTaco
- tweak: Telegnosis can now cause suffocation if overused
- tweak: Telegnosis users are no-longer considered SSD