### PR TITLE
Bring back chantry destructability

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/converter.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/converter.yml
@@ -79,4 +79,17 @@
     floodFillStarting: true
     corruptionMaxTicks: 12
     corruptionSpeed: 1.25
-  - type: CosmicPurifiable
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 400
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak

--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/structures.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/structures.yml
@@ -333,11 +333,22 @@
     range: 15
     sound:
       path: /Audio/_DV/CosmicCult/spire_draining.ogg
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
   - type: RCDDeconstructable
     deconstructable: false
-  - type: CosmicPurifiable
-    cleanseTime: 10
-    cleanseTimeChaplain: 5
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 300
+      behaviors: #excess damage, don't spawn entities.
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
   - type: PointLight
     radius: 2
     energy: 1.6
@@ -392,11 +403,22 @@
     range: 15
     sound:
       path: /Audio/_DV/CosmicCult/spire_draining.ogg
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: Metallic
   - type: RCDDeconstructable
     deconstructable: false
-  - type: CosmicPurifiable
-    cleanseTime: 10
-    cleanseTimeChaplain: 5
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 200
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: GlassBreak
   - type: PointLight
     radius: 2
     energy: 1.6


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The Vacuous Chantry, and other cult structures (Vacuous Spire, Multispectral Inhibitor), can once again be destroyed. Reverts a few changes made in https://github.com/DeltaV-Station/Delta-v/pull/4284

## Why / Balance
<img width="1066" height="87" alt="image" src="https://github.com/user-attachments/assets/9f85c735-763d-41e2-9155-6c9f0ae6289b" />
Requiring a bible user to destroy a Chantry makes it nigh impossible to security to deal with it before it becomes a much much much larger threat. Cultists no longer get to create four free colossuses because the only available bible users are busy/dead/cultists.

## Technical details
yaml ops

## Media
![ezgif-51d0f94085c88c](https://github.com/user-attachments/assets/e1a07b98-47cf-4064-92ad-956e50e7355e)

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Vacuous Chantry, Vacuous Spire, and Multispectral Inhibitor are once again destructible.
