### PR TITLE
Fix vacuous chantry name

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicFragmentationSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicFragmentationSystem.cs
@@ -20,7 +20,6 @@ public sealed class CosmicFragmentationSystem : EntitySystem
 {
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly CosmicCultSystem _cult = default!;
-    [Dependency] private readonly MetaDataSystem _metaData = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
@@ -99,7 +98,6 @@ public sealed class CosmicFragmentationSystem : EntitySystem
         EnsureComp<CosmicChantryComponent>(chantry, out var chantryComponent);
         chantryComponent.InternalVictim = wisp;
         chantryComponent.VictimBody = ent;
-        _metaData.SetEntityName(wisp, $"{ent}");
         _mind.TransferTo(mindId, wisp, mind: mind);
 
         var mins = chantryComponent.EventTime.Minutes;


### PR DESCRIPTION
## About the PR
Fixed borgs trapped in a vacuous chantry having a weird name.

## Why / Balance
Bugfix.

## Technical details
It tried to give the wisp borg's name, but it didn't work and instead resulted in a mess of component names and stuff. Ideally we'd fix it so that the wisp actually has borg's name, but this works too, since the borg is near the chantry anyway. Also I have no idea how to do it properly.

## Media
<img width="172" height="128" alt="изображение" src="https://github.com/user-attachments/assets/e74c65bb-fbee-4399-91ff-b2bbfae249cb" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- fix: Fixed borgs trapped in a vacuous chantry having weird names.
