### PR TITLE
Adds lights to more hologram projections

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -15,6 +15,10 @@
     state: icon
   - type: TimedDespawn
     lifetime: 90
+  - type: PointLight # DeltaV - lit holograms
+    enabled: true
+    radius: 3
+    color: yellow
   - type: Damageable
     damageContainer: Inorganic
   - type: Destructible
@@ -47,7 +51,11 @@
     noRot: true
   - type: Airtight
     noAirWhenFullyAirBlocked: false
-  - type: Holofan # DeltaV - for whitelisting
+  - type: Holofan # DeltaV - for whitelistin
+  - type: PointLight # DeltaV - lit holograms
+    enabled: true
+    radius: 3
+    color: yellow
 
 - type: entity
   id: HolosignSecurity

--- a/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Entities/Structures/Holographic/projections.yml
@@ -51,7 +51,7 @@
     noRot: true
   - type: Airtight
     noAirWhenFullyAirBlocked: false
-  - type: Holofan # DeltaV - for whitelistin
+  - type: Holofan # DeltaV - for whitelisting
   - type: PointLight # DeltaV - lit holograms
     enabled: true
     radius: 3

--- a/Resources/Prototypes/Nyanotrasen/Entities/Structures/Holographic/projections.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Structures/Holographic/projections.yml
@@ -8,3 +8,7 @@
     state: icon
   - type: TimedDespawn
     lifetime: 180
+  - type: PointLight
+    enabled: true
+    radius: 3
+    color: orange


### PR DESCRIPTION
## About the PR
A few holosign projections had lighting, while others didn't. This PR adds lights to the...
- Wet floor holosign
- Holofan
- Engineering holosign

This prevents the Engineering holosign from being nigh-invisible in emergencies involving power loss, and makes holofans more noticeable as a "I shouldn't go in there" thing. Wet floor sign could... also probably be useful.

I think I did the right thing with the Nyanotrasen file? I'm not to add DV comments to those, right?
## Media
<img width="703" height="683" alt="image" src="https://github.com/user-attachments/assets/4fc8bd59-bfe4-486c-a84e-f78af41be5ce" />
<img width="679" height="620" alt="image" src="https://github.com/user-attachments/assets/f6b24241-94e3-4c0a-9392-738a2257e7f1" />
<img width="521" height="606" alt="image" src="https://github.com/user-attachments/assets/de3593e8-0654-4fe3-b78f-c4871bb3eacb" />
<img width="357" height="178" alt="image" src="https://github.com/user-attachments/assets/2ac8124b-55ab-4210-ac4f-7abcaaf8805a" />
<img width="284" height="393" alt="image" src="https://github.com/user-attachments/assets/07e0bccd-419a-46e4-a681-7724acfb7012" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Minerva
- tweak: Janitorial and Engineering holosigns now emit light.
