### PR TITLE
1984 development random characters

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -43,7 +43,7 @@ preload_grids = false
 see_own_notes = true
 
 [ic]
-random_characters = true
+random_characters = false # DeltaV - disable development random characters
 random_species_weights = ""
 ssd_sleep_time = 3600
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
`random_characters = false`, saving everybody's time when developing

## Why / Balance
<img width="872" height="381" alt="image" src="https://github.com/user-attachments/assets/30c7557d-a925-4d8c-b550-c981562b32bd" />

random characters in development builds are like 80% "wow that's a terrible haircut" and 20% "oh i rolled vox/IPC time to right click control mob urist", can't be toggled ingame for some reason


catching species specific bugs? we have a tool for that it's called the PLAYERS

this saves everyone the hassle of having to create a file in some obscure .git folder to disable it manually without the changes being caught in your next commit

## Technical details
no

## Media
no

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
no

**Changelog**
no
