### PR TITLE
Changes justice radio frequecy

### DIFF
--- a/Resources/Prototypes/_DV/radio_channels.yml
+++ b/Resources/Prototypes/_DV/radio_channels.yml
@@ -2,7 +2,7 @@
   id: Justice
   name: chat-radio-justice
   keycode: "j"
-  frequency: 1420
+  frequency: 1422
   color: "#c70667"
 
 - type: radioChannel


### PR DESCRIPTION
## About the PR
This changes the justice radio frequency from an integer to a float.
## Why
This will now show the justice radio frequency as a float, instead of a integer, matching all the other frequencies in style.
Fixes #4363 
## Technical details
Changes the frequency by changing the last digit from zero to two. This is this automatically formatted to be a float instead of an integer.
## Media
<img width="345" height="370" alt="Screenshot_20250912_053021" src="https://github.com/user-attachments/assets/da68c006-3b1e-49f2-941f-2047a919c68b" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
## Breaking changes
There should be no breaking changes present.

**Changelog**
no cl