### PR TITLE
Give secoffs lethals in their guns roundstart

### DIFF
--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
@@ -3,17 +3,17 @@
 - type: loadout
   id: SecurityFirearmWeaponPistolPollock
   equipment:
-    pocket1: WeaponPistolPollockNonlethal
+    pocket1: WeaponPistolPollock
 
 - type: loadout
   id: SecurityFirearmWeaponPistolSLP57
   equipment:
-    pocket1: WeaponPistolSLP57Nonlethal
+    pocket1: WeaponPistolSLP57
 
 - type: loadout
   id: SecurityFirearmWeaponPistolMk58
   equipment:
-    pocket1: WeaponPistolMk58Nonlethal
+    pocket1: WeaponPistolMk58
 
 - type: loadout
   id: SecurityFirearmWeaponDisabler


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Security officer sidearms are now loaded with lethal rounds instead of rubbers when they spawn.

## Why / Balance
I think having 2 lethal / 1 rubber mags is a lot more useful then having 1 lethal / 2 rubber mags, especially in the (admittedly rare) edge case where you spawn and things have already gone sideways. Rubber mags are available from the secfab roundstart anyways, alongside disablers which secoffs should probably just take instead.

## Technical details
yamlops

## Media
<img width="787" height="222" alt="image" src="https://github.com/user-attachments/assets/50c7882e-8261-463f-adc0-fb4da98db1c5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Security officer sidearms are now loaded with lethal rounds at roundstart.
