### PR TITLE
Bring back sentient artifacts

### DIFF
--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -213,7 +213,6 @@
         sound:
           collection: MetalGlassBreak
   - type: Repairable # DeltaV - Destroyable sentient artifacts
-    doAfterDelay: 5 
 
 - type: artifactEffect
   id: EffectMultitool

--- a/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
+++ b/Resources/Prototypes/XenoArch/Effects/utility_effects.yml
@@ -181,27 +181,39 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/revolver.ogg
 
-# DeltaV: disabled sentience due to very rarely being good RP, and usually ending the round early
-#- type: artifactEffect
-#  id: EffectSentience
-#  targetDepth: 3
-#  effectHint: artifact-effect-hint-sentience
-#  permanentComponents:
-#  - type: GhostRole
-#    allowMovement: true
-#    allowSpeech: true
-#    makeSentient: true
-#    name: ghost-role-information-artifact-name
-#    description: ghost-role-information-artifact-description
-#    rules: ghost-role-information-freeagent-rules
-#    mindRoles:
-#    - MindRoleGhostRoleFreeAgent
-#    raffle:
-#      settings: default
-#  - type: GhostTakeoverAvailable
-#  - type: MovementSpeedModifier
-#    baseWalkSpeed: 0.25
-#    baseSprintSpeed: 0.5
+- type: artifactEffect
+  id: EffectSentience
+  targetDepth: 3
+  effectHint: artifact-effect-hint-sentience
+  permanentComponents:
+  - type: GhostRole
+    allowMovement: true
+    allowSpeech: true
+    makeSentient: true
+    name: ghost-role-information-artifact-name
+    description: ghost-role-information-artifact-description
+    rules: ghost-role-information-freeagent-rules
+    mindRoles:
+    - MindRoleGhostRoleFreeAgent
+    raffle:
+      settings: default
+  - type: GhostTakeoverAvailable
+  - type: MovementSpeedModifier
+    baseWalkSpeed: 0.25
+    baseSprintSpeed: 0.5
+  - type: Destructible # DeltaV - Destroyable sentient artifacts
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalGlassBreak
+  - type: Repairable # DeltaV - Destroyable sentient artifacts
+    doAfterDelay: 5 
 
 - type: artifactEffect
   id: EffectMultitool


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Sentient artifacts are back, but the node will also make them destructible.

## Why / Balance
Sentient artifacts are fun, and this change will bring them back in a way that hopefully prevents them from being an absolute menace to the station. 300 damage seems like a fair threshold, considering artifacts need to take a lot of punishment in the process of research. They can be repaired with a welder, too.

## Technical details
yamlops

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Sentient artifacts are back, and can be destroyed. Or repaired, with a welder.
