### PR TITLE
Actually make LPO's crew monitor actually show people on the station

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringBoundUserInterface.cs
@@ -26,7 +26,7 @@ public sealed class CrewMonitoringBoundUserInterface : BoundUserInterface
             // Begin DeltaV Additions - Find a station's grid instead of the current one for evil monitors
             if (EntMan.HasComponent<LongRangeCrewMonitorComponent>(Owner))
             {
-                gridUid = EntMan.System<LongRangeCrewMonitorSystem>().FindStationGridInMap(xform.MapID);
+                gridUid = EntMan.System<LongRangeCrewMonitorSystem>().FindLargestStationGridInMap(xform.MapID);
                 gridUid ??= xform.GridUid; // fall back to whatever grid this is on if it failed
             }
             // End DeltaV Additions

--- a/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorSystem.cs
+++ b/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorSystem.cs
@@ -7,22 +7,6 @@ namespace Content.Shared._DV.Medical.CrewMonitoring;
 public sealed class LongRangeCrewMonitorSystem : EntitySystem
 {
     /// <summary>
-    /// Finds an arbitrary station grid on the same map as the argument.
-    /// Returns null if no grid was found.
-    /// </summary>
-    public EntityUid? FindStationGridInMap(MapId map)
-    {
-        // also requiring MapGrid incase StationMember gets used for non-grids in the future
-        var query = EntityQueryEnumerator<StationMemberComponent, MapGridComponent>();
-        while (query.MoveNext(out var grid, out _, out _))
-        {
-            if (Transform(grid).MapID == map)
-                return grid;
-        }
-
-        return null;
-    }
-    /// <summary>
     /// Finds the largest (presumably the main station) grid on the same map as the argument.
     /// </summary>
     /// <param name="map"></param>

--- a/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorSystem.cs
+++ b/Content.Shared/_DV/Medical/CrewMonitoring/LongRangeCrewMonitorSystem.cs
@@ -22,4 +22,21 @@ public sealed class LongRangeCrewMonitorSystem : EntitySystem
 
         return null;
     }
+    /// <summary>
+    /// Finds the largest (presumably the main station) grid on the same map as the argument.
+    /// </summary>
+    /// <param name="map"></param>
+    /// <returns>Returns null if not found</returns>
+    public EntityUid? FindLargestStationGridInMap(MapId map)
+    {
+        // also requiring MapGrid incase StationMember gets used for non-grids in the future
+        (EntityUid?, int) biggest_grid = (null, 0);
+        var query = EntityQueryEnumerator<StationMemberComponent, MapGridComponent>();
+        while (query.MoveNext(out var grid, out _, out var mapgrid))
+        {
+            if (Transform(grid).MapID == map && mapgrid.ChunkCount > biggest_grid.Item2)
+                biggest_grid = (grid, mapgrid.ChunkCount);
+        }
+        return biggest_grid.Item1;
+    }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixed a bug with the LPO crew monitor which caused it to show the incorrect grid.

## Why / Balance
In release builds, the LPO crew monitor focuses onto the wrong grid. Making the crew monitor inaccurate.
Allows the listening post operatives to actually do their job.
## Technical details
Adds a new function which finds the biggest grid, as opposed to any.

## Media
https://github.com/user-attachments/assets/fddd189b-7057-4f0b-a71c-7b419d1094d3


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Nil.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed LPO crew monitor focusing on the wrong grid.

