### PR TITLE
Add formal security uniforms to Security Officer loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1304,6 +1304,8 @@
   - SeniorSecOfficerTurtleskirt
   - SeniorSecOfficerJumpsuit
   - SeniorSecOfficerJumpskirt
+  - SecurityFormalJumpsuit
+  - SecurityFormalJumpskirt
   # End DeltaV changes
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
@@ -78,6 +78,16 @@
   equipment:
     jumpsuit: ClothingUniformJumpskirtSecTurtle
 
+- type: loadout
+  id: SecurityFormalJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitSecFormal
+
+- type: loadout
+  id: SecurityFormalJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtSecFormal
+
 # OuterClothing
 
 - type: loadout


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Security Officers can now choose the Security Formal Suit and the Security Formal Dress roundstart in their loadout

## Why / Balance
hype moments and aura

## Technical details
yamlops

## Media
<img width="1077" height="828" alt="image" src="https://github.com/user-attachments/assets/3c755ad5-4f9a-40e7-95e9-be8af91db6fd" />
<img width="1067" height="806" alt="image" src="https://github.com/user-attachments/assets/63ea0ae9-5c6a-4204-be39-33405b0659c4" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Security officers can now choose formal uniforms in their loadout!
