### PR TITLE
Make cult less obvious on earlier stages

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -1,4 +1,3 @@
-using Content.Client.Parallax.Data;
 using Content.Server._DV.CosmicCult.Components;
 using Content.Server.Actions;
 using Content.Server.Administration.Logs;
@@ -116,7 +115,6 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     /// Mind role to add to cultists.
     /// </summary>
     public static readonly EntProtoId MindRole = "MindRoleCosmicCult";
-    private static readonly ProtoId<ParallaxPrototype> FinaleParallax = "CosmicFinaleParallax";
 
     public override void Initialize()
     {
@@ -184,7 +182,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             _audio.PlayGlobal(_tier3Sound, Filter.Broadcast(), false, AudioParams.Default);
 
             EnsureComp<ParallaxComponent>(mapData, out var parallax);
-            parallax.Parallax = FinaleParallax;
+            parallax.Parallax = "CosmicFinaleParallax";
             Dirty(mapData, parallax);
 
             EnsureComp<MapLightComponent>(mapData, out var mapLight);

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -174,6 +174,28 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         if (component.PrepareFinaleTimer is { } finalePrepTimer && _timing.CurTime >= finalePrepTimer)
         {
             component.PrepareFinaleTimer = null;
+            
+            var sender = Loc.GetString("cosmiccult-announcement-sender");
+            var mapData = _map.GetMap(_transform.GetMapId(component.MonumentInGame.Owner.ToCoordinates()));
+            _chatSystem.DispatchStationAnnouncement(component.MonumentInGame, Loc.GetString("cosmiccult-announce-pre-finale-progress"), sender, false, null, Color.FromHex("#4cabb3"));
+            _chatSystem.DispatchStationAnnouncement(component.MonumentInGame, Loc.GetString("cosmiccult-announce-pre-finale-warning"), null, false, null, Color.FromHex("#cae8e8"));
+            _audio.PlayGlobal(_tier3Sound, Filter.Broadcast(), false, AudioParams.Default);
+
+            EnsureComp<ParallaxComponent>(mapData, out var parallax);
+            parallax.Parallax = "CosmicFinaleParallax";
+            Dirty(mapData, parallax);
+
+            EnsureComp<MapLightComponent>(mapData, out var mapLight);
+            mapLight.AmbientLightColor = Color.FromHex("#210746");
+            Dirty(mapData, mapLight);
+
+            var lights = EntityQueryEnumerator<PoweredLightComponent>();
+            while (lights.MoveNext(out var light, out _))
+            {
+                if (!_rand.Prob(0.50f))
+                    continue;
+                _ghost.DoGhostBooEvent(light);
+            }
 
             if (TryComp<CosmicFinaleComponent>(component.MonumentInGame, out var finaleComp))
             {
@@ -197,15 +219,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             var mapData = _map.GetMap(_transform.GetMapId(component.MonumentInGame.Owner.ToCoordinates()));
             _chatSystem.DispatchStationAnnouncement(component.MonumentInGame, Loc.GetString("cosmiccult-announce-tier3-progress"), sender, false, null, Color.FromHex("#4cabb3"));
             _chatSystem.DispatchStationAnnouncement(component.MonumentInGame, Loc.GetString("cosmiccult-announce-tier3-warning"), null, false, null, Color.FromHex("#cae8e8"));
-            _audio.PlayGlobal(_tier3Sound, Filter.Broadcast(), false, AudioParams.Default);
-
-            EnsureComp<ParallaxComponent>(mapData, out var parallax);
-            parallax.Parallax = "CosmicFinaleParallax";
-            Dirty(mapData, parallax);
-
-            EnsureComp<MapLightComponent>(mapData, out var mapLight);
-            mapLight.AmbientLightColor = Color.FromHex("#210746");
-            Dirty(mapData, mapLight);
+            _audio.PlayGlobal(_tier2Sound, Filter.Broadcast(), false, AudioParams.Default);
 
             var lights = EntityQueryEnumerator<PoweredLightComponent>();
             while (lights.MoveNext(out var light, out _))
@@ -235,17 +249,13 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             component.Tier2DelayTimer = null;
             component.ExtraRiftTimer = _timing.CurTime + TimeSpan.FromSeconds(15);
 
-            //do spooky effects
+            //don't spooky effects
+            /*
             var sender = Loc.GetString("cosmiccult-announcement-sender");
             var mapData = _map.GetMap(_transform.GetMapId(component.MonumentInGame.Owner.ToCoordinates()));
             _chatSystem.DispatchStationAnnouncement(component.MonumentInGame, Loc.GetString("cosmiccult-announce-tier2-progress"), sender, false, null, Color.FromHex("#4cabb3"));
             _chatSystem.DispatchStationAnnouncement(component.MonumentInGame, Loc.GetString("cosmiccult-announce-tier2-warning"), null, false, null, Color.FromHex("#cae8e8"));
             _audio.PlayGlobal(_tier2Sound, Filter.Broadcast(), false, AudioParams.Default);
-
-            for (var i = 0; i < Convert.ToInt16(component.TotalCrew / 6); i++) // spawn # malign rifts equal to 16.67% of the playercount
-            {
-                SpawnRift();
-            }
 
             var lights = EntityQueryEnumerator<PoweredLightComponent>();
             while (lights.MoveNext(out var light, out _))
@@ -253,6 +263,12 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
                 if (!_rand.Prob(0.50f))
                     continue;
                 _ghost.DoGhostBooEvent(light);
+            }
+            */
+
+            for (var i = 0; i < Convert.ToInt16(component.TotalCrew / 6); i++) // spawn # malign rifts equal to 16.67% of the playercount
+            {
+                SpawnRift();
             }
 
             _monument.SetCanTierUp(component.MonumentInGame, true);

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -1,3 +1,4 @@
+using Content.Client.Parallax.Data;
 using Content.Server._DV.CosmicCult.Components;
 using Content.Server.Actions;
 using Content.Server.Administration.Logs;
@@ -115,6 +116,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     /// Mind role to add to cultists.
     /// </summary>
     public static readonly EntProtoId MindRole = "MindRoleCosmicCult";
+    private static readonly ProtoId<ParallaxPrototype> FinaleParallax = "CosmicFinaleParallax";
 
     public override void Initialize()
     {
@@ -182,7 +184,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
             _audio.PlayGlobal(_tier3Sound, Filter.Broadcast(), false, AudioParams.Default);
 
             EnsureComp<ParallaxComponent>(mapData, out var parallax);
-            parallax.Parallax = "CosmicFinaleParallax";
+            parallax.Parallax = FinaleParallax;
             Dirty(mapData, parallax);
 
             EnsureComp<MapLightComponent>(mapData, out var mapLight);

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -174,7 +174,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         if (component.PrepareFinaleTimer is { } finalePrepTimer && _timing.CurTime >= finalePrepTimer)
         {
             component.PrepareFinaleTimer = null;
-            
+
             var sender = Loc.GetString("cosmiccult-announcement-sender");
             var mapData = _map.GetMap(_transform.GetMapId(component.MonumentInGame.Owner.ToCoordinates()));
             _chatSystem.DispatchStationAnnouncement(component.MonumentInGame, Loc.GetString("cosmiccult-announce-pre-finale-progress"), sender, false, null, Color.FromHex("#4cabb3"));

--- a/Content.Server/_DV/StationEvents/Components/RandomMultipleSpawnRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/RandomMultipleSpawnRuleComponent.cs
@@ -1,6 +1,5 @@
 using Content.Server.StationEvents.Events;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server._DV.StationEvents.Components;
 
@@ -13,8 +12,8 @@ public sealed partial class RandomMultipleSpawnRuleComponent : Component
     /// <summary>
     /// The entity to be spawned.
     /// </summary>
-    [DataField("prototype", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
-    public string Prototype = string.Empty;
+    [DataField(required: true)]
+    public EntProtoId Prototype = string.Empty;
 
     /// <summary>
     /// The minimum amount of entities to be spawned.

--- a/Content.Server/_DV/StationEvents/Components/RandomMultipleSpawnRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/RandomMultipleSpawnRuleComponent.cs
@@ -1,0 +1,30 @@
+﻿using Content.Server.StationEvents.Events;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
+
+namespace Content.Server._DV.StationEvents.Components;
+
+/// <summary>
+/// Spawns a random amount of entities at a random tile on a station using TryGetRandomTile.
+/// </summary>
+[RegisterComponent, Access(typeof(RandomSpawnRule))]
+public sealed partial class RandomMultipleSpawnRuleComponent : Component
+{
+    /// <summary>
+    /// The entity to be spawned.
+    /// </summary>
+    [DataField("prototype", required: true, customTypeSerializer: typeof(PrototypeIdSerializer<EntityPrototype>))]
+    public string Prototype = string.Empty;
+
+    /// <summary>
+    /// The minimum amount of entities to be spawned.
+    /// </summary>
+    [DataField]
+    public int MinAmount = 1;
+
+    /// <summary>
+    /// The maximum amount of entities to be spawned.
+    /// </summary>
+    [DataField]
+    public int MaxAmount = 1;
+}

--- a/Content.Server/_DV/StationEvents/Components/RandomMultipleSpawnRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/RandomMultipleSpawnRuleComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Server.StationEvents.Events;
+using Content.Server.StationEvents.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 

--- a/Content.Server/_DV/StationEvents/Events/RandomMultipleSpawnRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/RandomMultipleSpawnRule.cs
@@ -1,0 +1,28 @@
+using Content.Server._DV.StationEvents.Components;
+using Content.Server.GameTicking.Rules.Components;
+using Content.Server.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.Random;
+
+namespace Content.Server._DV.StationEvents.Events;
+
+public sealed class RandomMultipleSpawnRule : StationEventSystem<RandomMultipleSpawnRuleComponent>
+{
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    protected override void Started(EntityUid uid, RandomMultipleSpawnRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        var amount = _random.Next(comp.MinAmount, comp.MaxAmount);
+        for (int i = 0; i < amount; i++)
+        {
+            if (TryFindRandomTile(out _, out _, out _, out var coords))
+            {
+                Sawmill.Info($"Spawning {comp.Prototype} at {coords}");
+                Spawn(comp.Prototype, coords);
+            }
+        }
+    }
+}

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -233,16 +233,16 @@ public sealed partial class DCCVars
         CVarDef.Create("cosmiccult.steward_vote_delay", 25, CVar.SERVER);
 
     /// <summary>
-    /// The delay between the monument getting upgraded to tier 2 and the crew learning of that fact. the monument cannot be upgraded again in this time.
+    /// The delay between the monument getting upgraded to tier 2 and rifts starting to appear. the monument cannot be upgraded again in this time.
     /// </summary>
     public static readonly CVarDef<int> CosmicCultT2RevealDelaySeconds =
-        CVarDef.Create("cosmiccult.t2_reveal_delay_seconds", 180, CVar.SERVER);
+        CVarDef.Create("cosmiccult.t2_reveal_delay_seconds", 30, CVar.SERVER);
 
     /// <summary>
     /// The delay between the monument getting upgraded to tier 3 and the crew learning of that fact. the monument cannot be upgraded again in this time.
     /// </summary>
     public static readonly CVarDef<int> CosmicCultT3RevealDelaySeconds =
-        CVarDef.Create("cosmiccult.t3_reveal_delay_seconds", 100, CVar.SERVER);
+        CVarDef.Create("cosmiccult.t3_reveal_delay_seconds", 180, CVar.SERVER);
 
     /// <summary>
     /// The delay between the monument getting upgraded to tier 3 and the finale starting.

--- a/Resources/Locale/en-US/_DV/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/_DV/abilities/psionic.ftl
@@ -49,6 +49,7 @@ psionic-power-precognition-random-sentience-result-message = Something bright an
 psionic-power-precognition-unknown-shuttle-cargo-lost-result-message = You see a vision of a simple ship of old Terra, adrift of the sea, far away from home.
 psionic-power-precognition-unknown-shuttle-traveling-cuisine-result-message = You see a vision of peace, a cozy meal sizzling on a warm stove. A delicious smells wafts through the air.
 psionic-power-precognition-unknown-shuttle-disaster-evac-pod-result-message = You see a vision of death and blood, of a destruction so complete only few survive, drifting through the coldness of space.
+psionic-power-precognition-rift-spawn-result-message = You see a small spark of energy, quickly expanding as it tears reality apart, twisting everything around it.
 
 psionic-eruption-begin = {CAPITALIZE(THE($user))} is being consumed by a psionic energy!
 psionic-eruption-annoy-minimal = You feel a pressure building up in your mind.

--- a/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_DV/cosmiccult/preset-cosmiccult.ftl
@@ -175,11 +175,11 @@ objective-condition-victory-desc = Beckon The Unknown, and herald the final curt
 
 cosmiccult-radio-tier1-progress = The Monument is beckoned unto the station...
 
-cosmiccult-announce-tier2-progress = An unnerving numbness prickles your senses.
-cosmiccult-announce-tier2-warning = Scanners detect a notable increase in Λ-CDM! Rifts in realspace may appear shortly. Please alert your station's chaplain if sighted.
+cosmiccult-announce-tier3-progress = An unnerving numbness prickles your senses.
+cosmiccult-announce-tier3-warning = Scanners detect an abnormal increase in Λ-CDM! Report any unnatural phenomena to security or epistemics.
 
-cosmiccult-announce-tier3-progress = Arcs of noospheric energy crackle across the station's groaning structure. The end draws near.
-cosmiccult-announce-tier3-warning = Critical increase in Λ-CDM detected. Infected personnel are to be subdued or neutralized on sight.
+cosmiccult-announce-pre-finale-progress = Arcs of noospheric energy crackle across the station's groaning structure. The end draws near.
+cosmiccult-announce-pre-finale-warning = Critical increase in Λ-CDM detected! We are monitoring the situation. Await further instructions.
 
 cosmiccult-announce-finale-warning = All station crew. The Λ-CDM anomaly is going supercritical, instruments failing; noospheric-to-real transitional event horizon IMMINENT. If you are not already on counter-protocol, immediately sortie and intervene. Repeat: Intervene immediately or die.
 

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -130,6 +130,21 @@
       mindRoles:
       - MindRoleListeningPost
 
+- type: entity
+  parent: BaseGameRule
+  id: MalignRiftSpawn
+  components:
+  - type: StationEvent
+    earliestStart: 15
+    weight: 6
+  - type: PrecognitionResult
+    message: psionic-power-precognition-rift-spawn-result-message
+  - type: RandomMultipleSpawnRule
+    prototype: CosmicMalignRift
+    minAmount: 1
+    maxAmount: 3
+    
+
 # Mid round antag spawns
 - type: entity
   abstract: true

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -143,7 +143,7 @@
     prototype: CosmicMalignRift
     minAmount: 1
     maxAmount: 3
-    
+
 
 # Mid round antag spawns
 - type: entity

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -4,6 +4,7 @@
     children:
     - id: MothroachSpawn
     - id: XenoVents
+    - id: MalignRiftSpawn
 
 - type: entityTable
   id: BasicAntagEventsTableDeltaV


### PR DESCRIPTION
## About the PR
There is now a random event that spawns 1-3 malign rifts in random spots.
Cult's stage transition effects have been pushed into later stages:
- Stage 2 now doesn't have any obvious effects (except for the rifts appearing, but that is no longer a clear sign of cult because of the random event).
- Stage 3 no longer changes the background, and uses stage 2's announcement and SFX.
- When the finale is ready, the old stage 3's effects take place (announcement, SFX and background change).

Announcemet texts have been slightly changed. Timers have also been adjusted: stage 1 -> 2 now only takes 30 secodns (was 180, I'd honestly remove the timer altogether, but my laziness won), and 2 -> 3 takes 180 seconds (previously 100 seconds), because this one actually has some effects that cultists have to worry about (most notably glowing eyes)

## Why / Balance
Cult, especially in the earlier stages, is a stealth antag. A stealth antag should not have a "hey everyone it's a cult round" mechanic. I was initially thinking of removing the announcements altogether, but the effects were just too cool to get rid of, so I instead moved the effects to later stages.

Now, for most of the round, it's up to the crew to deduce if it's a cult round, or just randomly spawning rifts, which increases player agency, and makes the gamemode feel slightly less "gamey".

## Technical details
New event type, RandomMultipleSpawnRule. It's like RandomSpawnRule, but spawns a random amount of entities instead of a single one. Used for the MalignRiftSpawn event to spawn 1-3 rifts in random spots. Otherwise just minor code copypasting.

## Media
Beginning of stage 3, first announcement.
<img width="465" height="114" alt="изображение" src="https://github.com/user-attachments/assets/c102898f-c016-46e4-b3c2-d17376b52771" />
End of stage 3, second announcement.
<img width="462" height="136" alt="изображение" src="https://github.com/user-attachments/assets/e4b4d065-a4ac-4e30-a6c9-509119c42ee6" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Malign rifts can now randomly spawn even outside of cosmic cult rounds.
- tweak: Cosmic cult's presence is now less obvious early in the round. Announcements have been moved to later stages.
