### PR TITLE
Return of Return of warops

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -88,8 +88,8 @@
     neck: SyndicateWhistle
     pocket2: CommanderUplinkRadio45TC # DeltaV - allows them to buy commander armor
     outerClothing: ClothingOuterCoatSyndieCapArmored # DeltaV - removal of armor
-#  inhand: # DeltaV - Removal Of War.
-#  - NukeOpsDeclarationOfWar
+  inhand:
+  - NukeOpsDeclarationOfWar
 
 #Nuclear Operative Medic Gear
 - type: startingGear


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<img src="https://github.com/user-attachments/assets/fc8a9fb8-7df5-438a-b693-35a3799c691e" alt="hell yeah" width="100">

War is back on the menu- albeit, optional this time.

## Why / Balance
~~stopsign told me to do it~~
I'm not gonna reiterate over everything Stopsign said in [the last warops PR](https://github.com/DeltaV-Station/Delta-v/pull/3561), so just assume I have most of those same points, but additionally-

If a squad of nukies wants to pursue open warfare, they should be allowed to. There's plenty of MRP gimmicks that the declarator enables- 'negotiating' with the crew, for example. Or really, any sort of roleplay that includes a nukie team revealing their presence. Right now, if they do so, they absolutely have no chance without the extra TC.

Declaring war will remain, I think, a rare and very off-meta choice. If the eight days of warops a couple months taught us anything, it's that crew is overwhelmingly likely to win. But regardless, nukies should be allowed to pursue that route if they wish.

War declarator custom message should also stay. Without it, there isn't any chance of the nukies being able to communicate with the crew. Hopefully, we can trust goldlisted commander players to not abuse it. Hopefully.

<sub>I know nukies aren't really SUPPOSED to "roleplay" with the crew, but still, it's more interesting then the sixteenth armory rush in a row</sub>

## Technical details
it would be extremely funny if something was somehow wrong with the yaml

## Media
no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Warops is back, albeit optional this time.
