### PR TITLE
survival scheduler part 3

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -432,14 +432,17 @@
   - type: RampingStationEventScheduler
     timeKeyPoints: # DeltaV
     - 10, 10
-    - 30, 8
+    - 10, 6
+    - 10, 1
+    - 10, 4
     - 15, 6
-    - 15, 8
-    - 15, 3
-    - 15, 8
-    - 15, 1
-    - 15, 5
-    - 30, 2.5
+    - 15, 4
+    - 20, 2
+    - 10, 1
+    - 10, 4
+    - 10, 3
+    - 10, 4
+    - 60, 5
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -434,15 +434,14 @@
     - 10, 10
     - 10, 6
     - 10, 1
-    - 10, 4
-    - 15, 6
+    - 10, 3
+    - 15, 5
     - 15, 4
     - 20, 2
     - 10, 1
     - 10, 4
     - 10, 3
-    - 10, 4
-    - 60, 5
+    - 70, 4
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
adjusts the survival scheduler to better suit the rounds

## Why / Balance
I looked back over what i had done last time and the feedback we received from it and realized I had made a few mistakes. this should give us more events, especially more antags, at an earlier time in the round. with minor reprieves in between.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Adjusted the survival scheduler.

