### PR TITLE
Make cult glyphs invisible to non-cultists during stages 1 and 2

### DIFF
--- a/Content.Server/_DV/CosmicCult/MonumentSystem.cs
+++ b/Content.Server/_DV/CosmicCult/MonumentSystem.cs
@@ -494,7 +494,7 @@ public sealed class MonumentSystem : SharedMonumentSystem
         ent.Comp.CurrentGlyph = glyphEnt;
         var evt = new CosmicCultAssociateRuleEvent(ent, glyphEnt);
         RaiseLocalEvent(ref evt);
-        
+
         var objectiveQuery = EntityQueryEnumerator<CosmicTierConditionComponent>();
         while (objectiveQuery.MoveNext(out var _, out var objectiveComp))
         {

--- a/Content.Shared/_DV/CosmicCult/SharedMonumentSystem.cs
+++ b/Content.Shared/_DV/CosmicCult/SharedMonumentSystem.cs
@@ -80,29 +80,9 @@ public abstract class SharedMonumentSystem : EntitySystem
     }
 
     #region UI listeners
-    private void OnGlyphSelected(Entity<MonumentComponent> ent, ref GlyphSelectedMessage args)
+    protected virtual void OnGlyphSelected(Entity<MonumentComponent> ent, ref GlyphSelectedMessage args)
     {
-        ent.Comp.SelectedGlyph = args.GlyphProtoId;
-
-        if (!_prototype.TryIndex(args.GlyphProtoId, out var proto))
-            return;
-
-        var xform = Transform(ent);
-
-        if (!TryComp<MapGridComponent>(xform.GridUid, out var grid))
-            return;
-
-        var localTile = _map.GetTileRef(xform.GridUid.Value, grid, xform.Coordinates);
-        var targetIndices = localTile.GridIndices + new Vector2i(0, -1);
-
-        if (ent.Comp.CurrentGlyph is { } curGlyph) _glyph.EraseGlyph(curGlyph);
-
-        var glyphEnt = Spawn(proto.Entity, _map.ToCenterCoordinates(xform.GridUid.Value, targetIndices, grid));
-        ent.Comp.CurrentGlyph = glyphEnt;
-        var evt = new CosmicCultAssociateRuleEvent(ent, glyphEnt);
-        RaiseLocalEvent(ref evt);
-
-        _ui.SetUiState(ent.Owner, MonumentKey.Key, new MonumentBuiState(ent.Comp));
+        // This never worked on the client anyway, moved to server (in a lazy way) because I can't check current tier here.
     }
 
     private void OnGlyphRemove(Entity<MonumentComponent> ent, ref GlyphRemovedMessage args)


### PR DESCRIPTION
## About the PR
Title. Just like the monument. Becomes visible when stage 3 is reached.

## Why / Balance
- Chap decides to randomly check maints
- Chap finds a glyph on the floor
- Chap tells security to lock down the whole room
- Cult can't do anything because it's an early stage
- Round turns into greenshift
- Nobody gets to have fun

## Technical details
Moved the method for scribing glyphs from shared to server (it never worekd on client anyway), check current tier, if it's lower than 3, add VisibillityComponent and set it to monument's vismask.

## Media
Non-cultist, no monu, no glyph
<img width="548" height="341" alt="изображение" src="https://github.com/user-attachments/assets/a2d67e94-4dba-4542-b952-ee87871b27d0" />
Cultist, glyph visible
<img width="398" height="276" alt="изображение" src="https://github.com/user-attachments/assets/51990cc6-ba68-4f33-9c74-2717bbd85766" />
Non-cultist, stage 3, glyph visible
<img width="383" height="361" alt="изображение" src="https://github.com/user-attachments/assets/93d4ef7e-2242-4805-a0a4-bdf4464d410a" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cosmic cult's glyph are no longer visible to non-cultists during the first and second stage.