### PR TITLE
Bugfix: IK-30 spread issues and dev configuration assertion crashes

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -256,6 +256,9 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: GunRequiresWield
+  - type: GunWieldBonus
+    minAngle: 0
+    maxAngle: 0
   - type: Gun
     fireRate: 1.5
     minAngle: 1


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixed the IK-30 spread bug when the weapon is wielded

## Technical details
<!-- Summary of code changes for easier review. -->
It inherits from BaseGunWieldable, which by default has a GunWieldBonusComponent
```yaml
  - type: GunWieldBonus
    minAngle: -20
    maxAngle: -30
```

The issue is that SharedWieldableSystem literally adds these values onto the base values:
```cs
private void OnGunRefreshModifiers(Entity<GunWieldBonusComponent> bonus, ref GunRefreshModifiersEvent args)
{
    if (TryComp(bonus, out WieldableComponent? wield) &&
        wield.Wielded)
    {
        args.MinAngle += bonus.Comp.MinAngle;
        args.MaxAngle += bonus.Comp.MaxAngle;
        args.AngleDecay += bonus.Comp.AngleDecay;
        args.AngleIncrease += bonus.Comp.AngleIncrease;
    }
}
```

The IK-30 (and the IK-60 inheriting from it) had a base minAngle of 1 and maxAngle of 4, causing these values to be negative, with maxAngle being smaller than minAngle.

I fixed it by simply adding a GunWieldBonus with 0-0 angles to the IK-30. The other alternative is to rework BaseGunWieldable but it's upstream territory.

A test should probably be written to scan for occurrences of this bug, since it's really easy to accidentally run into. But that should probably be done upstream.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed IK-30 and IK-60 spread glitches when wielded

