### PR TITLE
Glimmer event - random animation

### DIFF
--- a/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
@@ -1,0 +1,16 @@
+using Content.Server._DV.StationEvents.Events;
+
+namespace Content.Server._DV.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(RandomAnimationRule))]
+public sealed partial class RandomAnimationRuleComponent : Component
+{
+    [DataField]
+    public int MinAnimates = 5;
+
+    [DataField]
+    public int MaxAnimates = 7;
+
+    [DataField]
+    public float AnimationTime = 10f;
+}

--- a/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Server._DV.StationEvents.Components;
 public sealed partial class RandomAnimationRuleComponent : Component
 {
     [DataField]
-    public int MinAnimates = 5;
+    public int MinAnimates = 7;
 
     [DataField]
     public int MaxAnimates = 10;

--- a/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
@@ -9,8 +9,11 @@ public sealed partial class RandomAnimationRuleComponent : Component
     public int MinAnimates = 5;
 
     [DataField]
-    public int MaxAnimates = 7;
+    public int MaxAnimates = 10;
 
     [DataField]
-    public float AnimationTime = 10f;
+    public float MinTime = 7f;
+
+    [DataField]
+    public float MaxTime = 15f;
 }

--- a/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
@@ -16,6 +16,15 @@ public sealed class RandomAnimationRule : StationEventSystem<RandomAnimationRule
     [Dependency] private readonly RevenantAnimatedSystem _revenantAnimated = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
 
+    private EntityQuery<ItemComponent> _itemQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _itemQuery = GetEntityQuery<ItemComponent>();
+    }
+
     protected override void Started(EntityUid uid, RandomAnimationRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
     {
         base.Started(uid, comp, gameRule, args);
@@ -30,7 +39,7 @@ public sealed class RandomAnimationRule : StationEventSystem<RandomAnimationRule
             if (StationSystem.GetOwningStation(ent) != station)
                 continue;
 
-            if (!HasComp<ItemComponent>(ent) || !_revenantAnimated.CanAnimateObject(ent) || _container.IsEntityInContainer(ent))
+            if (!_itemQuery.HasComp(ent) || !_revenantAnimated.CanAnimateObject(ent) || _container.IsEntityInContainer(ent))
                 continue;
 
             targetList.Add((ent, animateable));

--- a/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
@@ -37,7 +37,6 @@ public sealed class RandomAnimationRule : StationEventSystem<RandomAnimationRule
         for (var i = 0; i < toAnimate && targetList.Count > 0; i++)
         {
             var animateTarget = _random.Pick(targetList);
-            Log.Info("Animating " + animateTarget.Owner);
             _revenantAnimated.TryAnimateObject(animateTarget, TimeSpan.FromSeconds(comp.AnimationTime));
             targetList.Remove(animateTarget);
         }

--- a/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
@@ -1,0 +1,46 @@
+using Content.Server._DV.StationEvents.Components;
+using Content.Server.Revenant.EntitySystems;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Chemistry;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Item;
+using Content.Shared.Magic.Components;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.Random;
+
+namespace Content.Server._DV.StationEvents.Events;
+
+public sealed class RandomAnimationRule : StationEventSystem<RandomAnimationRuleComponent>
+{
+
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly RevenantAnimatedSystem _revenantAnimated = default!;
+    [Dependency] private readonly SharedContainerSystem _container = default!;
+
+    protected override void Started(EntityUid uid, RandomAnimationRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        var targetList = new List<Entity<AnimateableComponent>>();
+        var query = EntityQueryEnumerator<AnimateableComponent>();
+        while (query.MoveNext(out var ent, out var animatable))
+        {
+            if (!HasComp<ItemComponent>(ent) || !_revenantAnimated.CanAnimateObject(ent) || _container.IsEntityInContainer(ent))
+                continue;
+
+            targetList.Add((ent, animatable));
+        }
+
+        var toAnimate = _random.Next(comp.MinAnimates, comp.MaxAnimates);
+
+        for (var i = 0; i < toAnimate && targetList.Count > 0; i++)
+        {
+            var animateTarget = _random.Pick(targetList);
+            Log.Info("Animating " + animateTarget.Owner);
+            _revenantAnimated.TryAnimateObject(animateTarget, TimeSpan.FromSeconds(comp.AnimationTime));
+            targetList.Remove(animateTarget);
+        }
+
+    }
+}

--- a/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/RandomAnimationRule.cs
@@ -1,11 +1,9 @@
 using Content.Server._DV.StationEvents.Components;
 using Content.Server.Revenant.EntitySystems;
 using Content.Server.StationEvents.Events;
-using Content.Shared.Chemistry;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Item;
 using Content.Shared.Magic.Components;
-using Content.Shared.Mobs.Components;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
 
@@ -22,24 +20,28 @@ public sealed class RandomAnimationRule : StationEventSystem<RandomAnimationRule
     {
         base.Started(uid, comp, gameRule, args);
 
+        if (!TryGetRandomStation(out var station))
+            return;
+
         var targetList = new List<Entity<AnimateableComponent>>();
         var query = EntityQueryEnumerator<AnimateableComponent>();
-        while (query.MoveNext(out var ent, out var animatable))
+        while (query.MoveNext(out var ent, out var animateable))
         {
+            if (StationSystem.GetOwningStation(ent) != station)
+                continue;
+
             if (!HasComp<ItemComponent>(ent) || !_revenantAnimated.CanAnimateObject(ent) || _container.IsEntityInContainer(ent))
                 continue;
 
-            targetList.Add((ent, animatable));
+            targetList.Add((ent, animateable));
         }
 
-        var toAnimate = _random.Next(comp.MinAnimates, comp.MaxAnimates);
+        var toAnimate = _random.Next(comp.MinAnimates, comp.MaxAnimates + 1);
 
         for (var i = 0; i < toAnimate && targetList.Count > 0; i++)
         {
-            var animateTarget = _random.Pick(targetList);
-            _revenantAnimated.TryAnimateObject(animateTarget, TimeSpan.FromSeconds(comp.AnimationTime));
-            targetList.Remove(animateTarget);
+            var animateTarget = _random.PickAndTake(targetList);
+            _revenantAnimated.TryAnimateObject(animateTarget, TimeSpan.FromSeconds(_random.NextFloat(comp.MinTime, comp.MaxTime)));
         }
-
     }
 }

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -183,5 +183,5 @@
   id: RandomAnimationEvent
   components:
   - type: GlimmerEvent
-    minimumGlimmer: 550
+    minimumGlimmer: 500
   - type: RandomAnimationRule

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -153,6 +153,14 @@
   - type: RandomSentienceRule
 
 - type: entity
+  parent: BaseGlimmerSignaturesEvent
+  id: RandomAnimationEvent
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 500
+  - type: RandomAnimationRule
+
+- type: entity
   parent: BaseGlimmerEvent
   id: ThavenMoodUpset
   components:
@@ -177,11 +185,3 @@
   - type: GlimmerEvent
     minimumGlimmer: 350
   - type: PsionicNosebleedRule
-
-- type: entity
-  parent: BaseGlimmerSignaturesEvent
-  id: RandomAnimationEvent
-  components:
-  - type: GlimmerEvent
-    minimumGlimmer: 500
-  - type: RandomAnimationRule

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -12,7 +12,7 @@
     - id: GlimmerRevenantSpawn
     - id: GlimmerMiteSpawn
     - id: GlimmerRandomSentience
-    - id: RandomAnimationEvent
+    - id: GlimmerRandomAnimation
     - id: ThavenMoodUpset
     - id: LockProbers
     - id: PsionicNosebleedEvent
@@ -154,7 +154,7 @@
 
 - type: entity
   parent: BaseGlimmerSignaturesEvent
-  id: RandomAnimationEvent
+  id: GlimmerRandomAnimation
   components:
   - type: GlimmerEvent
     minimumGlimmer: 500

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -12,10 +12,10 @@
     - id: GlimmerRevenantSpawn
     - id: GlimmerMiteSpawn
     - id: GlimmerRandomSentience
+    - id: RandomAnimationEvent
     - id: ThavenMoodUpset
     - id: LockProbers
     - id: PsionicNosebleedEvent
-    - id: RandomAnimationEvent
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -15,6 +15,7 @@
     - id: ThavenMoodUpset
     - id: LockProbers
     - id: PsionicNosebleedEvent
+    - id: RandomAnimationEvent
 
 - type: entity
   parent: BaseGameRule
@@ -176,3 +177,11 @@
   - type: GlimmerEvent
     minimumGlimmer: 350
   - type: PsionicNosebleedRule
+
+- type: entity
+  parent: BaseGlimmerSignaturesEvent
+  id: RandomAnimationEvent
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 550
+  - type: RandomAnimationRule


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
A new glimmer event is now possible past 500 glimmer, which temporarily animates a number of random objects on-station.

## Why / Balance
Past 500 glimmer is (imo) roughly the point where things are supposed to start to get really weird. So, here's a weird event to add to the pool.
The event animates between 7-10 objects for somewhere between 7-15 seconds each. From my limited testing, if I wandered in the hallway in front of Botany on Glacier when the event triggered, I'd have a bit less then a 50% chance of seeing something happen. So, for a crew consisting of more then one person, I think the current numbers would be pretty noticeable, but not TOO disruptive.

## Technical details
the EntityQueryEnumerator feels evil to me, but it seems to run fine
code's largely modified from the random sentience and artifact animation stuff

## Media
(disclaimer: out of the like 50 times i activated the event, this was the most interesting one, most were not this chaotic)

https://github.com/user-attachments/assets/e77437db-c698-4254-b757-5c8dab38a7e0

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Random objects may become animated at high glimmer levels.
