### PR TITLE
Move glyph of cessation to T2, glyph of warding to T3, sliglthly rebalance cult armor

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
@@ -23,12 +23,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
-        Heat: 0.6
-        Radiation: 0.6
-        Caustic: 0.6
+        Blunt: 0.8
+        Slash: 0.7
+        Piercing: 0.5
+        Heat: 0.5
+        Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/_DV/CosmicCult/MonumentPowers/glyphs.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/MonumentPowers/glyphs.yml
@@ -26,7 +26,7 @@
     sprite: _DV/CosmicCult/Objects/glyphs.rsi
     state: warding
   entity: CosmicGlyphWarding
-  tier: 2
+  tier: 3
 
 - type: glyph
   id: ccGlyphBlades
@@ -46,7 +46,7 @@
     sprite: _DV/CosmicCult/Objects/glyphs.rsi
     state: cessation
   entity: CosmicGlyphCessation
-  tier: 3
+  tier: 2
 
 - type: glyph
   id: ccGlyphTruth


### PR DESCRIPTION
## About the PR
Glyph of cessation is now available at tier 2, and glyph of warding at tier 3.
Cult armor resistances:
Blunt: 40% -> 20%
Slash: 40% -> 30%
Pierce: 40% -> 50%
Heat: 40% -> 50%
Radiation: 40% -> 0
Caustic: 40 -> 30%

## Why / Balance
Glyph of cessation is very rarely used, partially because it's made available late into the round, by which point cultists often just try to speedrun the remaining converts and start the finale. Thus, we make it available earlier.
Cult doesn't really need armor this early on, since at stage 2 stealth play is preferred, and cult armor is very obviously valid. Thus, we move it into stage 3, to keep the "2 new glyphs are unlocked with each tier" rule intact.
Since armor is now available later into the round, it's defence values have been slightly tweaked: "general gun" damage types (pierce and heat) have been slightly increased, while more exotic ones have recieved a nerf. This, hopefuly, should encourage security and epistemics to actually invest into more advanced arms, such as uranium ammo, x-ray cannons etc.
Also 30% of our players believe that cult is weak, so I think a small buff is warranted.

Russian UI jumpscare.
<img width="476" height="394" alt="изображение" src="https://github.com/user-attachments/assets/627ba8ef-f3d3-4afb-adf0-57b551157bc9" />


## Technical details
YAML gaming.

## Media
Numbers change.

## Requirements
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- tweak: Glyph of cessation is now available to the cosmic cult at stage 2, while glyph of warding has been moved to stage 3
- tweak: Cult armor is now more resistant to pierce and heat, but less resistant to other types of damage.
