### PR TITLE
Bugfix microwaves staying locked out after cooking finishes

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/MicrowaveSystem.cs
@@ -444,14 +444,15 @@ namespace Content.Server.Kitchen.EntitySystems
 
         private void OnAnchorChanged(EntityUid uid, MicrowaveComponent component, ref AnchorStateChangedEvent args)
         {
-            if (!args.Anchored) {
-                // DeltaV - start of microwave ejection bugfix
+            // DeltaV - start of microwave ejection bugfix
+            if (!args.Anchored) 
+            {
                 // DeltaV's MicrowaveEventsSystem changes prevent ejection from active microwave, so stop cooking first
                 StopCooking((uid, component));
                 _container.EmptyContainer(component.Storage);
                 UpdateUserInterfaceState(uid, component);
-                // DeltaV - end of microwave ejection bugfix
             }
+            // DeltaV - end of microwave ejection bugfix
         }
 
         private void OnSignalReceived(Entity<MicrowaveComponent> ent, ref SignalReceivedEvent args)

--- a/Content.Server/_Goobstation/Kitchen/MicrowaveEventsSystem.cs
+++ b/Content.Server/_Goobstation/Kitchen/MicrowaveEventsSystem.cs
@@ -23,6 +23,11 @@ public sealed class MicrowaveEventsSystem : EntitySystem
 
     private void OnRemoveAttempt(Entity<ActiveMicrowaveComponent> ent, ref ContainerIsRemovingAttemptEvent args)
     {
-        args.Cancel();
+        // DeltaV - start of microwave ejection bugfix
+        if (ent.Comp.LifeStage < ComponentLifeStage.Stopping) 
+        {
+            args.Cancel();
+        }
+        // DeltaV - end of microwave ejection bugfix
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Microwaves currently block you from ejecting their contents after cooking finishes. This is annoying for recipes like Baguette, where you cook Dough with a Beaker of salt and pepper. The now-empty beaker gets stuck in the microwave after cooking.

(see Media for demonstration)

The current workaround is to insert an item, which then lets you eject again. This is annoying.

Bugfix makes it so microwaves now eject all their contents when cooking completes (which is what upstream Wizden and other forks do / is the original behavior before factorio code).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

fixes #4201 

## Technical details
<!-- Summary of code changes for easier review. -->

- Added StopCooking() calls to various points in MicrowaveSystem where ejection or UI updates occur, so the microwave is stopped before "is microwave active" checks are performed.
- Because StopCooking() works by *deferring* a removal of the ActiveMicrowaveComponent, I also adjusted the two places that check for an ActiveMicrowaveComponent to check not only for the presence of the component but also whether it has a deferred removal queued up (these checks are in UpdateUserInterfaceState()'s IsMicrowaveBusy, and the MicrowaveEventsSystem factorio failsafe)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Aside from the typical microwave behavior, there are 4 edge cases which I've tested:

### Behavior 1: normal microwave behavior

**Current behavior**: microwave stays locked out after cooking, until you "kick" it (insert something, cut power, etc.)
![old_normal](https://github.com/user-attachments/assets/398ee6be-d689-49d2-829e-76bc1e4065b8)

**New behavior**: microwave ejects all contents after cooking (matches wizden)
![new_normal](https://github.com/user-attachments/assets/1cc2733c-0c42-49c5-bfca-04745686367d)

### Behavior 2: unanchoring a running microwave

**Current behavior**: items stuck inside, UI is weird
![old_wrench](https://github.com/user-attachments/assets/c465107e-3e33-4056-b080-7343a9ba603c)

**New behavior**: all contents eject when unanchored (matches wizden)
![new_wrench](https://github.com/user-attachments/assets/24328d44-e69b-4177-8cef-17fd8cbc45c6)

### Behavior 3: explosion from microwaving metal

**Current behavior**: items stuck inside, UI is weird
![old_explosion](https://github.com/user-attachments/assets/e27b8b19-30f8-4b43-b15c-65162b252b6c)

**New behavior**: all contents eject when exploded (matches wizden)
![new_explosion](https://github.com/user-attachments/assets/a8ea7459-1192-4bcc-b95c-8acdb443c670)

### Behavior 4: robotic arm extraction while cooking

**Behavior maintained**: robotic arm is not allowed to pull items out of a running microwave

Before fix:
![old_robotic_active](https://github.com/user-attachments/assets/2e68ad63-d324-4bad-878d-dda80cea378d)

Still works after fix:
![new_robotic_active](https://github.com/user-attachments/assets/607734f1-f131-48f3-967d-7f601a559252)

### Behavior 5: robotic arm extraction while off

**Behavior maintained**: robotic arm can pull out items when microwave is *not* running

Before fix:
![old_robotic_inactive](https://github.com/user-attachments/assets/96d199dd-c4fa-494e-9a0b-c7c59eff5b07)

Still works after fix:
![new_robotic_inactive](https://github.com/user-attachments/assets/0f2ba090-6a3c-4c61-b2fb-807ae01392e5)


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

N/A: no renames, etc.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: microwaves now eject their contents after cooking, instead of locking them in

