### PR TITLE
Make secret take total player amount into account, lower the required amount of players ready

### DIFF
--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;
@@ -22,6 +23,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!; // DeltaV
     [Dependency] private readonly GameTicker _ticker = default!; // begin Imp
 
     // Dictionary that contains the minimum round number for certain preset
@@ -90,6 +92,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     {
         var options = _prototypeManager.Index(weights).Weights.ShallowClone();
         var players = GameTicker.ReadyPlayerCount();
+        var totalPlayers = _playerManager.PlayerCount; //DeltaV
 
         GamePresetPrototype? selectedPreset = null;
         var sum = options.Values.Sum();
@@ -163,7 +166,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     /// <summary>
     /// Can the given preset be picked, taking into account the currently available player count?
     /// </summary>
-    private bool CanPick([NotNullWhen(true)] GamePresetPrototype? selected, int players)
+    private bool CanPick([NotNullWhen(true)] GamePresetPrototype? selected, int players, int totalPlayers) // DeltaV - respect total playercount
     {
         if (selected == null)
             return false;
@@ -179,6 +182,8 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
 
             if (ruleComp.MinPlayers > players && ruleComp.CancelPresetOnTooFewPlayers)
                 return false;
+
+            if (ruleComp.MinTotalPlayers > totalPlayers) return false; // DeltaV
         }
 
         if (_configurationManager.GetCVar(DCCVars.EnableBacktoBack) == true) // DeltaV

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -23,7 +23,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
     [Dependency] private readonly IAdminLogManager _adminLogger = default!;
-    [Dependency] private readonly IPlayerManager _playerManager = default!; // DeltaV
+    [Dependency] private readonly IPlayerManager _player = default!; // DeltaV
     [Dependency] private readonly GameTicker _ticker = default!; // begin Imp
 
     // Dictionary that contains the minimum round number for certain preset
@@ -92,7 +92,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     {
         var options = _prototypeManager.Index(weights).Weights.ShallowClone();
         var players = GameTicker.ReadyPlayerCount();
-        var totalPlayers = _playerManager.PlayerCount; //DeltaV
+        var totalPlayers = _player.PlayerCount; //DeltaV
 
         GamePresetPrototype? selectedPreset = null;
         var sum = options.Values.Sum();
@@ -151,7 +151,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     public bool CanPickAny(IEnumerable<ProtoId<GamePresetPrototype>> protos)
     {
         var players = GameTicker.ReadyPlayerCount();
-        var totalPlayers = _playerManager.PlayerCount; //DeltaV
+        var totalPlayers = _player.PlayerCount; //DeltaV
         foreach (var id in protos)
         {
             if (!_prototypeManager.TryIndex(id, out var selectedPreset))

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -9,7 +9,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
-using Robust.Server.Player;
+using Robust.Server.Player; // DeltaV
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;

--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -9,7 +9,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Random;
 using Content.Shared.CCVar;
 using Content.Shared.Database;
-using Robust.Shared.Player;
+using Robust.Server.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;
@@ -114,7 +114,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
                 break;
             }
 
-            if (CanPick(selectedPreset, players))
+            if (CanPick(selectedPreset, players, totalPlayers)) // DeltaV - total playercount
             {
                 preset = selectedPreset;
                 return true;
@@ -151,12 +151,13 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
     public bool CanPickAny(IEnumerable<ProtoId<GamePresetPrototype>> protos)
     {
         var players = GameTicker.ReadyPlayerCount();
+        var totalPlayers = _playerManager.PlayerCount; //DeltaV
         foreach (var id in protos)
         {
             if (!_prototypeManager.TryIndex(id, out var selectedPreset))
                 Log.Error($"Invalid preset {selectedPreset} in secret rule weights: {id}");
 
-            if (CanPick(selectedPreset, players))
+            if (CanPick(selectedPreset, players, totalPlayers)) // DeltaV - total playercount
                 return true;
         }
 

--- a/Content.Shared/GameTicking/Components/GameRuleComponent.cs
+++ b/Content.Shared/GameTicking/Components/GameRuleComponent.cs
@@ -24,6 +24,12 @@ public sealed partial class GameRuleComponent : Component
     public int MinPlayers;
 
     /// <summary>
+    /// DeltaV: the total amount of players on the server needed for this rule.
+    /// </summary>
+    [DataField]
+    public int MinTotalPlayers;
+
+    /// <summary>
     /// If true, this rule not having enough players will cancel the preset selection.
     /// If false, it will simply not run silently.
     /// </summary>

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -114,7 +114,8 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 10 # DeltaV - was 20
+    minTotalPlayers: 30 # DeltaV
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: NukieOperation # DeltaV - Nukie operations!
@@ -329,7 +330,8 @@
   parent: BaseGameRule
   components:
   - type: GameRule
-    minPlayers: 20
+    minPlayers: 10 # DeltaV - was 20
+    minTotalPlayers: 30 # DeltaV
     delay:
       min: 600
       max: 900

--- a/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/roundstart.yml
@@ -4,7 +4,8 @@
   components:
   - type: CosmicCultRule
   - type: GameRule
-    minPlayers: 25
+    minPlayers: 15
+    minTotalPlayers: 40
     delay:
       min: 60
       max: 120


### PR DESCRIPTION
## About the PR
Secret no takes total playercount into accout when rolling for a gamemode. The requried amount of players ready has been somewhat lowered.
Exact numbers:
Nukeops: 30 total players, 10 ready (previously 20 ready).
Zombies: 30 total players, 10 ready (previously 20 ready).
Cosmic cult: 40 total players, 15 ready (previously 25 ready).
Traitors and survival not changed (you can't really lower it any more).

## Why / Balance
On DeltaV, players often do not ready up in lobby, but latejoin within a minute from round start. Whether it is done to intentionally avoid major antags appearing, or to ensure that all departments are properly staffed is not really relevant. Either way, this often leads to situations, where despite the server having more than enough players for a gamemode to appear, the round can only be traitors or survival, because more than 50% of the players do not ready. And those are already the most common gamemodes purely from their weights. In rare cases, even a full server of 80 players would not have 20 players ready before roundstart.

This ensures that this doesn't happen, or at least happens way less. The requirement for total players ensures that there are indeed enough players for the gamemode to work properly. Numbers may need to be adjusted later.

## Technical details
Add a field to GameRuleComponen and check it against the total playercount.

## Media
Not needed.

## Requirements
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Important note
While I did make sure that this at least builds, I can't reasonably test this in any meaningful way, because my PC would literally explode if I try to launch 30 clients at once. This will require a test merge, or a test server to be launched, to make sure it doesn't break anything.

**Changelog**
:cl:
- tweak: Secret game mode now not only checks for amount of players ready, but also for the total player count. 
- tweak: Game modes now generally require less players to be ready during lobby.