### PR TITLE
Make some swing animations nicer

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.Effects.cs
@@ -55,6 +55,7 @@ public sealed partial class MeleeWeaponSystem
 
             if (meleeWeaponComponent.SwingLeft)
                 angle *= -1;
+            if (meleeWeaponComponent.ChangeSwingDirection) meleeWeaponComponent.SwingLeft = !meleeWeaponComponent.SwingLeft; // DeltaV - Nice swing animation for desword
         }
         _sprite.SetRotation((animationUid, sprite), localPos.ToWorldAngle());
         var distance = Math.Clamp(localPos.Length() / 2f, 0.2f, 1f);

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -102,8 +102,6 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             filter = Filter.Pvs(user, entityManager: EntityManager);
         }
 
-        if (TryComp<MeleeWeaponComponent>(weapon, out var comp) && comp.ChangeSwingDirection) comp.SwingLeft = !comp.SwingLeft; // DeltaV - Nice swing animation for desword
-
         RaiseNetworkEvent(new MeleeLungeEvent(GetNetEntity(user), GetNetEntity(weapon), angle, localPos, animation), filter);
     }
 

--- a/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Server/Weapons/Melee/MeleeWeaponSystem.cs
@@ -102,6 +102,8 @@ public sealed class MeleeWeaponSystem : SharedMeleeWeaponSystem
             filter = Filter.Pvs(user, entityManager: EntityManager);
         }
 
+        if (TryComp<MeleeWeaponComponent>(weapon, out var comp) && comp.ChangeSwingDirection) comp.SwingLeft = !comp.SwingLeft; // DeltaV - Nice swing animation for desword
+
         RaiseNetworkEvent(new MeleeLungeEvent(GetNetEntity(user), GetNetEntity(weapon), angle, localPos, animation), filter);
     }
 

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -115,6 +115,12 @@ public sealed partial class MeleeWeaponComponent : Component
     [DataField, AutoNetworkedField]
     public bool SwingLeft;
 
+    /// <summary>
+    /// DeltaV: if true, weapon will swing in different direction each strike. Purely cosmetic.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ChangeSwingDirection;
+
 
     // Sounds
 

--- a/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
+++ b/Content.Shared/Weapons/Melee/MeleeWeaponComponent.cs
@@ -118,7 +118,7 @@ public sealed partial class MeleeWeaponComponent : Component
     /// <summary>
     /// DeltaV: if true, weapon will swing in different direction each strike. Purely cosmetic.
     /// </summary>
-    [DataField, AutoNetworkedField]
+    [DataField]
     public bool ChangeSwingDirection;
 
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -332,6 +332,7 @@
   - type: MeleeWeapon
     wideAnimationRotation: -135
     attackRate: 2.0 # DeltaV - was 1.5
+    changeSwingDirection: true # DeltaV
     angle: 100
     damage:
       types:

--- a/Resources/Prototypes/_DV/CosmicCult/Objects/cosmicweapons.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Objects/cosmicweapons.yml
@@ -91,7 +91,9 @@
   - type: MeleeWeapon
     resistanceBypass: true
     angle: 0
+    wideAnimationRotation: 225
     animation: WeaponArcCosmic
+    wideAnimation: WeaponArcThrust
     attackRate: 0.62
     damage:
       types:


### PR DESCRIPTION
## About the PR
Vacuous lance (cult spear) now does a thrust animation and has correct angle.
Desword now changes swing direction with each strike.
I also wanted to change desword's swing animation to use normal esword sprite (current one looks as if the character holds the sword by the blade) but couldn't figure out a way to do so. Lmk if there is one and I just missed it.

## Why / Balance
Looks nice.

## Technical details
1 new field on the MeleeWeaponComponent

## Media

https://github.com/user-attachments/assets/78016597-783e-457b-ac44-6b598ef46913

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Double-bladed energy sword and vacuous lance have had their swing animations improved.
