### PR TITLE
Changes "credits" to "spesos" in the stock market

### DIFF
--- a/Content.Server/_DV/Cargo/Systems/StockMarketSystem.cs
+++ b/Content.Server/_DV/Cargo/Systems/StockMarketSystem.cs
@@ -175,7 +175,7 @@ public sealed class StockMarketSystem : EntitySystem
         var verb = amount > 0 ? "bought" : "sold";
         _adminLogger.Add(LogType.Action,
             LogImpact.Medium,
-            $"[StockMarket] {ToPrettyString(user):user} {verb} {Math.Abs(amount)} stocks of {company.LocalizedDisplayName} at {company.CurrentPrice:F2} credits each (Total: {totalValue})");
+            $"[StockMarket] {ToPrettyString(user):user} {verb} {Math.Abs(amount)} stocks of {company.LocalizedDisplayName} at {company.CurrentPrice:F2} spesos each (Total: {totalValue})");
 
         return true;
     }

--- a/Resources/Locale/en-US/_DV/cartridge-loader/cartridges.ftl
+++ b/Resources/Locale/en-US/_DV/cartridge-loader/cartridges.ftl
@@ -172,7 +172,7 @@ mail-metrics-progress-percent = Success rate: {$successRate}%
 # General
 stock-trading-program-name = StockTrading
 stock-trading-title = Intergalactic Stock Market
-stock-trading-balance = Balance: {$balance} credits
+stock-trading-balance = Balance: {$balance} spesos
 stock-trading-no-entries = No entries
 stock-trading-owned-shares = Owned: {$shares}
 stock-trading-buy-button = Buy


### PR DESCRIPTION
## About the PR
Changes "credits" to "spesos" in the stock market.

## Why / Balance
It feels like a weird oversight, and is one of the only few ingame mentions of credits (I only looked for plural) in the game

## Media
<img width="554" height="409" alt="image" src="https://github.com/user-attachments/assets/e978c1f5-be00-48c5-aded-50e6f3c6a007" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.