### PR TITLE
Allow Psionic Mantis knife to purge malign rifts

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/knives.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/knives.yml
@@ -10,6 +10,18 @@
       types:
         Slash: 10
         Holy: 5
+# Begin DeltaV Additions - let's the knife be used to clear rifts. Requires defined damage types so just set all to 0.
+  - type: Bible
+    damage:
+      types:
+        Caustic: 0
+    damageOnFail:
+      groups:
+        Brute: 0
+    damageOnUntrainedUse:
+      types:
+        Caustic: 0
+# End DeltaV Additions
   - type: StaminaDamageOnHit
     damage: 0
   - type: AntiPsionicWeapon

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -23,6 +23,7 @@
     components:
     - type: Psionic
     - type: MetapsionicPower
+    - type: BibleUser # DeltaV - Allows interactions with cosmic cult
 
 - type: startingGear
   id: ForensicMantisGear


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
This allows the Psionic Mantis to purge malign rifts with their knife. Simple change that just adds the BibleUser component to mantis and BibleComponent to the knife
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Psionic Mantis is allowed to break the metashield and stuff like this falls under their jobs purview. Probably should have been included in the initial PR.
## Technical details
<!-- Summary of code changes for easier review. -->
adds components to the mantis and anti-psionic knife.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
didn't take a video for this one
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The psionic mantis can now cleanse rifts alongside the chaplain


