### PR TITLE
Give mantis locker mindbreaker pills

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
@@ -23,6 +23,8 @@
       # - id: ClothingOuterCoatMantis
       - id: ClothingOuterWinterCoatMantis
       # - id: ClothingEyesGlassesSunglasses
+      - id: PillMindbreakerToxin # DeltaV - non-loadout mindbreaker available
+        amount: 2
       # Insulative headgear
       - id: ClothingHeadTinfoil
       - id: ClothingHeadCage


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Mantis locker now has two mindbreaker pills.

## Why / Balance
i am honestly surprised it didn't have this already, instead mantis just gets a singular pill in their job loadout. with this change, promoted manti and unfortunate mystagogues now have the ability to mindbreak people WITHOUT using a gun.

## Technical details
yamlops 
~~this is how i learn that 16gb of ram is not enough for ss14 development~~

## Media
no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Mantises now get two mindbreaker pills in their locker.
