### PR TITLE
Changes the default white shoes for Reporter and Zookeeper

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
@@ -8,7 +8,7 @@
     ClothingUniformJumpskirtAtmos: 3
     ClothingUniformJumpsuitAtmosCasual: 3
     ClothingUniformJumpskirtAtmosCasual: 3 # DeltaV
-    ClothingShoesColorWhite: 3
+    ClothingShoesBootsWork: 3 # DeltaV: Replaced white shoes
     ClothingHeadsetEngineering: 2
     ClothingHeadHelmetFire: 2
     ClothingOuterSuitFire: 2

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -17,7 +17,7 @@
 - type: startingGear
   id: ReporterGear
   equipment:
-    shoes: ClothingShoesColorWhite
+    shoes: ClothingShoesColorBlack # DeltaV: Replaced white shoes
     id: ReporterPDA
     ears: ClothingHeadsetService
   storage: # DeltaV: Give reporters tape recording equipment

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -20,7 +20,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitSafari
     head: ClothingHeadSafari
-    shoes: ClothingShoesColorWhite
+    shoes: ClothingShoesColorBlack # DeltaV: Replaced white shoes
     id: ZookeeperPDA
     ears: ClothingHeadsetService
   #storage:


### PR DESCRIPTION
## About the PR
The white shoes are horribly ugly as placeholders. Reporter and Zookeeper have them, and this PR replaces them. Also cleans up forgotten traces of the default white Atmospheric Tech shoes in the AtmosDrobe.

I'm not sure if this needs a changelog? I'll go with yes for now and I can just trim that off if I don't

Putting black shoes on the Zookeeper is a bit ehh but it's better than the white shoes
## Media
<img width="166" height="260" alt="image" src="https://github.com/user-attachments/assets/680365aa-1a43-4d73-80f2-d29d729f397e" />
<img width="168" height="269" alt="image" src="https://github.com/user-attachments/assets/1feee515-d899-4eb0-bd63-f0661896411a" />
<img width="396" height="217" alt="image" src="https://github.com/user-attachments/assets/721fa761-b15f-4b77-9198-86d3074e864c" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Minerva
- tweak: Reporter and Zookeeper now have black shoes instead of white shoes.
- fix: The AtmosDrobe now correctly stocks workboots instead of white shoes.