### PR TITLE
Cosmic cult entropy balance tweaks

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs
@@ -58,10 +58,11 @@ public sealed class CosmicSiphonSystem : EntitySystem
         {
             DistanceThreshold = 2f,
             Hidden = true,
-            BreakOnHandChange = true,
+            BreakOnHandChange = false,
             BreakOnDamage = true,
             BreakOnMove = true,
-            BreakOnDropItem = true,
+            BreakOnDropItem = false,
+            //TODO: make the cultist not rotate towards the target when we get #37958 from upstream
         };
         args.Handled = true;
         _doAfter.TryStartDoAfter(doargs);
@@ -82,7 +83,6 @@ public sealed class CosmicSiphonSystem : EntitySystem
         uid.Comp.EntropyBudget += uid.Comp.CosmicSiphonQuantity;
         Dirty(uid, uid.Comp);
 
-        _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(target, "EntropicDegen", TimeSpan.FromSeconds(21), true);
         if (_cosmicCult.EntityIsCultist(target))
         {
             _popup.PopupEntity(Loc.GetString("cosmicability-siphon-cultist-success", ("target", Identity.Entity(target, EntityManager))), uid, uid);
@@ -96,6 +96,7 @@ public sealed class CosmicSiphonSystem : EntitySystem
 
         if (uid.Comp.CosmicEmpowered) // if you're empowered there's a 50% chance to flicker lights on siphon
         {
+            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(target, "EntropicDegen", TimeSpan.FromSeconds(21), true); //only applies when empowered now
             _lights.Clear();
             _lookup.GetEntitiesInRange<PoweredLightComponent>(Transform(uid).Coordinates, 5, _lights, LookupFlags.StaticSundries);
             foreach (var light in _lights) // static range of 5. because.

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs
@@ -5,7 +5,6 @@ using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.Alert;
 using Content.Shared.DoAfter;
 using Content.Shared.IdentityManagement;
-using Content.Shared.Mind;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.NPC;
@@ -24,7 +23,6 @@ public sealed class CosmicSiphonSystem : EntitySystem
     [Dependency] private readonly GhostSystem _ghost = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
-    [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly CosmicCultSystem _cosmicCult = default!;
@@ -82,7 +80,7 @@ public sealed class CosmicSiphonSystem : EntitySystem
         uid.Comp.EntropyStored += uid.Comp.CosmicSiphonQuantity;
         uid.Comp.EntropyBudget += uid.Comp.CosmicSiphonQuantity;
         Dirty(uid, uid.Comp);
-
+        _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(target, "EntropicDegen", TimeSpan.FromSeconds(_random.Next(21) + 40), true); //40-60 seconds, 4-6 cold damage per siphon
         if (_cosmicCult.EntityIsCultist(target))
         {
             _popup.PopupEntity(Loc.GetString("cosmicability-siphon-cultist-success", ("target", Identity.Entity(target, EntityManager))), uid, uid);
@@ -96,7 +94,6 @@ public sealed class CosmicSiphonSystem : EntitySystem
 
         if (uid.Comp.CosmicEmpowered) // if you're empowered there's a 50% chance to flicker lights on siphon
         {
-            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(target, "EntropicDegen", TimeSpan.FromSeconds(21), true); //only applies when empowered now
             _lights.Clear();
             _lookup.GetEntitiesInRange<PoweredLightComponent>(Transform(uid).Coordinates, 5, _lights, LookupFlags.StaticSundries);
             foreach (var light in _lights) // static range of 5. because.

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
@@ -166,10 +166,10 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     private void OnGotEquipped(Entity<CosmicEquipmentComponent> ent, ref GotEquippedEvent args)
     {
         if (!EntityIsCultist(args.Equipee))
-            {
-                _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true); // TimeSpan.MaxValue causes a crash here, so we use FromDays(1) instead.
-                if (TryComp<CosmicEntropyDebuffComponent>(args.Equipee, out var comp)) comp.Degen = new(){DamageDict = new(){{"Cold", 0.5}, {"Asphyxiation", 1.5}}};
-            }
+        {
+            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true); // TimeSpan.MaxValue causes a crash here, so we use FromDays(1) instead.
+            if (TryComp<CosmicEntropyDebuffComponent>(args.Equipee, out var comp)) comp.Degen = new(){DamageDict = new(){{"Cold", 0.5}, {"Asphyxiation", 1.5}}};
+        }
     }
 
     private void OnGotUnequipped(Entity<CosmicEquipmentComponent> ent, ref GotUnequippedEvent args)

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
@@ -166,7 +166,10 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
     private void OnGotEquipped(Entity<CosmicEquipmentComponent> ent, ref GotEquippedEvent args)
     {
         if (!EntityIsCultist(args.Equipee))
-            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true); // TimeSpan.MaxValue causes a crash here, so we use FromDays(1) instead.
+            {
+                _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.Equipee, EntropicDegen, TimeSpan.FromDays(1), true); // TimeSpan.MaxValue causes a crash here, so we use FromDays(1) instead.
+                if (TryComp<CosmicEntropyDebuffComponent>(args.Equipee, out var comp)) comp.Degen = new(){DamageDict = new(){{"Cold", 0.5}, {"Asphyxiation", 1.5}}};
+            }
     }
 
     private void OnGotUnequipped(Entity<CosmicEquipmentComponent> ent, ref GotUnequippedEvent args)
@@ -179,6 +182,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
         if (!EntityIsCultist(args.User))
         {
             _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(args.User, EntropicDegen, TimeSpan.FromDays(1), true);
+            if (TryComp<CosmicEntropyDebuffComponent>(args.User, out var comp)) comp.Degen = new(){DamageDict = new(){{"Cold", 0.5}, {"Asphyxiation", 1.5}}};
             _popup.PopupEntity(Loc.GetString("cosmiccult-gear-pickup", ("ITEM", args.Equipped)), args.User, args.User, PopupType.MediumCaution);
         }
     }

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicEntropyDegenSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicEntropyDegenSystem.cs
@@ -1,7 +1,6 @@
 using Content.Shared._DV.CosmicCult.Components;
 using Robust.Shared.Timing;
 using Content.Shared.Damage;
-using Content.Shared.Popups;
 using Robust.Shared.Random;
 
 namespace Content.Server._DV.CosmicCult.EntitySystems;
@@ -15,7 +14,6 @@ public sealed partial class CosmicEntropyDegenSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
 
     public override void Initialize()
     {

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -212,7 +212,7 @@ public sealed partial class DCCVars
     /// How much entropy a convert is worth towards the next monument tier.
     /// </summary>
     public static readonly CVarDef<int> CosmicCultistEntropyValue =
-        CVarDef.Create("cosmiccult.cultist_entropy_value", 7, CVar.SERVER);
+        CVarDef.Create("cosmiccult.cultist_entropy_value", 10, CVar.SERVER);
 
     /// <summary>
     /// How much of the crew the cult is aiming to convert for a tier 3 monument.

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicEntropyDebuffComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicEntropyDebuffComponent.cs
@@ -26,8 +26,7 @@ public sealed partial class CosmicEntropyDebuffComponent : Component
     {
         DamageDict = new()
         {
-            { "Cold", 0.25},
-            { "Asphyxiation", 1.25},
+            { "Cold", 0.1},
         }
     };
 }


### PR DESCRIPTION
## About the PR
1. Cosmic cult now needs slightly more entropy to progress (7 -> 10 entropy per convert)
2. Siphoning entropy now deals it's damage slower.
3. Siphoning entropy no longer gets interrupted when changing hands or dropping an item.

## Why / Balance
1. Entropy was worth far too much for progression. Why bother getting yourself force ingress, if you can convert 2 engineers for the same amount of progress, who will probably be even better at opening doors?
2. The effect was far too obvious, which led to very awkward interactions ("Urist McCultist just stood next to me and now I'm suffocating? Hmmmm, yeah, that's probably an atmos issue despite me not gasping or anything") and sometimes borderline metagaming. I did not want to outright remove it, so I left it for the empowered cultists, because siphoning while empowered is fairly obvious already, thansk to the lights blinking.
3. Why the fuck it did in the first place? Not like you're using an item in your hand to do it.

## Technical details
Not really.

## Media
Not really.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Entropy is now less efficient for progressing the cosmic cult's monument.
- tweak: Siphoning entropy now deals it's damage much slower, and the total amount is randomized to make it less metagameable.