### PR TITLE
Increase entropic colossus' melee damage

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -203,9 +203,9 @@
     range: 2
     damage:
       types:
-        Blunt: 25
-        Asphyxiation: 5
-        Cold: 5
+        Blunt: 35
+        Asphyxiation: 10
+        Cold: 10
         Structural: 60
     soundHit:
       path: /Audio/_DV/CosmicCult/cosmicsword_glance.ogg


### PR DESCRIPTION
## About the PR
Entropic colossus melee damage has been increased from 25 blunt + 5 cold + 5 asphyx to 35 blunt + 10 cold + 10 asphyx. Structural damage not changed (60)

## Why / Balance
Smashing things very hard is pretty much the only thing a colossus can do, besides it's AOE attack, which has a rather long cooldown. You'd expect a thing whose sole job is to punch things hard to, well, punch things hard. However, it's damage per second current;y is **worse than a baseball bat** thanks to having 0.425 attack speed. And that's a midround antag associated with the cosmic cult, who have some of the best melee weapons in the game. And it's also very slow, so it's rather easy to just... not get hit by it. The proposed values still put it at lower DPS than cult weapons, but perhaps the highest damage per swing in the game (not counting admemery), which means that you **really** don't want to stand close to an agressive colossus, because most armors (again, not counting admemes) would allow you to survive 4 hits at best (or slightly more if you're an IPC).

## Technical details
YAML ops

## Media
Numbers change

## Requirements
- [ ] I have tested all added content and changes. (Numbers change)
- [ ] I have added media to this PR or it does not require an ingame showcase. (Numbers change)

**Changelog**
:cl:
- tweak: Entropic colossus' melee damage has been buffed.