### PR TITLE
Fix colossus healing

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
@@ -276,8 +276,6 @@
     primeTime: 5
   - type: InstantAction
     event: !type:EventCosmicColossusHibernate {}
-  - type: LimitedCharges
-    maxCharges: 2
 
 - type: entity
   id: ActionCosmicColossusEffigy


### PR DESCRIPTION
## About the PR
Colossus healing has unlimited charges again

## Why / Balance
They were removed in #4133, then brought back by commit 980bc05 (judging by commit history, even though said commit doesn't seem to add those 2 lines :/)
No idea why, commit doesn't even have a PR linked and is seemingly realted to upstream merge. Most likely unintended.

## Technical details
Remove 2 lines

## Media
No

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
Not really
