### PR TITLE
Don't lift mindwiping ROE on code white

### DIFF
--- a/.wiki/_DV/Laws/AlertProcedure.txt
+++ b/.wiki/_DV/Laws/AlertProcedure.txt
@@ -169,7 +169,7 @@ Elevated alert status. ''The station is suffering dangerously high levels of gli
 | style="border: 1px solid #000000;" | EVA suits heavily advised for engineers. Distribute emergency internals to crew. Prepare for detonation of [[Glimmer#Probers|probers]].
 |-
 | style="border: 1px solid #000000;" | Rules of Engagement
-| style="border: 1px solid #000000;" | Engage with minimal force required; ROE on mindwiping is lifted and may be performed by the Psionic Mantis, Chaplain or Mystagogue at their discretion.
+| style="border: 1px solid #000000;" | Engage with minimal force required; prioritize de-escalation whenever possible.
 |}
 
 == <span style="color:#36717d;>Gamma Alert</span> ==

--- a/Resources/ServerInfo/Guidebook/_DV/AlertProcedure.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/AlertProcedure.xml
@@ -65,7 +65,7 @@ On Delta-V, there are some restrictions on when certain alert levels can be used
 - [color=#a4885c]Secure Areas[/color]: Secure areas unbolted. HSAs and areas with an expectation of privacy, such as bedrooms, dorms, or medical treatment facilities, may be bolted as needed.
 - [color=#a4885c]Medical[/color]: Full suit sensors heavily advised. Prepare for increased incidents of burn and brain damage.
 - [color=#a4885c]Engineering[/color]: EVA suits heavily advised for engineers. Distribute emergency internals to crew. Prepare for detonation of probers.
-- [color=#a4885c]ROE[/color]: Engage with minimal force required; ROE on mindwiping is lifted and may be performed by the Psionic Mantis, Chaplain or Mystagogue at their discretion.
+- [color=#a4885c]ROE[/color]: Engage with minimal force required; prioritize de-escalation whenever possible.
 
 ## Code Gamma
 [color=#db7093]Emergency alert status. Central Command has called the Gamma Alert; the Station is on its last legs, almost everyone is dead, or there is another existential crisis affecting the station.[/color]


### PR DESCRIPTION
## About the PR
Mindwiping is no longer free on code white, epistemics have to follow the standart ROE.

## Why / Balance
The main issue here is the cosmic cult. You can't just mindwipe someone for "being a cultist". However, you can just set alert level to white, and now you can deconvert all you want without consequences.
This was originaly introduced to combat psionics on code white, because using telegnosis is not a crime, and you can't mindwipte for that. This is no longer necessary, since we have noospheric tampering now, and using abilities under high glimmer could be seen as that.
ROE is still lifted when on code octarine, because obviously it is.

## Technical details
No

## Media
No

## Requirements
No

## Breaking changes
No

**Changelog**
:cl:
- tweak: ROE on mindwiping is no longer lifted on code white. Try to see if you can charge the offender with noöspheric tampering (or any other crime in which psionic or otherwordly powers were used)