### PR TITLE
Changes the salvage directional sign to not call it a department

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/signs.yml
@@ -192,7 +192,7 @@
   parent: BaseSignDirectional
   id: SignDirectionalSalvage
   name: salvage sign
-  description: A direction sign, pointing out which way the Salvage department is.
+  description: A direction sign, pointing out which way Salvage is. # DeltaV - Salvage isn't a department
   components:
   - type: Sprite
     state: direction_salvage


### PR DESCRIPTION
## About the PR
Title.

Salvage is not a department. Not yet, at least.
## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.