### PR TITLE
small laser + big laser buffs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -241,7 +241,7 @@
     - SemiAuto
   - type: HitscanBatteryAmmoProvider
     proto: RedLaserPractice
-    fireCost: 62.5
+    fireCost: 50 #Delta-V was 62.5
   - type: StaticPrice
     price: 300
 
@@ -255,7 +255,7 @@
     price: 420
   - type: HitscanBatteryAmmoProvider
     proto: RedLaser
-    fireCost: 62.5
+    fireCost: 50 #Delta-V was 62.5
 
 - type: entity
   name: pulse pistol

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -96,7 +96,7 @@
   id: RedHeavyLaser
   damage:
     types:
-      Heat: 35 #Delta-V was 28
+      Heat: 32 #Delta-V was 28
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -20,7 +20,7 @@
   id: RedLaser
   damage:
     types:
-      Heat: 14
+      Heat: 20 #Delta-V was 14
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser
@@ -96,7 +96,7 @@
   id: RedHeavyLaser
   damage:
     types:
-      Heat: 28
+      Heat: 35 #Delta-V was 28
   muzzleFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_beam_heavy


### PR DESCRIPTION
deltanedas dont merge that one without approval either

## About the PR
laser rifles now deal 20 damage which should make them an actual weapon
laser cannon now deals 32 damage which should make them pretty strong

## Why / Balance
Hitscan laser rifles require two hands to shoot and do no damage, as such they are woefully weak. 

## Technical details
2nrs changed


**Changelog**

:cl:
- tweak: Laser Rifles now deal more damage 
- tweak: Laser Cannons now deal more damage
- tweak: Laser Rifles and their practice counterparts can be shot more before needing to recharge
-->
