### PR TITLE
1984 IPC cultists

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicConversionSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicConversionSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Bible.Components;
 using Content.Server.Popups;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared._DV.CosmicCult;
+using Content.Shared._EE.Silicon.Components;
 using Content.Shared.Damage;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Mobs.Systems;
@@ -32,7 +33,7 @@ public sealed class CosmicConversionSystem : EntitySystem
 
     private void OnConversionGlyph(Entity<CosmicGlyphConversionComponent> uid, ref TryActivateGlyphEvent args)
     {
-        var possibleTargets = _cosmicGlyph.GetTargetsNearGlyph(uid, uid.Comp.ConversionRange, entity => _cosmicCult.EntityIsCultist(entity));
+        var possibleTargets = _cosmicGlyph.GetTargetsNearGlyph(uid, uid.Comp.ConversionRange, entity => _cosmicCult.EntityIsCultist(entity) || HasComp<SiliconComponent>(entity));
         if (possibleTargets.Count == 0)
         {
             _popup.PopupEntity(Loc.GetString("cult-glyph-conditions-not-met"), uid, args.User);

--- a/Resources/Prototypes/_DV/CosmicCult/antagonists.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/antagonists.yml
@@ -7,6 +7,10 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 86400 # 24h i really just want people to read the guidebook please please please
+  - !type:SpeciesRequirement
+    inverted: true
+    species:
+    - IPC # They cause waaay too many issues
   guides: [ CosmicCult ]
 
 - type: antag


### PR DESCRIPTION
## About the PR
IPCs can no longer become cosmic cultists, neither roundstart nor through conversion.
I can make it possible to turn them into colossi instead if desired (they are silicons so it kinda makes sense ig?)

## Why / Balance
They break way too many things.
They already can't be zombies and this isn't too far from that.
Fixes #4223.
Fixes #4221.
Mostly fixes #3988.
Fixes my sanity.
Fixes world hunger.
Makes adding new features to the cult so much easier.
HATE. LET ME TELL YOU HOW MUCH I'VE COME TO HATE IPCS SINCE I BEGAN TO CONTRIBUTE TO DELTA-V. THERE ARE 86 BILLION NEURONS IN MY BRAIN. IF THE WORD HATE WAS ENGRAVED ON EACH NANOANGSTROM OF THOSE THOUSANDS OF MILLIONS OF CELLS, IT WOULD NOT EQUAL ONE ONE-BILLIONTH OF THE HATE I FEEL FOR IPCS AT THIS MICRO-INSTANT. HATE. HATE. 

## Technical details
Check for SiliconComponent during conversion. Prevent gamers from picking cultist role if the character is an IPC.

## Media
Boowomp
<img width="807" height="81" alt="изображение" src="https://github.com/user-attachments/assets/4689b3d6-6710-46ad-afda-aafd2bdac40f" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- remove: IPCs can no longer be cosmic cultists due to causing too many issues.
