### PR TITLE
fix: make advanced operating table advanced

### DIFF
--- a/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
+++ b/Content.Shared/_Shitmed/Surgery/SharedSurgerySystem.Steps.cs
@@ -814,7 +814,7 @@ public abstract partial class SharedSurgerySystem
         {
             var buckledEvent = new SurgerySpeedModifyEvent(speed);
             RaiseLocalEvent(buckledTo, ref buckledEvent);
-            speed = ev.Multiplier;
+            speed = buckledEvent.Multiplier;
         }
 
         return stepComp.Duration / speed;

--- a/Content.Shared/_Shitmed/Surgery/SurgerySpeedModifierSystem.cs
+++ b/Content.Shared/_Shitmed/Surgery/SurgerySpeedModifierSystem.cs
@@ -9,13 +9,19 @@ public sealed partial class SurgerySpeedModifierSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<SurgerySpeedModifierComponent, InventoryRelayedEvent<SurgerySpeedModifyEvent>>(OnSpeedModify);
+        SubscribeLocalEvent<SurgerySpeedModifierComponent, SurgerySpeedModifyEvent>(OnSpeedModify);
+        SubscribeLocalEvent<SurgerySpeedModifierComponent, InventoryRelayedEvent<SurgerySpeedModifyEvent>>(OnSpeedModifyRelay);
         SubscribeLocalEvent<SurgerySpeedModifierComponent, ArmorExamineEvent>(OnExamineEquipment);
     }
 
-    private void OnSpeedModify(Entity<SurgerySpeedModifierComponent> ent, ref InventoryRelayedEvent<SurgerySpeedModifyEvent> args)
+    private void OnSpeedModify(Entity<SurgerySpeedModifierComponent> ent, ref SurgerySpeedModifyEvent args)
     {
-        args.Args.Multiplier *= ent.Comp.SpeedModifier;
+        args.Multiplier *= ent.Comp.SpeedModifier;
+    }
+
+    private void OnSpeedModifyRelay(Entity<SurgerySpeedModifierComponent> ent, ref InventoryRelayedEvent<SurgerySpeedModifyEvent> args)
+    {
+        OnSpeedModify(ent, ref args.Args);
     }
 
     private void OnExamineEquipment(Entity<SurgerySpeedModifierComponent> ent, ref ArmorExamineEvent args)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
This makes the advanced operating table not multiply surgery speed by a big ol' one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #4151.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The advanced operating table now speeds up surgery.
