### PR TITLE
Fixed coscult finale warning appearing too early

### DIFF
--- a/Content.Server/_DV/CosmicCult/Components/CosmicFinaleComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicFinaleComponent.cs
@@ -38,7 +38,7 @@ public sealed partial class CosmicFinaleComponent : Component
     public TimeSpan FinaleRemainingTime = TimeSpan.FromSeconds(362);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan VisualsThreshold = TimeSpan.FromSeconds(240);
+    public TimeSpan VisualsThreshold = TimeSpan.FromSeconds(120);
 
     [DataField, AutoNetworkedField]
     public TimeSpan CheckWait = TimeSpan.FromSeconds(5);

--- a/Content.Server/_DV/CosmicCult/Components/CosmicFinaleComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicFinaleComponent.cs
@@ -38,7 +38,7 @@ public sealed partial class CosmicFinaleComponent : Component
     public TimeSpan FinaleRemainingTime = TimeSpan.FromSeconds(362);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan VisualsThreshold = TimeSpan.FromSeconds(120);
+    public TimeSpan VisualsThreshold = TimeSpan.FromSeconds(125);
 
     [DataField, AutoNetworkedField]
     public TimeSpan CheckWait = TimeSpan.FromSeconds(5);


### PR DESCRIPTION
## About the PR
Title. Previously it would be issued when the monument progresses from finaleBuffer to finaleActive. FinaleBuffer is no longer a thing, so it should have been issued 240 seconds after the finale started. However, apparently Kazne is bad at basic algebra, so it was issued 240 seconds before the finale ended, which caused it to be out of sync with the music change. I am also bad at basic algebra, so instead of fixing the equation I just replaced the constant :trollface:

## Why / Balance
Bugfix good.

## Technical details
1 line ops.

## Media
It works.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
Honestly I don't even care enough to write a changelog entry.
