### PR TITLE
Buff kobolds

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1630,8 +1630,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      60: Critical
-      125: Dead
+      80: Critical # DeltaV - was 60
+      160: Dead # DeltaV - was 125
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.5
     baseSprintSpeed: 5

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1627,11 +1627,11 @@
       path: /Audio/Animals/lizard_happy.ogg
     interactFailureSound:
       path: /Audio/Items/wirecutter.ogg
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      80: Critical # DeltaV - was 60
-      160: Dead # DeltaV - was 125
+  #- type: MobThresholds # DeltaV - buff kobolds
+  #  thresholds:
+  #    0: Alive
+  #    60: Critical
+  #    125: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.5
     baseSprintSpeed: 5


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Kobolds now have a crit/death threshold of ~~80/160,~~ 100/200, formerly 60/125.

## Why / Balance
I get that kobolds do *technically* have an advantage over monkies by virtue of having +10% movespeed and 9 melee damage, but I don't think those advantages warrant essentially halving their health. Anecdotally, if I'm gibbed and my brain needs to be placed in either a kobold or a monkey, I don't want to be punished for choosing the cooler one.

ideally it'd just be the same as monkies at 100/200, but 🤷 i am probably missing some edge case in which this could be exploited

This will not affect syndicate/nukeop reinforcement kobolds, which already have a threshold of 100/200 by default.

## Technical details
yamlops

## Media
<img width="612" height="498" alt="image" src="https://github.com/user-attachments/assets/99b417b9-e136-4053-b791-5ea1928eeb18" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Kobolds now have the same crit/death thresholds as monkies and humans
