### PR TITLE
Colossus rebalance take 2

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/Colossus/CosmicSunderSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/Colossus/CosmicSunderSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
+using Content.Shared.Stunnable;
 using Robust.Shared.Timing;
 
 namespace Content.Server._DV.CosmicCult.Abilities;
@@ -9,6 +10,7 @@ public sealed class CosmicSunderSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedStunSystem _stun = default!;
 
     public override void Initialize()
     {
@@ -25,6 +27,7 @@ public sealed class CosmicSunderSystem : EntitySystem
         _appearance.SetData(ent, ColossusVisuals.Status, ColossusStatus.Action);
         _transform.SetCoordinates(ent, args.Target);
         _transform.AnchorEntity(ent);
+        _stun.TryStun(ent, ent.Comp.AttackWait, true);
 
         comp.Attacking = true;
         comp.AttackHoldTimer = comp.AttackWait + _timing.CurTime;

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicColossusComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicColossusComponent.cs
@@ -48,9 +48,9 @@ public sealed partial class CosmicColossusComponent : Component
 
     [DataField] public TimeSpan IngressDoAfter = TimeSpan.FromSeconds(4);
 
-    [DataField] public TimeSpan AttackWait = TimeSpan.FromSeconds(1.5);
+    [DataField] public TimeSpan AttackWait = TimeSpan.FromSeconds(2);
 
-    [DataField] public TimeSpan HibernationWait = TimeSpan.FromSeconds(20);
+    [DataField] public TimeSpan HibernationWait = TimeSpan.FromSeconds(30);
 
     [DataField] public TimeSpan DeathWait = TimeSpan.FromMinutes(15);
 

--- a/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
@@ -264,7 +264,7 @@
   description: Slumber your body for a period of time to regenerate integrity. Must be done on stable ground.
   components:
   - type: Action
-    useDelay: 120
+    useDelay: 180
     checkCanInteract: false
     itemIconStyle: NoItem
     icon:

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -236,6 +236,13 @@
   - type: GuideHelp
     guides:
     - CosmicColossus
+  - type: PassiveDamage
+    allowedStates:
+    - Alive
+    damage:
+      groups:
+        Brute: -0.1 #2 of each type per minute
+        Burn: -0.066 #~1 of each type per minute
 
 - type: entity
   parent: [ MobCosmicColossusBase ]

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -236,13 +236,6 @@
   - type: GuideHelp
     guides:
     - CosmicColossus
-  - type: PassiveDamage
-    allowedStates:
-    - Alive
-    damage:
-      groups:
-        Brute: -0.1 #2 of each type per minute
-        Burn: -0.066 #~1 of each type per minute
 
 - type: entity
   parent: [ MobCosmicColossusBase ]
@@ -264,6 +257,13 @@
     mobile: true
     autoDisable: false
     corruptionReduction: 0
+  - type: PassiveDamage
+    allowedStates:
+    - Alive
+    damage:
+      groups:
+        Brute: -1
+        Burn: -0.5
 
 - type: entity
   parent: [ MobCosmicColossusBase ]

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -101,7 +101,7 @@
     baseWalkSpeed: 2
     baseSprintSpeed: 3
     baseWeightlessModifier: 1
-    weightlessAcceleration: 1.5
+    weightlessAcceleration: 2.5
     weightlessFriction: 1
   - type: AmbientSound
     volume: +8
@@ -117,8 +117,8 @@
     - DoorBumpOpener
     - Unimplantable
   - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
+    damageContainer: InorganicMetaphysical
+    damageModifierSet: EntropicColossus
   - type: Bloodstream
     bloodMaxVolume: 650
     maxBleedAmount: 0.1
@@ -207,9 +207,9 @@
     range: 2
     damage:
       types:
-        Blunt: 25
-        Asphyxiation: 5
-        Cold: 5
+        Blunt: 35
+        Asphyxiation: 10
+        Cold: 10
         Structural: 60
     soundHit:
       path: /Audio/_DV/CosmicCult/cosmicsword_glance.ogg
@@ -224,14 +224,6 @@
   - type: MeleeThrowOnHit
     speed: 8
     distance: 7
-  - type: Reflect
-    reflectProb: .15
-    spread: 120
-    soundOnReflect:
-      path: /Audio/_DV/CosmicCult/cosmicsword_glance.ogg
-      params:
-        variation: 0.2
-        volume: -6
   - type: GhostRole
     name: ghost-role-information-colossus-name
     description: ghost-role-information-colossus-description
@@ -280,7 +272,6 @@
       0: Alive
       400: Dead
   - type: CosmicColossus
-    hibernationWait: 30
 
 - type: speechSounds
   id: ColossusSpeech

--- a/Resources/Prototypes/_DV/CosmicCult/damage_modifier_sets.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/damage_modifier_sets.yml
@@ -1,0 +1,12 @@
+- type: damageModifierSet
+  id: EntropicColossus
+  coefficients:
+    Blunt: 0.7
+    Slash: 0.7
+    Piercing: 0.7
+    Heat: 0.8
+  flatReductions:
+    Blunt: 10
+    Slash: 5
+    Piercing: 5
+    Heat: 5


### PR DESCRIPTION
## About the PR
Second attempt to rebalance the colossus, with more thought put into it this time. Changes made:
It now uses InorganicMetaphysical damageContainer instead of StructuralInorganic. This means that it no longer takes structural damage, but does take holy damage.
15% reflect chance was removed.
Damage per hit was increased by 20 (25 blunt + 5 cold + 5 asphyx -> 35 blunt 10 cold 10 asphyx).
Slumber shell's cooldown 120 -> 180 seconds.
Damage resistances were tweaked to mainly revolve around flat resists.
Format: percentage resist% (+flat resist).
Before:
Blunt: 30% (+5)
Slash: 50%
Piercing: 30%
Heat: 0% (+5)
Shock: -20%
Structural: 50%
After:
Blunt: 30% (+10)
Slash: 30% (+5)
Piercing: 30% (+5)
Heat: 20% (+5)

And finally, colossi can no longer attack immediately after doing the teleport attack (for two seconds).
Also all colossi now take 30 seconds to heal. Previously it only affected ones made by the cult. Woops.
Also colossi are now slightly more agile in 0G (but are still slow). Because like. They fly at all times. They (logically) don't care about gravity.

## Why / Balance
Previously, the colossus was pretty weak, except for one trick that could one-shot targets if done right, that being teleporting on top of someone and then immediatelly hitting them, pushing them through 3-5 waves of the attack, which killed pretty much any target on the spot.
Now, the one simple trick has been removed, and instead the colossus' raw stats were increased to promote the "tough guy that punches very hard, but you can easily outrun it and kill from a safe distance" playstyle. Flat resistances were introduced to discourage "quantity over quality" attacks, like janitors trying to fight the colossus with a mop. Things like shivs and crowbars would deal very little or no damage at all, while actual guns are still rather effective (though somewhat less so than before this PR). Ideally you want to use slow but strong weapons, like laser cannons, shotguns with slugs, the gamblagator, etc.
Slumber shell's cooldown was increased because it had shown to be rather opressive at times, where the crew have to deal just a little more damage, but the colossus manages to hide for half a minute and heal. quite a lot of damage.
Colossi can no longer take structural damage. While the implication of a "living wall" are kinda funny, things like energy swords or beamdev were dealing much more damage than they should (161 damage per fucking second in case of the beamdev).
Fun fact: cultists are *supposed* to take holy damage during the finale, but it just never worked. That's why colossi can take it now, and, in fact, have no resistance to it (just like shock or caustic, if you get your hands on those).

## Technical details
YAML gaming.

## Media
Mostly numbers.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Entropic colossi now have increased damage and resistances. 15% reflect chance has been removed, though.
- tweak: Entropic colossi now take holy damage, but don't take structural damage anymore.
- tweak: Slumber Shell (colossus' healing) cooldown 120 -> 180 seconds.
- fix: Entropic colossi can no longer attack immediately after teleporting, which allowed unavoidable one-shot kills.
- fix: Midround entropic colossi now take 30 seconds to heal, just like ones created by cult.