### PR TITLE
allow ghosting if mind swap or telegnosis goes wrong

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -145,8 +145,8 @@ namespace Content.Server.Abilities.Psionics
             // DeltaV - start of trapped ghost fix
             // If you're able to swap back to your original body, you should swap back before you ghost.
             if (TryComp<MindSwappedComponent>(args.Mind.CurrentEntity, out var component)
-                && _actions.GetAction(component.MindSwapReturnActionEntity) is {} action
-                && action.Comp.AttachedEntity is {} user)
+                && _actions.GetAction(component.MindSwapReturnActionEntity) is { } action
+                && action.Comp.AttachedEntity is not null)
             {
                 args.Result = false;
                 args.Handled = true;

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -138,15 +138,20 @@ namespace Content.Server.Abilities.Psionics
             if (args.Handled)
                 return;
 
-            if (!HasComp<MindSwappedComponent>(args.Mind.CurrentEntity))
-                return;
-
             //No idea where the viaCommand went. It's on the internal OnGhostAttempt, but not this layer. Maybe unnecessary.
             /*if (!args.viaCommand)
                 return;*/
 
-            args.Result = false;
-            args.Handled = true;
+            // DeltaV - start of trapped ghost fix
+            // If you're able to swap back to your original body, you should swap back before you ghost.
+            if (TryComp<MindSwappedComponent>(args.Mind.CurrentEntity, out var component)
+                && _actions.GetAction(component.MindSwapReturnActionEntity) is {} action
+                && action.Comp.AttachedEntity is {} user)
+            {
+                args.Result = false;
+                args.Handled = true;
+            }
+            // DeltaV - end of trapped ghost fix
         }
 
         private void OnSwapInit(EntityUid uid, MindSwappedComponent component, ComponentInit args)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

When you use Telegnosis or Mind Swap and your original body dies, you become "trapped in this new vessel".

Now, with this PR, being in that state allows you to `/ghost`. (you couldn't ghost before, it wouldn't let you, meaning you were _literally_ trapped forever)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes https://github.com/DeltaV-Station/Delta-v/issues/4195

Everyone should be able to ghost at basically all times -- now you can, you just need to use the "return to your original body" power first, if it's available to you. I think the idea behind that limitation was just so that you don't grief by mind swapping someone and then immediately `/ghost` to trap them.

## Technical details
<!-- Summary of code changes for easier review. -->

I think this is the simplest approach - only block ghosting if you're able to use the "return to original body" power.

I considered touching other code in the mind swap system, but it's a spaghetti mess. The whole mind system (`.TransferTo`, `MindSwappedComponent`, `MassMindSwap`, etc.) needs a refactor.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->


https://github.com/user-attachments/assets/f871fadb-3424-4d25-afa8-21792d37b60a


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Dying in telegnosis no longer prevents you from ghosting
