### PR TITLE
Make kitsune and felinids denser (faster drag speed)

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -15,7 +15,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.28
-        density: 140
+        density: 150
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
@@ -10,7 +10,7 @@
       fix1:
         shape: !type:PhysShapeCircle
           radius: 0.35
-        density: 50
+        density: 160
         restitution: 0.0
         mask:
         - MobMask


### PR DESCRIPTION
## About the PR
Kitsune now have a density value of 160 (previously **fucking 50**), and felinids have 150 (previously 140). Base value is 185. This lets them drag things faster, and being dragged slower themselves.

## Why / Balance
While a kitsune secoff dragging an oni prisoner at the speed of 1 meter per hour is kinda funny, it gets really old really fast, especially if you're the secoff (or the prisoner) in question. Felinids are larger than rodentia, so they had their density increased a bit, too. Kitsune are literally the same size as humans, so their density is also nearly equivalent now (though, admittedly, still noticeably lower than other species, just not so drammatically).

## Technical details
I put them in a hydraulic press so now they're denser. Countless felinids were harmed while making this PR.

## Media
Numbas

## Requirements
- [X] I have tested all added content and changes. (Surprisingly, I still did)
- [X] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- tweak: Kitsune and felinids are no longer as bad at dragging things. Still worse than most other species, though.
