### PR TITLE
decrease emote cd to 3s

### DIFF
--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -7,5 +7,5 @@ namespace Content.Shared._RMC14.CCVar;
 public sealed partial class RMCCVars : CVars
 {
     public static readonly CVarDef<float> RMCEmoteCooldownSeconds =
-        CVarDef.Create("rmc.emote_cooldown_seconds", 5f, CVar.SERVER | CVar.REPLICATED);
+        CVarDef.Create("rmc.emote_cooldown_seconds", 3f, CVar.SERVER | CVar.REPLICATED);
 }


### PR DESCRIPTION
## About the PR
changed a 5 to a 3

## Why / Balance
result of a discord poll, people want the dogs to bark slightly more


## Media
meow

## Requirements

- [ X ] I have not tested any added content and changes.


## Breaking changes
i have done 0 tests, i dont know if it works, i dont know C#, i dont have a test enviroment to run this

**Changelog**

:cl:
- tweak: reduced the emote cooldown to 3s from 5s


