### PR TITLE
More subtle mark fixes

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -690,8 +690,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         cultComp.StoredDamageContainer = Comp<DamageableComponent>(uid).DamageContainerID!.Value;
         EnsureComp<IntrinsicRadioReceiverComponent>(uid);
         TransferCultAssociation(converter, uid);
-        TryComp<CosmicFinaleComponent>(component.MonumentInGame, out var finaleComp);
-        if (finaleComp.FinaleActive)
+        if (TryComp<CosmicFinaleComponent>(cult.Comp.MonumentInGame, out var finaleComp) && finaleComp.FinaleActive)
         {
             EnsureComp<CosmicStarMarkComponent>(uid);
         }

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -690,7 +690,11 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         cultComp.StoredDamageContainer = Comp<DamageableComponent>(uid).DamageContainerID!.Value;
         EnsureComp<IntrinsicRadioReceiverComponent>(uid);
         TransferCultAssociation(converter, uid);
-
+        TryComp<CosmicFinaleComponent>(component.MonumentInGame, out var finaleComp)
+        if (finaleComp.FinaleActive)
+        {
+            EnsureComp<CosmicStarMarkComponent>(uid);
+        }
         if (cult.Comp.CurrentTier == 3)
         {
             _damage.SetDamageContainerID(uid, "BiologicalMetaphysical");
@@ -702,7 +706,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                 cultComp.UnlockedInfluences.Add(influenceProto.ID);
             }
 
-            EnsureComp<CosmicStarMarkComponent>(uid);
+            EnsureComp<CosmicSubtleMarkComponent>(uid);
             EnsureComp<PressureImmunityComponent>(uid);
             EnsureComp<TemperatureImmunityComponent>(uid);
         }

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -690,7 +690,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         cultComp.StoredDamageContainer = Comp<DamageableComponent>(uid).DamageContainerID!.Value;
         EnsureComp<IntrinsicRadioReceiverComponent>(uid);
         TransferCultAssociation(converter, uid);
-        TryComp<CosmicFinaleComponent>(component.MonumentInGame, out var finaleComp)
+        TryComp<CosmicFinaleComponent>(component.MonumentInGame, out var finaleComp);
         if (finaleComp.FinaleActive)
         {
             EnsureComp<CosmicStarMarkComponent>(uid);

--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.Finale.cs
@@ -108,6 +108,7 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
         var query = EntityQueryEnumerator<CosmicCultComponent>();
         while (query.MoveNext(out var cultist, out var cultComp))
         {
+            RemComp<CosmicSubtleMarkComponent>(cultist);
             EnsureComp<CosmicStarMarkComponent>(cultist);
         }
     }


### PR DESCRIPTION
## About the PR
Subtle mark now properly gets added if someone is converted at stage 3, and astral brand is applied if someone is converted during finale (which is where the respective marks appear normally). Also subtle mark gets removed when astral brand gets added (you don't really need glowing eyes when your entire face is a giant ass glowing star).

## Why / Balance
Bugfixes.

## Technical details
I forgor to do this when first implementing it. Woops.

## Media
No.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Cosmic cult conversion at late stages now applies subtle/star marks properly.
