### PR TITLE
Remove art director from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,6 @@
 /Resources/*.yml @DeltaV-Station/yaml-maintainers
 /Resources/**/*.yml @DeltaV-Station/yaml-maintainers
 
-# Sprites - Art Director
-/Resources/Textures/ @AftrLite
-
 # Lobby art and music - automatically direction issues since its immediately visible to players
 /Resources/Audio/Lobby/ @DeltaV-Station/direction
 /Resources/Textures/LobbyScreens/ @DeltaV-Station/direction

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,9 @@
 /Resources/*.yml @DeltaV-Station/yaml-maintainers
 /Resources/**/*.yml @DeltaV-Station/yaml-maintainers
 
+# Sprites - Direction in lack of art director
+/Resources/Textures/ @DeltaV-Station/direction
+
 # Lobby art and music - automatically direction issues since its immediately visible to players
 /Resources/Audio/Lobby/ @DeltaV-Station/direction
 /Resources/Textures/LobbyScreens/ @DeltaV-Station/direction


### PR DESCRIPTION
Fixes this
<img width="319" height="66" alt="image" src="https://github.com/user-attachments/assets/133d5e2e-4cac-4c1f-957c-ca3d289a5401" />

Texture changes are now a direction thing in lack of art director