### PR TITLE
People with the Numb trait no longer scream during surgery

### DIFF
--- a/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
+++ b/Content.Server/_Shitmed/Medical/Surgery/SurgerySystem.cs
@@ -16,6 +16,7 @@ using Content.Shared._DV.Surgery;
 using Content.Shared.FixedPoint;
 using Content.Shared.Forensics.Components;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Traits.Assorted;
 // End DeltaV Additions
 using Content.Shared._Shitmed.Medical.Surgery;
 using Content.Shared._Shitmed.Medical.Surgery.Conditions;
@@ -262,6 +263,8 @@ public sealed class SurgerySystem : SharedSurgerySystem
     private void OnStepScreamComplete(Entity<SurgeryStepEmoteEffectComponent> ent, ref SurgeryStepEvent args)
     {
         if (HasComp<AnesthesiaComponent>(args.Body)) // DeltaV
+            return;
+        if (HasComp<PainNumbnessComponent>(args.Body)) // DeltaV
             return;
 
         _chat.TryEmoteWithChat(args.Body, ent.Comp.Emote);


### PR DESCRIPTION
## About the PR
You shouldn't even be able to feel pain with the Numb trait and roleplaying away involuntary screaming during surgery with it is kind of hard

This only prevents screaming `(or whatever other emotes uses this function???)`

Please note I'm terrible at C# and I only just found out in this PR that I could reference namespaces in using directives and have it work
## Media
<img width="444" height="244" alt="image" src="https://github.com/user-attachments/assets/7467c980-9ff5-4d18-a1bd-707d7c205e74" />
<img width="152" height="171" alt="image" src="https://github.com/user-attachments/assets/06a4bf30-0460-40a0-abca-52052ffa0d29" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- fix: People with the Numb trait no longer scream during surgery. Anesthesia is still largely required.