### PR TITLE
(early upstream merge) Fix broken psionics, ai abilities, other powers

### DIFF
--- a/Content.Client/Actions/ActionsSystem.cs
+++ b/Content.Client/Actions/ActionsSystem.cs
@@ -426,7 +426,12 @@ namespace Content.Client.Actions
 
         private void OnEntityTargetAttempt(Entity<EntityTargetActionComponent> ent, ref ActionTargetAttemptEvent args)
         {
-            if (args.Handled || args.Input.EntityUid is not { Valid: true } entity)
+            if (args.Handled)
+                return;
+
+            args.Handled = true;
+
+            if (args.Input.EntityUid is not { Valid: true } entity)
                 return;
 
             // let world target component handle it
@@ -436,8 +441,6 @@ namespace Content.Client.Actions
                 DebugTools.Assert(HasComp<WorldTargetActionComponent>(ent), $"Action {ToPrettyString(ent)} requires WorldTargetActionComponent for entity-world targeting");
                 return;
             }
-
-            args.Handled = true;
 
             var action = args.Action;
             var user = args.User;

--- a/Content.Shared/Actions/Components/TargetActionComponent.cs
+++ b/Content.Shared/Actions/Components/TargetActionComponent.cs
@@ -1,5 +1,5 @@
-using Content.Shared.Actions;
 ﻿using Content.Shared.Interaction;
+using Content.Shared.Physics;
 ﻿using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 
@@ -37,6 +37,16 @@ public sealed partial class TargetActionComponent : Component
     [DataField]
     public bool CheckCanAccess = true;
 
+    /// <summary>
+    ///     The collision group to use to check for accessibility if <see cref="CheckCanAccess" /> is true.
+    /// </summary>
+    [DataField]
+    public CollisionGroup AccessMask = SharedInteractionSystem.InRangeUnobstructedMask;
+
+    /// <summary>
+    ///     The allowed range for a target to be. If zero or negative, the range check is skipped,
+    ///     unless <see cref="CheckCanAccess"/> is true.
+    /// </summary>
     [DataField]
     public float Range = SharedInteractionSystem.InteractionRange;
 

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -417,13 +417,18 @@ public abstract class SharedActionsSystem : EntitySystem
             return comp.CanTargetSelf;
 
         var targetAction = Comp<TargetActionComponent>(uid);
+
         // not using the ValidateBaseTarget logic since its raycast fails if the target is e.g. a wall
         if (targetAction.CheckCanAccess)
-            return _interaction.InRangeAndAccessible(user, target, range: targetAction.Range);
+            return _interaction.InRangeAndAccessible(user, target, targetAction.Range, targetAction.AccessMask);
 
-        // if not just checking pure range, let stored entities be targeted by actions
-        // if it's out of range it probably isn't stored anyway...
-        return _interaction.CanAccessViaStorage(user, target);
+        // Just check normal in range, allowing <= 0 range to mean infinite range.
+        if (targetAction.Range > 0
+            && !_transform.InRange(user, target, targetAction.Range))
+            return false;
+
+        // If checkCanAccess isn't set, we allow targeting things in containers
+        return _interaction.IsAccessible(user, target);
     }
 
     public bool ValidateWorldTarget(EntityUid user, EntityCoordinates target, Entity<WorldTargetActionComponent> ent)

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -85,7 +85,11 @@ namespace Content.Shared.Interaction
         private EntityQuery<UseDelayComponent> _delayQuery;
         private EntityQuery<ActivatableUIComponent> _uiQuery;
 
-        private const CollisionGroup InRangeUnobstructedMask = CollisionGroup.Impassable | CollisionGroup.InteractImpassable;
+        /// <summary>
+        /// The collision mask used by default for
+        /// <see cref="InRangeUnobstructed(MapCoordinates,MapCoordinates,float,CollisionGroup,Ignored?,bool)" />
+        /// </summary>
+        public const CollisionGroup InRangeUnobstructedMask = CollisionGroup.Impassable | CollisionGroup.InteractImpassable;
 
         public const float InteractionRange = 1.5f;
         public const float InteractionRangeSquared = InteractionRange * InteractionRange;

--- a/Resources/Prototypes/Magic/teleport_spells.yml
+++ b/Resources/Prototypes/Magic/teleport_spells.yml
@@ -35,7 +35,8 @@
       sprite: Objects/Magic/Eldritch/eldritch_actions.rsi
       state: voidblink
   - type: TargetAction
-    checkCanAccess: false
+    accessMask:
+    - Opaque
     repeat: false
     range: 16
   - type: EntityTargetAction


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Proposing we early-merge an upstream PR ([#38731](https://github.com/space-wizards/space-station-14/pull/38731)) that fixed targeted entity actions, many of which are currently broken.

This PR fixes the following abilities that simply did not cast when you clicked them:
- Psionics:
  - Dispel - Fixes https://github.com/DeltaV-Station/Delta-v/issues/4376 (DeltaV)
  - Mind Swap (psionic version)
  - Pyrokinesis (this power isn't in the pool, perhaps because we couldn't get it working due to this bug? Should we add this into the pool now?)
- Station AI Purchasable Abilities - Fixes https://github.com/DeltaV-Station/Delta-v/issues/4357 (DeltaV)
  - RGB Light
  - Light Synthesize
  - HONK.mp3
  - Nanite Borg Repairs
- Cosmic Cult: Lapse Power (the one that turns someone blue and silent)
- Wizard: Void Applause Spell (trade places with something)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is a decently-sized list of broken stuff. I think it's a good idea to merge the fix in ASAP, before the next big upstream merge.

The Mystagogue not being able to use their power right now is kinda bad.

## Technical details
<!-- Summary of code changes for easier review. -->

I simply cherry-picked the fix. Checking the git log, I don't see any other commits on these files that are related / followup PRs -- this PR should be all that we need.

Broken abilities were all those with both 1. an EntityTargetAction component, and 2. a TargetAction with `checkCanAccess: false`.

I tested before/after of *all* TargetAction abilities, just to be safe (even those that are WorldTarget instead of Entity). They all still continue to function, and properly obey their targeting rules (e.g. can target through walls / can't through walls)

The full list of tested actions (the full list of TargetAction in the codebase):
- Psionics: Dispel, MindSwap (ActionMindSwapPsionic), NoosphericZap, Pyrokinesis
- AI abilities: all 6 of them
- Cosmic Cult abilities (including collosus versions): Siphon, Lapse, Shunt, Ingress, Nova, Sunder, Fragmentation
- Revenant animate
- Goliath tentacles
- Ninja katana dash
- Stethescope breath listening
- Dragon: devour, breath
- Wizard: animate staff, mind swap (ActionMindSwap -- different than psionic version), fireball, blink, void applause, smite, slippery, cluwne

Note: rgb staff was broken before, and is still broken. I think it's just missing its TargetAction component - we should open a separate pr to fix that.

Let me know if you have questions about the exact functionality of any of these; I have testing notes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Example: dispel now actually casts

![dispel](https://github.com/user-attachments/assets/efa843a8-ad8a-433a-b9c4-8a8a2e276c48)


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: These abilities now actually function: Dispel, Mind Swap (Psionics); RGB, Light Synth, Honk, Nanites (AI Abilities); Lapse (Cosmic Cult); Void Applause (Wizard)
