### PR TITLE
emergency crash bugfix ops

### DIFF
--- a/Resources/Textures/_DV/Shaders/highglimmer.swsl
+++ b/Resources/Textures/_DV/Shaders/highglimmer.swsl
@@ -3,7 +3,7 @@
 
 const highp float TimeScale = 0.2;
 
-uniform highp float size = 1;
+uniform highp float size;
 
 void fragment() {
     vec2 iResolution = vec2(1.0);

--- a/Resources/Textures/_DV/Shaders/highglimmer.swsl
+++ b/Resources/Textures/_DV/Shaders/highglimmer.swsl
@@ -6,31 +6,31 @@ const highp float TimeScale = 0.2;
 uniform highp float size;
 
 void fragment() {
-    vec2 iResolution = vec2(1.0);
-    vec2 I = UV * iResolution;
+    highp vec2 iResolution = vec2(1.0);
+    highp vec2 I = UV * iResolution;
 
 	//Raymarch depth
-    float z = 0.0;
+    highp float z = 0.0;
 	//Step distance
-    float d = 0.0;
+    highp float d = 0.0;
 	//Raymarch iterator
-    float i = 0.0;
+    highp float i = 0.0;
 	//Animation time
-    float t = TIME * TimeScale;
+    highp float t = TIME * TimeScale;
 
-    vec4 O = vec4(0.0);
+    highp vec4 O = vec4(0.0);
 
 	//Clear fragColor and raymarch (some amount of) steps
-    while (i++ < 25) {
+    while (i++ < 25.0) {
         // sample point (from ray direction)
-        vec3 p = z * normalize(vec3(I + I, 0.0) - iResolution.xyx) + 0.1;
+        highp vec3 p = z * normalize(vec3(I + I, 0.0) - iResolution.xyx) + 0.1;
 
         // polar coordinates
         p = vec3(atan(p.y, p.x) * 2.0, p.z / (3.0*(3.0-size)), length(p.xy) - 4.5 - z * (0.5 * 2.8-size));
 
         // apply turbulence
         d = 0.0;
-        float j = 0.0;
+        highp float j = 0.0;
         while (++j < 9.0)
             p += sin(p.yzx * j - t + 0.2 * i) / j;
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
glimmer shader should no longer CRASH THE GAME for some players at startup

## Technical details
after the last server update, couple of people started reporting that the game consistently crashes on startup. got one of them to send me their logs, relevant error appears to be
```
Unhandled exception. Robust.Client.Graphics.Clyde.ShaderCompilationException: Failed to compile vertex shader, see inner for details (and error.glsl for formatted source).
 ---> Robust.Client.Graphics.Clyde.ShaderCompilationException: ERROR: 0:235: 'uniform' :  cannot initialize this type of qualifier 
 ```
considering that the glimmer thing is the only thing to touch shaders in that update, i assume it's due to that
~~just removed the initialization for size, hopefully that's good enough. i can't reproduce the crash myself so i am praying this works~~ okay it turns out that if you simply look at the game wrong when writing a swsl shader it will crash on startup. why do i need to define every single float as highp why cant it just infer that

should probably be speedmerged for obvious reasons

edit: the crash seems to happen on any device running ss14 in compatibility mode. huh.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed the game crashing on startup when running in compatibility mode.
