### PR TITLE
remove sec hardsuit insuls

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -31,7 +31,6 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatStandard
   - type: AllowSuitStorage
-  - type: Insulated
   - type: DamageOnShootProtection
     slots: OUTERCLOTHING
     damageProtection:


### PR DESCRIPTION
let me know if it works? im blind editing here



## About the PR
partially reverts #3369


## Why / Balance
secoffs can: 
- ask for insuls if they really need a pair
- open their eyes when flying around in space
- take the L and get shocked

Security Hardsuits are the only suits which have innate shock immunity, this benefit is not granted to Captain, Engineering, or even the CE. The reasoning to give this to security instead of making them get insuls like anyone else is insufficient.
Sec, like any other role, should get the tools required for the job instead of just having them by virtue of existing. If the AI is malf, they should go grab breaching charges or insuls from engi/cargo, like the rest of the peasants (and command). 
Sec having insuls in their hardsuit because "what if someone shocks them", feels like sec having psyonics proof helmets in their hardsuit because "what if someone mass sleeps them".

## Technical details
killed 1 line


**Changelog**

:cl:
- remove: Security Hardsuits are no longer insulated

-->
