### PR TITLE
Minor-ish cult ability rebalance

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultSystem.cs
@@ -241,11 +241,11 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
 
     private void OnRefreshMoveSpeed(EntityUid uid, InfluenceStrideComponent comp, RefreshMovementSpeedModifiersEvent args)
     {
-        args.ModifySpeed(1.1f, 1.1f);
+        args.ModifySpeed(1.15f, 1.15f);
     }
     private void OnImpositionMoveSpeed(EntityUid uid, CosmicImposingComponent comp, RefreshMovementSpeedModifiersEvent args)
     {
-        args.ModifySpeed(0.65f, 0.65f);
+        args.ModifySpeed(0.8f, 0.8f);
     }
     #endregion
 

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicCultComponent.cs
@@ -68,8 +68,8 @@ public sealed partial class CosmicCultComponent : Component
     /// <summary>
     /// The duration of Shunt Subjectivity's trip to the cosmic void
     /// </summary>
-    [DataField] public TimeSpan CosmicBlankDuration = TimeSpan.FromSeconds(22);
-    public static readonly TimeSpan DefaultCosmicBlankDuration = TimeSpan.FromSeconds(22);
+    [DataField] public TimeSpan CosmicBlankDuration = TimeSpan.FromSeconds(9);
+    public static readonly TimeSpan DefaultCosmicBlankDuration = TimeSpan.FromSeconds(9);
 
     /// <summary>
     /// The duration of Vacuous Imposition's shield.

--- a/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
@@ -151,7 +151,7 @@
   description: Use a concentrated blast of power to force a secure doorway open.
   components:
   - type: Action
-    useDelay: 25
+    useDelay: 15
     itemIconStyle: NoItem
     icon:
       sprite: _DV/CosmicCult/Icons/cosmiccult_abilities.rsi
@@ -170,7 +170,7 @@
   description: You negate any incoming damage for a short time.
   components:
   - type: Action
-    useDelay: 160
+    useDelay: 80
     checkCanInteract: false
     itemIconStyle: NoItem
     icon:
@@ -186,13 +186,13 @@
   description: Hurl a large and disruptive blast of astral energy.
   components:
   - type: Action
-    useDelay: 45
+    useDelay: 60
     itemIconStyle: NoItem
     icon:
       sprite: _DV/CosmicCult/Icons/cosmiccult_abilities.rsi
       state: nova
   - type: TargetAction
-    range: 60
+    range: 6000 # You're just picking a direction anyways
   - type: WorldTargetAction
     event: !type:EventCosmicNova {}
 


### PR DESCRIPTION
## About the PR
Tweaks some values for cult abilities, specificaly:
Astral stride speed bonus 10% -> 15%
Vacuous imposition speed penalty 35% -> 20%
Vacuous imposition cooldown 160 -> 80 seconds
Force ingress cooldown 25 -> 15 seconds
Shunt subjectivity duration 22 -> 9 seconds (empowered duration is still 26 seconds)
Astral nova cooldown 45 -> 60 secodns

## Why / Balance
Astral stride and vacuous imposition were completely overshadowed by astral nova, so I buffed the former and slightly nerfed the latter. Who needs 6 seconds of not taking damage and being slow as fuck, when you can throw a ball of cosmic energy that instantly stuns everyone AND looks sick as hell? Now at least the cooldown is slightly longer, though I'd probably make it even longer than that, but eh.
Astral stride is slightly more useful now. 10% speed boost is just too little for 18 entropy (which is quite a lot of entropy).
Vacuous imposition's cooldown has been made significantly shorter, and the speed penalty has been reduced. What's the point of taking no damage, if you can't even get close to your opponent to hit them? Sure, you can make them retreat a little, maybe tank a few shots for your allies, but again, it's just bad compared to the power of astral nova.
Force ingress was lliterally just worse JoL, now they at least have the same speed (with the added benefit for the ability having a cooldown instead of a do-after).
Shunt's duration was just absurdly long. Like holy shit man use cuffs or something, they're practically free. Also the empowerment increasing that time by whopping 4 seconds was kinda silly.

## Technical details
Numbers

## Media
Numbers

## Requirements
Numbers

## Breaking changes
Numbers

**Changelog**
:cl:
- tweak: Cosmic cult's abilities got a rebalance. Check the PR for details.
