### PR TITLE
Nerf prober explosion lowering glimmer

### DIFF
--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -222,7 +222,7 @@ namespace Content.Server.Psionics.Glimmer
             var slope = (float) (11 - _glimmerSystem.Glimmer / 100);
             var maxIntensity = 20;
 
-            var removed = (float) _glimmerSystem.Glimmer * _random.NextFloat(0.1f, 0.15f);
+            var removed = (float) _glimmerSystem.Glimmer * _random.NextFloat(0.06f, 0.08f);
             _glimmerSystem.Glimmer -= (int) removed;
             BeamRandomNearProber(uid, _glimmerSystem.Glimmer / 350, _glimmerSystem.Glimmer / 50);
             _explosionSystem.QueueExplosion(uid, "Default", totalIntensity, slope, maxIntensity);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Prober explosions now lower glimmer by 6%-8%, down from 10%-15%.

## Why / Balance
quote proxy in the discord in regards to the [xenoarch exponential point output thing](https://github.com/DeltaV-Station/Delta-v/pull/4164):
> If the RA wants to extract at 900, he should be able to afford speedboots in the 90 seconds he has left in his body.

i agree with this statement. which is why it's a bit lame that when the prober blows, it automatically blasts glimmer down below mindswap levels instantly. nine times out of ten, the prober will blow before the mindswap event gets a chance to trigger. 
this change makes it so if the prober blows between roughly 950-1000, glimmer won't always be instantly reduced back to safe levels. epi will have to rely on their other methods of lowering glimmer (see: mindbreaking) to get things safe again
## Technical details
nyano code no comments bweeeeeh

## Media
nope

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Prober explosions now lower glimmer substantially less.
