### PR TITLE
Make effigy of entropy an actually scary anomaly

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/effigy.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/effigy.yml
@@ -95,8 +95,8 @@
       - MobCosmicLodestarHostile
     - settings:
         spawnOnSuperCritical: true
-        minAmount: 4
-        maxAmount: 7
+        minAmount: 8
+        maxAmount: 12
         maxRange: 8
       spawns:
       - MobCosmicCustodianHostile

--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/effigy.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/effigy.yml
@@ -76,7 +76,7 @@
     supercriticalSound:
       path: /Audio/_DV/CosmicCult/effigy_supercritical.ogg
     nextPulseTime: 1
-    minPulseLength: 60
+    minPulseLength: 40
     maxPulseLength: 80
     minContituty: 0.4
     maxContituty: 0.8
@@ -85,8 +85,8 @@
     entries:
     - settings:
         spawnOnPulse: true
-        minAmount: 2
-        maxAmount: 3
+        minAmount: 4
+        maxAmount: 6
         minRange: 3
         maxRange: 4.5
       spawns:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
adjusted the effigy of entropy to be able to pulse more often (RNG based), spawn more mobs per pulse, and spawn more mobs per supercritical.

## Why / Balance
this big giant colossus comes on station, starts plowing through station security, only to spawn the most laughably tame object that is defeatable with a couple chimp shots. yes you do have to be able to scan this but I personally have yet to see this thing actually go supercritical, the mobs are way too weak to only spawn in small batches and so they have been adjusted as well.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: The effigy of entropy anomaly is now more powerful.

