### PR TITLE
Make mindbreaking lower glimmer

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Random.Helpers;
 using Content.Server.EUI;
 using Content.Server.Psionics;
 using Content.Server.Mind;
+using Content.Shared.Jittering;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.StatusEffect;
@@ -23,6 +24,7 @@ namespace Content.Server.Abilities.Psionics
         [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
         [Dependency] private readonly EuiManager _euiManager = default!;
         [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
+        [Dependency] private readonly SharedJitteringSystem _jittering = default!;
         [Dependency] private readonly GlimmerSystem _glimmerSystem = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
 
@@ -129,6 +131,8 @@ namespace Content.Server.Abilities.Psionics
             _glimmerSystem.Glimmer -= _random.Next(50, 70);
 
             _statusEffectsSystem.TryAddStatusEffect(uid, "Stutter", TimeSpan.FromMinutes(1), false, "StutteringAccent");
+            _statusEffectsSystem.TryAddStatusEffect(uid, "KnockedDown", TimeSpan.FromSeconds(3), false, "KnockedDown");
+            _jittering.DoJitter(uid, TimeSpan.FromSeconds(10), false);
 
             RemComp<PsionicComponent>(uid);
         }

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -126,6 +126,8 @@ namespace Content.Server.Abilities.Psionics
                 }
             }
 
+            _glimmerSystem.Glimmer -= _random.Next(50, 70);
+
             _statusEffectsSystem.TryAddStatusEffect(uid, "Stutter", TimeSpan.FromMinutes(5), false, "StutteringAccent");
 
             RemComp<PsionicComponent>(uid);

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -128,7 +128,7 @@ namespace Content.Server.Abilities.Psionics
 
             _glimmerSystem.Glimmer -= _random.Next(50, 70);
 
-            _statusEffectsSystem.TryAddStatusEffect(uid, "Stutter", TimeSpan.FromMinutes(5), false, "StutteringAccent");
+            _statusEffectsSystem.TryAddStatusEffect(uid, "Stutter", TimeSpan.FromMinutes(1), false, "StutteringAccent");
 
             RemComp<PsionicComponent>(uid);
         }

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -5,14 +5,10 @@ using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
 using Content.Server.EUI;
 using Content.Server.Psionics;
-using Content.Server.Mind;
 using Content.Shared.Jittering;
-using Content.Shared.Mind;
-using Content.Shared.Mind.Components;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Random;
 using Robust.Shared.Prototypes;
-using Robust.Server.GameObjects;
 using Robust.Shared.Player;
 
 namespace Content.Server.Abilities.Psionics


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Mindbreaking a psionic now substantially lowers glimmer, by somewhere between 50Ψ-70Ψ.
The effects of mindbreaking have also been slightly tweaked, with those mindbroken dropping to the floor momentarily and jittering for a bit, instead of just a stutter when they (maybe) talked.

## Why / Balance
Currently, most of the ways to lower glimmer are out of Epi's control. For example:
- Random pulses (random)
- Glimmer mites (also random, plus you need to pray nobody's keeping it as a pet)
- Other assorted glimmer pests (random)
- Botany (botany)
- Sacrifices (barely lowers glimmer at all, also what the fuck)

This change puts some of the power back in Epi's hands. It makes the Mantis' job actually useful, and provides a genuine reason for them to maintain a psionic registry. If code white is called and glimmer NEEDS to go back down NOW, the Mantis now actually has a reason to utilize their lifted RoE. They can go have their protag moment and save the station. Awesome.
<sub> Plus, I mean, psionics literally need to agree to a popup saying "you may be hunted". Might as well fulfill that. </sub>

## Technical details
this is pretty contingent on https://github.com/DeltaV-Station/Delta-v/pull/4119, since what's the point of this if the mantis can't actually mindbreak anyone

## Media

https://github.com/user-attachments/assets/64a84505-3fec-4f09-bc6f-01c5d86355c1

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Mindbreaking now reduces glimmer by 50Ψ-70Ψ.
- tweak: It is now more obvious when somebody gets mindbroken.
