### PR TITLE
Nuke ops mald pr tm

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Syndicate_Gadgets/war_declarator.yml
@@ -22,6 +22,6 @@
           type: WarDeclaratorBoundUserInterface
     - type: WarDeclarator
       message: war-declarator-default-message
-      sound: /Audio/Announcements/Alerts/code_red.ogg # DeltaV
+      sound: /Audio/Announcements/war.ogg
     - type: AccessReader
       access: [["NuclearOperative"]]

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/syndicate.yml
@@ -39,4 +39,4 @@
   components:
     - type: Store
       balance:
-        Telecrystal: 67 # not 65 but this is for nukies.
+        Telecrystal: 75 # not 65 but this is for nukies.


### PR DESCRIPTION
## About the PR
Loneop uplink 67TC -> 75 TC
War declarator makes the proper sound now instead of code red

## Why / Balance
Duplicate sounds bad, war.ogg good
Loneop no longer gets free magboots and bloodred thanks to #4174 so a little buff is warranted imo (not even covers the price of items lost)

## Technical details
YAML ops

## Media
No

## Requirements
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Loneops get 75TC instead of 67 now (they no longer get free suit).
- fix: Nuclear operative war declaration now uses the correct sound.
