### PR TITLE
Add in-game date to the PDA

### DIFF
--- a/Content.Client/PDA/PdaMenu.xaml
+++ b/Content.Client/PDA/PdaMenu.xaml
@@ -43,9 +43,11 @@
             <ContainerButton Name="StationTimeButton">
                 <RichTextLabel Name="StationTimeLabel" Access="Public"/>
             </ContainerButton>
+            <!-- Begin DeltaV changes -->
             <ContainerButton Name="CurrentDateButton">
                 <RichTextLabel Name="CurrentDateLabel" Access="Public"/>
             </ContainerButton>
+            <!-- End DeltaV changes -->
             <ContainerButton Name="StationAlertLevelInstructionsButton">
                 <RichTextLabel Name="StationAlertLevelInstructions" Access="Public"/>
             </ContainerButton>

--- a/Content.Client/PDA/PdaMenu.xaml
+++ b/Content.Client/PDA/PdaMenu.xaml
@@ -43,6 +43,9 @@
             <ContainerButton Name="StationTimeButton">
                 <RichTextLabel Name="StationTimeLabel" Access="Public"/>
             </ContainerButton>
+            <ContainerButton Name="CurrentDateButton">
+                <RichTextLabel Name="CurrentDateLabel" Access="Public"/>
+            </ContainerButton>
             <ContainerButton Name="StationAlertLevelInstructionsButton">
                 <RichTextLabel Name="StationAlertLevelInstructions" Access="Public"/>
             </ContainerButton>

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -32,6 +32,7 @@ namespace Content.Client.PDA
         private string _stationName = Loc.GetString("comp-pda-ui-unknown");
         private string _alertLevel = Loc.GetString("comp-pda-ui-unknown");
         private string _instructions = Loc.GetString("comp-pda-ui-unknown");
+        private string _currentDate = Loc.GetString("comp-pda-ui-unknown"); // DeltaV - PDA date
         
 
         private int _currentView;
@@ -125,6 +126,13 @@ namespace Content.Client.PDA
                 _clipboard.SetText(_instructions);
             };
 
+            // Begin DeltaV additions
+            CurrentDateButton.OnPressed += _ =>
+            {
+                _clipboard.SetText(_currentDate);
+            };
+            // End DeltaV additions
+
             
 
 
@@ -187,6 +195,14 @@ namespace Content.Client.PDA
                 "comp-pda-ui-station-alert-level-instructions",
                 ("instructions", _instructions))
             );
+            // Begin DeltaV additions
+            if (state.PdaOwnerInfo.CurrentDate is { } curDate)
+                _currentDate = curDate.ToString("d");
+                CurrentDateLabel.SetMarkup(Loc.GetString(
+                    "comp-pda-ui-current-date",
+                    ("date", _currentDate)
+                ));
+            // End DeltaV additions
 
             AddressLabel.Text = state.Address?.ToUpper() ?? " - ";
 

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -197,7 +197,7 @@ namespace Content.Client.PDA
             );
             // Begin DeltaV additions
             if (state.PdaOwnerInfo.CurrentDate is { } curDate)
-                _currentDate = curDate.ToString("d");
+                _currentDate = curDate.ToString("dd/mm/yyyy");
                 CurrentDateLabel.SetMarkup(Loc.GetString(
                     "comp-pda-ui-current-date",
                     ("date", _currentDate)

--- a/Content.Client/PDA/PdaMenu.xaml.cs
+++ b/Content.Client/PDA/PdaMenu.xaml.cs
@@ -197,7 +197,7 @@ namespace Content.Client.PDA
             );
             // Begin DeltaV additions
             if (state.PdaOwnerInfo.CurrentDate is { } curDate)
-                _currentDate = curDate.ToString("dd/mm/yyyy");
+                _currentDate = curDate.ToString("dd MMMM yyyy");
                 CurrentDateLabel.SetMarkup(Loc.GetString(
                     "comp-pda-ui-current-date",
                     ("date", _currentDate)

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -7,6 +7,7 @@ using Content.Server.PDA.Ringer;
 using Content.Server.Station.Systems;
 using Content.Server.Store.Systems;
 using Content.Server.Traitor.Uplink;
+using Content.Shared._DV.CCVars; // DeltaV - PDA date
 using Content.Shared.Access.Components;
 using Content.Shared.CartridgeLoader;
 using Content.Shared.Chat;
@@ -19,6 +20,7 @@ using Content.Shared.PDA;
 using Content.Shared.PDA.Ringer;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration; // DeltaV - PDA date
 using Robust.Shared.Containers;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
@@ -37,6 +39,9 @@ namespace Content.Server.PDA
         [Dependency] private readonly UnpoweredFlashlightSystem _unpoweredFlashlight = default!;
         [Dependency] private readonly ContainerSystem _containerSystem = default!;
         [Dependency] private readonly IdCardSystem _idCard = default!;
+        [Dependency] private readonly IConfigurationManager _config = default!; // DeltaV
+
+        private static DateTime ServerDate; // DeltaV - PDA
 
         public override void Initialize()
         {
@@ -59,6 +64,13 @@ namespace Content.Server.PDA
             SubscribeLocalEvent<EntityRenamedEvent>(OnEntityRenamed, after: new[] { typeof(IdCardSystem) });
             SubscribeLocalEvent<AlertLevelChangedEvent>(OnAlertLevelChanged);
             SubscribeLocalEvent<PdaComponent, InventoryRelayedEvent<ChameleonControllerOutfitSelectedEvent>>(ChameleonControllerOutfitItemSelected);
+
+            // Begin DeltaV additions
+            Subs.CVar(_config,
+                DCCVars.YearOffset,
+                value => ServerDate = DateTime.Today.AddYears(value),
+                true);
+            // End DeltaV additions
         }
 
         private void ChameleonControllerOutfitItemSelected(Entity<PdaComponent> ent, ref InventoryRelayedEvent<ChameleonControllerOutfitSelectedEvent> args)
@@ -189,6 +201,7 @@ namespace Content.Server.PDA
             var hasInstrument = HasComp<InstrumentComponent>(uid);
             var showUplink = HasComp<UplinkComponent>(uid) && IsUnlocked(uid);
 
+            pda.currentDate = pda.dateOverride == new DateTime() ? ServerDate : pda.dateOverride; // DeltaV - PDA date
             UpdateStationName(uid, pda);
             UpdateAlertLevel(uid, pda);
             // TODO: Update the level and name of the station with each call to UpdatePdaUi is only needed for latejoin players.
@@ -211,6 +224,7 @@ namespace Content.Server.PDA
                     ActualOwnerName = pda.OwnerName,
                     IdOwner = id?.FullName,
                     JobTitle = id?.LocalizedJobTitle,
+                    CurrentDate = pda.currentDate, // DeltaV - PDA date
                     StationAlertLevel = pda.StationAlertLevel,
                     StationAlertColor = pda.StationAlertColor
                 },

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -201,7 +201,7 @@ namespace Content.Server.PDA
             var hasInstrument = HasComp<InstrumentComponent>(uid);
             var showUplink = HasComp<UplinkComponent>(uid) && IsUnlocked(uid);
 
-            pda.currentDate = pda.dateOverride == new DateTime() ? ServerDate : pda.dateOverride; // DeltaV - PDA date
+            pda.CurrentDate = pda.DateOverride == new DateTime() ? ServerDate : pda.DateOverride; // DeltaV - PDA date
             UpdateStationName(uid, pda);
             UpdateAlertLevel(uid, pda);
             // TODO: Update the level and name of the station with each call to UpdatePdaUi is only needed for latejoin players.
@@ -224,7 +224,7 @@ namespace Content.Server.PDA
                     ActualOwnerName = pda.OwnerName,
                     IdOwner = id?.FullName,
                     JobTitle = id?.LocalizedJobTitle,
-                    CurrentDate = pda.currentDate, // DeltaV - PDA date
+                    CurrentDate = pda.CurrentDate, // DeltaV - PDA date
                     StationAlertLevel = pda.StationAlertLevel,
                     StationAlertColor = pda.StationAlertColor
                 },

--- a/Content.Server/PDA/PdaSystem.cs
+++ b/Content.Server/PDA/PdaSystem.cs
@@ -201,7 +201,7 @@ namespace Content.Server.PDA
             var hasInstrument = HasComp<InstrumentComponent>(uid);
             var showUplink = HasComp<UplinkComponent>(uid) && IsUnlocked(uid);
 
-            pda.CurrentDate = pda.DateOverride == new DateTime() ? ServerDate : pda.DateOverride; // DeltaV - PDA date
+            pda.CurrentDate = pda.DateOverride ?? ServerDate; // DeltaV - PDA date
             UpdateStationName(uid, pda);
             UpdateAlertLevel(uid, pda);
             // TODO: Update the level and name of the station with each call to UpdatePdaUi is only needed for latejoin players.

--- a/Content.Shared/PDA/PdaComponent.cs
+++ b/Content.Shared/PDA/PdaComponent.cs
@@ -39,6 +39,6 @@ namespace Content.Shared.PDA
         [ViewVariables] public string? StationAlertLevel;
         [ViewVariables] public Color StationAlertColor = Color.White;
         [DataField] public DateTime CurrentDate; // DeltaV - PDA date
-        [DataField] public DateTime DateOverride; // DeltaV - PDA date
+        [DataField] public DateTime? DateOverride; // DeltaV - PDA date
     }
 }

--- a/Content.Shared/PDA/PdaComponent.cs
+++ b/Content.Shared/PDA/PdaComponent.cs
@@ -38,7 +38,7 @@ namespace Content.Shared.PDA
         [ViewVariables] public string? StationName;
         [ViewVariables] public string? StationAlertLevel;
         [ViewVariables] public Color StationAlertColor = Color.White;
-        [ViewVariables] public DateTime currentDate; // DeltaV - PDA date
-        [DataField("dateOverride")] public DateTime dateOverride; // DeltaV - PDA date
+        [DataField] public DateTime CurrentDate; // DeltaV - PDA date
+        [DataField] public DateTime DateOverride; // DeltaV - PDA date
     }
 }

--- a/Content.Shared/PDA/PdaComponent.cs
+++ b/Content.Shared/PDA/PdaComponent.cs
@@ -38,5 +38,7 @@ namespace Content.Shared.PDA
         [ViewVariables] public string? StationName;
         [ViewVariables] public string? StationAlertLevel;
         [ViewVariables] public Color StationAlertColor = Color.White;
+        [ViewVariables] public DateTime currentDate; // DeltaV - PDA date
+        [DataField("dateOverride")] public DateTime dateOverride; // DeltaV - PDA date
     }
 }

--- a/Content.Shared/PDA/PdaUpdateState.cs
+++ b/Content.Shared/PDA/PdaUpdateState.cs
@@ -49,5 +49,6 @@ namespace Content.Shared.PDA
         public string? JobTitle;
         public string? StationAlertLevel;
         public Color StationAlertColor;
+        public DateTime? CurrentDate; // DeltaV - PDA date
     }
 }

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -106,6 +106,12 @@ public sealed partial class DCCVars
     public static readonly CVarDef<bool> Shipyard =
         CVarDef.Create("shuttle.shipyard", true, CVar.SERVERONLY);
 
+    /// <summary>
+    /// What year it is in the game. Actual value shown in game is server date + this value.
+    /// </summary>
+    public static readonly CVarDef<int> YearOffset =
+        CVarDef.Create("game.current_year_offset", 550, CVar.SERVERONLY);
+
     /*
      * Feedback webhook
      */

--- a/Resources/Locale/en-US/_DV/pda/pda-component.ftl
+++ b/Resources/Locale/en-US/_DV/pda/pda-component.ftl
@@ -1,0 +1,1 @@
+comp-pda-ui-current-date = Current date: [color=white]{ $date }[/color]

--- a/Resources/Locale/en-US/pda/pda-component.ftl
+++ b/Resources/Locale/en-US/pda/pda-component.ftl
@@ -54,5 +54,3 @@ comp-pda-ui-unassigned = Unassigned
 
 pda-notification-message = [font size=12][bold]PDA[/bold] { $header }: [/font]
     "{ $message }"
-
-comp-pda-ui-current-date = Current date: [color=white]{ $date }[/color]

--- a/Resources/Locale/en-US/pda/pda-component.ftl
+++ b/Resources/Locale/en-US/pda/pda-component.ftl
@@ -54,3 +54,5 @@ comp-pda-ui-unassigned = Unassigned
 
 pda-notification-message = [font size=12][bold]PDA[/bold] { $header }: [/font]
     "{ $message }"
+
+comp-pda-ui-current-date = Current date: [color=white]{ $date }[/color]


### PR DESCRIPTION
## About the PR
PDA now displays the current in-universe date! The date is set to today + 550 years (based on that one splash text from the launcher), but can be easily changes if we actually had a canon IC year and I just didn't know about it.

## Why / Balance
Actually knowing what year it is is good for roleplay. And paperwork. By the way, did you know you can just copy the text fields from the PDA menu? Works for this one, too.

## Technical details
The current date is fetched from the server during PdaSystem initialization to avoid time zone shenanigans. The year offset is a DCCVar, so we can easily change it if need be. There is a DateOverride field on the PdaComponent, but apparently you can't VV a DateTime, so if you want to make a very convincing time travel admeme, you'll need a custom PDA prototype.

## Media
I have no idea how to format dates properly bruh
<img width="229" height="73" alt="изображение" src="https://github.com/user-attachments/assets/d57418d1-983f-4b12-a65b-688a05f316fd" />



## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: PDAs now display the current in-universe date! It was 2575 all along.
