### PR TITLE
Kill Trials

### DIFF
--- a/.wiki/_DV/Laws/SpaceLaw.txt
+++ b/.wiki/_DV/Laws/SpaceLaw.txt
@@ -14,6 +14,12 @@ It is highly recommended to read the '''[[Standard Operating Procedure|Standard 
 * '''[[Standard Operating Procedure#Trial Procedure|Trial Procedure]]:''' A criminal trial’s Judge must be, in sequential order: The Chief Justice, the Court Clerk, an impartial member of Justice or Station Command, or the Warden. The Prosecution should ideally be the Prosecutor, or an available member of Station Command or Station Security in that order. The Defense should ideally be a member of the Justice department assigned to the defendant, though they are allowed to represent themselves if they wish. If insufficient crew are available, the Judge is fully authorized and strongly encouraged to pass a sentence of Extended Confinement until a proper trial can be held.
 * '''[[Alert Procedure]]:''' Codes Blue, Red, Gamma, and Delta authorize Security to carry progressively more advanced firearms, and loosen '''[[Standard Operating Procedure#Rules of Engagement|Rules of Engagement]]''' regarding their use. The latter two suspend the right to individual privacy (allowing warrantless searches), allow for warrantless departmental raids, and place the station in martial law.
 
+==Procedural Defense==
+If a defendant is accused of trial, they are granted the privilege to challenge the legitimacy of charges of claims brought against them. Any of the following may be invoked:
+:*Double Jeopardy Clause: accused persons may are not to be charged on the same charges following an acquittal or conviction, except in the case of acquittal and subsequent credible admission of guilt.
+:*Entrapment Clause: accused persons found to be induced or coerced into the commission of the crimes listed in the charges are to be acquitted.
+:*Exclusionary Clause: evidence collected and/or analyzed in violation of accused persons’ rights under law is inadmissible.
+
 === Crime Codes Quick Reference ===
 Use this to quickly find the Crime Code Numbers.
 
@@ -91,10 +97,8 @@ Capital Sentences are organized in order of severity, with the least severe last
 ** Whenever any execution is performed, outside of Martial Law, a general announcement must be made stating who was executed, and for what reason.
 ** The convict may either face execution by firing squad, by lethal electrocution, by being ejected from the station via an airlock (being "spaced"), or by a method of their choosing, at the Judge's sole discretion.
 ** If recoverable, their remains must either be cremated, processed via the biomass reclaimer, or stored in the morgue.
-* '''Decorporealization:''' Stripping the convict's mind from their body into a more restrictive form, such as a cyborg or soul gem.
 * '''Exfiltration:''' Immediate retrieval of the convict via a CentComm or GALPOL prison transport.
 ** The prisoner may be held within the permanent brig until the transport arrives.
-** If transport cannot be arranged, default to other capital sentences.
 * '''Extended Confinement:''' Placing the convict into the Permanent Brig until the end of the shift, where they are to be transported to Central Command for processing.
 ** The convict has the same rights as any other prisoner within the Permanent Brig, whether they arrived by transport or were sentenced to Extended Confinement.
 :<!--                      -->

--- a/.wiki/_DV/Laws/SpaceLaw.txt
+++ b/.wiki/_DV/Laws/SpaceLaw.txt
@@ -15,7 +15,7 @@ It is highly recommended to read the '''[[Standard Operating Procedure|Standard 
 * '''[[Alert Procedure]]:''' Codes Blue, Red, Gamma, and Delta authorize Security to carry progressively more advanced firearms, and loosen '''[[Standard Operating Procedure#Rules of Engagement|Rules of Engagement]]''' regarding their use. The latter two suspend the right to individual privacy (allowing warrantless searches), allow for warrantless departmental raids, and place the station in martial law.
 
 ==Procedural Defense==
-If a defendant is accused of trial, they are granted the privilege to challenge the legitimacy of charges of claims brought against them. Any of the following may be invoked:
+If a defendant is accused of a crime, they are granted the privilege to challenge the legitimacy of charges of claims brought against them. Any of the following may be invoked:
 :*Double Jeopardy Clause: accused persons may are not to be charged on the same charges following an acquittal or conviction, except in the case of acquittal and subsequent credible admission of guilt.
 :*Entrapment Clause: accused persons found to be induced or coerced into the commission of the crimes listed in the charges are to be acquitted.
 :*Exclusionary Clause: evidence collected and/or analyzed in violation of accused persons’ rights under law is inadmissible.

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -7,10 +7,10 @@ The terms specified below are defined for further use within the procedures.
 :*Commanding Officer / CO: An officer appointed to lead the station and its Command department, whether it be the Captain by Nanotrasen, or an Acting CO by Station Command.
 :* Command Staff/Station Command: Members of the Command department who lead a department aboard the station.
 :* Crew: All sophonts employed by Station Command, or by NT to reside on the station and perform an established function therein. This includes any sophont listed on the Crew Manifest or issued a functional NT identification and access card. Individuals imprisoned by NT, along with those imprisoned during the course of a shift for violations of Space Law, are considered Crew.
-:* Judge: An indivudal legally appointed to preside over a criminal or civil trial, as specified within Trial Procedure.
+:* Judge: An indivudal legally appointed to preside over a hearing, as specified within Hearing Procedure.
 :* Detainee: Any sophont whose free movement has been curtailed by law enforcement on suspicion of criminal activity. They have not, however, been officially charged with a crime.
 :* Arrestee: Any sophont who has been formally charged with a crime.
-:* Prisoner: Any sophont who has been sentenced for the commission of a crime, or awaiting trial for a capital offense.
+:* Prisoner: Any sophont who has been sentenced for the commission of a crime, or awaiting a hearing for a capital offense.
 :* Permanent Brig/Permabrig/Brig: A secure location for the long-term confinement of Prisoners. Typically outfitted to sustain the basic survival needs of the Prisoners within.
 ==Right to Refuse Service==
 All crew operating within their designated job locations are given the right to refuse service at any time for disorderly or abusive conduct. Additionally, all crew members are permitted to use nonlethal force to remove noncompliant or disorderly individuals only when such persons pose a threat to the safety of staff members, or disrupt the orderly functioning of the station. Service may not be refused to first responders acting to address or mitigate an emergency or crisis situation, unless such conduct is egregiously disorderly or abusive.
@@ -143,7 +143,7 @@ Any such being is considered a sophont, and thus a legal person, regardless of t
 
 The unauthorised jailbreaking or uplifting of property into the status of Sophont is still a criminal offense however, and those found guilty of doing so may be found guilty of sabotage or vandalism.
 
-An entity’s status as a sophont may be challenged during the process of charging and trialing the individual or another for crimes which utilize the term sophont in the legal language of the crime. The Defense or Prosecution will present evidence indicating that it meets, or does not meet, the criteria above. The Judge will then arbitrate upon the entity's status as a sophont.
+An entity’s status as a sophont may be challenged during the process of charging the individual for crimes which utilize the term sophont in the legal language of the crime. The Defense or Prosecution will present evidence indicating that it meets, or does not meet, the criteria above. The Judge will then arbitrate upon the entity's status as a sophont.
 
 Any synthetic/silicon/inorganic entity with a non-sophont status, is to be classified as a standard synthetic entity. Synthetic entities are the property of the party that constructs or employs the entity, unless otherwise stated by relevant contract or legal document. To damage or destroy such an entity is to damage or destroy the aforementioned party’s property.
 =Commanding Officer=
@@ -179,7 +179,7 @@ Should such a situation arise in which the CO is unfit for their position and de
 
 A mutiny, defined as a coordinated effort to depose the commanding officer or officers of a vessel for committing unlawful acts, requires the crew to neutralize the offending staff with non-lethal force where applicable, and lethal measures and weapons only in acts of self-preservation or when given no other option. The commanding officer or officers, as well as their loyalists, are all bound to Space Law, the current alert level and its corresponding RoE.
 
-Should the mutiny be unsuccessful, only the head officer(s) who approved the mutiny may be charged with sedition and receive a trial, while all mutineers may be demoted, processed by law enforcement, and charged for the crimes they have committed.
+Should the mutiny be unsuccessful, only the head officer(s) who approved the mutiny may be charged with sedition and receive a hearing, while all mutineers may be demoted, processed by law enforcement, and charged for the crimes they have committed.
 
 Should the mutiny be successful, the head officer(s) who approved the mutiny must select a new Commanding Officer per Line of Succession. The new CO will then sentence the previous heads of staff for their crimes per Space Law.
 
@@ -276,7 +276,7 @@ Warrants represent official orders to the security department, issued by the Jus
 * Individual Warrants may order the search or detainment of an individual, or the arrest of the individual with evidence. This may also include surgical procedures, cursory implant inspections, or any other invasive searches with evidence. These warrants must include a name, the actions prescribed (search, arrest, etc.), and a description if applicable.
 * Search Warrants may order the search of an entire departmental area, by force if necessary, and may order the arrest of listed individuals implicated in a crime or crimes with probable cause or evidence. Search Warrants should include an area, a brief description of the probable cause, and a list of individuals if applicable.
 ==Injunctions==
-The Chief Justice, Commanding Officer, or Judge of a trial are fully authorized to issue injunctions: legally-binding, written orders restricting Inhabitants from doing something disruptive to station productivity or personal rights.
+The Chief Justice, Commanding Officer, or Judge of a hearing are fully authorized to issue injunctions: legally-binding, written orders restricting Inhabitants from doing something disruptive to station productivity or personal rights.
 These may be issued on discretion. Injunctions may not compel someone to violate Space Law or SOP, and the issuer is liable for abuse of power charges if this is misused. An injunction must include a list of affected names and a detailed description of the restrictions to be valid.
 =Hearings=
 NanoTrasen authorizes its Justice Department to conduct Hearings in order to determine if a person accused of sufficient crimes may be held in indefinite custody, to be handed over to GalPol at the end of the shift.
@@ -294,7 +294,7 @@ The prosecution should consist of either a prosecutor, any member of the justice
 
 Neither prosecution nor defense may interrupt one another during presentation of evidence, including objecting to witness statements made. In the case of a witness making demonstrably untrue statements, perjury and contempt of court may be charged as necessary. It is encouraged the judge pay attention and inquire about competing claims to truth.
 
-==Conducting the hearing==
+==Hearing Procedure==
 A Hearing should take no longer than 10 minutes, and follows these steps:
 
 0. Prosecution informs the Judge, the Accused and the Defense of all charges. The Accused is asked if they want to plead guilty.

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -190,7 +190,7 @@ Crew of foreign vessels may be refused entry, at any time and for any reason, an
 
 Crimes committed against the station or its inhabitants, on station or abroad, are grounds to charge the perpetrator according to the laws of the station. Should visiting entities break the law, or be suspected of doing so, and flee aboard their own vessel, law enforcement personnel are authorized to board the vessel in continuous “hot” pursuit and are fully authorized to effect an arrest upon the relevant party.
 
-=Security Regulations=
+=Security and Justice Regulations=
 ==Security Jurisdiction==
 Law enforcement personnel are bound by trespass and assault laws, and thus cannot operate outside accessible areas, or perform searches without a Probable Cause, a warrant, or a heightened alert level that specifically allows such action. Advanced surgical procedures and cursory implant investigations must be performed by a trained member of the Medical department, operating under their [[Standard Operating Procedure#Standard of Care|Standard of Care]].
 
@@ -200,38 +200,6 @@ However, officers are allowed to trespass into a department in “hot pursuit”
 While actively enforcing the law, officers are held to the standard of Probable Cause. This phrase represents a reasonable suspicion that a crime has been, or is being, committed, and does not require the officer to have solid evidence of criminal activity. Examples of Probable Cause include witnessing criminal activity or credible reports of such.
 
 When judged, Probable Cause is to be interpreted within the context of the entirety of the station’s circumstances at the time of the incident. Probable Cause negates the need of a warrant for searches, and, once concluded, should be promptly reported to the Prosecutor, Warden, or Head of Security for review.
-
-==Detainment and Arrest==
-Any sophont may be detained by a law enforcement officer with Probable Cause. In detainment, the officer will inform the Detainee of the crime they are suspected of committing. They may be held on-site or moved to a strategically sound location, restrained at the officer’s discretion, and detained while law enforcement officers determine if they can proceed with an arrest. Such a detention should last no longer than five (5) minutes. A Detainee may not be searched, unless consent is given or they are placed under arrest, and their detention should be concluded within five minutes of its start, by either Arresting them or releasing them.
-
-Any sophont which may have committed a crime, assuming Probable Cause, or has been formally charged with the commission of a crime, may be arrested. In an arrest, the suspect will be restrained by a member of law enforcement, informed of their charges, and taken to the brig for search and processing under Brig Procedure. Any Controlled Items in possession of the Arrestee without licensure or dispensation must be confiscated, along with items used in commission of the crime(s), and will be held indefinitely by law enforcement as described in [[Standard Operating Procedure#Evidence Handling|Evidence Handling]]. Legal counsel may be requested by an Arrestee or Detainee, and must be provided if available.
-
-==Brig Procedure==
-When confining an Arrestee within the Brig, they should be transferred to the Warden for processing:
-
-* A full search of the Arrestee and their possessions.
-* The confiscation of any Controlled Items or items used in commission of the crime, along with any equipment not befitting a prisoner
-* The confining of the Arrestee within a temporary holding cell.
-* [[Standard Operating Procedure#Sentencing|Sentencing]] the Arrestee.
-
-If the Arrestee is sentenced for a Capital-level crime, they are to be transferred to the Permanent Brig, pending trial. If the Warden is unavailable, the arresting officer must process the Arrestee as stated above. All confiscated items must be handled as dictated within [[Standard Operating Procedure#Evidence Handling|Evidence Handling]].
-
-==Sentencing==
-Any law enforcement individual is authorized to pass sentences on all Grand Felony, Felony and Misdemeanor-level crimes; however, the Prosecutor is responsible for overseeing sentences passed, and is authorized to correct sentences or even acquit them, in accordance with both Space Law and [[Standard Operating Procedure#Paroles and Pardons|Paroles and Pardons]]. Both capital charges and sentences must be placed by the Prosecutor or Court Clerk; if neither are available, the Warden or Head of Security are authorized to press capital charges and request sentencing for them, under Trial Procedure.
-
-In the case that the accused requests appeal for a Grand Felony- or Felony-level sentence, the Court Clerk should be called to preside over a small, swift adjudication, where the Prosecutor and accused will argue their sides. The Clerk will then decide the sentence, or acquittal, of the accused. If the Clerk is unavailable, the Chief Justice or the Warden can perform appeals. If neither are available, any available member of Station Command is authorized to adjudicate on the case.
-
-Additionally, any sentence meeting or exceeding twenty-five (25) minutes, regardless of the severity of the crime(s) committed, will require a trial. If the total sentence still meets or exceeds twenty-five minutes after the conclusion of a lawful trial, the Judge is fully authorized and encouraged to upgrade their sentence to Extended Confinement.
-
-Once a sentence has commenced, it must be concluded at or before the agreed-upon time.
-
-== Evidence Handling ==
-When evidence of a crime is secured, it is the responsibility of the arresting officer or Warden to properly handle it, at the penalty of Obstruction of Justice and/or demotion.
-
-Evidence should be organized by individual and crime, and stored together (e.g., in a bag, in one separate locker, etc) and then placed in an area locked behind security access.
-
-If a prisoner is released from a temporary holding cell OR the Brig, any of their equipment that is neither a Controlled Item nor used in the commission of their crimes must be returned to them.
-
 == Rules of Engagement ==
 Law enforcement personnel hold a Category D Armaments License, and are authorized at all times to use lethal force to the extent necessary to neutralize adversaries under any of the following circumstances:
 
@@ -281,127 +249,65 @@ Should prisoners repeatedly and maliciously antagonize law enforcement, to an ex
 
 Moreover, prisoners are liable for any and all crimes that they commit while held either in the temporary holding cells or the Permanent Brig, and may receive trial for more restrictive punishments if their actions warrant a capital sentence.
 
-==Paroles and Pardons==
-Prisoners may be allowed parole, per the discretion of the Warden, the Head of Security, or the CO. Alternatively, they may request a parole hearing as described within Trial Procedure.
+==Arrest and Sentencing==
+Any sophont, that has been formally charged with the commission of a crime, or can be assumed to have committed a crime under Probable Cause may be arrested by a member of Security. In an arrest, the suspect will be restrained, informed of their charges, and moved to the Brig for processing.
+Legal counsel may be requested by an Arrestee, and must be provided if available.
+At the brig, prisoner is thoroughly searched and confined to a holding cell. Any items on their person they are not authorized to possess are confiscated and sent to the justice department for processing and storage as evidence. It is the duty of both the Warden and the Chief Justice to ensure evidence is handled properly and safely.
+The prisoner is sentenced according to Space Law.
+Any items deemed unbefitting of a prisoner may be taken for the duration of incarceration and must be returned at the end of the sentence.
+Any member of Security is authorized to pass sentences on all Grand Felony, Felony, and Misdemeanor-level crimes. The Chief Justice is authorized to pass sentences on all Crimes, and to correct, or even acquit them, in accordance with Space Law.
 
-Prisoners seeking parole may request legal counsel before the hearing, but they must represent themselves. A prisoner who is granted parole is to be treated as a member of the station’s crew with all benefits and responsibilities thereof, and is encouraged to seek gainful employment from relevant command staff.
+Should the Prisoners sentence exceed a total of 20 minutes, or if the crimes charged include a capital crime, the prisoner is transported to the Permabrig to await their hearing.
+==Appeals, Parole, Pardons==
+Appeals are handled by the Chief Justice. Attorneys may appeal a past ruling, if presented with new evidence. If the evidence exonerates the Prisoner, their sentence is adjusted as necessary.
+A Prisoner sentenced to a Felony or Grand Felony crime may request an appeal by the Clerk or Chief Justice, these appeals may be denied for any reason.
 
-Additionally, a pardon can be issued to any entity accused of, or sentenced to, crimes, by the arresting officer, the Judge of a trial, or the Warden in the case of those within the permanent brig, if deemed in the best interest of the crew and vessel, and when the circumstances of the defendant or their offense warrant a suspension of their sentence.
+Prisoners may additionally receive parole per discretion of the Warden, Head of Security, or CO. Parolees are encouraged to seek gainful employment on station.
+A pardon may be issued to any sophont accused of, or sentenced to, crimes, if deemed in the best interest of the crew and vessel, and when the circumstances of the defendant or their offense warrant a suspension of their sentence. A pardon may be issued by the Arresting Officer, Warden, in case of the Prisoners or the Judge of a hearing and must be accompanied by an announcement, explaining who was pardoned, of what crime, and for what reason.
 
-=Justice Regulations=
-==Pressing Charges==
-===Criminal Charges===
-Any crew member may press charges against any other crew member. An individual may be charged of a crime if and only if it can be argued beyond a reasonable doubt that the accused had committed an act in the nature and fashion as described by a particular criminal charge.
+==Pressing Criminal Charges==
+Any crew member may press charges against any other crew member. An individual may be charged of a crime, if it can be reasonably argued, that the accused had committed an act in the nature and fashion as described by a particular criminal charge.
 
 Multiple counts of one crime can be charged. For illegal actions against the station abroad, each incident separated by a reasonable period of inaction, lawful conduct, or another crime is interpreted as one count. For crimes directly bereaving a person (violent acts, theft of personal property etc.), the same applies in addition to each victim being one count. In the case of possession, theft, or any incident involving several separate and distinct items, one charge may be applied per relevant item.
 
 Charges that are a direct escalation of one another in nature cannot be simultaneously held against the perpetrator if they pertain to the same incident and the same victim/item (if applicable). Then, only the most severe of these charges applies. Additionally, if one charge incorporates another charge within its definition or description, the perpetrator cannot be held accountable for both; rather, only the most severe of these charges applies.
-===Civil Charges===
-Any crew member can sue any other crew member for inflicting them with damages caused by a breach of duty. To sue is to request compensation for said damages. To do so, the victim must prove:
-*'''Damages:''' That the victim was inflicted with an emotional, physical, or monetary damage
-*'''Breach of duty:''' That the defendant had a duty which they failed to uphold(e.g., a duty to not endanger crew, a duty to act respectfully), leading to the victim being inflicted with a damage
-*'''Severity:''' That the damage was severe enough to warrant the compensation requested
-Compensation can either be explicitly specified by the victim or left for the court to decide. Either way, the court is free to modify the compensation as it sees fit. Most often, compensation is rendered in the form of court orders compelling a crew member to do something (e.g., return an item, make an apology, or permanently avoid a certain area). Court orders should be written and stamped with the notary stamp.
+==Warrants==
+Warrants represent official orders to the security department, issued by the Justice Department. Warrants are only valid when issued by either the Chief Justice or Court Clerk, or in both of their absences, the Commanding Officer or Head of Security.
 
-==Court Orders==
-The individuals specified in the three sections below can issue Court Orders, which are legally-enforced documents that carry the penalty of an Obstruction of Justice charge and forced compliance with the order by security. Each order has its own requirements and authorized issuers, but are all implied to require '''''the stamp (where applicable) and signature of the issuer to be valid.'''''
-===Warrants===
-Warrants represent official orders to the security department, issued by relevant officers or the Justice Department. Warrants are only valid when issued by either the Chief Justice or Court Clerk, or in both of their absences, the Commanding Officer or head of station Security.
-
-* Individual Warrants may order the search or detainment of an individual, or the arrest of the individual with evidence. This may also include surgical procedures, cursory implant inspections, or any other invasive searches with both probable cause and evidence. These warrants should include a name, the actions prescribed (detainment, search, arrest, etc.), and a description if applicable.
+* Individual Warrants may order the search or detainment of an individual, or the arrest of the individual with evidence. This may also include surgical procedures, cursory implant inspections, or any other invasive searches with evidence. These warrants must include a name, the actions prescribed (detainment, search, arrest, etc.), and a description if applicable.
 * Search Warrants may order the search of an entire departmental area, by force if necessary, and may order the arrest of listed individuals implicated in a crime or crimes with probable cause and evidence. Search Warrants should include an area, a brief description of the probable cause, and a list of individuals if applicable.
-
-===Injunctions===
+==Injunctions==
 The Chief Justice, Commanding Officer, or Judge of a trial are fully authorized to issue injunctions: legally-binding, written orders restricting Inhabitants from doing something disruptive to station productivity or personal rights.
-These may be issued on discretion or as relief for Civil Trials. Injunctions may not compel someone to violate Space Law or SOP, and the issuer is liable for abuse of power charges if this is misused. An injunction must include a list of affected names and a detailed description of the restrictions to be valid.
+These may be issued on discretion. Injunctions may not compel someone to violate Space Law or SOP, and the issuer is liable for abuse of power charges if this is misused. An injunction must include a list of affected names and a detailed description of the restrictions to be valid.
+=Hearings=
+NanoTrasen authorizes its Justice Department to conduct Hearings in order to determine if a person accused of a higher crime may be held in indefinite custody, to be handed over to GalPol at the end of the shift.
+The purpose of these hearings is not to determine legally binding guilt, but to measure how feasible their guilt is; and to avoid lawsuits which would tarnish the NanoTrasen brand.
 
-===Subpoenas===
-The Chief Justice, Court Clerk, or Judge of a trial may issue Subpoenas, which are trial-related Court Orders compelling an individual to produce evidence or make themselves present at a location for court. A subpoena can order an individual to:
+Hearings are a tool of Space Law. Like any other action that represents the Law, they are subject to Procedural Defense.
 
-* Appear as a witness, defendant, plaintiff, or prosecution;
-* Produce evidence for a trial;
-* Appear for questioning in deposition.
+A hearing must be held for capital charges, and for sentences that exceed a total of 20 minutes when added together. The right for a hearing may be waived by the suspect by pleading guilty, under martial law, or in absence of any Justice personnel on station.
 
-A subpoena must include a list of names, a detailed description of evidence requested or reason for appearing, and a reasonable time frame no shorter than 3 minutes. The individuals summoned by the subpoena must be informed of its presence for it to be a valid order. This can be done via general announcement, fax, verbal announcement, or otherwise.
+A hearing is conducted by a Judge (chosen in order from: CJ, Clerk, CO, Command), who charged with ensuring the hearing is completed, decides the time and location of the hearing, and whether they want to make the hearing accessible to the public or not. A hearing must include the Judge and Prosecution, and should additionally include the accused and defense, if available. The Judge has the right to find any person in the hearing guilty of contempt of court.
 
-=== Affidavits ===
-An Affidavit is a legal document, consisting of a formal written statement of witness. An Affidavit must be written by the witness, or Affiant, who must state their relation to the incident at hand, and must be signed and stamped (if applicable) by a member of Security, Justice, or Command, who is verifying that the contents of the Affidavit are true to the best of their knowledge. The witness to the Affidavit must not be directly connected to the incident.
+Defense must be provided to the accused if requested and should consist of either an attorney, any member of the justice department, or any sophont chosen by the accused.
+The prosecution should consist of either a prosecutor, any member of the justice department, or any member of station security.
 
-Affidavits are considered valid witness statements for use in a trial (see Trial Procedure, below), and can be used either in tandem with a verbal witness statement, or to obtain testimony from an affiant whose job requirements and/or personal circumstances make attending a trial unfeasible.
+Neither prosecution nor defense may interrupt one another during presentation of evidence, including objecting to witness statements made. In the case of a witness making demonstrably untrue statements, perjury and contempt of court may be charged as necessary. It is encouraged the judge pay attention and inquire about competing claims to truth.
 
-An affidavit may be impeached- and thus removed from evidence- if the Prosecution or Defense can introduce testimony or other evidence that directly contradicts the statements recorded within the Affidavit. The Affiant may then be liable for criminal charges.
+==Conducting the hearing==
+A Hearing should take no longer than 10 minutes, and follows these steps:
 
-=Trial Procedure=
-A trial may be requested for civil disputes and capital charges. Civil charges may be refused, depending on the availability and discretion of a potential Judge; however, capital crimes require a trial. This also includes non-capital trials required as dictated within Sentencing guidelines. Miscellaneous trials, such as those described within Paroles and Pardons, only require the Judge and the defendant.
+0. Prosecution informs the Judge, the Accused and the Defense of all charges. The Accused is asked if they want to plead guilty
+1. The Judge checks whether every required person is present, and begins the hearing.
+2. The Prosecution reads charges.
+3. The Prosecution presents all evidence to support the charges.
+4. The Attorney contests the prosecution's version of events and presents their own evidence.
+5. The Judge rules on whether the suspect reasonably has committed the crime. If the accused is found not guilty of a more severe version of a crime, the Judge may still find them guilty of a less severe version (for example if found not guilty of murder, the accused may be found guilty of manslaughter), despite the crime not being charged.
+6. Any Ruling is enacted; if a party refuses to follow through with the ruling, they may suffer criminal penalties.
 
-Criminal trials may be waived if a suspect pleads guilty to a member of the Justice or Security department, or to station command. Their sentence should be passed by a Judge immediately, without the need for a full hearing. The Judge should also sentence the defendant summarily if they are held in contempt of court during the trial.
-
-The trial takes the form of an arbitration court hearing, presided over by an appointed Judge, and including adequate Prosecution and Defense, as dictated below. All charges, arguments, and evidence must be filed with the Judge before the case begins. The trial shall begin when the Defense, Prosecution, and Judge are all present and ready to begin. A trial does not need to be open to the public.
-
-The Judge is charged with ensuring the trial is completed in a timely manner, and is granted the power to charge someone with Contempt of Court, under Space Law, if they disrupt the case. Suitable Judges should be chosen from the following list, in sequential order:
-
-# The Chief Justice
-# The Clerk
-# An impartial member of the Justice department.
-# An impartial member of Station Command.
-# The Warden.
-
-The Defense should ideally be a member of the Justice department assigned to argue in favor of the defendant; if none are available, the defendant may choose to represent themselves.
-
-The Prosecution should ideally be the Prosecutor; if they are unavailable, the case should be prosecuted by an unbiased member of Station Command or a law enforcement officer, in that order.
-
-If there is not a viable and/or willing Defense or Prosecution, the Judge is fully authorized and strongly encouraged to pass a summary sentence of Extended Confinement until an adequate trial can be held.
-
-==Criminal Trials==
-A criminal case should take no longer than 25 minutes in total. Criminal cases should either have security personnel present, or plan to have them present by the end of the trial.
-:#The judge brings the court in session.
-:#Prosecution opens the proceedings, stating the charges and introducing witnesses and exhibits that will be brought forward during the presentation of evidence. They may also recommend a sentence to the judge, appropriate to the charge based on their opening statement.
-:#Defense enters their plea- Guilty or Not Guilty.
-:#If Guilty, the Judge is authorized to immediately pass a ruling, as stated below.
-:#If Not Guilty, they are to provide their own opening statement and introduce their own witnesses and exhibits where applicable.
-:#Presentation of evidence follows, lead by Prosecution, then Defense.
-:#*Cross-examination may be requested following submission of individual exhibits or witnesses, and granted at the Judge's discretion.
-:#Finally, closing statements are made by the Prosecution, Defense, and Prosecution once more due to burden of proof. No new evidence can be introduced within a closing statement.
-:#A ruling will be issued by the Judge, written down, and stamped with the Notary stamp, the Judge's stamp, and their signature.
-:#The Judge adjourns the court. Any present or soon-to-be-present Security personnel will then enact the ruling.
-
-== Civil Trials ==
-Civil cases do not require Prosecution or Defense, but they may receive assistance from either both before and during the case. Both the defendant and plaintiff must be made to summon at the court, if a party does not appear out of either refusal or negligence, or fails to comply with a court order from a civil trial, that party may be charged with contempt of court, a felony. A civil case involves seeking damages from a defendant, which could be monetary, an item, or otherwise. A civil case should take no longer than 15 minutes in total.
-
-# The Judge brings the court into session.
-# Plaintiff opens proceedings by stating the damages, before introducing witnesses and exhibits that will be brought forward during presentation of evidence. They may also reccomend civil relief to the judge, appropriate to the damages listed wthin their opening statement.
-# Defendant follows with their opening statement, contradicting the Plaintiff's theories and assertions. They will also introduce their own witnesses and exhibits, where applicable.
-# Presentation of evidence follows, led by the Plaintiff, then the Defendant.
-#* Cross-examination may be requested following submission of individual exhibits or witnesses, and granted at the Judge's discretion.
-# Finally, closing statements are made by the Plaintiff, Defense, and Plaintiff once more due to burden of proof. No new evidence should be introduced or referenced by these statements.
-# A ruling will be made by the Judge, written, and stamped by the Notary stamp, the Judge's stamp, and signed by the Judge.
-# The Judge adjourns court.
-
-Any ruling shall then be enacted; if a party refuses to follow through with the ruling, they may suffer criminal penalties.
-
-== Presentation of Evidence ==
-
-===Eyewitness Testimony===
-Any sophont or other entity willing and capable of presenting themselves before court under oath and present at the scene of the crime as a bystander or a victim at the time of its commission, may offer eyewitness testimony before the court at request of defense or prosecution. Extra time may be granted to either side at the behest of the Judge to allow for witnesses not currently present.
-
-===Objection to Testimony===
-Any witness that falls under the following conditions may be excused as a witness or have their testimony deemed inadmissible:
-:*The witness lacks the mental, intellectual, or other capacity to understand the context of the case.
-:*The witness's inclusion will cause substantial cost or delay to the case, proceedings, or upkeep of the station.
-:*The witness is the judge.
-===General Objections===
-Both parties in a trial may object to testimony to have the testimony deemed inadmissible, move past the question, or rephrase a question to keep a trial within time limit:
-:* '''Hearsay:''' The witness testifies using an out-of-court statement by an individual not present in court, thereby rendering it impossible to verify. This testimony will be inadmissible.
-:* '''Asked and answered:''' A question is posed that has already been answered previously by a witness. Such a question must be skipped.
-:* '''Narrative:''' A question is posed that would require a significantly long answer with multiple facts, or when the witness chooses to answer a question in this way. The question must be reworded, or the witness must be reminded to answer promptly and stay on topic.
-
-Objections are completely at the discretion of the judge, who does not always need to sustain an objection even if it is within these guidelines. It is up to the judge to decide if an objection is proper or necessary to keep the trial quick and fair.
-
-==Procedural Defense==
-Whereas a defendant is placed on trial, they are granted the privilege to challenge the legitimacy of charges or claims brought against them by the legal process. Any of the following may be invoked:
-:*Issue Preclusion/Double Jeopardy Clause: accused persons may not be tried on the same charges following an acquittal or conviction, except in the case of acquittal and subsequent credible admission of guilt.
-:*Entrapment Clause: accused persons found to be induced or coerced by law enforcement into the commission of the crimes listed in the charges may be acquitted or have their sentence reduced.
-:*Exclusionary Clause: evidence collected and/or analyzed in violation of accused persons’ rights under law may be inadmissible in court.
+Suspects who are found guilty of a part of the charged crimes, in a way where the total sentence does not exceed 20 minutes, may be released immediately, at the judges discretion.
+A capital sentence should be approved under Space Law.
+The default sentence for suspects guilty of a capital crime is permanent confinement. If there is no doubt of the suspects guilt of a capital crime, or a guilty plea to a capital crime, and the nature of the crime is judged to be extreme and heinous, the Judge is authorized to sentence the prisoner to be executed.
 =Medical Regulations=
 ==Standard of Care==
 

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -192,7 +192,7 @@ Crimes committed against the station or its inhabitants, on station or abroad, a
 
 =Security and Justice Regulations=
 ==Security Jurisdiction==
-Law enforcement personnel are bound by trespass and assault laws, and thus cannot operate outside accessible areas, or perform searches without a Probable Cause, or a warrant. Advanced surgical procedures and cursory implant investigations must be performed by a trained member of the Medical department, operating under their [[Standard Operating Procedure#Standard of Care|Standard of Care]].
+Law enforcement personnel are bound by trespass and assault laws, and thus cannot operate outside accessible areas, or perform searches without a Probable Cause, or a [[Standard Operating Procedure#Warrants|warrant]]. Advanced surgical procedures and cursory implant investigations must be performed by a trained member of the Medical department, operating under their [[Standard Operating Procedure#Standard of Care|Standard of Care]].
 
 However, officers are allowed to trespass into a department in “hot pursuit” of a suspect who has fled from an accessible area, who they have Probable Cause to believe has committed a crime
 
@@ -250,14 +250,14 @@ Should prisoners repeatedly and maliciously antagonize law enforcement, to an ex
 Moreover, prisoners are liable for any and all crimes that they commit while held either in the temporary holding cells or the Permanent Brig, and may, in the case of the Permanent Brig, be placed in solitary confinement for the duration of the sentence the committed crimes incur.
 
 ==Arrest and Sentencing==
-Any sophont, that has been formally charged with the commission of a crime, or can be assumed to have committed a crime under Probable Cause may be arrested by a member of Security. In an arrest, the suspect will be restrained, informed of their charges, and moved to the Brig for processing.
+Any sophont, that has been formally charged with the commission of a crime, or can be assumed to have committed a crime under [[Standard Operating Procedure#Probable Cause]] may be arrested by a member of Security. In an arrest, the suspect will be restrained, informed of their charges, and moved to the Brig for processing.
 Legal counsel may be requested by an Arrestee, and must be provided if available.
-At the brig the prisoner is thoroughly searched and confined to a holding cell. Any items on their person they are not authorized to possess are confiscated and sent to the justice department for processing and storage as evidence. It is the duty of both the Warden and the Chief Justice to ensure evidence is handled properly and safely.
+At the brig the prisoner is searched and confined to a holding cell. Any items on their person they are not authorized to possess are confiscated and sent to the justice department for processing and storage as evidence. It is the duty of both the Warden and the Chief Justice to ensure evidence is handled properly and safely.
 The prisoner is sentenced according to Space Law.
 Any items deemed unbefitting of a prisoner may be taken for the duration of incarceration and must be returned at the end of the sentence.
 Any member of Security is authorized to pass sentences on all Grand Felony, Felony, and Misdemeanor-level crimes. The Chief Justice, or in their absence the Head of Security, is authorized to pass sentences on all Crimes, and to correct, or even acquit them, in accordance with Space Law.
 
-Should the Prisoners sentence exceed a total of 25 minutes, or if the crimes charged include a capital crime, the prisoner is transported to the Permabrig to await their hearing. If after 25 minutes a hearing still has not been conducted, the prisoner is offered to be implanted with a tracking implant andreleased, and to arrive to the hearing when it happens. Failure to attend constitutes contempt of court.
+Should the Prisoners sentence exceed a total of 25 minutes, or if the crimes charged include a capital crime, the prisoner is transported to the Permabrig to await their [[Standard Operating Procedure#Hearings|Hearing]]. If after 25 minutes a hearing still has not been conducted, the prisoner is offered to be implanted with a tracking implant andreleased, and to arrive to the hearing when it happens. Failure to attend constitutes contempt of court.
 ==Appeals, Parole, Pardons==
 Appeals are handled by the Chief Justice. Attorneys may appeal a past ruling on behalf of their client, if presented with new evidence. If the evidence exonerates the Prisoner, their sentence is adjusted as necessary by the Chief Justice.
 A Prisoner sentenced to a Felony or Grand Felony crime may request an appeal by the Clerk or Chief Justice, these appeals may be denied for any reason.
@@ -305,7 +305,7 @@ A Hearing should take no longer than 10 minutes, and follows these steps:
 5. The Judge rules on whether the suspect reasonably has committed the crime. If the accused is found not guilty of a more severe version of a crime, the Judge may still find them guilty of a less severe version (for example if found not guilty of murder, the accused may be found guilty of manslaughter), despite the crime not being charged.
 6. Any Ruling is enacted; if a party refuses to follow through with the ruling, they may suffer criminal penalties.
 
-Suspects who are found guilty of a part of the charged crimes, in a way where the total sentence does not exceed 20 minutes, may be released immediately, at the judges discretion.
+Suspects who are found guilty of a part of the charged crimes, in a way where the total sentence does not exceed 25 minutes, may be released immediately, at the judges discretion.
 A capital sentence should be approved under Space Law.
 The default sentence for suspects guilty of a capital crime is permanent confinement. If there is no doubt of the suspects guilt of a capital crime, or a guilty plea to a capital crime, and the nature of the crime is judged to be extreme and heinous, the Judge is authorized to sentence the prisoner to be executed.
 =Medical Regulations=

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -273,7 +273,7 @@ Charges that are a direct escalation of one another in nature cannot be simultan
 ==Warrants==
 Warrants represent official orders to the security department, issued by the Justice Department. Warrants are only valid when issued by either the Chief Justice or Clerk, or in both of their absences, the Commanding Officer or Head of Security.
 
-* Individual Warrants may order the search or detainment of an individual, or the arrest of the individual with evidence. This may also include surgical procedures, cursory implant inspections, or any other invasive searches with evidence. These warrants must include a name, the actions prescribed (search, arrest, etc.), and a description if applicable.
+* Individual Warrants may order the search of an individual, or the arrest of the individual with evidence. This may also include surgical procedures, cursory implant inspections, or any other invasive searches with evidence. These warrants must include a name, the actions prescribed (search, arrest, etc.), and a description if applicable.
 * Search Warrants may order the search of an entire departmental area, by force if necessary, and may order the arrest of listed individuals implicated in a crime or crimes with probable cause or evidence. Search Warrants should include an area, a brief description of the probable cause, and a list of individuals if applicable.
 ==Injunctions==
 The Chief Justice, Commanding Officer, or Judge of a hearing are fully authorized to issue injunctions: legally-binding, written orders restricting Inhabitants from doing something disruptive to station productivity or personal rights.

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -192,14 +192,14 @@ Crimes committed against the station or its inhabitants, on station or abroad, a
 
 =Security and Justice Regulations=
 ==Security Jurisdiction==
-Law enforcement personnel are bound by trespass and assault laws, and thus cannot operate outside accessible areas, or perform searches without a Probable Cause, a warrant, or a heightened alert level that specifically allows such action. Advanced surgical procedures and cursory implant investigations must be performed by a trained member of the Medical department, operating under their [[Standard Operating Procedure#Standard of Care|Standard of Care]].
+Law enforcement personnel are bound by trespass and assault laws, and thus cannot operate outside accessible areas, or perform searches without a Probable Cause, or a warrant. Advanced surgical procedures and cursory implant investigations must be performed by a trained member of the Medical department, operating under their [[Standard Operating Procedure#Standard of Care|Standard of Care]].
 
 However, officers are allowed to trespass into a department in “hot pursuit” of a suspect who has fled from an accessible area, who they have Probable Cause to believe has committed a crime
 
 ==Probable Cause==
-While actively enforcing the law, officers are held to the standard of Probable Cause. This phrase represents a reasonable suspicion that a crime has been, or is being, committed, and does not require the officer to have solid evidence of criminal activity. Examples of Probable Cause include witnessing criminal activity or credible reports of such.
+While actively enforcing the law, officers are held to the standard of Probable Cause. This phrase represents a reasonable suspicion that a crime has very recently been, or is currently being, committed, and does not require the officer to have solid evidence of criminal activity. Examples of Probable Cause include witnessing criminal activity or credible reports of such.
 
-When judged, Probable Cause is to be interpreted within the context of the entirety of the station’s circumstances at the time of the incident. Probable Cause negates the need of a warrant for searches, and, once concluded, should be promptly reported to the Prosecutor, Warden, or Head of Security for review.
+When judged, Probable Cause is to be interpreted within the context of the entirety of the station’s circumstances at the time of the incident. Probable Cause negates the need of a warrant for searches, and, once concluded, is to be promptly reported to the Prosecutor, Warden, or Head of Security for review.
 == Rules of Engagement ==
 Law enforcement personnel hold a Category D Armaments License, and are authorized at all times to use lethal force to the extent necessary to neutralize adversaries under any of the following circumstances:
 
@@ -214,19 +214,19 @@ Law enforcement personnel hold a Category D Armaments License, and are authorize
 Despite their allowance of lethal force, Security is required to follow the Rules of Engagement of the current Alert Level, as outlined within [[Alert Procedure]].
 
 == Martial Law ==
-Martial Law may only be declared by Central Command. Under Martial Law:
-* Arrests, searches, and departmental raids may be performed at the discretion of security personnel and without a warrant.
-* Security is fully authorised to take whatever actions deemed necessary to neutralise or repel station threats.
-* Security is authorized to summarily execute station threats.
-* Security is no longer bound to the Rules of Engagement.
-* Security is not obligated to provide any medical care to prisoners and detainees, including revival.
+Martial Law may only be declared by Central Command. Under Martial Law Security is:
+* able to perform arrests, searches, and departmental raids at their discretion and without a warrant.
+* authorised to take whatever actions deemed necessary to neutralise or repel station threats.
+* authorized to summarily execute station threats.
+* not bound to the Rules of Engagement.
+* not obligated to provide any medical care to prisoners and detainees, including revival.
 
 == Armory Procedure ==
 The armory and its usage are governed by the Warden. The Warden is responsible for stocking, distributing, and recording the collection of weapons used by the station during the shift. They are also afforded the authority to arm security at their discretion, so long as the weaponry distributed is in appropriate response to [[Alert Procedure]].
 
 All weaponry distributed from armory is issued on a temporary basis. While issued, the weaponry remains as station property, and the wielder assumes a duty to protect the weapon and return it to the Warden when ordered. No non-crew may be issued weaponry from the armory.
 
-The Warden is accountable for responsibly issuing weapons. Any weaponry issued during a heightened alert level must be returned when the alert has been lowered, or when the threat is no longer present. The weaponry issued must be proportionate to the threat posed, and explosives should not be used unless absolutely necessary.
+The Warden is accountable for responsibly issuing weapons. Any weaponry issued during a heightened alert level must be returned when the alert has been lowered, or when the threat is no longer present. The weaponry issued must be proportionate to the threat posed, and weapons which threaten the structural integrity of the station should not be used unless absolutely necessary.
 ==Treatment of Prisoners==
 Prisoners have certain rights that must be upheld by law enforcement and Station Command. ''Prisoners must be provided with the following'':
 
@@ -241,55 +241,55 @@ Prisoners have certain rights that must be upheld by law enforcement and Station
 
 Additionally, prisoners sentenced to Extended Confinement have certain rights but also '''more firm restrictions that must be upheld by law enforcement''':
 
-* Visitation may be permitted only for prisoners sentenced to Extended Confinement. One person may visit such a prisoner for a period of no longer than ten minutes. A reason must be provided for the visit, and the visitor must consent to a search of their belongings. The prisoner is then unable to receive another visitor for another ten minutes.
-* Prisoners may request retrial for capital crimes; these requests may be refused depending on the discretion and availability of the court clerk, chief justice, or at the discretion of the warden or head of station security.
-* Prisoners may request or may otherwise be given parole with a hearing by the Chief Justice, Court Clerk, or in their absence, the head of station security or commanding officer (see Paroles and Pardons).
+* Visitation may be permitted only for prisoners sentenced to Extended Confinement. A reason must be provided for the visit, and the visitor must consent to a search of their belongings.
+* Prisoners may request an appeal for capital crimes; these requests may be refused depending on the discretion and availability of the Clerk, Chief Justice, or at the discretion of the warden or head of station security.
+* Prisoners may request or may otherwise be given parole by the Warden or Head of Security.
 
 Should prisoners repeatedly and maliciously antagonize law enforcement, to an extent where continued extended confinement becomes infeasible, the warden is fully authorized and encouraged to upgrade the relevant prisoners’ sentences to Exfiltration summarily.
 
-Moreover, prisoners are liable for any and all crimes that they commit while held either in the temporary holding cells or the Permanent Brig, and may receive trial for more restrictive punishments if their actions warrant a capital sentence.
+Moreover, prisoners are liable for any and all crimes that they commit while held either in the temporary holding cells or the Permanent Brig, and may, in the case of the Permanent Brig, be placed in solitary confinement for the duration of the sentence the committed crimes incur.
 
 ==Arrest and Sentencing==
 Any sophont, that has been formally charged with the commission of a crime, or can be assumed to have committed a crime under Probable Cause may be arrested by a member of Security. In an arrest, the suspect will be restrained, informed of their charges, and moved to the Brig for processing.
 Legal counsel may be requested by an Arrestee, and must be provided if available.
-At the brig, prisoner is thoroughly searched and confined to a holding cell. Any items on their person they are not authorized to possess are confiscated and sent to the justice department for processing and storage as evidence. It is the duty of both the Warden and the Chief Justice to ensure evidence is handled properly and safely.
+At the brig the prisoner is thoroughly searched and confined to a holding cell. Any items on their person they are not authorized to possess are confiscated and sent to the justice department for processing and storage as evidence. It is the duty of both the Warden and the Chief Justice to ensure evidence is handled properly and safely.
 The prisoner is sentenced according to Space Law.
 Any items deemed unbefitting of a prisoner may be taken for the duration of incarceration and must be returned at the end of the sentence.
-Any member of Security is authorized to pass sentences on all Grand Felony, Felony, and Misdemeanor-level crimes. The Chief Justice is authorized to pass sentences on all Crimes, and to correct, or even acquit them, in accordance with Space Law.
+Any member of Security is authorized to pass sentences on all Grand Felony, Felony, and Misdemeanor-level crimes. The Chief Justice, or in their absence the Head of Security, is authorized to pass sentences on all Crimes, and to correct, or even acquit them, in accordance with Space Law.
 
-Should the Prisoners sentence exceed a total of 20 minutes, or if the crimes charged include a capital crime, the prisoner is transported to the Permabrig to await their hearing.
+Should the Prisoners sentence exceed a total of 25 minutes, or if the crimes charged include a capital crime, the prisoner is transported to the Permabrig to await their hearing. If after 25 minutes a hearing still has not been conducted, the prisoner is offered to be implanted with a tracking implant andreleased, and to arrive to the hearing when it happens. Failure to attend constitutes contempt of court.
 ==Appeals, Parole, Pardons==
-Appeals are handled by the Chief Justice. Attorneys may appeal a past ruling, if presented with new evidence. If the evidence exonerates the Prisoner, their sentence is adjusted as necessary.
+Appeals are handled by the Chief Justice. Attorneys may appeal a past ruling on behalf of their client, if presented with new evidence. If the evidence exonerates the Prisoner, their sentence is adjusted as necessary by the Chief Justice.
 A Prisoner sentenced to a Felony or Grand Felony crime may request an appeal by the Clerk or Chief Justice, these appeals may be denied for any reason.
 
-Prisoners may additionally receive parole per discretion of the Warden, Head of Security, or CO. Parolees are encouraged to seek gainful employment on station.
-A pardon may be issued to any sophont accused of, or sentenced to, crimes, if deemed in the best interest of the crew and vessel, and when the circumstances of the defendant or their offense warrant a suspension of their sentence. A pardon may be issued by the Arresting Officer, Warden, in case of the Prisoners or the Judge of a hearing and must be accompanied by an announcement, explaining who was pardoned, of what crime, and for what reason.
-
+Prisoners may additionally receive parole per discretion of the Warden, Head of Security, or CO. Parolees are encouraged to seek gainful employment on station. Parolees may have any sentence escalated to permanent confinement regardless of severity.
+A pardon may be issued to any sophont accused of, or sentenced to, crimes, if deemed in the best interest of the crew and vessel, and when the circumstances of the defendant or their offense warrant a suspension of their sentence. A pardon may be issued by the Arresting Officer or Warden, in case of the Prisoners, or the Judge of a hearing and must be accompanied by an announcement, explaining who was pardoned, of what crime, and for what reason.
 ==Pressing Criminal Charges==
-Any crew member may press charges against any other crew member. An individual may be charged of a crime, if it can be reasonably argued, that the accused had committed an act in the nature and fashion as described by a particular criminal charge.
+Any crew member may press charges against any other crew member. An individual may be charged of a crime, if it can be reasonably argued, that the accused has committed an act in the nature and fashion as described by the particular criminal charge.
 
 Multiple counts of one crime can be charged. For illegal actions against the station abroad, each incident separated by a reasonable period of inaction, lawful conduct, or another crime is interpreted as one count. For crimes directly bereaving a person (violent acts, theft of personal property etc.), the same applies in addition to each victim being one count. In the case of possession, theft, or any incident involving several separate and distinct items, one charge may be applied per relevant item.
 
 Charges that are a direct escalation of one another in nature cannot be simultaneously held against the perpetrator if they pertain to the same incident and the same victim/item (if applicable). Then, only the most severe of these charges applies. Additionally, if one charge incorporates another charge within its definition or description, the perpetrator cannot be held accountable for both; rather, only the most severe of these charges applies.
 ==Warrants==
-Warrants represent official orders to the security department, issued by the Justice Department. Warrants are only valid when issued by either the Chief Justice or Court Clerk, or in both of their absences, the Commanding Officer or Head of Security.
+Warrants represent official orders to the security department, issued by the Justice Department. Warrants are only valid when issued by either the Chief Justice or Clerk, or in both of their absences, the Commanding Officer or Head of Security.
 
-* Individual Warrants may order the search or detainment of an individual, or the arrest of the individual with evidence. This may also include surgical procedures, cursory implant inspections, or any other invasive searches with evidence. These warrants must include a name, the actions prescribed (detainment, search, arrest, etc.), and a description if applicable.
-* Search Warrants may order the search of an entire departmental area, by force if necessary, and may order the arrest of listed individuals implicated in a crime or crimes with probable cause and evidence. Search Warrants should include an area, a brief description of the probable cause, and a list of individuals if applicable.
+* Individual Warrants may order the search or detainment of an individual, or the arrest of the individual with evidence. This may also include surgical procedures, cursory implant inspections, or any other invasive searches with evidence. These warrants must include a name, the actions prescribed (search, arrest, etc.), and a description if applicable.
+* Search Warrants may order the search of an entire departmental area, by force if necessary, and may order the arrest of listed individuals implicated in a crime or crimes with probable cause or evidence. Search Warrants should include an area, a brief description of the probable cause, and a list of individuals if applicable.
 ==Injunctions==
 The Chief Justice, Commanding Officer, or Judge of a trial are fully authorized to issue injunctions: legally-binding, written orders restricting Inhabitants from doing something disruptive to station productivity or personal rights.
 These may be issued on discretion. Injunctions may not compel someone to violate Space Law or SOP, and the issuer is liable for abuse of power charges if this is misused. An injunction must include a list of affected names and a detailed description of the restrictions to be valid.
 =Hearings=
-NanoTrasen authorizes its Justice Department to conduct Hearings in order to determine if a person accused of a higher crime may be held in indefinite custody, to be handed over to GalPol at the end of the shift.
+NanoTrasen authorizes its Justice Department to conduct Hearings in order to determine if a person accused of sufficient crimes may be held in indefinite custody, to be handed over to GalPol at the end of the shift.
 The purpose of these hearings is not to determine legally binding guilt, but to measure how feasible their guilt is; and to avoid lawsuits which would tarnish the NanoTrasen brand.
 
-Hearings are a tool of Space Law. Like any other action that represents the Law, they are subject to Procedural Defense.
+Hearings are a tool of Space Law. Like any other action that represents the Law, they are subject to Procedural Defense as detailed in Space Law.
 
-A hearing must be held for capital charges, and for sentences that exceed a total of 20 minutes when added together. The right for a hearing may be waived by the suspect by pleading guilty, under martial law, or in absence of any Justice personnel on station.
+A hearing must be held for capital charges, and for sentences that exceed a total of 25 minutes when added together. The right for a hearing may be waived by the suspect by pleading guilty, under martial law, or in absence of any Justice personnel on station.
 
-A hearing is conducted by a Judge (chosen in order from: CJ, Clerk, CO, Command), who charged with ensuring the hearing is completed, decides the time and location of the hearing, and whether they want to make the hearing accessible to the public or not. A hearing must include the Judge and Prosecution, and should additionally include the accused and defense, if available. The Judge has the right to find any person in the hearing guilty of contempt of court.
+A hearing is conducted by a Judge (chosen in order from: Chief Justice, Clerk, Commanding Officer, Command), who charged is with ensuring the hearing is completed, decides the time and location of the hearing, and whether they want to make the hearing accessible to the public or not. A hearing must include the Judge and Prosecution, and should additionally include the accused and defense, if available. The Judge has the right to find any person in the hearing guilty of contempt of court.
+Hearings are concerned with any and all crimes the accused is currently charged with, not just capital crimes.
 
-Defense must be provided to the accused if requested and should consist of either an attorney, any member of the justice department, or any sophont chosen by the accused.
+Defense must be provided to the accused if requested and feasible, and should consist of either an attorney, any member of the justice department, or any sophont chosen by the accused.
 The prosecution should consist of either a prosecutor, any member of the justice department, or any member of station security.
 
 Neither prosecution nor defense may interrupt one another during presentation of evidence, including objecting to witness statements made. In the case of a witness making demonstrably untrue statements, perjury and contempt of court may be charged as necessary. It is encouraged the judge pay attention and inquire about competing claims to truth.
@@ -297,9 +297,9 @@ Neither prosecution nor defense may interrupt one another during presentation of
 ==Conducting the hearing==
 A Hearing should take no longer than 10 minutes, and follows these steps:
 
-0. Prosecution informs the Judge, the Accused and the Defense of all charges. The Accused is asked if they want to plead guilty
-1. The Judge checks whether every required person is present, and begins the hearing.
-2. The Prosecution reads charges.
+0. Prosecution informs the Judge, the Accused and the Defense of all charges. The Accused is asked if they want to plead guilty.
+1. The Judge confirms that every required person is present, and begins the hearing.
+2. The Prosecution reads the charges. Any crimes not charged are not subject to the hearing and cannot be accounted for in sentencing.
 3. The Prosecution presents all evidence to support the charges.
 4. The Attorney contests the prosecution's version of events and presents their own evidence.
 5. The Judge rules on whether the suspect reasonably has committed the crime. If the accused is found not guilty of a more severe version of a crime, the Judge may still find them guilty of a less severe version (for example if found not guilty of murder, the accused may be found guilty of manslaughter), despite the crime not being charged.


### PR DESCRIPTION
## About the PR
reduced sec and justice regulations from 4100 words to 2600 words
replaced criminal trials with shorter, less thorough hearings
removed civil trials
moved Procedural Defense to Space Law
essentially rewrote the following sections of SoP:
Security:
- Detainment and Arrest
- Brig Procedure
- Sentencing
- Evidence Handling
- Paroles and Pardons

Justice:
- Charges
- Court Orders
- Trials
- Presentation of Evidence
 
## Why / Balance
The justice department is a unique aspect of Delta V i cherish very much. The department has been designed around conducting trials, however it was an open secret that trials do not work and have a host of problems:
Justice does not have the autonomy necessary to make trials happen. What this means is that Justice is reliant on other departments to even attempt to do their jobs.
Justice has no way to enforce their rulings: Justice is completely at the mercy of securitys goodwill, said goodwill is in very sparse supply. As a department justice is de facto alligned with Security and as such unable to prosecute them, even in cases where Justice wants to prosecute them, the lack of stun batons in CJ's office prevents such a feat.

The original intention of trials is unfitting for the kind of game Delta V's SS14 is. Trials require a massive amount of setup and require a large number of willing participants with little interuptions. Trials in real life take months to years, trials in SS14 are supposed to take 30 minutes. The conditions to have a fruitful trial are not present.
Trials take too long to set up, Trials take too long to be resolved. The results of trials happen so late into the round they may aswell not have happened at all. 

Due to justices severe lack of agency, and justices inability to be anything other than a tider under heavy RP rules on shifts that were not Traitor shifts (as in, the majority of the rounds), The justice department has suffered from heavy player attrition. It is not uncommon to see justice almost, or completely, empty.
Despite the fact that the department is often empty, the legal framework for trials still informed all security/antag interactions. This frankly was and is not fun for either party. Security needs to pretend there will be a trial eventually, and the antag has to decide if they want to hope a CJ decides to exit cryo and flip a coin on whether they get walled by Security.

As such, trials are being killed so that the idea can survive: The idea that security does atleast need some kind of evidence in order to RR you by throwing you into perma until the end of the round. Hearings serve the purpose of checking if security has the right guy. Hearings serve the purpose of hopefully training secoffs to not crumble under such hardball questions as 'what is that guy in for' and 'do we have literally any proof of that'. 

Replacing trials with hearings is the first step to focus our security department, to retool justice into a department more concerned with internal oversight, while giving it the tools necessary to actually do their job, and to enhance antags interactions with the security and with our beloved SLOP.

## Technical details
_wiki changes



**Changelog**

:cl:
- remove: removed Trials
- add: added hearings, a quicker way to check if you have the right guy
- remove: you can no longer 'detain' people. Just put the cuffs on them.
- add: being coerced into crime is now a legal defense
- add: Procedural Defense is now a right outside of trial
- add: Permanent Prisoners may now receive solitary confinement as a punishment
- add: Permanent Prisoners pending a hearing may be released after being implanted with a tracker
- remove: removed decorp as a valid capital sentence
- remove: civil trials are no longer spelled out in SoP, doesnt mean you can't do them anymore though.
- tweak: evidence now is secured in the Justice department
- tweak: and much more, re-read the "Security and Justice Regulations" in SoP, i promise its shorter now.

