### PR TITLE
Actually add flash protection to cult helmets

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
@@ -108,7 +108,7 @@
         Slash: 0.90
         Piercing: 0.90
         Heat: 0.90
-  - type: EyeProtection
+  - type: FlashImmunity
   - type: TypingIndicatorClothing
     proto: CosmicTyping
   - type: SpeechOverride


### PR DESCRIPTION
## About the PR
#4108 was supposed to give coscult's helmets flash protection. However, I am apparently stupid, and gave them eye protection instead, which protects your eyes from welding, not flashes. Now it actually gives flash protection, and not welding protection.

## Why / Balance
See #4108.
Direction review probably not needed, because that one was approved already, it just didn't work.

## Technical details
Added the correct component this time.

## Media
https://www.youtube.com/watch?v=dQw4w9WgXcQ

## Requirements
- [X] I have not tested all added content and changes. Neither I did last time.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Cult helmets now actually provide flash protection. For real this time.