### PR TITLE
1984 prober lockout [mald PR]

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -14,7 +14,7 @@
     - id: GlimmerRandomSentience
     - id: GlimmerRandomAnimation
     - id: ThavenMoodUpset
-    - id: LockProbers
+    #- id: LockProbers
     - id: PsionicNosebleedEvent
 
 - type: entity
@@ -170,13 +170,13 @@
     glimmerBurnUpper: 70
   - type: ThavenMoodUpsetRule
 
-- type: entity
-  parent: BaseGlimmerEvent
-  id: LockProbers
-  components:
-  - type: GlimmerEvent
-    minimumGlimmer: 500
-  - type: LockProbersRule
+#- type: entity
+#  parent: BaseGlimmerEvent
+#  id: LockProbers
+#  components:
+#  - type: GlimmerEvent
+#    minimumGlimmer: 500
+#  - type: LockProbersRule
 
 - type: entity
   parent: BaseGlimmerEvent


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Prober lockout gone (for real this time)

## Why / Balance
you know, until today i never really knew how insanely stupid the lockout was. you LITERALLY can't do anything about it other then let it explode? even if you get a drainer, i don't even know if it also gains the glimmer-tied efficiency of the prober. doesn't matter anyways because there is zero chance you get a drainer within the 10 minutes you have before a locked prober reaches 1000 and blows

probers can still duplicate and like randomly turn themselves on(?) so. the risk remains, and with the exponential glimmer increase of the prober, those are inherently dangerous enough. prober lockout was already really rare anyways, been playing MG for a good while and today was the first time I actually saw it happen myself

## Technical details
yaml op

## Media
nah

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
this pr is so funny it makes me want to merge without looking
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Prober lockouts are no more.
