### PR TITLE
eguns

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -244,7 +244,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
   - type: Gun
-  - fireRate: 2 # DeltaV - parent changed to 1.5
+    fireRate: 2 # DeltaV - parent changed to 1.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -621,7 +621,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
   - type: Gun
-  - fireRate: 2 # DeltaV - parent changed to 1.5
+    fireRate: 2 # DeltaV - parent changed to 1.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
@@ -669,7 +669,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
   - type: Gun
-  - fireRate: 2 # DeltaV - parent changed to 1.5
+    fireRate: 2 # DeltaV - parent changed to 1.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -148,6 +148,14 @@
     - state: mag-unshaded-4
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
+      # Begin DeltaV additions
+  - type: Gun
+    fireRate: 2 # DeltaV - parent changed to 1.5
+    soundGunshot:
+      path: /Audio/_DV/Weapons/Guns/Gunshots/laser.ogg
+    soundEmpty:
+      path: /Audio/_DV/Weapons/Guns/Empty/dry_fire.ogg
+      # End DeltaV additions
   - type: HitscanBatteryAmmoProvider
     proto: RedMediumLaser
     fireCost: 62.5
@@ -236,6 +244,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi
   - type: Gun
+  - fireRate: 2 # DeltaV - parent changed to 1.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto
@@ -612,6 +621,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
   - type: Gun
+  - fireRate: 2 # DeltaV - parent changed to 1.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider
@@ -659,6 +669,7 @@
   - type: Clothing
     sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
   - type: Gun
+  - fireRate: 2 # DeltaV - parent changed to 1.5
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: HitscanBatteryAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -14,7 +14,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 1.5
+    fireRate: 1.5 # DeltaV was 2
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -14,7 +14,7 @@
     - suitStorage
   - type: AmmoCounter
   - type: Gun
-    fireRate: 2
+    fireRate: 1.5
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -377,7 +377,7 @@
       map: ["enum.GunVisualLayers.MagUnshaded"]
       shader: unshaded
   - type: Gun
-    fireRate: 2
+    fireRate: 1.5 # was 2
     soundGunshot:
       path: /Audio/_DV/Weapons/Guns/Gunshots/laser.ogg
     soundEmpty:


### PR DESCRIPTION
deltanedas dont merge without direction approval

## About the PR
Reduces the fireRate of all Eguns to 1.5 from 2

## Why / Balance
Eguns as a whole feature decent fire rate with good damage per shot all the while being perfectly accurate one handed.
Lasers feature less damage and reduced accuracy when unwielded.  Adds an extra trade-off to picking the Egun and its derivatives.

Affected guns: 
Energy Gun, X-01, Mini Energy Gun, PDW-9, Advanced Energy Gun.
Pulse Pistol, Xray Cannon, Taser
(makeshift laser pistol, tesla gun, eye of the behonker)

## Technical details
changed parent, set firerate of antique laser, retro laser, advanced laser to 2


**Changelog**

:cl:
- tweak: Energy Guns have had their fire rates reduced.

