### PR TITLE
Lower warops minimum nukies to 3

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -81,7 +81,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Minimal operatives count for war declaration
     /// </summary>
     [DataField]
-    public int WarDeclarationMinOps = 4;
+    public int WarDeclarationMinOps = 3; // DeltaV
 
     [DataField]
     public WinType WinType = WinType.Neutral;

--- a/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/NukeopsRuleComponent.cs
@@ -81,7 +81,7 @@ public sealed partial class NukeopsRuleComponent : Component
     ///     Minimal operatives count for war declaration
     /// </summary>
     [DataField]
-    public int WarDeclarationMinOps = 3; // DeltaV
+    public int WarDeclarationMinOps = 3; // DeltaV - was 4
 
     [DataField]
     public WinType WinType = WinType.Neutral;


### PR DESCRIPTION
## About the PR
War can now be declared with 3 nukies instead of 4.

## Why / Balance
Round #23353 was warops with three nukies (curator intervention), and from what I'm hearing it went REALLY well.
Honestly, might be worth considering just lowering the amount to 1. I don't know what circumstances leads to a round with only one or two nukies, but if that happens, the crew will probably be unrobust enough to want time to prepare anyways.

## Technical details
number ops

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have tested all added content and changes.
what am i supposed to launch three instances for this or something. it's the right number trust
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Warops can now be declared with just 3 nukies.
