### PR TITLE
Makes tape recorders signal-compatible

### DIFF
--- a/Content.Shared/_DV/TapeRecorder/Components/TapeRecorderComponent.cs
+++ b/Content.Shared/_DV/TapeRecorder/Components/TapeRecorderComponent.cs
@@ -1,4 +1,6 @@
 using Content.Shared._DV.TapeRecorder.Systems;
+using Content.Shared._DV.DeviceLinking.Systems;
+using Content.Shared.DeviceLinking;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -80,4 +82,20 @@ public sealed partial class TapeRecorderComponent : Component
     {
         Params = AudioParams.Default.WithVolume(-2f).WithMaxDistance(3f)
     };
+
+    /// <summary>
+    /// Ports for signal control
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> PausePort = "Pause";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> RecordPort = "Record";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> PlaybackPort = "Playback";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> RewindPort = "Rewind";
+
 }

--- a/Content.Shared/_DV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
+++ b/Content.Shared/_DV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
@@ -10,6 +10,8 @@ using Content.Shared.Tag;
 using Content.Shared.Toggleable;
 using Content.Shared.UserInterface;
 using Content.Shared.Whitelist;
+using Content.Shared.DeviceLinking;
+using Content.Shared.DeviceLinking.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
@@ -43,6 +45,7 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
         SubscribeLocalEvent<TapeRecorderComponent, ExaminedEvent>(OnRecorderExamined);
         SubscribeLocalEvent<TapeRecorderComponent, ChangeModeTapeRecorderMessage>(OnChangeModeMessage);
         SubscribeLocalEvent<TapeRecorderComponent, AfterActivatableUIOpenEvent>(OnUIOpened);
+        SubscribeLocalEvent<TapeRecorderComponent, SignalReceivedEvent>(OnSignalReceived);
 
         SubscribeLocalEvent<TapeCassetteComponent, ExaminedEvent>(OnTapeExamined);
         SubscribeLocalEvent<TapeCassetteComponent, DamageChangedEvent>(OnDamagedChanged);
@@ -410,6 +413,27 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
             cooldown);
 
         _ui.SetUiState(uid, TapeRecorderUIKey.Key, state);
+    }
+
+    private void OnSignalReceived(Entity<TapeRecorderComponent> ent, ref SignalReceivedEvent args)
+    {
+        if (args.Port == ent.Comp.PausePort)
+        {
+            SetMode(ent, TapeRecorderMode.Stopped);
+        }
+        else if (args.Port == ent.Comp.RecordPort)
+        {
+            SetMode(ent, TapeRecorderMode.Recording);
+        }
+        else if (args.Port == ent.Comp.PlaybackPort)
+        {
+            SetMode(ent, TapeRecorderMode.Playing);
+
+        }
+        else if (args.Port == ent.Comp.RewindPort)
+        {
+            SetMode(ent, TapeRecorderMode.Rewinding);
+        }
     }
 }
 

--- a/Content.Shared/_DV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
+++ b/Content.Shared/_DV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
@@ -428,7 +428,6 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
         else if (args.Port == ent.Comp.PlaybackPort)
         {
             SetMode(ent, TapeRecorderMode.Playing);
-
         }
         else if (args.Port == ent.Comp.RewindPort)
         {

--- a/Resources/Locale/en-US/_DV/linkports/link-ports.ftl
+++ b/Resources/Locale/en-US/_DV/linkports/link-ports.ftl
@@ -1,3 +1,7 @@
-
 signal-port-name-power-toggle = Toggle Power
 signal-port-description-power-toggle = A signal port, that toggles power state when it recieves a signal.
+
+signal-port-description-playback = Start audio playback.
+signal-port-description-record = Start recording audio.
+signal-port-description-rewind = Rewind audio.
+signal-port-description-pause = Stop playing, recording, or rewinding.

--- a/Resources/Prototypes/_DV/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/_DV/DeviceLinking/sink_ports.yml
@@ -2,3 +2,23 @@
   id: PowerToggle
   name: signal-port-name-power-toggle
   description: signal-port-description-power-toggle
+
+- type: sinkPort
+  id: Pause
+  name: tape-recorder-menu-stopped-button
+  description: signal-port-description-pause
+
+- type: sinkPort
+  id: Record
+  name: tape-recorder-menu-recording-button
+  description: signal-port-description-record
+
+- type: sinkPort
+  id: Playback
+  name: tape-recorder-menu-playing-button
+  description: signal-port-description-playback
+
+- type: sinkPort
+  id: Rewind
+  name: tape-recorder-menu-rewinding-button
+  description: signal-port-description-rewind

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -50,6 +50,17 @@
     interfaces:
       enum.TapeRecorderUIKey.Key:
         type: TapeRecorderBoundUserInterface
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - Pause
+    - Record
+    - Playback
+    - Rewind
 
 - type: entity
   parent: TapeRecorder


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Makes tape recorders signal-compatible. There are four ports in the exact order the buttons display on the tape recorder
1. Pause
2. Record
3. Playback
4. Rewind

## Why / Balance
I think this'd open up a lot of cool stuff for antagonists, Security, or just anyone. You could...
1. Set a recorder trap that activates as soon as a door opens. You'd need to check to make sure the room isn't bugged
5. Make a greeter for your department.
6. Make something to ~~yell at~~ advertise to passers-by in the hallways.
7. Leave anonymous `(this is possible even as a non-syndie. damage tapes and it hides the name)` threatening messages that play as soon as a door opens instead of leaving a tape on the ground and hoping it gets played.
8. Set up an intercom with a tape recorder to send alerts (like a door opening, or batteries discharging), or a delayed message to divert attention
9. Just generally use it as a signal output. Right now, signals don't have enough good, noticeable outputs. Best noticeable output I can think of is a figurine
10. Use a dead mans signaler for blackmail (true or voice changered) using an intercom and a hidden tape recorder

I am a bit worried about someone... automatically recursing these to spam chat or whatever? But you could do that anyway with tape recorders to an extent. I've never seen it happen once

## Technical details
I'm terrible at C# so please scrutinize this PR like you're certain I don't know what I'm doing. It is a surprise to me every time I successfully do something like this

Closing the game and reopening it seems weird? If this is clientsided to an extent, it might desync from the rest of the players. I'm not sure if this is just a tape recorder issue. Or if it even is an issue

I used the tape recorder UI FTL entries for the port names. They're meant to say the same things anyway

I have tested...
- Controlling it with signals in-hand. UI updates instantly
- Removing the tape, switching mode via signal, and then inserting the tape. Starts in pause
- Using it without a tape. Faint, distinct clicking noise. Doesn't do anything
- Recording or playing when the tape is at 100%. Clicks twice (likely the mode switching and then immediately switching back), pauses. Double-clicking is weird but minor enough for me to not care

## Media
<img width="453" height="260" alt="image" src="https://github.com/user-attachments/assets/ee2d80a0-845c-4997-9324-cd43faa00197" />

(these arent the best examples, but these are connected to play or record. these would wait as long as they'd have to for a trigger)

https://github.com/user-attachments/assets/cdaedb52-9298-42e0-88b9-ed9319ee318f

https://github.com/user-attachments/assets/bc1a5217-07cc-40ec-b0d6-270ccaf53f10



(this one isnt even a feature the PR added. just showing off the fact you can damage tapes to hide the name)
<img width="438" height="91" alt="image" src="https://github.com/user-attachments/assets/4215553a-f8b3-466c-bce8-0cc14c1f8e62" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Minerva
- add: Tape recorders can now be controlled using four signal ports corresponding to their buttons.