### PR TITLE
Bring back HOS trenchcoat

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -351,7 +351,7 @@
     - id: ClothingEyesGlassesSecurity
     - id: ClothingHeadsetAltSecurity
     - id: ClothingMaskNeckGaiter
-#    - id: ClothingOuterCoatHoSTrench # DeltaV - removed for incongruence
+    - id: ClothingOuterCoatHoSTrench
     - id: ClothingShoesBootsJack
     - id: DoorRemoteSecurity
     - id: HoloprojectorSecurity

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/head_of_security.yml
@@ -35,6 +35,11 @@
   equipment:
     outerClothing: ClothingOuterCoatStasecHoS
 
+- type: loadout
+  id: HeadOfSecurityTrenchcoat
+  equipment:
+    outerClothing: ClothingOuterCoatHoSTrench
+
 # Shoes
 - type: loadout
   id: HeadOfSecurityWinterBoots

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -420,6 +420,7 @@
   - PlateCarrier
   - DuraVest
   - StasecWinterCoatHoS
+  - HeadOfSecurityTrenchcoat
 
 ## Detective
 - type: loadoutGroup


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
HOS trenchcoat is now available in loadout and in their locker.

## Why / Balance
not sure what a "metafriend token" is but i was offered five of them to do this. i am assuming that is a lot

trenchcoat looks cool, was one of many casualties of the rather ill-recieved https://github.com/DeltaV-Station/Delta-v/pull/1854. lgtm

## Technical details
yaml op

## Media
<img width="1091" height="796" alt="image" src="https://github.com/user-attachments/assets/770d30c0-5d3b-484a-ba34-d1e913eeccf8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Head of Security's trenchcoat is available once more, in both loadouts and their locker.
