### PR TITLE
kill profession surgery speed

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -44,6 +44,7 @@
       - type: CommandStaff
       - type: PsionicBonusChance # DeltaV - makes it more likely to become psionic.
         flatBonus: 0.025
+
 - type: startingGear
   id: CMOGear
   equipment:

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -44,12 +44,10 @@
       - type: CommandStaff
       - type: PsionicBonusChance # DeltaV - makes it more likely to become psionic.
         flatBonus: 0.025
-  # Begin DeltaV Removals
   #- !type:AddComponentSpecial
   #  components:
   #  - type: SurgerySpeedModifier
   #    speedModifier: 1.5 # DeltaV
-  # End DeltaV Removals
 - type: startingGear
   id: CMOGear
   equipment:

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -44,10 +44,6 @@
       - type: CommandStaff
       - type: PsionicBonusChance # DeltaV - makes it more likely to become psionic.
         flatBonus: 0.025
-  #- !type:AddComponentSpecial
-  #  components:
-  #  - type: SurgerySpeedModifier
-  #    speedModifier: 1.5 # DeltaV
 - type: startingGear
   id: CMOGear
   equipment:

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -44,12 +44,12 @@
       - type: CommandStaff
       - type: PsionicBonusChance # DeltaV - makes it more likely to become psionic.
         flatBonus: 0.025
-  # Shitmed Change
-  - !type:AddComponentSpecial
-    components:
-    - type: SurgerySpeedModifier
-      speedModifier: 1.5 # DeltaV
-
+  # Begin DeltaV Removals
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: SurgerySpeedModifier
+  #    speedModifier: 1.5 # DeltaV
+  # End DeltaV Removals
 - type: startingGear
   id: CMOGear
   equipment:

--- a/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
@@ -14,13 +14,11 @@
   - Medical
   - Surgery
   - Maintenance
-  # Begin DeltaV Removals
   #special:
   #- !type:AddComponentSpecial
   #  components:
   #  - type: SurgerySpeedModifier
   #    speedModifier: 1.25
-  # End DeltaV Removals
 - type: startingGear
   id: SurgeonGear
   equipment:

--- a/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
@@ -14,12 +14,13 @@
   - Medical
   - Surgery
   - Maintenance
-  special:
-  - !type:AddComponentSpecial
-    components:
-    - type: SurgerySpeedModifier
-      speedModifier: 1.25
-
+  # Begin DeltaV Removals
+  #special:
+  #- !type:AddComponentSpecial
+  #  components:
+  #  - type: SurgerySpeedModifier
+  #    speedModifier: 1.25
+  # End DeltaV Removals
 - type: startingGear
   id: SurgeonGear
   equipment:

--- a/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
@@ -14,11 +14,6 @@
   - Medical
   - Surgery
   - Maintenance
-  #special:
-  #- !type:AddComponentSpecial
-  #  components:
-  #  - type: SurgerySpeedModifier
-  #    speedModifier: 1.25
 - type: startingGear
   id: SurgeonGear
   equipment:

--- a/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Medical/surgeon.yml
@@ -14,6 +14,7 @@
   - Medical
   - Surgery
   - Maintenance
+
 - type: startingGear
   id: SurgeonGear
   equipment:


### PR DESCRIPTION
dont merge without approval

## About the PR
removed surgery speed modifier from CMO and Surgeon, it only remains for tools and equipment

## Why / Balance
innate modifiers bad

**Changelog**
:cl:

- tweak: Promoted CMOs or Surgeons are now just as fast at surgery as their roundstart counterparts.
