### PR TITLE
Make shunt's do-after hidden

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
@@ -43,19 +43,17 @@ public sealed class CosmicBlankSystem : EntitySystem
 
     private void OnCosmicBlank(Entity<CosmicCultComponent> uid, ref EventCosmicBlank args)
     {
-        if (_cosmicCult.EntityIsCultist(args.Target) || HasComp<CosmicBlankComponent>(args.Target) || HasComp<BibleUserComponent>(args.Target) || HasComp<ActiveNPCComponent>(args.Target))
+        if (args.Args.Target is not { } target)
+            return;
+        if (_cosmicCult.EntityIsCultist(target) || HasComp<CosmicBlankComponent>(target) || HasComp<BibleUserComponent>(target) || HasComp<ActiveNPCComponent>(target) || !TryComp<MindContainerComponent>(target, out var mindContainer) || !mindContainer.HasMind)
         {
             _popup.PopupEntity(Loc.GetString("cosmicability-generic-fail"), uid, uid);
             return;
         }
         if (args.Handled)
             return;
-        if (!TryComp<MindContainerComponent>(target, out var mindContainer) || !mindContainer.HasMind)
-        {
-            return;
-        }
 
-        var doargs = new DoAfterArgs(EntityManager, uid, uid.Comp.CosmicBlankDelay, new EventCosmicBlankDoAfter(), uid, args.Target)
+        var doargs = new DoAfterArgs(EntityManager, uid, uid.Comp.CosmicBlankDelay, new EventCosmicBlankDoAfter(), uid, target)
         {
             DistanceThreshold = 1.5f,
             Hidden = true,

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
@@ -50,6 +50,10 @@ public sealed class CosmicBlankSystem : EntitySystem
         }
         if (args.Handled)
             return;
+        if (!TryComp<MindContainerComponent>(target, out var mindContainer) || !mindContainer.HasMind)
+        {
+            return;
+        }
 
         var doargs = new DoAfterArgs(EntityManager, uid, uid.Comp.CosmicBlankDelay, new EventCosmicBlankDoAfter(), uid, args.Target)
         {

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicBlankSystem.cs
@@ -54,14 +54,13 @@ public sealed class CosmicBlankSystem : EntitySystem
         var doargs = new DoAfterArgs(EntityManager, uid, uid.Comp.CosmicBlankDelay, new EventCosmicBlankDoAfter(), uid, args.Target)
         {
             DistanceThreshold = 1.5f,
-            Hidden = false,
+            Hidden = true,
             BreakOnDamage = true,
             BreakOnMove = true,
             BreakOnDropItem = true,
         };
         args.Handled = true;
         _doAfter.TryStartDoAfter(doargs);
-        _popup.PopupEntity(Loc.GetString("cosmicability-blank-begin", ("target", Identity.Entity(uid, EntityManager))), uid, args.Target);
     }
 
     public override void Update(float frameTime)

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -136,7 +136,7 @@ public sealed class CosmicRiftSystem : EntitySystem
         comp.CosmicGlareStun = TimeSpan.FromSeconds(1);
         comp.CosmicImpositionDuration = TimeSpan.FromSeconds(7.4);
         comp.CosmicBlankDuration = TimeSpan.FromSeconds(26);
-        comp.CosmicBlankDelay = TimeSpan.FromSeconds(0.4);
+        comp.CosmicBlankDelay = TimeSpan.FromSeconds(0.8);
         comp.Respiration = false;
         EnsureComp<PressureImmunityComponent>(args.User);
         EnsureComp<TemperatureImmunityComponent>(args.User);

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
@@ -62,8 +62,8 @@ public sealed partial class CosmicCultComponent : Component
     /// <summary>
     /// The duration of the doAfter for Shunt Subjectivity
     /// </summary>
-    [DataField] public TimeSpan CosmicBlankDelay = TimeSpan.FromSeconds(0.6f);
-    public static readonly TimeSpan DefaultCosmicBlankDelay = TimeSpan.FromSeconds(0.6f);
+    [DataField] public TimeSpan CosmicBlankDelay = TimeSpan.FromSeconds(1.0f);
+    public static readonly TimeSpan DefaultCosmicBlankDelay = TimeSpan.FromSeconds(1.0f);
 
     /// <summary>
     /// The duration of Shunt Subjectivity's trip to the cosmic void


### PR DESCRIPTION
## About the PR
The do-after for shunt subjectivity is now hidden. The popup at the start has also been removed.
Do-after is now 1 second long (or 0.8 if empowered) instead of 0.6 seconds (or 0.4 if empowered).
Also you can no longer use shunt on SSD people (it didn't do anythin anyway, just wasted the charge).

## Why / Balance
It's supposed to be a "very long stun, but you can't use it in combat because both targets have to stand still", which was mostly achieved by the incredibly short do-after. However, sometimes people still managed to react in time, which just felt like the ability doesn't work as intended.
Also, before this change it was possible to use shunt mid-combat if the target is slowed down, or just didn't move enough from the initial spot. Thus, the do-after was amde a little longer to prevent that from happening.

## Technical details
Not really.

## Media
Not really.

## Requirements
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: The do-after for shunt subjectivity now takes longer, but is invisible to others.
