### PR TITLE
Beam Dev nerf

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -372,7 +372,7 @@
     sprite: Objects/Weapons/Grenades/empgrenade.rsi
   - type: EmpOnTrigger
     range: 5.5
-    energyConsumption: 50000
+    energyConsumption: 100000 # Delta V, Was 50000
   - type: DeleteOnTrigger
   - type: Appearance
   - type: TimerTriggerVisuals

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -354,7 +354,7 @@
       path: /Audio/_DV/Weapons/Guns/Gunshots/beamcannon.ogg
   - type: HitscanBatteryAmmoProvider
     proto: BeamDev
-    fireCost: 600
+    fireCost: 1200
   - type: Battery
     maxCharge: 300000
     startingCharge: 300000

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -48,8 +48,8 @@
   id: BeamDev
   damage:
     types:
-      Heat: 6
-      Structural: 20
+      Heat: 4.5
+      Structural: 15
   muzzleFlash:
     sprite: _DV/Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -48,8 +48,8 @@
   id: BeamDev
   damage:
     types:
-      Heat: 4.5
-      Structural: 15
+      Heat: 6
+      Structural: 20
   muzzleFlash:
     sprite: _DV/Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: muzzle_laser


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Beam dev max ammo size halfed and emps buffed to be more capable of disabling the beam dev (3 emps to completetly disable) (Yes this is getting made because of the liltenhead video)

## Why / Balance
Direction requested to make the beamdev more counterable
## Technical details
Beam dev damage values adjusted
cost per shot from 600 to 12000
Emp grenade power consumption from 50000 to 100000
(Literally 2 lines of yml)
## Media
<img width="578" height="282" alt="image" src="https://github.com/user-attachments/assets/5d598574-2117-4317-bf36-67bdd57cdc89" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Beam Dev battery size to 250 from 500 
- tweak: Emp grenades now drain twice as much power