### PR TITLE
Moves 1 single incorrect-seeming character in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@
 Small fixes/refactors are exempt. -->
 
 ## Requirements
-<!-- Confirm the following by placing an X in the brackets [X]: -->
+<!-- Confirm the following by placing an X in the brackets: [X] -->
 - [ ] I have tested all added content and changes.
 - [ ] I have added media to this PR or it does not require an ingame showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


### PR DESCRIPTION
## About the PR
There's a ":" in the comment of the "Requirements" section that looks incorrectly placed. The lines don't start with
`- [ ]:`, they start with `- [ ]`

`<!-- Confirm the following by placing an X in the brackets [X]: -->`
- [ ]: There is no `:` and it looks weird in the comment

This is extremely trivial but it bothers me with every PR

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
