### PR TITLE
nukies 15 35

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -114,8 +114,8 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 10 # DeltaV - was 20
-    minTotalPlayers: 30 # DeltaV
+    minPlayers: 15 # DeltaV - was 20
+    minTotalPlayers: 35 # DeltaV
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: NukieOperation # DeltaV - Nukie operations!

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -114,7 +114,7 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 15 # DeltaV - was 20
+    minPlayers: 10 # DeltaV - was 20
     minTotalPlayers: 35 # DeltaV
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml


### PR DESCRIPTION
dont merge without direction approval


## Why / Balance
the 20 ghosts staring at the 3 nukies declare war against the janitor, 2 med inters, 3 permas and 3 tiders

not 15 45 cause i want to see nukies before 9pm cest

**Changelog**
:cl:

- tweak: nukies now require 35 players instead of 30

