### PR TITLE
Prevent accidental activation of coscult finale

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -38,7 +38,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
             {
                 DistanceThreshold = 1f, Hidden = false, BreakOnHandChange = true, BreakOnDamage = true, BreakOnMove = true
             };
-            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User, type: LargeCaution);
             _doAfter.TryStartDoAfter(doargs);
             args.Handled = true;
         }

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -8,6 +8,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
 using Content.Shared.Interaction;
 using Content.Shared.UserInterface;
+using Content.Shared.Popups;
 using Robust.Shared.Utility;
 
 namespace Content.Server._DV.CosmicCult;
@@ -38,7 +39,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
             {
                 DistanceThreshold = 1f, Hidden = false, BreakOnHandChange = true, BreakOnDamage = true, BreakOnMove = true
             };
-            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User, type: PopupType.LargeCaution);
+            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User, PopupType.LargeCaution);
             _doAfter.TryStartDoAfter(doargs);
             args.Handled = true;
         }

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -39,7 +39,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
             {
                 DistanceThreshold = 1f, Hidden = false, BreakOnHandChange = true, BreakOnDamage = true, BreakOnMove = true
             };
-            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User, PopupType.LargeCaution);
+            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User);
             _doAfter.TryStartDoAfter(doargs);
             args.Handled = true;
         }
@@ -50,7 +50,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
             {
                 DistanceThreshold = 1f, Hidden = false, BreakOnHandChange = true, BreakOnDamage = true, BreakOnMove = true
             };
-            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-beckon-begin"), args.User, args.User);
+            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-beckon-begin"), args.User, args.User, PopupType.LargeCaution);
             _doAfter.TryStartDoAfter(doargs);
             args.Handled = true;
         }

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -38,7 +38,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
             {
                 DistanceThreshold = 1f, Hidden = false, BreakOnHandChange = true, BreakOnDamage = true, BreakOnMove = true
             };
-            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User, type: LargeCaution);
+            _popup.PopupEntity(Loc.GetString("cosmiccult-finale-cancel-begin"), args.User, args.User, type: PopupType.LargeCaution);
             _doAfter.TryStartDoAfter(doargs);
             args.Handled = true;
         }

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -25,7 +25,7 @@ cosmiccult-finale-speedup = The beckoning quickens! Energy surges through the su
 cosmiccult-finale-degen = You feel yourself unravelling!
 cosmiccult-finale-location = Scanners are detecting an enormous Λ-CDM spike {$location}!
 cosmiccult-finale-cancel-begin = Your mind's willpower begins to shatter the ritual...
-cosmiccult-finale-beckon-begin = The whispers in the back of your mind intensify...
+cosmiccult-finale-beckon-begin = Doing this will activate the final stage! Are you sure?
 cosmiccult-finale-beckon-success = You beckon for the final curtain call.
 
 cosmiccult-monument-powerdown = The Monument falls eerily silent.


### PR DESCRIPTION
## About the PR
When beckoning the Unknown, instead of some flavor text, the popup now states "Doing this will activate the final stage! Are you sure?" with big red text.

## Why / Balance
Hopefuly should prevent a clueless cultist from activating the finale too early.

## Technical details
2 line ops.

## Media
No.

## Requirements
- [X] I do not have to test any future added content and changes.
- [X] I am absolutely certain that nobody reads those, as confirmed by a previous PR of mine.

**Changelog**
Too minor.
