### PR TITLE
escape pod doors open when evac shuttle arrives

### DIFF
--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -478,6 +478,17 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         }
 
         _commsConsole.UpdateCommsConsoleInterface();
+
+        // DeltaV - start of escape pod docking
+        var podAirlockQuery = AllEntityQuery<DockingComponent>();
+        while (podAirlockQuery.MoveNext(out var uid, out var dockingComp))
+        {
+            if (HasComp<EscapePodComponent>(Transform(uid).ParentUid) && dockingComp.DockedWith != null)
+            {
+                _dock.TryOpenDockedDoors((uid, dockingComp));
+            }
+        }
+        // DeltaV - end of escape pod docking
     }
 
     private void SetupEmergencyShuttle()


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Fixes https://github.com/DeltaV-Station/Delta-v/issues/4256 (assuming people want it fixed with this approach)

Escape pod doors remain closed all shift, but now with this PR they will bolt open automatically when the evac shuttle arrives. They close automatically when the shuttle leaves - that part was already working and hasn't changed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The closed pod doors are locked with Externals access requirement. This is a problem, because _all_ crew really ought to be able to use the escape pods to evacuate.

An alternative approach could've been to bolt open the doors for the entire shift, but I think this approach is better. Please discuss on https://github.com/DeltaV-Station/Delta-v/issues/4256 .

## Technical details
<!-- Summary of code changes for easier review. -->

There's a part of the docking sequence that triggers the doors to bolt open after two crafts dock. This PR simply calls that piece of the code again when the evac shuttle arrives. It filters for the pod doors by looking for the EscapePodComponent, which is already part of the pod in `escape_pod_small.yml`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

![escape_pod_arrive](https://github.com/user-attachments/assets/34c90f6d-a882-400a-bd45-f9fe7c698866)

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Escape pods can now be used by all crew, not just those with Externals access; all pod doors now open automatically when the evac shuttle arrives.
