### PR TITLE
Fix cosmic subtle mark not being removed properly

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -758,6 +758,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         RemComp<PressureImmunityComponent>(uid);
         RemComp<TemperatureImmunityComponent>(uid);
         RemComp<CosmicStarMarkComponent>(uid);
+        RemComp<CosmicSubtleMarkComponent>(uid);
         _damage.SetDamageContainerID(uid.Owner, uid.Comp.StoredDamageContainer);
         _antag.SendBriefing(uid, Loc.GetString("cosmiccult-role-deconverted-fluff"), Color.FromHex("#4cabb3"), _deconvertSound);
         _antag.SendBriefing(uid, Loc.GetString("cosmiccult-role-deconverted-briefing"), Color.FromHex("#cae8e8"), null);


### PR DESCRIPTION
## About the PR
Alright, so the new stage 3 is very cool and people seem to like it. One small, insignificant issue. The subtle mark is not removed on deconversion. I just forgot to add that. Whoopsie

## Why / Balance
It's kinda important that people don't look like cultists when they aren't.

## Technical details
How this was not noticed until now is beyond me honestly.

## Media
No

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Only thing broken here is my brain.

**Changelog**
:cl:
- fix: Cosmic subtle mark now gets properly removed on deconversion.
