### PR TITLE
id card computer now sets access when selecting a job preset

### DIFF
--- a/Content.Server/_DV/Access/Systems/IdCardConsoleSystem.Toggle.cs
+++ b/Content.Server/_DV/Access/Systems/IdCardConsoleSystem.Toggle.cs
@@ -55,5 +55,7 @@ public sealed partial class IdCardConsoleSystem
         // TODO: only log changes when ejecting the id
         _adminLogger.Add(LogType.Action, LogImpact.Medium,
             $"{ToPrettyString(user):user} has {verb} access level '{args.Id}' {prefix} {ToPrettyString(targetId):entity}");
+
+        UpdateUserInterface(ent.Owner, ent.Comp, args);
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Fixes https://github.com/DeltaV-Station/Delta-v/issues/3803

Previously the job preset's access were just flashing up and then immediately being erased -- they weren't actually being set, due to our changes to how the client-server messaging works in PR https://github.com/deltaV-Station/Delta-v/pull/3238

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

UI bug fix

## Technical details
<!-- Summary of code changes for easier review. -->

Just extended the client-server messaging approach we added in the previous PR I linked: since accesses don't get sent in `SubmitData()` anymore, we should send the job preset ones in the new way as well (`OnToggleAccess`).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

![id_preset](https://github.com/user-attachments/assets/d41b5293-6666-4132-9d5a-11793c33a8fb)

You can see I also verified that accesses you can't change aren't changed by the preset dropdown:
1. centcomm grants AA ("Captain")
2. mystagogue changes preset to "Assistant"
3. centcomm checks the ID -- sees that it still mostly has AA, just minus all the accesses that Mysta could remove

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
