### PR TITLE
Remove glyph of knowledge/truth actiavtion time

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/glyphs.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/glyphs.yml
@@ -52,7 +52,6 @@
   - type: CosmicGlyphConversion
     negateProtection: true
   - type: CosmicGlyph
-    activationTime: 4 # To prevent people from just using the glyph the moment a target's shunt ends. Go get cuffs.
     requiredCultists: 3
     activationDamage:
       types:
@@ -73,7 +72,6 @@
         map: ["base"]
   - type: CosmicGlyphConversion
   - type: CosmicGlyph
-    activationTime: 4 # To prevent people from just using the glyph the moment a target's shunt ends. Go get cuffs.
     requiredCultists: 2
     activationDamage:
       types:


### PR DESCRIPTION
## About the PR
Coscult's glyphs of knowledge/truth now activate instantly.

## Why / Balance
Apparently, direction (or at least Proxything) dislike that, but they didn't notice me adding it because it was a part of the largely cosmetic PR. I've spent two hours making sounds just for that, by the way. Can I get out of the basement now? Please?

## Technical details
Removed 2 lines of YAML.

## Media
Numbers change.

## Requirements
- [ ] I have tested all added content and changes. (Numbers change)
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Cosmic cult's conversion glyphs charging animation has been removed.
