### PR TITLE
Some loosely connected cosmic cult tweaks

### DIFF
--- a/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
+++ b/Content.Server/_DV/CosmicCult/Components/CosmicMalignRiftComponent.cs
@@ -14,29 +14,17 @@ public sealed partial class CosmicMalignRiftComponent : Component
     [DataField]
     public bool Occupied;
 
-    [DataField]
-    public EntProtoId PurgeVFX = "CleanseEffectVFX";
-
-    [DataField]
-    public SoundSpecifier PurgeSound = new SoundPathSpecifier("/Audio/_DV/CosmicCult/cleanse_deconversion.ogg");
-
     // [DataField]
     // public EntProtoId GrailID = "NullRodGrail"; // Not implemented at this time
 
     [DataField]
-    public TimeSpan BibleTime = TimeSpan.FromSeconds(35);
+    public TimeSpan AbsorbTime = TimeSpan.FromSeconds(20);
 
     [DataField]
-    public TimeSpan ChaplainTime = TimeSpan.FromSeconds(20);
+    public TimeSpan MinPulseTime = TimeSpan.FromSeconds(10);
 
     [DataField]
-    public TimeSpan AbsorbTime = TimeSpan.FromSeconds(35);
-
-    [DataField]
-    public TimeSpan MinPulseTime = TimeSpan.FromSeconds(20);
-
-    [DataField]
-    public TimeSpan MaxPulseTime = TimeSpan.FromSeconds(60);
+    public TimeSpan MaxPulseTime = TimeSpan.FromSeconds(30);
 
     [DataField]
     public float PulseRange = 15f;

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicPurifiableSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicPurifiableSystem.cs
@@ -1,32 +1,21 @@
 using Content.Server._DV.CosmicCult.Components;
-using Content.Server.Actions;
-using Content.Server.Atmos.Components;
 using Content.Server.Bible.Components;
 using Content.Server.Popups;
 using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.DoAfter;
-using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
-using Content.Shared.StatusEffect;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Random;
-using Robust.Shared.Timing;
 
 namespace Content.Server._DV.CosmicCult.EntitySystems;
 
 public sealed class CosmicPurifiableSystem : EntitySystem
 {
-    [Dependency] private readonly ActionsSystem _actions = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
-    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
     public override void Initialize()
     {

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicPurifiableSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicPurifiableSystem.cs
@@ -1,0 +1,72 @@
+using Content.Server._DV.CosmicCult.Components;
+using Content.Server.Actions;
+using Content.Server.Atmos.Components;
+using Content.Server.Bible.Components;
+using Content.Server.Popups;
+using Content.Shared._DV.CosmicCult;
+using Content.Shared._DV.CosmicCult.Components;
+using Content.Shared.DoAfter;
+using Content.Shared.Humanoid;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.StatusEffect;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._DV.CosmicCult.EntitySystems;
+
+public sealed class CosmicPurifiableSystem : EntitySystem
+{
+    [Dependency] private readonly ActionsSystem _actions = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<CosmicPurifiableComponent, InteractUsingEvent>(OnInteractUsing);
+        SubscribeLocalEvent<CosmicPurifiableComponent, EventPurgeRiftDoAfter>(OnPurgeDoAfter);
+    }
+
+    private void OnInteractUsing(Entity<CosmicPurifiableComponent> uid, ref InteractUsingEvent args)
+    {
+        if (args.Handled || !HasComp<BibleComponent>(args.Used))
+            return;
+
+        _popup.PopupEntity(Loc.GetString("cosmiccult-rift-beginpurge"), args.User, args.User);
+        var doargs = new DoAfterArgs(EntityManager,
+            args.User,
+            (HasComp<BibleUserComponent>(args.User) ? uid.Comp.CleanseTimeChaplain : uid.Comp.CleanseTime),
+            new EventPurgeRiftDoAfter(),
+            uid,
+            uid)
+        {
+            DistanceThreshold = 1.5f, Hidden = false, BreakOnDamage = true, BreakOnDropItem = true,
+            BreakOnMove = true, MovementThreshold = 2f,
+        };
+        _doAfter.TryStartDoAfter(doargs);
+    }
+
+    private void OnPurgeDoAfter(Entity<CosmicPurifiableComponent> uid, ref EventPurgeRiftDoAfter args)
+    {
+        if (args.Args.Target == null || args.Cancelled || args.Handled)
+            return;
+
+        args.Handled = true;
+        var tgtpos = Transform(uid).Coordinates;
+        Spawn(uid.Comp.PurgeVFX, tgtpos);
+        _audio.PlayPvs(uid.Comp.PurgeSound, args.User);
+        _popup.PopupCoordinates(
+            Loc.GetString("cosmiccult-rift-purge", ("NAME", Identity.Entity(args.Args.User, EntityManager))),
+            Transform(args.Args.User).Coordinates,
+            PopupType.Medium);
+        QueueDel(uid);
+    }
+}

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -5,10 +5,12 @@ using Content.Server.Bible.Components;
 using Content.Server.Popups;
 using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
+using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
 using Robust.Shared.Audio.Systems;
@@ -28,22 +30,22 @@ public sealed class CosmicRiftSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly EntityLookupSystem _lookup = default!;
 
-    private readonly HashSet<Entity<HumanoidAppearanceComponent>> _humanoids = [];
+    private readonly HashSet<Entity<MobStateComponent>> _mobs = [];
 
     private EntityQuery<CosmicCultComponent> _cultistsQuery;
     private EntityQuery<BibleUserComponent> _chaplainsQuery;
+    private EntityQuery<CosmicColossusComponent> _colossiQuery;
 
     public override void Initialize()
     {
         base.Initialize();
         SubscribeLocalEvent<CosmicMalignRiftComponent, InteractHandEvent>(OnInteract);
-        SubscribeLocalEvent<CosmicMalignRiftComponent, InteractUsingEvent>(OnInteractUsing);
         SubscribeLocalEvent<CosmicCultComponent, EventAbsorbRiftDoAfter>(OnAbsorbDoAfter);
-        SubscribeLocalEvent<CosmicMalignRiftComponent, EventPurgeRiftDoAfter>(OnPurgeDoAfter);
         SubscribeLocalEvent<CosmicMalignRiftComponent, ComponentInit>(OnRiftStarted);
 
         _cultistsQuery = GetEntityQuery<CosmicCultComponent>();
         _chaplainsQuery = GetEntityQuery<BibleUserComponent>();
+        _colossiQuery = GetEntityQuery<CosmicColossusComponent>();
     }
 
     private void OnRiftStarted(Entity<CosmicMalignRiftComponent> ent, ref ComponentInit args)
@@ -63,16 +65,21 @@ public sealed class CosmicRiftSystem : EntitySystem
 
             var pos = Transform(uid).Coordinates;
             Spawn(comp.PulseVFX, pos);
-            _lookup.GetEntitiesInRange<HumanoidAppearanceComponent>(pos, comp.PulseRange, _humanoids);
-            _humanoids.RemoveWhere(target => _chaplainsQuery.HasComp(target) || _cultistsQuery.HasComp(target));
-            foreach(var humanoid in _humanoids)
+            _lookup.GetEntitiesInRange<MobStateComponent>(pos, comp.PulseRange, _mobs);
+            _mobs.RemoveWhere(target => _chaplainsQuery.HasComp(target) || _cultistsQuery.HasComp(target) || _colossiQuery.HasComp(target));
+            foreach(var humanoid in _mobs)
             {
                 if (!pos.TryDistance(EntityManager, Transform(humanoid).Coordinates, out var distance)) continue;
                 if (!_random.Prob(comp.PulseProb)) continue;
                 var damageMultiplier = Math.Clamp(comp.PulseRange / distance, 1, 10); //0.2 damage per second at max distance, up to 2 per second if closer
                 var effectDuration = _random.Next(10, 40); //2-8 damage at max distance, 20-80 damage at min distance
                 _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(humanoid, "EntropicDegen", TimeSpan.FromSeconds(effectDuration), true);
-                if (TryComp<CosmicEntropyDebuffComponent>(humanoid, out var debuff)) debuff.Degen = new(){DamageDict = new(){{"Cold", 0.05 * damageMultiplier}, {"Asphyxiation", 0.15 * damageMultiplier}}};
+                if (TryComp<CosmicEntropyDebuffComponent>(humanoid, out var debuff)) debuff.Degen = 
+                new(){DamageDict = new(){
+                    {"Cold", 0.05 * damageMultiplier}, 
+                    {"Asphyxiation", 0.15 * damageMultiplier}, 
+                    {"Ion", 0.15 * damageMultiplier}
+                }};
             }
         }
     }
@@ -82,12 +89,6 @@ public sealed class CosmicRiftSystem : EntitySystem
         if (args.Handled || uid.Comp.Occupied)
         {
             _popup.PopupEntity(Loc.GetString("cosmiccult-rift-inuse"), args.User, args.User);
-            return;
-        }
-
-        if (HasComp<BibleUserComponent>(args.User))
-        {
-            _popup.PopupEntity(Loc.GetString("cosmiccult-rift-chaplainoops"), args.User, args.User);
             return;
         }
 
@@ -117,48 +118,6 @@ public sealed class CosmicRiftSystem : EntitySystem
             MovementThreshold = 0.5f,
         };
         _doAfter.TryStartDoAfter(doargs);
-    }
-
-    private void OnInteractUsing(Entity<CosmicMalignRiftComponent> uid, ref InteractUsingEvent args)
-    {
-        if (args.Handled || uid.Comp.Occupied)
-        {
-            _popup.PopupEntity(Loc.GetString("cosmiccult-rift-inuse"), args.User, args.User);
-            return;
-        }
-
-        if (HasComp<BibleComponent>(args.Used))
-        {
-            uid.Comp.Occupied = true;
-            _popup.PopupEntity(Loc.GetString("cosmiccult-rift-beginpurge"), args.User, args.User);
-            var doargs = new DoAfterArgs(EntityManager,
-                args.User,
-                uid.Comp.BibleTime,
-                new EventPurgeRiftDoAfter(),
-                uid,
-                uid)
-            {
-                DistanceThreshold = 1.5f, Hidden = false, BreakOnDamage = true, BreakOnDropItem = true,
-                BreakOnMove = true, MovementThreshold = 2f,
-            };
-            _doAfter.TryStartDoAfter(doargs);
-        }
-        else if (TryComp<CleanseOnUseComponent>(args.Used, out var comp) && comp.CanPurge)
-        {
-            uid.Comp.Occupied = true;
-            _popup.PopupEntity(Loc.GetString("cosmiccult-rift-beginpurge"), args.User, args.User);
-            var doargs = new DoAfterArgs(EntityManager,
-                args.User,
-                uid.Comp.ChaplainTime,
-                new EventPurgeRiftDoAfter(),
-                uid,
-                uid)
-            {
-                DistanceThreshold = 1.5f, Hidden = false, BreakOnDamage = true, BreakOnDropItem = true,
-                BreakOnMove = true, MovementThreshold = 2f,
-            };
-            _doAfter.TryStartDoAfter(doargs);
-        }
     }
 
     private void OnAbsorbDoAfter(Entity<CosmicCultComponent> uid, ref EventAbsorbRiftDoAfter args)
@@ -193,24 +152,5 @@ public sealed class CosmicRiftSystem : EntitySystem
             Transform(args.Args.User).Coordinates,
             PopupType.MediumCaution);
         QueueDel(target);
-    }
-
-    private void OnPurgeDoAfter(Entity<CosmicMalignRiftComponent> uid, ref EventPurgeRiftDoAfter args)
-    {
-        if (args.Args.Target == null || args.Cancelled || args.Handled)
-        {
-            uid.Comp.Occupied = false;
-            return;
-        }
-
-        args.Handled = true;
-        var tgtpos = Transform(uid).Coordinates;
-        Spawn(uid.Comp.PurgeVFX, tgtpos);
-        _audio.PlayPvs(uid.Comp.PurgeSound, args.User);
-        _popup.PopupCoordinates(
-            Loc.GetString("cosmiccult-rift-purge", ("NAME", Identity.Entity(args.Args.User, EntityManager))),
-            Transform(args.Args.User).Coordinates,
-            PopupType.Medium);
-        QueueDel(uid);
     }
 }

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -71,10 +71,10 @@ public sealed class CosmicRiftSystem : EntitySystem
                 var damageMultiplier = Math.Clamp(comp.PulseRange / distance, 1, 10); //0.2 damage per second at max distance, up to 2 per second if closer
                 var effectDuration = _random.Next(10, 40); //2-8 damage at max distance, 20-80 damage at min distance
                 _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(mob, "EntropicDegen", TimeSpan.FromSeconds(effectDuration), true);
-                if (TryComp<CosmicEntropyDebuffComponent>(mob, out var debuff)) debuff.Degen = 
+                if (TryComp<CosmicEntropyDebuffComponent>(mob, out var debuff)) debuff.Degen =
                 new(){DamageDict = new(){
-                    {"Cold", 0.05 * damageMultiplier}, 
-                    {"Asphyxiation", 0.15 * damageMultiplier}, 
+                    {"Cold", 0.05 * damageMultiplier},
+                    {"Asphyxiation", 0.15 * damageMultiplier},
                     {"Ion", 0.15 * damageMultiplier}
                 }};
             }

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -7,13 +7,11 @@ using Content.Shared._DV.CosmicCult;
 using Content.Shared._DV.CosmicCult.Components;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
-using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Content.Shared.StatusEffect;
-using Robust.Shared.Audio.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -22,7 +20,6 @@ namespace Content.Server._DV.CosmicCult.EntitySystems;
 public sealed class CosmicRiftSystem : EntitySystem
 {
     [Dependency] private readonly ActionsSystem _actions = default!;
-    [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
@@ -67,14 +64,14 @@ public sealed class CosmicRiftSystem : EntitySystem
             Spawn(comp.PulseVFX, pos);
             _lookup.GetEntitiesInRange<MobStateComponent>(pos, comp.PulseRange, _mobs);
             _mobs.RemoveWhere(target => _chaplainsQuery.HasComp(target) || _cultistsQuery.HasComp(target) || _colossiQuery.HasComp(target));
-            foreach(var humanoid in _mobs)
+            foreach(var mob in _mobs)
             {
-                if (!pos.TryDistance(EntityManager, Transform(humanoid).Coordinates, out var distance)) continue;
+                if (!pos.TryDistance(EntityManager, Transform(mob).Coordinates, out var distance)) continue;
                 if (!_random.Prob(comp.PulseProb)) continue;
                 var damageMultiplier = Math.Clamp(comp.PulseRange / distance, 1, 10); //0.2 damage per second at max distance, up to 2 per second if closer
                 var effectDuration = _random.Next(10, 40); //2-8 damage at max distance, 20-80 damage at min distance
-                _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(humanoid, "EntropicDegen", TimeSpan.FromSeconds(effectDuration), true);
-                if (TryComp<CosmicEntropyDebuffComponent>(humanoid, out var debuff)) debuff.Degen = 
+                _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(mob, "EntropicDegen", TimeSpan.FromSeconds(effectDuration), true);
+                if (TryComp<CosmicEntropyDebuffComponent>(mob, out var debuff)) debuff.Degen = 
                 new(){DamageDict = new(){
                     {"Cold", 0.05 * damageMultiplier}, 
                     {"Asphyxiation", 0.15 * damageMultiplier}, 

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicPurifiableComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicPurifiableComponent.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.CosmicCult.Components;
+
+[RegisterComponent]
+[AutoGenerateComponentPause]
+public sealed partial class CosmicPurifiableComponent : Component
+{
+    [DataField]
+    public EntProtoId PurgeVFX = "CleanseEffectVFX";
+
+    [DataField]
+    public SoundSpecifier PurgeSound = new SoundPathSpecifier("/Audio/_DV/CosmicCult/cleanse_deconversion.ogg");
+
+    [DataField]
+    public TimeSpan CleanseTime = TimeSpan.FromSeconds(35);
+
+    [DataField]
+    public TimeSpan CleanseTimeChaplain = TimeSpan.FromSeconds(20);
+
+    ///<summary>
+    /// If true, only an entity with a BibleUserComponent can purge this entity
+    ///</summary>
+    [DataField]
+    public bool BibleUserRequired = false;
+}

--- a/Content.Shared/_DV/CosmicCult/Components/CosmicPurifiableComponent.cs
+++ b/Content.Shared/_DV/CosmicCult/Components/CosmicPurifiableComponent.cs
@@ -23,5 +23,5 @@ public sealed partial class CosmicPurifiableComponent : Component
     /// If true, only an entity with a BibleUserComponent can purge this entity
     ///</summary>
     [DataField]
-    public bool BibleUserRequired = false;
+    public bool BibleUserRequired;
 }

--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/converter.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/converter.yml
@@ -79,17 +79,4 @@
     floodFillStarting: true
     corruptionMaxTicks: 12
     corruptionSpeed: 1.25
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 400
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
+  - type: CosmicPurifiable

--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/structures.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/structures.yml
@@ -272,6 +272,7 @@
     corruptionSpeed: 8
     corruptionChance: 1
     corruptionReduction: 0.16
+  - type: CosmicPurifiable
 
 ##################### SPIRE
 - type: entity
@@ -332,22 +333,11 @@
     range: 15
     sound:
       path: /Audio/_DV/CosmicCult/spire_draining.ogg
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
   - type: RCDDeconstructable
     deconstructable: false
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 300
-      behaviors: #excess damage, don't spawn entities.
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
+  - type: CosmicPurifiable
+    cleanseTime: 10
+    cleanseTimeChaplain: 5
   - type: PointLight
     radius: 2
     energy: 1.6
@@ -402,22 +392,11 @@
     range: 15
     sound:
       path: /Audio/_DV/CosmicCult/spire_draining.ogg
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: Metallic
   - type: RCDDeconstructable
     deconstructable: false
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 200
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: GlassBreak
+  - type: CosmicPurifiable
+    cleanseTime: 10
+    cleanseTimeChaplain: 5
   - type: PointLight
     radius: 2
     energy: 1.6

--- a/Resources/Prototypes/_DV/CosmicCult/glyphs.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/glyphs.yml
@@ -38,6 +38,9 @@
           Cooldown: {state: cooldown}
   - type: Appearance
   - type: InteractionOutline
+  - type: CosmicPurifiable # Because why the hell not
+    cleanseTime: 10
+    cleanseTimeChaplain: 5
 
 - type: entity
   parent: CosmicGlyphBase


### PR DESCRIPTION
## About the PR
Malign rifts now "pulse" twice as often on average. "Pulses" now affect all mobs, not just humanoids (except for cultsits, chaplains, and colossi). Pulses deal ion damage now (same amount as asphyx).
Purging malign rifts as chaplain now takes 20 seconds. Non-chaplains still need 35 seconds. Absorbing rifts also takes 20 seconds now (down from 35).
Vacuous chantries, vacuous spires and multispectral inhibitors are no longer destructible. Instead, they can be purged with a bible, just like a malign rift (the latter two take less time: 5 seconds for chaplains, 10 seconds for non-chaplains). Oh, yeah, cult glyphs can also be removed in the same way. Because why not. Kinda makes sense doesn't it?

## Why / Balance
Damage from malign rifts was way too low, especially on IPCs who don't asphyxiate, and did not have the intended effect. Hopefuly now they should be scarier, and not only for humanoids, but pretty much any creature. Piles of dead mice around rifts may also become a thing.
Time difference for purging rifts for chaplains was already in the component, but it didn't work as intended. Absorbtion time was also lowered, because "staring at the rift for almost a minute" isn't really engaging gameplay for anyone involved.
Getting rid of cult objects is currently very unintuitive. Rifts need the chaplain to shout at them, chantries need to be broken by damaging them, and don't even get me started on effigies (not changing those ones, though, that's for a different PR). Now, if you see a weird cult thing, the solution is pretty much always to call the chaplain, or just smack it with a bible yourself if you have one.
Chantries especially are quite problematic right now. Cultists don't even bother defending them, and instead just start the ritual and skebaddle. Security then gets to the chantry, but due to either the metashield, or literally not knowing what to do (it's really tanky, so you can just magdump it, see no effect, and think that it's not how you destroy it), end up just staring at it until the ritual completes.

## Technical details
"Kill this thing with a bible and a long do-after" has been moved from the CosmicMalignRiftComponent to a new CosmicPurifiableComponent. Said component was applied to a few other entities. Aside from that, it's just numbers and other minor tweaks.

## Media
There isn't really that much to show here.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Malign rifts are more dangerous now.
- tweak: Chaplains and mystagogues now have an easier time purging malign rifts. Cultists also absorb them faster now.
- tweak: Vacuous chantry, multispectral inhibitor and vacuous spire are no longer destructible. Instead, you have to purge them with a bible, just like a malign rift.
- tweak: Cosmic cult's glyphs can now be purged with a bible.
