### PR TITLE
Readds HoS parade outfits to loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1215,9 +1215,9 @@
   - HeadofSecurityJumpskirtGrey
   - HeadofSecurityJumpsuitBlue
   - HeadofSecurityJumpskirtBlue
-  #- HeadofSecurityParadeSuit # Removed for incongruence
-  #- HeadofSecurityParadeSkirt # Removed for incongruence
   # End DeltaV changes
+  - HeadofSecurityParadeSuit
+  - HeadofSecurityParadeSkirt
 
 - type: loadoutGroup
   id: HeadofSecurityNeck

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1210,14 +1210,14 @@
   - HeadofSecurityTurtleneckSkirt
   - HeadofSecurityFormalSuit
   - HeadofSecurityFormalSkirt
+  - HeadofSecurityParadeSuit
+  - HeadofSecurityParadeSkirt
   # Begin DeltaV changes
   - HeadofSecurityJumpsuitGrey
   - HeadofSecurityJumpskirtGrey
   - HeadofSecurityJumpsuitBlue
   - HeadofSecurityJumpskirtBlue
   # End DeltaV changes
-  - HeadofSecurityParadeSuit
-  - HeadofSecurityParadeSkirt
 
 - type: loadoutGroup
   id: HeadofSecurityNeck


### PR DESCRIPTION
## About the PR
This PR readds the HoS parade outfits to the loadout. They were originally removed in #1854. I don't entirely understand why, but I think it was something to do with visions for DV which may no longer apply. The PR didn't fully remove them because they could still be obtained from the uniform printer, unless that was a later change

The dresser hasn't been touched since more stuff has been added and I really don't want to try to fit more in. And it probably isn't the most useful thing to have in there anyway.

Made on request and because more loadout fashion options is a good thing.

## Media
(backpack and armor removed for visibility)
<img width="159" height="248" alt="image" src="https://github.com/user-attachments/assets/a0625185-1118-4c1a-840d-097aa445fa8d" />
<img width="159" height="247" alt="image" src="https://github.com/user-attachments/assets/7fd57a4f-bb6b-4aca-b749-d1075db99c46" />
<img width="150" height="256" alt="image" src="https://github.com/user-attachments/assets/0dcdc714-d256-4b67-9a62-f47ddb12d3ed" />
<img width="151" height="250" alt="image" src="https://github.com/user-attachments/assets/8cd840be-5e26-42ee-a463-c503c53c4127" />
<img width="776" height="606" alt="image" src="https://github.com/user-attachments/assets/8b0102c8-0a80-4e5c-bad5-067cc39bd837" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Minerva
- add: The HoS parade outfits can now be added in the HoS loadout.
