### PR TITLE
Allow cultists to absorb another rift after expending their empowerment

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicFragmentationSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicFragmentationSystem.cs
@@ -1,4 +1,5 @@
 using Content.Server._DV.Objectives.Events;
+using Content.Server.Actions;
 using Content.Server.Antag;
 using Content.Shared.Popups;
 using Content.Server.Radio.Components;
@@ -23,6 +24,7 @@ public sealed class CosmicFragmentationSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
+    [Dependency] private readonly ActionsSystem _actions = default!;
 
     private ProtoId<RadioChannelPrototype> _cultRadio = "CosmicRadio";
 
@@ -49,6 +51,8 @@ public sealed class CosmicFragmentationSystem : EntitySystem
         comp.CosmicImpositionDuration = CosmicCultComponent.DefaultCosmicImpositionDuration;
         comp.CosmicBlankDuration = CosmicCultComponent.DefaultCosmicBlankDuration;
         comp.CosmicBlankDelay = CosmicCultComponent.DefaultCosmicBlankDelay;
+        _actions.RemoveAction(ent, comp.CosmicFragmentationActionEntity);
+        comp.CosmicFragmentationActionEntity = null;
     }
 
     private void OnCosmicFragmentation(Entity<CosmicCultComponent> ent, ref EventCosmicFragmentation args)

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -128,6 +128,7 @@ public sealed class CosmicRiftSystem : EntitySystem
         var actionEnt = _actions.AddAction(uid, uid.Comp.CosmicFragmentationAction);
         Spawn(uid.Comp.AbsorbVFX, tgtpos);
         comp.ActionEntities.Add(actionEnt);
+        comp.CosmicFragmentationActionEntity = actionEnt;
         comp.CosmicEmpowered = true;
         comp.CosmicSiphonQuantity = 2;
         comp.CosmicGlareRange = 10;

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -55,12 +55,6 @@ public sealed class CosmicRiftSystem : EntitySystem
             return;
         }
 
-        if (cultist.WasEmpowered)
-        {
-            _popup.PopupEntity(Loc.GetString("cosmiccult-rift-wasempowered"), args.User, args.User);
-            return;
-        }
-
         args.Handled = true;
         uid.Comp.Occupied = true;
         _popup.PopupEntity(Loc.GetString("cosmiccult-rift-beginabsorb"), args.User, args.User);
@@ -134,7 +128,6 @@ public sealed class CosmicRiftSystem : EntitySystem
         var actionEnt = _actions.AddAction(uid, uid.Comp.CosmicFragmentationAction);
         Spawn(uid.Comp.AbsorbVFX, tgtpos);
         comp.ActionEntities.Add(actionEnt);
-        comp.WasEmpowered = true;
         comp.CosmicEmpowered = true;
         comp.CosmicSiphonQuantity = 2;
         comp.CosmicGlareRange = 10;

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
@@ -145,6 +145,10 @@ public sealed partial class CosmicCultComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<AlertPrototype> EntropyAlert = "CosmicEntropy";
+
+    [DataField]
+    public EntityUid? CosmicFragmentationActionEntity;
+
     #endregion
 
     /// <summary>

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
@@ -129,10 +129,6 @@ public sealed partial class CosmicCultComponent : Component
     /// Wether or not this cultist has been empowered by a Malign Rift.
     /// </summary>
     [DataField, AutoNetworkedField] public bool CosmicEmpowered;
-    /// <summary>
-    /// Wether or not this cultist was previously empowered by a Malign Rift.
-    /// </summary>
-    [DataField, AutoNetworkedField] public bool WasEmpowered;
 
     /// <summary>
     /// Wether or not this cultist needs to respirate.


### PR DESCRIPTION
## About the PR
Cultists can now absorb any amount of rifts, as long as they have spent their previous one by using null fragmentation.
Also null fragmentation action is now removed on use (it had 1 charge anyway so why keep it if you can't use it anymore).

## Why / Balance
The restriction was mildly annoying and didn't really promote any meaningful teamplay that much. Also makes people more likely to create colossi earlier into the round , because right now it is seen as too high of a risk and a waste of empowerment.

## Technical details
Kill WasEmpowered and anything that referenced it.
Store null fragmentation action on the cult comp and remove it when used to avoid having 100500 duplicate actions if empowered repeatedly.

## Media
No.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cosmic cultists can now absorb a rift again after expending their empowerment.
