### PR TITLE
Psibreaker bugfix

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Guns/Projectiles/shotgun.yml
@@ -22,6 +22,7 @@
   - type: SolutionInjectOnProjectileHit
     transferAmount: 15
     blockSlots: NONE #tranquillizer darts shouldn't be blocked by a mask
+    solution: ammo
   - type: InjectableSolution
     solution: ammo
   - type: GuideHelp

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/special.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/special.yml
@@ -90,6 +90,7 @@
   - type: SolutionInjectOnProjectileHit
     transferAmount: 9
     blockSlots: NONE #shouldn't be blocked by a mask
+    solution: ammo
   - type: InjectableSolution
     solution: ammo
   - type: GuideHelp


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Mindbreaker .35 and soulbreaker slugs actually work now, injecting reagent into targets.

## Why / Balance
I genuinely think this has been broken for months, and nobody ever noticed because manti never actually mindbreak anybody.

## Technical details
:(

## Media
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e081a9a3-5c10-42e0-bb9c-7b936ce5abea" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The Mantis' psibreaker pistol actually removes psionics now.
