### PR TITLE
Add 3 spoons to the sustenance vendor

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/sustenance.yml
@@ -24,6 +24,7 @@
     ReagentTinPowderedJuiceCherry: 1
     ReagentTinPowderedJuiceGrape: 1
     ReagentTinPowderedJuiceLemon: 1
+    Spoon: 3
     # End DeltaV Additions
   contrabandInventory:
     FoodTinMRE: 3


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added three spoons to the sustenance vendor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Requested change - not all permabrigs have a condiments vendor or spoons. This results in no spoons to mix juices. https://discord.com/channels/968983104247185448/1395772424464629790

## Technical details
<!-- Summary of code changes for easier review. -->
It's YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
It's YAML

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have tested all added content and changes. - It's YAML
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
It's YAML

**Changelog**

:cl:

- tweak: 3 spoons have been added to the sustenance vendor. Prisoners can now mix juices with them.

