### PR TITLE
Rebalance desword some more

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -312,9 +312,8 @@
         variation: 0.250
     activatedDamage:
         types: # DeltaV - was 12 slash, 12 heat, 15 structural
-            Slash: 9
-            Heat: 9
-            Structural: 8
+            Slash: 15
+            Heat: 10
   - type: ItemToggleActiveSound
     activeSound:
       path: /Audio/Weapons/ebladehum.ogg
@@ -331,7 +330,7 @@
   #  wieldSound: null # esword light sound instead
   - type: MeleeWeapon
     wideAnimationRotation: -135
-    attackRate: 2.0 # DeltaV - was 1.5
+    attackRate: 1.8 # DeltaV - was 1.5
     changeSwingDirection: true # DeltaV
     angle: 100
     damage:


### PR DESCRIPTION
## About the PR
Made desword even better at cutting people, even worse at cutting everything else. It now deals 45 damage per second (up from 36), 50% more than the esword, but has no structural damage at all.

## Why / Balance
People, like, stopped using the normal esword altogether, because desword was pretty good at dealing with structures as well, and, quote, "it looks cool". Thus, I made it even worse at dealing with structures, and made it better at it's primary role of killing people. Maybe 45DPS is a bit too much, but eh, it's still like two times worse than any actual gun. Give us some melee options that actually don't suck.

## Requirements
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Double-bladed energy sword is now better at killing people, but worse at dealing with structures,
