### PR TITLE
Tweak cosmic cult win conditions

### DIFF
--- a/Content.Server/_DV/CosmicCult/Components/CosmicCultRuleComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicCultRuleComponent.cs
@@ -146,23 +146,23 @@ public enum WinType : byte
     /// </summary>
     CultComplete,
     /// <summary>
-    ///    Cult major win. The Monument reached Stage 3 and was fully empowered.
+    ///    Cult major win. The Monument didn't complete, The crew escaped, but the Cult Leader also escaped.
     /// </summary>
     CultMajor,
     /// <summary>
-    ///    Cult minor win. Even if the crew escaped, The Monument reached Stage 3.
+    ///    Cult minor win. The Monument didn't complete, The crew escaped, but at least two cultists also escaped.
     /// </summary>
     CultMinor,
     /// <summary>
-    ///     Neutral. The Monument didn't reach Stage 3, The crew escaped, but the Cult Leader also escaped.
+    ///     Neutral. No cultists made it to midpoint alive.
     /// </summary>
     Neutral,
     /// <summary>
-    ///     Crew minor win. The monument didn't reach Stage 3, The crew escaped, and Cult leader was killed, deconverted, or left on the station.
+    ///     Crew minor win. The monument didn't reach Stage 3. Boring.
     /// </summary>
     CrewMinor,
     /// <summary>
-    ///     Crew major win. The monument didn't reach Stage 3, The crew escaped, and the cult was killed.
+    ///     Crew major win. All cultists are either dead or arrested.
     /// </summary>
     CrewMajor,
     /// <summary>

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -397,10 +397,10 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     private bool CultistsAlive()
     {
         var query = EntityQueryEnumerator<CosmicCultComponent, MobStateComponent>();
-        while (query.MoveNext(out _, out var comp, out var mob))
+        while (query.MoveNext(out var ent, out _, out var mobComp))
         {
-            if (TryComp<CuffableComponent>(mob, out var cuffed) && cuffed.CuffedHandCount > 0) continue;
-            if (mob.Running && mob.CurrentState != MobState.Dead)
+            if (TryComp<CuffableComponent>(ent, out var cuffed) && cuffed.CuffedHandCount > 0) continue;
+            if (mobComp.Running && mobComp.CurrentState != MobState.Dead)
                 return true;
         }
 
@@ -409,12 +409,12 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
 
     private void OnMobStateChanged(Entity<CosmicCultComponent> ent, ref MobStateChangedEvent args)
     {
-        CheckForActiveCultists()
+        CheckForActiveCultists();
     }
 
     private void OnCuffStateChanged(Entity<CosmicCultComponent> ent, ref CuffedStateChangeEvent args)
     {
-        CheckForActiveCultists()
+        CheckForActiveCultists();
     }
 
     private void CheckForActiveCultists()
@@ -454,7 +454,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         else if (CultistsAtCentcom >= 2)
             SetWinType(ent, WinType.CultMinor); //The Monument wasn't completed, but at least two cultists are alive and at Midpoint.
         else 
-            SetWinType(ent, WinType.CrewMinor); //The monument wasn't completed, no cultists escaped to midpoint. Some cultists still remain on the station, though.
+            SetWinType(ent, WinType.Neutral); //The monument wasn't completed, no cultists escaped to midpoint. Some cultists still remain on the station, though.
 
         if (CultistsAlive()) return; //If there are no cultists alive, ignore all previous checks, crew alreay won.
 

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -439,7 +439,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         while (wrapup.MoveNext(out var cultist, out _, out var cultistLocation))
         {
             if (cultistLocation.MapUid != null && centcomm.Contains(cultistLocation.MapUid.Value))
-            { 
+            {
                 if (TryComp<CuffableComponent>(cultist, out var cuffed) && cuffed.CuffedHandCount > 0) continue; // If they are cuffed, they should be deconverted soon, so we don't count them.
                 CultistsAtCentcom++;
                 if (HasComp<CosmicCultLeadComponent>(cultist))
@@ -453,7 +453,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             SetWinType(ent, WinType.CultMajor); //The Monument wasn't completed, but the cult leader's alive and at Midpoint.
         else if (CultistsAtCentcom >= 2)
             SetWinType(ent, WinType.CultMinor); //The Monument wasn't completed, but at least two cultists are alive and at Midpoint.
-        else 
+        else
             SetWinType(ent, WinType.Neutral); //The monument wasn't completed, no cultists escaped to midpoint. Some cultists still remain on the station, though.
 
         if (CultistsAlive()) return; //If there are no cultists alive, ignore all previous checks, crew alreay won.

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -17,6 +17,8 @@ using Content.Server.Radio.Components;
 using Content.Server.Roles;
 using Content.Server.RoundEnd;
 using Content.Server.Shuttles.Systems;
+using Content.Shared.Cuffs;
+using Content.Shared.Cuffs.Components;
 using Content.Server.Voting.Managers;
 using Content.Server.Voting;
 using Content.Shared._DV.CCVars;
@@ -130,6 +132,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         SubscribeLocalEvent<CosmicCultComponent, ComponentShutdown>(OnComponentShutdown);
         SubscribeLocalEvent<CosmicGodComponent, ComponentInit>(OnGodSpawn);
         SubscribeLocalEvent<CosmicCultComponent, MobStateChangedEvent>(OnMobStateChanged);
+        SubscribeLocalEvent<CosmicCultComponent, CuffedStateChangeEvent>(OnCuffStateChanged);
 
         Subs.CVar(_config,
             DCCVars.CosmicCultT2RevealDelaySeconds,
@@ -325,7 +328,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         var query = QueryActiveRules();
         while (query.MoveNext(out var ruleUid, out _, out var cultRule, out _))
         {
-            SetWinType((ruleUid, cultRule), WinType.CultComplete); //here's no coming back from this. Cult wins this round
+            SetWinType((ruleUid, cultRule), WinType.CultComplete); // There's no coming back from this. Cult wins this round
             QueueDel(cultRule.MonumentInGame); // The monument doesn't need to stick around postround! Into the bin with you.
             QueueDel(cultRule.MonumentSlowZone); // cease exist
 
@@ -396,7 +399,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         var query = EntityQueryEnumerator<CosmicCultComponent, MobStateComponent>();
         while (query.MoveNext(out _, out var comp, out var mob))
         {
-            if (mob.Running && mob.CurrentState == MobState.Alive)
+            if (TryComp<CuffableComponent>(mob, out var cuffed) && cuffed.CuffedHandCount > 0) continue;
+            if (mob.Running && mob.CurrentState != MobState.Dead)
                 return true;
         }
 
@@ -404,6 +408,16 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     }
 
     private void OnMobStateChanged(Entity<CosmicCultComponent> ent, ref MobStateChangedEvent args)
+    {
+        CheckForActiveCultists()
+    }
+
+    private void OnCuffStateChanged(Entity<CosmicCultComponent> ent, ref CuffedStateChangeEvent args)
+    {
+        CheckForActiveCultists()
+    }
+
+    private void CheckForActiveCultists()
     {
         if (CultistsAlive())
             return;
@@ -418,35 +432,37 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     private void ConfirmWinState(Entity<CosmicCultRuleComponent> ent)
     {
         var tier = ent.Comp.CurrentTier;
-        var leaderAlive = false;
+        var LeaderAtCentcom = false;
+        var CultistsAtCentcom = 0;
         var centcomm = _emergency.GetCentcommMaps();
         var wrapup = AllEntityQuery<CosmicCultComponent, TransformComponent>();
         while (wrapup.MoveNext(out var cultist, out _, out var cultistLocation))
         {
             if (cultistLocation.MapUid != null && centcomm.Contains(cultistLocation.MapUid.Value))
-            {
+            { 
+                if (TryComp<CuffableComponent>(cultist, out var cuffed) && cuffed.CuffedHandCount > 0) continue; // If they are cuffed, they should be deconverted soon, so we don't count them.
+                CultistsAtCentcom++;
                 if (HasComp<CosmicCultLeadComponent>(cultist))
-                    leaderAlive = true;
-            }
-        }
-        if (tier < 3 && leaderAlive)
-            SetWinType(ent, WinType.Neutral); //The Monument isn't Tier 3, but the cult leader's alive and at Centcomm! a Neutral outcome
-        var monument = AllEntityQuery<CosmicFinaleComponent>();
-        while (monument.MoveNext(out var monumentUid, out var comp))
-        {
-            _sound.StopStationEventMusic(ent, StationEventMusicType.CosmicCult);
-            if (tier == 3 && comp.CurrentState == FinaleState.Unavailable)
-            {
-                SetWinType(ent, WinType.CultMinor); //The crew escaped, and The Monument wasn't fully empowered. a small win
-            }
-            else if (comp.CurrentState != FinaleState.Unavailable)
-            {
-                SetWinType(ent, WinType.CultMajor); //Despite the crew's escape, The Finale is available or active. Major win
+                    LeaderAtCentcom = true;
             }
         }
 
-        if (CultistsAlive())
-            return; // There's still cultists alive! stop checking stuff
+        if (tier < 3)
+            SetWinType(ent, WinType.CrewMinor); //The monument didn't even reach tier 3, which means that either cult had a skill issue, or crew evacuated early. Minor win.
+        else if (LeaderAtCentcom) //If the monument reached tier 3, all cultists have glowing eyes now, so you shouldn't let them evacuate without cuffs on.
+            SetWinType(ent, WinType.CultMajor); //The Monument wasn't completed, but the cult leader's alive and at Midpoint.
+        else if (CultistsAtCentcom >= 2)
+            SetWinType(ent, WinType.CultMinor); //The Monument wasn't completed, but at least two cultists are alive and at Midpoint.
+        else 
+            SetWinType(ent, WinType.CrewMinor); //The monument wasn't completed, no cultists escaped to midpoint. Some cultists still remain on the station, though.
+
+        if (CultistsAlive()) return; //If there are no cultists alive, ignore all previous checks, crew alreay won.
+
+        if (tier <= 1) //Prevent the cult getting cooked by accident before anyone even knows there's a cult.
+        {
+            SetWinType(ent, WinType.CrewMinor); //If we somehow get here at the end of the round, we'll still count this as a crew minor.
+            return;
+        }
 
         _roundEnd.DoRoundEndBehavior(ent.Comp.RoundEndBehavior, ent.Comp.EvacShuttleTime, ent.Comp.RoundEndTextSender, ent.Comp.RoundEndTextShuttleCall, ent.Comp.RoundEndTextAnnouncement);
         ent.Comp.RoundEndBehavior = RoundEndBehavior.Nothing; // prevent this being called multiple times.
@@ -455,7 +471,6 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         var gameruleMonument = ent.Comp.MonumentInGame;
         if (TryComp<CosmicFinaleComponent>(gameruleMonument, out var finComp))
         {
-            _monument.Disable(gameruleMonument);
             finComp.CurrentState = FinaleState.Unavailable;
             _popup.PopupCoordinates(Loc.GetString("cosmiccult-monument-powerdown"), Transform(gameruleMonument).Coordinates, PopupType.Large);
             _sound.StopStationEventMusic(gameruleMonument, StationEventMusicType.CosmicCult);
@@ -465,7 +480,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         if (ent.Comp.TotalCult == 0)
             SetWinType(ent, WinType.CrewComplete); // No cultists registered! That means everyone got deconverted
         else
-            SetWinType(ent, WinType.CrewMajor); // There's still cultists registered, but if we got here, that means they're all dead
+            SetWinType(ent, WinType.CrewMajor); // There's still cultists registered, but if we got here, that means they're all dead or in cuffs
     }
 
     protected override void AppendRoundEndText(EntityUid uid,

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -55,12 +55,12 @@ cosmiccult-roundend-crewmajor = [color=green]Crew major victory![/color]
 cosmiccult-roundend-crewcomplete = [color=green]Crew complete victory![/color]
 
 cosmiccult-summary-cultcomplete = The cosmic cultists ushered in the end!
-cosmiccult-summary-cultmajor = The cosmic cultists' victory will be inevitable.
-cosmiccult-summary-cultminor = The Monument was completed, but not fully empowered.
-cosmiccult-summary-neutral = The cult will live to see another day.
-cosmiccult-summary-crewminor = The cult has been left stewardless.
+cosmiccult-summary-cultmajor = The cult's steward made it to Midpoint unnoticed. The cult will live to see another day.
+cosmiccult-summary-cultminor = Several cultists made it to Midpoint unnoticed. The cult will live to see another day.
+cosmiccult-summary-neutral = No cultists made it to midpoint, but some remain on the station. The struggle continues.
+cosmiccult-summary-crewminor = The Monument did not reach full power.
 cosmiccult-summary-crewmajor = All cosmic cultists were eliminated.
-cosmiccult-summary-crewcomplete = Every single cosmic cultist was deconverted!
+cosmiccult-summary-crewcomplete = All cosmic cultists were deconverted!
 
 cosmiccult-elimination-shuttle-call = Based on scans from our long-range sensors, the Λ-CDM anomaly has subsided. We thank you for your prudence. An emergency shuttle has been automatically called to the station for decontamination and debriefing procedures. ETA: {$time} {$units}. Please note, if the psychological impact of the anomaly is negligible, you may recall the shuttle to extend the shift.
 cosmiccult-elimination-announcement = Based on scans from our long-range sensors, the Λ-CDM anomaly has subsided. We thank you for your prudence. An emergency shuttle is already inbound. Return to CentComm safely for decontamination and debriefing procedures.


### PR DESCRIPTION
## About the PR
Cosmic cult win conditions have been changed to the following:
- Cult complete: successfully summoning the Unknown (unchanged, obviously)
- Cult major: monument had reached tier 3, cult steward made it to midpoint alive and unrestrained.
- Cult minor: same as cult major, but any 2 cultists and no steward.
- Neutral outcome: monument reached tier 3, but no cultists managed to escape.
- Crew minor: the monument didn't reach tier 3.
- Crew major: all cultists are dead or in handcuffs.
- Crew complete: all cultists were deconverted.

Also, a few minor tweaks:
Cultists are now only considered "dead" for the objectives if they are actually dead (and not crit) or in handcuffs (if you're cuffed at round end, you are getting deconverted soon).
If all cultists die, the automatic shuttle call no longer completely bricks the monument, instead only making the finale unavailable.
Additionaly, the automatic shuttle call doesn't happen if the monument did not yet reach stage 2 (the crew likely doesn't even know that cult exists yet, and while funny, the round ending due to all cultists accidentally dying would not be very nice).

## Why / Balance
Current win conditions encourage crew to not even let the cult to progress, which is:
1. Not fun for anyone involved.
2. Nearly impossible to do if cultists are competent.

Most rounds would therefore end in a cult major, due to the monument reaching stage 3 and one sneaky cultist hiding somewhere in a random locker.
The new win conditions instead encourage crew to prepare during stages 1 and 2, and then, when cultists are clearly visible, arrest and deconvert all of them, while also not letting them complete their own objective.
This also makes obtaining a major win actually challenging for the cult, as the steward would have to somehow reach midpoint, which would be quite complicated, since security at this point is (mechanicaly) encouraged to cult-check everyone who enters evac.

### Note:
For some reason, checking for entities at midpoint does not work in dev env (not only with cult but in general), so I was not able to test the minor and major cult wins properly. I am fairly certain that they will work on release, though, and even if they don't, worst case scenario it would just turn into a neutral outcome.

## Technical details
A few tweaks here and there, updated locale and comments.

## Media
Not really.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cosmic cult win conditions are more fair now. Check PR for details.