### PR TITLE
emergency laser buff

### DIFF
--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_emergency.yml
@@ -4,6 +4,6 @@
     sprite: _Impstation/Objects/Weapons/Guns/Battery/emergency_laser_gun.rsi
     state: icon
   product: EmergencyLaserCrate
-  cost: 2500
+  cost: 2500 #Delta-V was 5000
   category: cargoproduct-category-name-emergency
   group: market

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_emergency.yml
@@ -4,6 +4,6 @@
     sprite: _Impstation/Objects/Weapons/Guns/Battery/emergency_laser_gun.rsi
     state: icon
   product: EmergencyLaserCrate
-  cost: 5000
+  cost: 2500
   category: cargoproduct-category-name-emergency
   group: market

--- a/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_emergency.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Cargo/cargo_emergency.yml
@@ -4,6 +4,6 @@
     sprite: _Impstation/Objects/Weapons/Guns/Battery/emergency_laser_gun.rsi
     state: icon
   product: EmergencyLaserCrate
-  cost: 2500 #Delta-V was 5000
+  cost: 2500 # DeltaV was 5000
   category: cargoproduct-category-name-emergency
   group: market

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/emergency.yml
@@ -7,4 +7,4 @@
   - type: StorageFill
     contents:
     - id: EmergencyWeaponLaserCarbine
-      amount: 5 #Delta-V was 4
+      amount: 5 # DeltaV was 4

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/emergency.yml
@@ -2,9 +2,9 @@
   parent: CrateCommandSecure
   id: EmergencyLaserCrate
   name: emergency lasers crate
-  description: A crate of ten emergency laser rifles, the cheapest thing we can legally call a gun.
+  description: A crate of five emergency laser rifles, the cheapest thing we can legally call a gun.
   components:
   - type: StorageFill
     contents:
     - id: EmergencyWeaponLaserCarbine
-      amount: 10 #Delta-V was 4
+      amount: 5 #Delta-V was 4

--- a/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/emergency.yml
+++ b/Resources/Prototypes/_Impstation/Catalog/Fills/Crates/emergency.yml
@@ -2,9 +2,9 @@
   parent: CrateCommandSecure
   id: EmergencyLaserCrate
   name: emergency lasers crate
-  description: A crate of four emergency laser rifles, for situations where getting clearance isn't an option.
+  description: A crate of ten emergency laser rifles, the cheapest thing we can legally call a gun.
   components:
   - type: StorageFill
     contents:
     - id: EmergencyWeaponLaserCarbine
-      amount: 4
+      amount: 10 #Delta-V was 4

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -2,7 +2,7 @@
   id: EmergencyRedLaser
   damage:
     types:
-      Heat: 16 #Delta-V was 12
+      Heat: 16 # DeltaV was 12
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser

--- a/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -2,7 +2,7 @@
   id: EmergencyRedLaser
   damage:
     types:
-      Heat: 12
+      Heat: 16 #Delta-V was 12
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser


### PR DESCRIPTION
DELTANEDAS DO NOT MERGE THIS WITHOUT DIRECTION APPROVAL

## Why / Balance
Emergency Lasers are completely worthless: they do no damage, they are inaccurate unless wielded, and they constantly broadcast your location.
Keeping their damage pretty bad but supplying you with 10 at a time should help them actually fill their role of a weapon you can mass distribute to crew.


**Changelog**
:cl:
- tweak: Emergency Lasers now come in boxes of 10
- tweak: Emergency Lasers now do almost as much damage as a real gun


