### PR TITLE
Improve HoS combat hardsuit movement speed

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -39,7 +39,7 @@
     damageProtection:
       flatReductions:
         Blunt: 10
-
+# Security Combat Hardsuit
 - type: entity
   parent: ClothingOuterHardsuitCombatStandard
   id: ClothingOuterHardsuitCombatOfficer
@@ -85,7 +85,7 @@
     sprintModifier: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatMedical
-
+# Corpsman Combat Hardsuit
 - type: entity
   parent: ClothingOuterHardsuitCombatMedical
   id: ClothingOuterHardsuitCombatCorpsman
@@ -133,7 +133,7 @@
     sprintModifier: 0.60
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatRiot
-
+# Warden Combat Hardsuit
 - type: entity
   parent: ClothingOuterHardsuitCombatRiot
   id: ClothingOuterHardsuitCombatWarden
@@ -177,11 +177,11 @@
   - type: StaminaResistance
     damageCoefficient: 0.2
   - type: ClothingSpeedModifier
-    walkModifier: 0.80
-    sprintModifier: 0.80
+    walkModifier: 0.85
+    sprintModifier: 0.85
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCombatAdvanced
-
+# HoS Combat Hardsuit
 - type: entity
   parent: ClothingOuterHardsuitCombatAdvanced
   id: ClothingOuterHardsuitCombatHoS


### PR DESCRIPTION
## About the PR
Changed movement penalty from 80% to 85% (5% increase in movement speed)

## Why / Balance
The HoS hardsuit is advertised as an advanced suit, however it is not. It offer's negligible returns. In the event that an HoS is present in a fight with their personal hardsuit, this should be giving them at least a slight advantage over regular security.

Also Cleaned up the YML file

## Requirements

- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- tweak: Improved HoS Hardsuit movement speed
