### PR TITLE
colossus flat res

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/damage_modifier_sets.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/damage_modifier_sets.yml
@@ -1,12 +1,7 @@
 - type: damageModifierSet
   id: EntropicColossus
   coefficients:
-    Blunt: 0.7
-    Slash: 0.7
-    Piercing: 0.7
-    Heat: 0.8
-  flatReductions:
-    Blunt: 10
-    Slash: 5
-    Piercing: 5
-    Heat: 5
+    Blunt: 0.5
+    Slash: 0.5
+    Piercing: 0.5
+    Heat: 0.65


### PR DESCRIPTION
dont merge without approval

## About the PR
removed the colossus' flat resistances

## Why / Balance
wasnt fun. the way damage increases in ss14 is largely by increasing the number of hits instead of increasing the damage per hit. 
flat damage reduction massively favors some weapons over others, leaving shotguns with slugs dealing massive damage to a colossus while beam cannons actually do 0 dps.

**Changelog**
:cl:
- tweak: the colossus defence values have been tweaked.
