### PR TITLE
Fix Book of Mysteries casting

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -209,7 +209,7 @@ public sealed class ActionButton : Control, IEntityControl
             if (_entities.TryGetComponent(Action, out AutoRechargeComponent? autoRecharge))
             {
                 var chargeTimeRemaining = _sharedChargesSys.GetNextRechargeTime((Action.Value, actionCharges, autoRecharge));
-                chargesText.AddText(Loc.GetString($"{Environment.NewLine}Time Til Recharge: {chargeTimeRemaining}"));
+                chargesText.AddText(Loc.GetString($"{Environment.NewLine}Time Til Recharge: {chargeTimeRemaining.TotalSeconds:F1} seconds")); //DeltaV - Better formatted, easier to read.
             }
         }
 

--- a/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
+++ b/Content.Client/UserInterface/Systems/Actions/Controls/ActionButton.cs
@@ -209,7 +209,7 @@ public sealed class ActionButton : Control, IEntityControl
             if (_entities.TryGetComponent(Action, out AutoRechargeComponent? autoRecharge))
             {
                 var chargeTimeRemaining = _sharedChargesSys.GetNextRechargeTime((Action.Value, actionCharges, autoRecharge));
-                chargesText.AddText(Loc.GetString($"{Environment.NewLine}Time Til Recharge: {chargeTimeRemaining.TotalSeconds:F1} seconds")); //DeltaV - Better formatted, easier to read.
+                chargesText.AddText(Loc.GetString($"{Environment.NewLine}Time Til Recharge: {chargeTimeRemaining.TotalSeconds:F1} seconds")); // DeltaV - Better formatted, easier to read.
             }
         }
 

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -18,7 +18,7 @@
       posData: !type:TargetInFront
   - type: SpeakOnAction
     sentence: action-speech-spell-forcewall
-  #Begin DeltaV Additions - Allows this to actually charge when learned from the Book of Mysteries.
+  # Begin DeltaV Additions - Allows this to actually charge when learned from the Book of Mysteries.
   - type: AutoRecharge
     rechargeDuration: 90
   #End DeltaV Additions

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -18,3 +18,7 @@
       posData: !type:TargetInFront
   - type: SpeakOnAction
     sentence: action-speech-spell-forcewall
+  #Begin DeltaV Additions - Allows this to actually charge when used from the Book of Mysteries.
+  - type: AutoRecharge
+    rechargeDuration: 90
+  #End DeltaV Additions

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -21,4 +21,4 @@
   # Begin DeltaV Additions - Allows this to actually charge when learned from the Book of Mysteries.
   - type: AutoRecharge
     rechargeDuration: 90
-  #End DeltaV Additions
+  # End DeltaV Additions

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseAction
   id: ActionForceWall
-  name: Force Wall #DeltaV
+  name: Force Wall # DeltaV
   description: Creates a magical barrier.
   components:
   - type: Action

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseAction
   id: ActionForceWall
-  name: forcewall
+  name: Force Wall
   description: Creates a magical barrier.
   components:
   - type: Action
@@ -18,7 +18,7 @@
       posData: !type:TargetInFront
   - type: SpeakOnAction
     sentence: action-speech-spell-forcewall
-  #Begin DeltaV Additions - Allows this to actually charge when used from the Book of Mysteries.
+  #Begin DeltaV Additions - Allows this to actually charge when learned from the Book of Mysteries.
   - type: AutoRecharge
     rechargeDuration: 90
   #End DeltaV Additions

--- a/Resources/Prototypes/Magic/forcewall_spells.yml
+++ b/Resources/Prototypes/Magic/forcewall_spells.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: BaseAction
   id: ActionForceWall
-  name: forcewall
+  name: Force Wall #DeltaV
   description: Creates a magical barrier.
   components:
   - type: Action
@@ -18,7 +18,7 @@
       posData: !type:TargetInFront
   - type: SpeakOnAction
     sentence: action-speech-spell-forcewall
-  #Begin DeltaV Additions - Allows this to actually charge when used from the Book of Mysteries.
+  #Begin DeltaV Additions - Allows this to actually charge when learned from the Book of Mysteries.
   - type: AutoRecharge
     rechargeDuration: 90
   #End DeltaV Additions


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The Book of Mysteries' Force Wall now actually works! It'll gain a charge every 90 seconds and can store up to 3.
I slightly edited the "Time til recharge" string too to make it easier to read, it seems to only be used by Spellbooks like this and it showed the full timestamp (first time touching C# so hopefully I did it right)

## Why / Balance
Fixes #4154 !

## Media
<img width="394" height="167" alt="book" src="https://github.com/user-attachments/assets/14ab2f24-354e-4750-b17b-1a57737ca1e3" />
<img width="321" height="234" alt="wall" src="https://github.com/user-attachments/assets/3b3bbb4b-a0c7-495b-95e9-b56d9429c40a" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The Mystagogue's Book of Mysteries can now charge Force Wall again.
