### PR TITLE
Bugfix station beacons not showing up on map

### DIFF
--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -170,13 +170,15 @@ public sealed partial class NavMapSystem : SharedNavMapSystem
 
     private void OnNavMapBeaconMapInit(EntityUid uid, NavMapBeaconComponent component, MapInitEvent args)
     {
+        // DeltaV - start of beacon map bugfix
         if (component.DefaultText == null || component.Text != null)
         {
             // temporary fix until issue is resolved upstream:
             // https://github.com/space-wizards/space-station-14/issues/37691
-            UpdateNavMapBeaconData(uid, component); // DeltaV
+            UpdateNavMapBeaconData(uid, component);
             return;
         }
+        // DeltaV - end of beacon map bugfix
 
         component.Text = Loc.GetString(component.DefaultText);
         Dirty(uid, component);

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -170,17 +170,18 @@ public sealed partial class NavMapSystem : SharedNavMapSystem
 
     private void OnNavMapBeaconMapInit(EntityUid uid, NavMapBeaconComponent component, MapInitEvent args)
     {
-        // DeltaV - start of beacon bugfix
-        // function reworked as a temporary fix until issue is resolved upstream:
-        // https://github.com/space-wizards/space-station-14/issues/37691
-        if (component.Text == null && component.DefaultText != null) 
+        if (component.DefaultText == null || component.Text != null)
         {
-            component.Text = Loc.GetString(component.DefaultText);
-            Dirty(uid, component);
+            // temporary fix until issue is resolved upstream:
+            // https://github.com/space-wizards/space-station-14/issues/37691
+            UpdateNavMapBeaconData(uid, component); // DeltaV
+            return;
         }
 
+        component.Text = Loc.GetString(component.DefaultText);
+        Dirty(uid, component);
+
         UpdateNavMapBeaconData(uid, component);
-        // DeltaV - end of beacon bugfix
     }
 
     private void OnNavMapBeaconAnchor(EntityUid uid, NavMapBeaconComponent component, ref AnchorStateChangedEvent args)

--- a/Content.Server/Pinpointer/NavMapSystem.cs
+++ b/Content.Server/Pinpointer/NavMapSystem.cs
@@ -170,13 +170,17 @@ public sealed partial class NavMapSystem : SharedNavMapSystem
 
     private void OnNavMapBeaconMapInit(EntityUid uid, NavMapBeaconComponent component, MapInitEvent args)
     {
-        if (component.DefaultText == null || component.Text != null)
-            return;
-
-        component.Text = Loc.GetString(component.DefaultText);
-        Dirty(uid, component);
+        // DeltaV - start of beacon bugfix
+        // function reworked as a temporary fix until issue is resolved upstream:
+        // https://github.com/space-wizards/space-station-14/issues/37691
+        if (component.Text == null && component.DefaultText != null) 
+        {
+            component.Text = Loc.GetString(component.DefaultText);
+            Dirty(uid, component);
+        }
 
         UpdateNavMapBeaconData(uid, component);
+        // DeltaV - end of beacon bugfix
     }
 
     private void OnNavMapBeaconAnchor(EntityUid uid, NavMapBeaconComponent component, ref AnchorStateChangedEvent args)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixed a bug that was preventing some station beacons from showing up on the station map screens for the entire round. This especially affected custom-named station beacons.

Reviewers may want to audit [the list of **newly-visible beacons**](https://docs.google.com/document/d/13d69jt6kXtBfIZ70D4SlsF11ZNmJjB3Z4Gb8dlqVTiE/edit?usp=sharing) that were placed but previously invisible. Some beacon names may deserve a change (e.g., on Elegance, I've already removed some duplicate beacons, and do we really want a room named "Admin Ass. Office"?)

## Why / Balance
Map makers intended these beacons to be visible on the map. This facilitates players' exploration of our unique DeltaV map features (I had never heard of Hive's Bomb Testing or Lighthouse's Laser Tag before).

## Technical details
UpdateNavMapBeaconData is now called after every beacon's initialization, rather than just some, to ensure the map system updates itself (by calling Dirty) at least once after all beacons are initialized.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
The list of newly visible beacons on every map is shown in text and image form on [this commentable google doc](https://docs.google.com/document/d/13d69jt6kXtBfIZ70D4SlsF11ZNmJjB3Z4Gb8dlqVTiE/edit?usp=sharing).

As an example:

**Arena, before the bugfix:**

<img width="668" height="689" alt="arena_before" src="https://github.com/user-attachments/assets/59ec00cd-961b-4316-8804-38f7d1ecb001" />

**Arena, after the bugfix:**
(I've marked newly-revealed beacons with a green star)

<img width="1460" height="688" alt="arena" src="https://github.com/user-attachments/assets/47d5165d-5517-451f-9998-3280e088f8ad" />

(the _arena itself_ was missing from the map, lol)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed custom-named station beacons sometimes not being shown on the station map UIs.
