### PR TITLE
Colossus healing tweaks

### DIFF
--- a/Resources/Locale/en-US/_DV/cosmiccult/abilities.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/abilities.ftl
@@ -1,6 +1,7 @@
 cosmicability-generic-fail = Your influence fails to take hold..
 
 cosmicability-glare-confirm = Press again to activate Null Glare.
+cosmicability-hibernate-confirm = Press again to activate Slumber Shell.
 
 cosmicability-siphon-cultist-success = Your attempts to draw entropy chill {CAPITALIZE(THE($target))}
 cosmicability-siphon-success = You silently draw Entropy from {CAPITALIZE(THE($target))}.

--- a/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
@@ -229,8 +229,10 @@
   name: Slumber Shell
   description: Slumber your body for a period of time to regenerate integrity. Must be done on stable ground.
   components:
-  - type: LimitedCharges
-    maxCharges: 2
+  - type: ConfirmableAction
+    popup: cosmicability-hibernate-confirm
+    confirmDelay: 0.1
+    primeTime: 5
   - type: InstantAction
     useDelay: 120
     checkCanInteract: false

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -276,6 +276,7 @@
       0: Alive
       400: Dead
   - type: CosmicColossus
+    hibernationWait: 30
 
 - type: speechSounds
   id: ColossusSpeech


### PR DESCRIPTION
## About the PR
Entropic colossus' healing ability now:
1. Requires confirmation before use
2. No longer has limited charges
3. Takes more time (20 -> 30 seconds)

## Why / Balance
1. Sometimes people accidentally use it mid-combat, which usually results in their death and it's kinda uncool. You're not supposed to use it in a rush anyway, so having to click one more time is insignificant.
2. Healing being limited meant that the colossus itself is limited. Any other role can heal indefinitely if played correctly (dragon can eat bodies, rev can just wait to regenerate, humanoids can steal chems or something, etc.), so it didn't make much sense why colossi cannot. Besides, colossus can't ever heal to full health, because the ability only heals half of the current damage, so it still makes sense to use it as late as possible to maximize healing.
3. To compensate for the inifinite charges. I was depating whether I should do this or increase cooldown, but came to the conclusion that current cooldown (120 seconds) is long enough.

## Technical details
YAML ops.

## Media
No.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Entropic colossus' Slumber Shell now has infinite charges, longer hybernation time (20s -> 30s), and a confirmation popup.
