### PR TITLE
Glimmer event - psionic nosebleed

### DIFF
--- a/Content.Server/_DV/StationEvents/Components/PsionicNosebleedRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/PsionicNosebleedRuleComponent.cs
@@ -1,0 +1,10 @@
+using Content.Server._DV.StationEvents.Events;
+
+namespace Content.Server._DV.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(PsionicNosebleedRule))]
+public sealed partial class PsionicNosebleedRuleComponent : Component
+{
+    [DataField]
+    public float BleedAmount = 2.5f;
+}

--- a/Content.Server/_DV/StationEvents/Events/PsionicNosebleedRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/PsionicNosebleedRule.cs
@@ -1,0 +1,38 @@
+using Content.Server._DV.StationEvents.Components;
+using Content.Server.Body.Systems;
+using Content.Server.Psionics.Glimmer;
+using Content.Server.Station.Systems;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Content.Shared.Psionics.Glimmer;
+
+namespace Content.Server._DV.StationEvents.Events;
+
+public sealed class PsionicNosebleedRule : StationEventSystem<PsionicNosebleedRuleComponent>
+{
+    [Dependency] private readonly GlimmerSystem _glimmer = default!;
+    [Dependency] private readonly StationSystem _stationSystem = default!;
+    [Dependency] private readonly GlimmerReactiveSystem _glimmerReactiveSystem = default!;
+    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+    protected override void Started(EntityUid uid, PsionicNosebleedRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        var query = EntityQueryEnumerator<PsionicComponent, MobStateComponent>();
+        while (query.MoveNext(out var psion, out _, out _))
+        {
+            if (_mobStateSystem.IsAlive(psion) && !HasComp<PsionicInsulationComponent>(psion))
+            {
+                _popup.PopupEntity(Loc.GetString("psionic-nosebleed-message"), psion, psion, PopupType.MediumCaution);
+                _bloodstreamSystem.TryModifyBleedAmount(psion, comp.BleedAmount);
+            }
+        }
+    }
+}

--- a/Content.Server/_DV/StationEvents/Events/PsionicNosebleedRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/PsionicNosebleedRule.cs
@@ -1,24 +1,18 @@
 using Content.Server._DV.StationEvents.Components;
 using Content.Server.Body.Systems;
-using Content.Server.Psionics.Glimmer;
-using Content.Server.Station.Systems;
 using Content.Server.StationEvents.Events;
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
-using Content.Shared.Psionics.Glimmer;
 
 namespace Content.Server._DV.StationEvents.Events;
 
 public sealed class PsionicNosebleedRule : StationEventSystem<PsionicNosebleedRuleComponent>
 {
-    [Dependency] private readonly GlimmerSystem _glimmer = default!;
-    [Dependency] private readonly StationSystem _stationSystem = default!;
-    [Dependency] private readonly GlimmerReactiveSystem _glimmerReactiveSystem = default!;
-    [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
-    [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private readonly MobStateSystem _mob = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     protected override void Started(EntityUid uid, PsionicNosebleedRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
@@ -26,12 +20,12 @@ public sealed class PsionicNosebleedRule : StationEventSystem<PsionicNosebleedRu
         base.Started(uid, comp, gameRule, args);
 
         var query = EntityQueryEnumerator<PsionicComponent, MobStateComponent>();
-        while (query.MoveNext(out var psion, out _, out _))
+        while (query.MoveNext(out var psion, out _, out var mobState))
         {
-            if (_mobStateSystem.IsAlive(psion) && !HasComp<PsionicInsulationComponent>(psion))
+            if (_mob.IsAlive(psion, mobState) && !HasComp<PsionicInsulationComponent>(psion))
             {
                 _popup.PopupEntity(Loc.GetString("psionic-nosebleed-message"), psion, psion, PopupType.MediumCaution);
-                _bloodstreamSystem.TryModifyBleedAmount(psion, comp.BleedAmount);
+                _bloodstream.TryModifyBleedAmount(psion, comp.BleedAmount);
             }
         }
     }

--- a/Resources/Locale/en-US/_DV/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/_DV/abilities/psionic.ftl
@@ -1,3 +1,5 @@
+psionic-nosebleed-message = Your nose starts gushing blood!
+
 psionic-power-precognition-failure-by-damage = Your concentration was broken! You fail to decipher anything of use.
 psionic-power-precognition-no-event-result-message = You see a vision of an undisturbed lake.
 

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -14,6 +14,7 @@
     - id: GlimmerRandomSentience
     - id: ThavenMoodUpset
     - id: LockProbers
+    - id: PsionicNosebleedEvent
 
 - type: entity
   parent: BaseGameRule
@@ -167,3 +168,11 @@
   - type: GlimmerEvent
     minimumGlimmer: 500
   - type: LockProbersRule
+
+- type: entity
+  parent: BaseGlimmerEvent
+  id: PsionicNosebleedEvent
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 400
+  - type: PsionicNosebleedRule

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -174,5 +174,5 @@
   id: PsionicNosebleedEvent
   components:
   - type: GlimmerEvent
-    minimumGlimmer: 400
+    minimumGlimmer: 350
   - type: PsionicNosebleedRule


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
A new glimmer event is now possible past 350 glimmer, which gives all psionics a sudden nosebleed.

## Why / Balance
Now that the prober lockout is gone, I think glimmer events are going to be generally more prominent. Thus, this is the first of hopefully many attempts at introducing some more variety to the existing pool. Ideally, further attempts will be somewhat more interesting, but it's nice to have some subtler additions like this too. I think.
This event only inflicts 2.5 stacks of bleed- enough to be a bit alarming visually, but not enough to inflict any actual damage. More of a roleplay event, if anything.

## Technical details
apparently psionic.ftl is, in fact, the correct place to put glimmer strings

## Media
<img width="291" height="163" alt="image" src="https://github.com/user-attachments/assets/2856f3b8-c6fc-464c-8c0e-89717276cedb" />
<img width="500" alt="image" src="https://github.com/user-attachments/assets/66e15e33-6a4b-44b3-88fb-abe2d7c1bed3" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Psionics may now get nosebleeds at higher glimmer levels.
