### PR TITLE
Make anti-psionic ammo not require bluespace

### DIFF
--- a/Resources/Prototypes/_DV/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/security.yml
@@ -88,7 +88,6 @@
   materials:
     Plastic: 1250
     Steel: 75
-    Bluespace: 75
 
 - type: latheRecipe
   parent: BaseAmmoRecipe
@@ -97,7 +96,6 @@
   materials:
     Plastic: 300
     Steel: 200
-    Bluespace: 200
     Glass: 100
 
 # Tools


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Soulbreaker and mindbreaker rounds no longer require bluespace to print from a secfab.

## Why / Balance
\>be me, mystagogue, sole epi member
\>awake from an unfortunate [environmental disruption induced](https://discord.com/channels/968983104247185448/968983104951836742/1404022501058547733) surgery, glimmer 700 and rising, oshit.jpg
\>mantis took everything out of the locker and cryo'd with it (awesome), medical is only like three people so chem won't be fast enough
\>run to security with nothing but a jumpsuit PDA and headset, "AI CODE WHITE"
\>bust through security door right as code white is announced, "WARDEN I NEEDSSS A SSSHOTGUN AND SSSOULBREAKER ROUNDSSS ASSSAP", about to become the first person ever to use soulbreaker rounds
\>"sorry boss we need bluespace for that"
\>"you needsss WHAT"

why does it even need bluespace in the first place ! easily the most useless ammo type, already locked behind T2 research, only printable from a secfab, and it needs BLUESPACE???

that being said, if we ever get a psionic antag (when i code it :godo:) this change might be worth reverting. but as-is, this is a good change i think. makes mantis' job a lot easier (good luck forcing somebody to swallow a pill without a disabler) and gives all of epi more options in emergencies

## Technical details
yamlops

## Media
it works trust

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Anti-psionic ammunition no longer requires bluespace crystals to manufacture.
