### PR TITLE
Remove beam devastator from spawn tables

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/safes.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/safes.yml
@@ -62,7 +62,6 @@
   - type: EntityTableSpawner
     table: !type:GroupSelector
       children:
-      - id: GunSafeBeamDevastator
       - id: GunSafeRocketLauncher
       - id: GunSafeGamblagator
 

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/security.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/security.yml
@@ -22,7 +22,6 @@
       tableId: RPGTable
     - !type:NestedSelector
       tableId: GamblagatorTable
-    - id: WeaponBeamDevastator
 
 - type: entityTable
   id: RPGTable


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
beam devastator no longer able to spawn naturally in rounds.

## Why / Balance
im not happy with where it is. Also angry dm's begone. If someone wants to add an overheat mechanic or try their shot at balancing it in the future they are welcome to do so.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- remove: Beam Devastator is no longer obtainable.

