### PR TITLE
Make mindshields actually useful against cosmic cult

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -681,7 +681,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             !_playerMan.TryGetSessionById(mind.UserId, out var session))
             return;
 
-        if (HasComp<MindShieldComponent>(uid)) RemCompDeferred<MindShieldComponent>(uid);
+        RemCompDeferred<MindShieldComponent>(uid);
 
         _role.MindAddRole(mindId, MindRole, mind, true);
 

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -35,6 +35,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Mind;
+using Content.Shared.Mindshield.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Mobs;
@@ -679,6 +680,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         if (!_mind.TryGetMind(uid, out var mindId, out var mind) ||
             !_playerMan.TryGetSessionById(mind.UserId, out var session))
             return;
+
+        if (HasComp<MindShieldComponent>(uid)) RemCompDeferred<MindShieldComponent>(uid);
 
         _role.MindAddRole(mindId, MindRole, mind, true);
 

--- a/Content.Shared/_DV/CosmicCult/SharedCosmicCultSystem.cs
+++ b/Content.Shared/_DV/CosmicCult/SharedCosmicCultSystem.cs
@@ -3,6 +3,8 @@ using Content.Shared.Antag;
 using Content.Shared.Examine;
 using Content.Shared.Ghost;
 using Content.Shared.Mind;
+using Content.Shared.Mindshield.Components;
+using Content.Shared.Popups;
 using Content.Shared.Roles;
 using Content.Shared.Verbs;
 using Content.Shared._DV.Roles;
@@ -17,6 +19,7 @@ public abstract class SharedCosmicCultSystem : EntitySystem
 {
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly SharedRoleSystem _role = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly ExamineSystemShared _examine = default!;
 
@@ -24,6 +27,7 @@ public abstract class SharedCosmicCultSystem : EntitySystem
     {
         base.Initialize();
 
+        SubscribeLocalEvent<MindShieldComponent, ComponentStartup>(MindShieldImplanted);
         SubscribeLocalEvent<CosmicCultComponent, ComponentGetStateAttemptEvent>(OnCosmicCultCompGetStateAttempt);
         SubscribeLocalEvent<CosmicCultLeadComponent, ComponentGetStateAttemptEvent>(OnCosmicCultCompGetStateAttempt);
         SubscribeLocalEvent<CosmicCultComponent, ComponentStartup>(DirtyCosmicCultComps);
@@ -113,5 +117,12 @@ public abstract class SharedCosmicCultSystem : EntitySystem
         {
             Dirty(uid, comp);
         }
+    }
+
+    private void MindShieldImplanted(EntityUid uid, MindShieldComponent comp, ComponentStartup args)
+    {
+        if (!HasComp<CosmicCultComponent>(uid)) return;
+        RemCompDeferred<MindShieldComponent>(uid);
+        _popup.PopupEntity(Loc.GetString("cosmic-mindshield-failed"), uid);
     }
 }

--- a/Content.Shared/_DV/CosmicCult/SharedCosmicCultSystem.cs
+++ b/Content.Shared/_DV/CosmicCult/SharedCosmicCultSystem.cs
@@ -28,7 +28,7 @@ public abstract class SharedCosmicCultSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<MindShieldComponent, ImplantImplantedEvent>(MindShieldImplanted);
+        SubscribeLocalEvent<MindShieldImplantComponent, ImplantImplantedEvent>(MindShieldImplanted);
         SubscribeLocalEvent<CosmicCultComponent, ComponentGetStateAttemptEvent>(OnCosmicCultCompGetStateAttempt);
         SubscribeLocalEvent<CosmicCultLeadComponent, ComponentGetStateAttemptEvent>(OnCosmicCultCompGetStateAttempt);
         SubscribeLocalEvent<CosmicCultComponent, ComponentStartup>(DirtyCosmicCultComps);
@@ -120,10 +120,10 @@ public abstract class SharedCosmicCultSystem : EntitySystem
         }
     }
 
-    private void MindShieldImplanted(Entity<MindShieldComponent> ent, ref ImplantImplantedEvent args)
+    private void MindShieldImplanted(Entity<MindShieldImplantComponent> ent, ref ImplantImplantedEvent args)
     {
-        if (!HasComp<CosmicCultComponent>(ent)) return;
-        RemCompDeferred<MindShieldComponent>(ent);
+        if (args.Implanted is not {} target || !HasComp<CosmicCultComponent>(target)) return;
+        RemCompDeferred<MindShieldComponent>(target);
         _popup.PopupEntity(Loc.GetString("cosmic-mindshield-failed"), ent);
     }
 }

--- a/Content.Shared/_DV/CosmicCult/SharedCosmicCultSystem.cs
+++ b/Content.Shared/_DV/CosmicCult/SharedCosmicCultSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.Antag;
 using Content.Shared.Examine;
 using Content.Shared.Ghost;
+using Content.Shared.Implants;
 using Content.Shared.Mind;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
@@ -27,7 +28,7 @@ public abstract class SharedCosmicCultSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<MindShieldComponent, ComponentStartup>(MindShieldImplanted);
+        SubscribeLocalEvent<MindShieldComponent, ImplantImplantedEvent>(MindShieldImplanted);
         SubscribeLocalEvent<CosmicCultComponent, ComponentGetStateAttemptEvent>(OnCosmicCultCompGetStateAttempt);
         SubscribeLocalEvent<CosmicCultLeadComponent, ComponentGetStateAttemptEvent>(OnCosmicCultCompGetStateAttempt);
         SubscribeLocalEvent<CosmicCultComponent, ComponentStartup>(DirtyCosmicCultComps);
@@ -119,10 +120,10 @@ public abstract class SharedCosmicCultSystem : EntitySystem
         }
     }
 
-    private void MindShieldImplanted(EntityUid uid, MindShieldComponent comp, ComponentStartup args)
+    private void MindShieldImplanted(Entity<MindShieldComponent> ent, ref ImplantImplantedEvent args)
     {
-        if (!HasComp<CosmicCultComponent>(uid)) return;
-        RemCompDeferred<MindShieldComponent>(uid);
-        _popup.PopupEntity(Loc.GetString("cosmic-mindshield-failed"), uid);
+        if (!HasComp<CosmicCultComponent>(ent)) return;
+        RemCompDeferred<MindShieldComponent>(ent);
+        _popup.PopupEntity(Loc.GetString("cosmic-mindshield-failed"), ent);
     }
 }

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -194,7 +194,7 @@ cosmiccult-entropy-unavailable = You can't do that right now.
 cosmiccult-astral-ascendant = {$name}, Ascendant
 cosmiccult-astral-minion = {$name}, Malign
 cosmiccult-gear-pickup = You can feel yourself unravelling while you hold the {$ITEM}!
-cosmic-mindshield-failed = The implant had been overloaded by cosmic energy and failed to activate!
+cosmic-mindshield-failed = The implant was overloaded by cosmic energy and failed to activate!
 
 cosmiccult-silicon-subverted-briefing =
     Malign light courses through your circuitry.

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -194,6 +194,7 @@ cosmiccult-entropy-unavailable = You can't do that right now.
 cosmiccult-astral-ascendant = {$name}, Ascendant
 cosmiccult-astral-minion = {$name}, Malign
 cosmiccult-gear-pickup = You can feel yourself unravelling while you hold the {$ITEM}!
+cosmic-mindshield-failed = The implant had been overloaded by cosmic energy and failed to activate!
 
 cosmiccult-silicon-subverted-briefing =
     Malign light courses through your circuitry.


### PR DESCRIPTION
## About the PR
Cosmic cultists cannot be mindshielded anymore. If you try to do that, a mindshield would just not work, like it does with a headrev. Converting someone with a glyph of truth also disables their mindshield.

## Why / Balance
Having a cult impostor among security/command is cool and adds a lot of possible strategies for said cult. The impostor being completely undetectable until later stages is not so cool, however. This PR ensures that you **can** have cult impostors among security/command, but forces said impostors to play carefuly, because it is fairly easy to identify them by lack of a mindshield. It also makes mindshielding crewmembers (willingly!) a viable strategy against a cult, since this would force them to deshield people before conversion, or use the more expensive glyph of truth. Mindshields are only obtainable through logi, which gives them more reasons to get involved in a cult round.

## Technical details
HasComp + RemComp, that's it.

## Media
No.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- tweak: Cosmic cultists can no longer be mindshielded, causing the implant to immediately fail on insertion.
