### PR TITLE
silicons now hidden from records when filtering by fingerprint or dna

### DIFF
--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -404,10 +404,12 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
                 !someRecord.JobTitle.ToLower().Contains(filterLowerCaseValue),
             StationRecordFilterType.Species =>
                 !someRecord.Species.ToLower().Contains(filterLowerCaseValue),
-            StationRecordFilterType.Prints => someRecord.Fingerprint != null
-                && IsFilterWithSomeCodeValue(someRecord.Fingerprint, filterLowerCaseValue),
-            StationRecordFilterType.DNA => someRecord.DNA != null
-                && IsFilterWithSomeCodeValue(someRecord.DNA, filterLowerCaseValue),
+            // DeltaV - start of silicon bio filters fix
+            StationRecordFilterType.Prints => someRecord.Fingerprint == null
+                || IsFilterWithSomeCodeValue(someRecord.Fingerprint, filterLowerCaseValue),
+            StationRecordFilterType.DNA => someRecord.DNA == null
+                || IsFilterWithSomeCodeValue(someRecord.DNA, filterLowerCaseValue),
+            // DeltaV - end of silicon bio filters fix
             _ => throw new IndexOutOfRangeException(nameof(filter.Type)),
         };
     }

--- a/Content.Server/_CD/Records/Consoles/CharacterRecordConsoleSystem.cs
+++ b/Content.Server/_CD/Records/Consoles/CharacterRecordConsoleSystem.cs
@@ -167,10 +167,12 @@ public sealed class CharacterRecordConsoleSystem : EntitySystem
         {
             StationRecordFilterType.Name =>
                 !nameJob.Contains(filterLowerCaseValue, StringComparison.CurrentCultureIgnoreCase),
-            StationRecordFilterType.Prints => record.Fingerprint != null
-                && IsFilterWithSomeCodeValue(record.Fingerprint, filterLowerCaseValue),
-            StationRecordFilterType.DNA => record.DNA != null
-                                                && IsFilterWithSomeCodeValue(record.DNA, filterLowerCaseValue),
+            // DeltaV - start of silicon bio filters fix
+            StationRecordFilterType.Prints => record.Fingerprint == null
+                || IsFilterWithSomeCodeValue(record.Fingerprint, filterLowerCaseValue),
+            StationRecordFilterType.DNA => record.DNA == null
+                || IsFilterWithSomeCodeValue(record.DNA, filterLowerCaseValue),
+            // DeltaV - start of silicon bio filters fix
             _ => throw new ArgumentOutOfRangeException(nameof(filter), "Invalid Character Record filter type"),
         };
     }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Fixes https://github.com/DeltaV-Station/Delta-v/issues/4044

When searching for a particular fingerprint or dna sequence in the records console, this PR now hides Station AI, Cyborgs, and IPCs (who don't have fingerprints/dna). Clearing the filter will continue to show those players.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

See the attached issue - annoying having to mentally filter these players out.

## Technical details
<!-- Summary of code changes for easier review. -->

It was a simple logic bug in the upstream logic. It slipped through because DeltaV seems to be the only fork where it matters: silicons don't _ever_ show up in records in any other forks I've seen. It's not really worth making a PR to fix this in wizden or CD for this reason.

I'm pretty sure the CharacterRecordConsoleSystem from cosmatic-drift fork has usurped the upstream StationRecordsSystem (changing the first file fixed the problem, while changing the second file had no effect). Nevertheless, fixed it in both files for posterity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

![records](https://github.com/user-attachments/assets/47686245-731d-4617-8b6c-33e37a685d8e)

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

Super minor - no breaking changes and not worth a changelog:

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
