### PR TITLE
Makes the experimental RCDs description not lie

### DIFF
--- a/Resources/Locale/en-US/_DV/prototypes/entities/objects/tools/tools.ftl
+++ b/Resources/Locale/en-US/_DV/prototypes/entities/objects/tools/tools.ftl
@@ -1,0 +1,2 @@
+ent-RCDRecharging = experimental RCD
+  .desc = A rapid construction device which creates compressed matter on the fly using an internal fabricator.

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -382,7 +382,7 @@
   id: RCDRecharging
   parent: RCD
   name: experimental RCD
-  description: Cyborg-mounted Rapid Construction Device which creates compressed matter on the fly using an internal fabricator.
+  description: A rapid construction device which creates compressed matter on the fly using an internal fabricator. # DeltaV - Not cyborg mounted anymore.
   suffix: AutoRecharge
   components:
   - type: LimitedCharges

--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -382,7 +382,7 @@
   id: RCDRecharging
   parent: RCD
   name: experimental RCD
-  description: A rapid construction device which creates compressed matter on the fly using an internal fabricator. # DeltaV - Not cyborg mounted anymore.
+  description: Cyborg-mounted Rapid Construction Device which creates compressed matter on the fly using an internal fabricator.
   suffix: AutoRecharge
   components:
   - type: LimitedCharges


### PR DESCRIPTION
## About the PR
Description said it is "cyborg-mounted" which isn't really true. It can be made on DeltaV. This PR
1. Lowercases "Rapid Construction Device" in the description because it's the only title-case reference to this. Also looked a bit weird without "Cyborg-mounted"
2. Removes "Cyborg-mounted" from the description

Fixes #4407

## Media
<img width="504" height="246" alt="image" src="https://github.com/user-attachments/assets/317da738-928f-4d11-9c77-49f978c77fd8" />
<img width="374" height="90" alt="image" src="https://github.com/user-attachments/assets/c0054330-1e40-465f-a447-20050d89d9ab" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->