### PR TITLE
Add flash protection to cult helmets

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
@@ -110,3 +110,4 @@
         Slash: 0.90
         Piercing: 0.90
         Heat: 0.90
+  - type: EyeProtection


### PR DESCRIPTION
## About the PR
Cult helmets now have flash protection.

## Why / Balance
Flash meta is kidna bad.
Pretty much all other antags have their own flash protection. Syndies and nukies get syndicate gas masks, ninja gets their own mask too, dragon is just straight up immune, etc. etc. Flash is not meant to be a tool against major antags.
Also, there are very few ways for cultists to get flash protection, aside from stealing sec glasses (nobody ever does that and it's not exactly scalable), having engi print welding gas masks (have to have a competent engi cultist **and** have said masks researched), or wearing a welding mask instead of a cult helmet (which just looks silly).
Edit 1: flash meta is also especially good against cultsits, since they are predominantly melee fighters, so they can't even "just hold M1 in the general direction of the enemy", because said enemy will just walk away while the cultist is blinded and slow, then shoot said cultist from a safe distance.

## Technical details
1 line ops.

## Media
No.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cult helmets now provide flash protection.
