### PR TITLE
Population Increase, Horizon Shutdown

### DIFF
--- a/Resources/ConfigPresets/DeltaV/apoapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/apoapsis.toml
@@ -1,6 +1,6 @@
 [game]
 hostname         = "[EN][MRP] Delta-v (Ψ) | Apoapsis [US East 1]"
-soft_max_players = 80
+soft_max_players = 100
 
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"

--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -1,6 +1,6 @@
 [game]
 hostname           = "[EN][MRP] Delta-v (Ψ) | Periapsis [US East 2]"
-soft_max_players   = 50
+soft_max_players   = 60
 
 [vote]
 preset_enabled = true


### PR DESCRIPTION
## About the PR
Brings back the glory days, Increases Apo to 100 pop, Peri to 60 pop

## Why / Balance
Discussed with staff teams with an overwhelming YES, confirmed with the Host that these are the files needed to change

## Media
![glory_days_mr__incredible_poster__by_josephpatrickbrennan_dk0vj3f-fullview](https://github.com/user-attachments/assets/61198bf2-5295-4006-b3c3-bf87b6c44cc8)

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Apoapsis Hits 100 pop
