### PR TITLE
Fixes not being able to toggle combat mode while incapacitated

### DIFF
--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -221,7 +221,7 @@
     event: !type:ToggleClothingEvent
 
 - type: entity
-  parent: BaseAction
+  parent: BaseMentalAction
   id: ActionCombatModeToggle
   name: "[color=red]Combat Mode[/color]"
   description: Enter combat mode


### PR DESCRIPTION
## About the PR
Changed the parent type for the `ActionCombatModeToggle` entity from `BaseAction` to `BaseMentalAction`.
## Why / Balance
This will allow the player to toggle combat mode while incapacitated.
Fixes #4228 
## Technical details
Changes the parent from `BaseAction` to `BaseMentalAction` within `types.yml`.
Cross referenced with upstream which is using the `BaseMentalAction`.

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
## Breaking changes
No breaking changes should be present.

**Changelog**

:cl:
- fix: Fixed combat toggle not working while incapacitated.