### PR TITLE
Add Epistemics caveat about Glimmer

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -111,6 +111,7 @@ Epistemics employees are permitted to use their lab spaces as they see fit, with
 
 * Any sophont experimentation must be done with the consent of the test subject, and must not have an undue risk of life. The Mystagogue or CO may terminate any experiment for safety or ethical purposes and at their discretion.
 * Testing of any explosives or weapons that risk hull penetration or mass destruction must be done at an off-station site.
+* Glimmer levels must be controlled so that they, or their negative effects, do not damage the station or station property, complicate station personnel's work, harm or kill station personnel.
 
 Epistemics personnel may also utilise Controlled Items within the confines of designated testing areas and in a manner directly approved jointly by the Mystagogue and by the Head of Security or CO.
 


### PR DESCRIPTION
## About the PR
Making the Epistemics more responsible for their actions, specifically - Glimmer levels.

## Why / Balance
Epistemics is the least regulated department. The recent changes to the Glimmer generation and its new effect on research points generation lead to many epi players getting Glimmer dangerously high, negatively impacting the experience of everyone with code Whites becoming too common and often the entire epistemics department exploding. This addition to SOP will, hopefully, make such behavior less common.

## Technical details
Added a line to the epi caveats list in the SOP file.

## Media
Not required.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- add: Epistemics SOP caveat about controlling Glimmer levels.
