### PR TITLE
Make IPCs resistant to barotrauma damage

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
@@ -179,8 +179,8 @@
     - type: Barotrauma # DeltaV - uncommented
       damage:
         types:
-          Blunt: 0.5 # DeltaV - was 0.28
-          Heat: 0.25 # DeltaV
+          Blunt: 0.28
+          Heat: 0.1 # DeltaV
     - type: Identity
     #  soundHit:
     #    path: /Audio/Effects/metalbreak.ogg


### PR DESCRIPTION
## About the PR
IPCs are now more resistant to barotrauma damage. This allows them to survive in a vaccum for approximately twice as long as a human.

## Why / Balance
IPC players are rather disappointed now that IPCs can't just walk into space with zero consequences. However, seeing an IPC in a hardsuit brings me a lot of joy, so I only give them a resistance rather than immunity.

## Technical details
No

## Media
No

## Requirements
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: IPCs are now more resistant to spacing damage, taking nearly two times less of it than other species.
