### PR TITLE
Make malign rifts actually (kinda) dangerous

### DIFF
--- a/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
@@ -35,13 +35,19 @@ public sealed partial class CosmicMalignRiftComponent : Component
     public TimeSpan MinPulseTime = TimeSpan.FromSeconds(20);
 
     [DataField]
-    public TimeSpan MaxPulseTime = TimeSpan.FromSeconds(80);
+    public TimeSpan MaxPulseTime = TimeSpan.FromSeconds(60);
 
     [DataField]
     public float PulseRange = 15f;
+    /// <summary>
+    /// The chance for each entity in range to be affected by a pulse
+    /// </summary>
+    [DataField]
+    public float PulseProb = 0.75f;
 
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextPulseTime = default!;
 
-    [DataField] public EntProtoId PulseVFX = "CosmicGenericVFX";
+    [DataField]
+    public EntProtoId PulseVFX = "CosmicGenericVFX";
 }

--- a/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
@@ -5,6 +5,7 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Server._DV.CosmicCult.Components;
 
 [RegisterComponent]
+[AutoGenerateComponentPause]
 public sealed partial class CosmicMalignRiftComponent : Component
 {
     [DataField]
@@ -45,7 +46,7 @@ public sealed partial class CosmicMalignRiftComponent : Component
     [DataField]
     public float PulseProb = 0.75f;
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    [AutoPausedField, DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextPulseTime = default!;
 
     [DataField]

--- a/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
@@ -1,5 +1,6 @@
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Server._DV.CosmicCult.Components;
 
@@ -29,4 +30,18 @@ public sealed partial class CosmicMalignRiftComponent : Component
 
     [DataField]
     public TimeSpan AbsorbTime = TimeSpan.FromSeconds(35);
+
+    [DataField]
+    public TimeSpan MinPulseTime = TimeSpan.FromSeconds(20);
+
+    [DataField]
+    public TimeSpan MaxPulseTime = TimeSpan.FromSeconds(80);
+
+    [DataField]
+    public float PulseRange = 15f;
+
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextPulseTime = default!;
+
+    [DataField] public EntProtoId PulseVFX = "CosmicGenericVFX";
 }

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -29,7 +29,7 @@ public sealed class CosmicRiftSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     private readonly HashSet<Entity<HumanoidAppearanceComponent>> _humanoids = [];
-    
+
     private EntityQuery<CosmicCultComponent> _cultistsQuery;
     private EntityQuery<BibleUserComponent> _chaplainsQuery;
 
@@ -41,7 +41,7 @@ public sealed class CosmicRiftSystem : EntitySystem
         SubscribeLocalEvent<CosmicCultComponent, EventAbsorbRiftDoAfter>(OnAbsorbDoAfter);
         SubscribeLocalEvent<CosmicMalignRiftComponent, EventPurgeRiftDoAfter>(OnPurgeDoAfter);
         SubscribeLocalEvent<CosmicMalignRiftComponent, ComponentInit>(OnRiftStarted);
-        
+
         _cultistsQuery = GetEntityQuery<CosmicCultComponent>();
         _chaplainsQuery = GetEntityQuery<BibleUserComponent>();
     }

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -48,7 +48,7 @@ public sealed class CosmicRiftSystem : EntitySystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
-        
+
         var query = EntityQueryEnumerator<CosmicMalignRiftComponent>();
         while (query.MoveNext(out var uid, out var comp))
         {

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -63,6 +63,7 @@ public sealed class CosmicRiftSystem : EntitySystem
                 foreach(var humanoid in _humanoids)
                 {
                     if (!pos.TryDistance(EntityManager, Transform(humanoid).Coordinates, out var distance)) continue;
+                    if (!_random.Prob(comp.PulseProb)) continue;
                     var damageMultiplier = Math.Clamp(comp.PulseRange / distance, 1, 10); //0.2 damage per second at max distance, up to 2 per second if closer
                     var effectDuration = _random.Next(10, 40); //2-8 damage at max distance, 20-80 damage at min distance
                     _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(humanoid, "EntropicDegen", TimeSpan.FromSeconds(effectDuration), true);

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -29,6 +29,9 @@ public sealed class CosmicRiftSystem : EntitySystem
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     private readonly HashSet<Entity<HumanoidAppearanceComponent>> _humanoids = [];
+    
+    private EntityQuery<CosmicCultComponent> _cultistsQuery;
+    private EntityQuery<BibleUserComponent> _chaplainsQuery;
 
     public override void Initialize()
     {
@@ -38,6 +41,9 @@ public sealed class CosmicRiftSystem : EntitySystem
         SubscribeLocalEvent<CosmicCultComponent, EventAbsorbRiftDoAfter>(OnAbsorbDoAfter);
         SubscribeLocalEvent<CosmicMalignRiftComponent, EventPurgeRiftDoAfter>(OnPurgeDoAfter);
         SubscribeLocalEvent<CosmicMalignRiftComponent, ComponentInit>(OnRiftStarted);
+        
+        _cultistsQuery = GetEntityQuery<CosmicCultComponent>();
+        _chaplainsQuery = GetEntityQuery<BibleUserComponent>();
     }
 
     private void OnRiftStarted(Entity<CosmicMalignRiftComponent> ent, ref ComponentInit args)
@@ -58,7 +64,7 @@ public sealed class CosmicRiftSystem : EntitySystem
             var pos = Transform(uid).Coordinates;
             Spawn(comp.PulseVFX, pos);
             _lookup.GetEntitiesInRange<HumanoidAppearanceComponent>(pos, comp.PulseRange, _humanoids);
-            _humanoids.RemoveWhere(target => HasComp<BibleUserComponent>(target) || HasComp<CosmicCultComponent>(target));
+            _humanoids.RemoveWhere(target => _chaplainsQuery.HasComp<BibleUserComponent>(target) || _cultistsQuery.HasComp<CosmicCultComponent>(target));
             foreach(var humanoid in _humanoids)
             {
                 if (!pos.TryDistance(EntityManager, Transform(humanoid).Coordinates, out var distance)) continue;

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -6,10 +6,14 @@ using Content.Server.Popups;
 using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.DoAfter;
+using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server._DV.CosmicCult.EntitySystems;
 
@@ -19,6 +23,12 @@ public sealed class CosmicRiftSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+
+    private readonly HashSet<Entity<HumanoidAppearanceComponent>> _humanoids = [];
 
     public override void Initialize()
     {
@@ -27,6 +37,39 @@ public sealed class CosmicRiftSystem : EntitySystem
         SubscribeLocalEvent<CosmicMalignRiftComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<CosmicCultComponent, EventAbsorbRiftDoAfter>(OnAbsorbDoAfter);
         SubscribeLocalEvent<CosmicMalignRiftComponent, EventPurgeRiftDoAfter>(OnPurgeDoAfter);
+        SubscribeLocalEvent<CosmicMalignRiftComponent, ComponentInit>(OnRiftStarted);
+    }
+
+    private void OnRiftStarted(Entity<CosmicMalignRiftComponent> ent, ref ComponentInit args)
+    {
+        ent.Comp.NextPulseTime = _timing.CurTime + _random.Next(ent.Comp.MinPulseTime, ent.Comp.MaxPulseTime);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+        
+        var query = EntityQueryEnumerator<CosmicMalignRiftComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (_timing.CurTime >= comp.NextPulseTime)
+            {
+                comp.NextPulseTime = _timing.CurTime + _random.Next(comp.MinPulseTime, comp.MaxPulseTime);
+
+                var pos = Transform(uid).Coordinates;
+                Spawn(comp.PulseVFX, pos);
+                _lookup.GetEntitiesInRange<HumanoidAppearanceComponent>(pos, comp.PulseRange, _humanoids);
+                _humanoids.RemoveWhere(target => HasComp<BibleComponent>(target) || HasComp<CosmicCultComponent>(target));
+                foreach(var humanoid in _humanoids)
+                {
+                    if (!pos.TryDistance(EntityManager, Transform(humanoid).Coordinates, out var distance)) continue;
+                    var damageMultiplier = Math.Clamp(comp.PulseRange / distance, 1, 10); //0.2 damage per second at max distance, up to 2 per second if closer
+                    var effectDuration = _random.Next(10, 40); //2-8 damage at max distance, 20-80 damage at min distance
+                    _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(humanoid, "EntropicDegen", TimeSpan.FromSeconds(effectDuration), true);
+                    if (TryComp<CosmicEntropyDebuffComponent>(humanoid, out var debuff)) debuff.Degen = new(){DamageDict = new(){{"Cold", 0.05 * damageMultiplier}, {"Asphyxiation", 0.15 * damageMultiplier}}};
+                }
+            }
+        }
     }
 
     private void OnInteract(Entity<CosmicMalignRiftComponent> uid, ref InteractHandEvent args)

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -54,7 +54,7 @@ public sealed class CosmicRiftSystem : EntitySystem
         {
             if (_timing.CurTime < comp.NextPulseTime) continue;
             comp.NextPulseTime = _timing.CurTime + _random.Next(comp.MinPulseTime, comp.MaxPulseTime);
-            
+
             var pos = Transform(uid).Coordinates;
             Spawn(comp.PulseVFX, pos);
             _lookup.GetEntitiesInRange<HumanoidAppearanceComponent>(pos, comp.PulseRange, _humanoids);

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -64,7 +64,7 @@ public sealed class CosmicRiftSystem : EntitySystem
             var pos = Transform(uid).Coordinates;
             Spawn(comp.PulseVFX, pos);
             _lookup.GetEntitiesInRange<HumanoidAppearanceComponent>(pos, comp.PulseRange, _humanoids);
-            _humanoids.RemoveWhere(target => _chaplainsQuery.HasComp<BibleUserComponent>(target) || _cultistsQuery.HasComp<CosmicCultComponent>(target));
+            _humanoids.RemoveWhere(target => _chaplainsQuery.HasComp(target) || _cultistsQuery.HasComp(target));
             foreach(var humanoid in _humanoids)
             {
                 if (!pos.TryDistance(EntityManager, Transform(humanoid).Coordinates, out var distance)) continue;


### PR DESCRIPTION
## About the PR
Malign rifts now periodically deal damage to all humanoids, depending on the distance between said humanoid and the rift. The effect does not apply to cosmic cultists and bibleUsers (chaplain and mystagogue).
More specifically, it applies 10-40 seconds of entropic degen status effect, which deals anywhere between 0.2 to 2 damage (25% cold, 75% asphyx) per second, based on the distance (the closer, the higher), to all targets within 15 tiles every 20 to 60 seconds. Every "pulse" is followed by a visual effect to make it clear that something has happened.

## Why / Balance
1. Makes malign rifts actually dangerous to be around, thus giving the crew more reasons to want to purge them besides just "ugly floors".
2. Prevents crew from camping the rifts until a chaplain arrives to purge them. See a rift, walk away, then tell everyone about it through radio. Standing near it to make sure cultists don't get it may kill you.
3. Makes siphoning entropy less metagameable, because now "I don't know why but I have 4 cold damage" could not only mean "this is a cult round", but also "there's a randomly spawned rift somewhere and this dude just didn't notice it".

## Technical details
Every 20-80 seconds apply a status effect to all entities with HumanoidAppearanceComponent and no CosmicCultComponent nor BibleUserComponent. Most values are stored on the prototype.

## Media
Tested, works.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Malign rifts sometimes deal damage to everyone around them now. Get away, or you may get hurt! Further away. Like, don't even look at it.
