### PR TITLE
ipc heat/cold

### DIFF
--- a/Resources/Prototypes/_EE/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_EE/Damage/modifier_sets.yml
@@ -2,7 +2,7 @@
   id: IPC
   coefficients:
     Poison: 0
-    Cold: 0.5
-    Heat: 1.5
+    Cold: 0.9 # DeltaV - was 0.5
+    Heat: 1.1 # DeltaV - was 1.5
     Shock: 2.0
     Radiation: 0.5 # DeltaV - was not real


### PR DESCRIPTION
dont merge this without approval

## About the PR
changed nrs

## Why / Balance
taking 1.5 heat makes IPC insanely vulnerable to heat, which is a common damage type
taking .5 cold makes IPC insanely resistant to cold, which is a way less common type, except on cult rounds.
normalises these 2 values compared to the rest of species resistances/weaknesses to more common damage types. 
Shock and Rads unchanged because those are gimmick damage types and not commonly used in weapons.

**Changelog**
:cl:
- tweak: IPC now take 10% more heat damage (instead of 50%)
- tweak: IPC now take 10% less cold damage (instead of 50%)

