### PR TITLE
ik30 nerf

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/laser.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/laser.yml
@@ -13,7 +13,7 @@
     whitelist:
       tags:
       - CartridgeLaser
-    capacity: 20
+    capacity: 10
   - type: Item
     size: Small
   - type: ContainerContainer

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/laser.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/laser.yml
@@ -13,7 +13,7 @@
     whitelist:
       tags:
       - CartridgeLaser
-    capacity: 10
+    capacity: 20
   - type: Item
     size: Small
   - type: ContainerContainer

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -255,6 +255,7 @@
     sprite: _DV/Objects/Weapons/Guns/Rifles/lasercarbine.rsi
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
+  - type: GunRequiresWield
   - type: Gun
     fireRate: 1.5
     minAngle: 1

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -256,7 +256,7 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
-    fireRate: 3
+    fireRate: 1.5
     minAngle: 1
     maxAngle: 4
     selectedMode: SemiAuto

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -255,7 +255,7 @@
     sprite: _DV/Objects/Weapons/Guns/Rifles/lasercarbine.rsi
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
-#  - type: GunRequiresWield
+  - type: GunRequiresWield
   - type: Gun
     fireRate: 1.5
     minAngle: 1

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -255,7 +255,7 @@
     sprite: _DV/Objects/Weapons/Guns/Rifles/lasercarbine.rsi
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
-  - type: GunRequiresWield
+#  - type: GunRequiresWield
   - type: Gun
     fireRate: 1.5
     minAngle: 1


### PR DESCRIPTION
DELTANEDAS DONT MERGE BEFORE APPROVAL


## About the PR
needs 2 hands to fire now
halved fire rate of the IK30

## Why / Balance
IK30 is overall an overtuned weapon featuring a good damage type, the ability to fire through glass, the ability to be reloaded with mags, very good damage per mag and very good damage per second.
It is without a doubt the best in slot weapon for security. I would like to introduce some doubt

## Technical details
yaml


**Changelog**
:cl:
- tweak: IK30 has had its fire rate halved and now requires two hands to fire
