### PR TITLE
Fixes atmospheric technician loadout shoe selection for red shoes

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1043,7 +1043,6 @@
   # Begin DeltaV Additions
   - WorkBoots
   - BlueShoes
-  - RedShoes
   - OrangeShoes
   - RedShoes
   - AtmosWinterBoots


### PR DESCRIPTION
## About the PR
Fixes the atmospheric technician loadout page when it comes to red shoes, showing as a drop down menu.
## Why / Balance
There should not be a drop down menu for one pair of shoes.
Fixes #4325 
## Technical details
Removes a duplicate entry within `loadoutGroup` for `AtmosphericTechnicianShoes`.
## Media
<img width="795" height="418" alt="Screenshot_20250913_064042" src="https://github.com/user-attachments/assets/a64348c7-3989-402f-ab7b-b5d676374f69" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
## Breaking changes
No breaking changes should be present.

**Changelog**
:cl:
- fix: Fixed red shoe selection for atmospheric technician in loadout menu.