### PR TITLE
Twek IK-30 some more

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -255,11 +255,13 @@
     sprite: _DV/Objects/Weapons/Guns/Rifles/lasercarbine.rsi
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
-  - type: GunRequiresWield
+  - type: GunWieldBonus
+    minAngle: -28
+    maxAngle: -34
   - type: Gun
     fireRate: 1.5
-    minAngle: 1
-    maxAngle: 4
+    minAngle: 30
+    maxAngle: 40
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
## About the PR
IK-30 no longer requires weilding. IK-30's accuracy when weilded has been adjusted to actually make the gun **more** accurate when weilded (has very awful accuracy when not weilded, so weilding is still pretty much required).

## Why / Balance
For the longest time it was bugged, and weilding it actually made it **less** accurate. Then the nerf came, forcing everyone to weild it, which in turn made the weapon practicaly unusable. Now it actually behaves like any other gun.

## Technical details
YAML ops

## Media
Numbers change

## Requirements
Numbers change

**Changelog**
:cl:
- tweak: The IK-30 no longer requires weilding.
- fix: IK-30 now actually becomes more accurate when weilded instead of becoming less accurate.
