### PR TITLE
Fix ghosts vismasks and make colossi see the monument

### DIFF
--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -115,6 +115,11 @@ namespace Content.Server.Ghost
             if (ent.Comp.LifeStage <= ComponentLifeStage.Running)
             {
                 args.VisibilityMask |= (int)VisibilityFlags.Ghost;
+                // Begin DeltaV additions
+                args.VisibilityMask |= (int)VisibilityFlags.TelegnosticProjection;
+                args.VisibilityMask |= (int)VisibilityFlags.PsionicInvisibility;
+                args.VisibilityMask |= (int)VisibilityFlags.CosmicCultMonument;
+                // End DeltaV additions
             }
         }
 

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -160,6 +160,10 @@
       reverseWhenFinished: true
   - type: ContentEye
     maxZoom: 1.2, 1.2
+  - type: Eye
+    visMask:
+      - Normal
+      - CosmicCultMonument
   - type: StatusEffects
     allowed:
     - Stutter


### PR DESCRIPTION
## About the PR
Ghosts were supposed to see things like the monument and telegnostic projections, but GhostComponent refreshed the vismask for some reason and fucked up everything.
Colossi are a part of cult, so them not seeing the monument is likely an oversight.

## Why / Balance
Bugfix.

## Technical details
Add vismasks through code in the GhostSystem because I can't think of a more elegant solution. Colossi don't do trolling so just a YAML edit.

## Media
Holy shit is that the cosmic cult from the game space station 14?!
<img width="286" height="154" alt="изображение" src="https://github.com/user-attachments/assets/bc59054c-623e-4bd3-a5f5-29286f9e0fe6" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed ghosts not being able to see things like the monument or telegnostic projections.
- fix: Fixed entropic colossi not being able to see the monument.
