### PR TITLE
Stale PR/Issue Automation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        exempt-issue-labels: 'Priority: 1-Urgent,ignore-stale'
+        days-before-stale: 90
+        stale-issue-message: 'This issue will close in 2 days due to inactivity'
+        days-before-close: 2
+        stale-pr-message: 'This Pull Request will close in 2 days due to inactivity'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        remove-stale-when-updated: true


### PR DESCRIPTION
Github only issue, Addresses Stale PR's and Issues, Marks them for deletion after 90 days of inactivity

Ignore-stale and Priority 1 labels are ignored from this automation