### PR TITLE
A few small fixes

### DIFF
--- a/Resources/Locale/en-US/_CD/records/corrections.ftl
+++ b/Resources/Locale/en-US/_CD/records/corrections.ftl
@@ -1,5 +1,6 @@
-ent-CriminalRecordsComputerCircuitboard = security records computer board
-    .desc = A computer printed circuit board for a security records computer.
+# DeltaV - Was security records computer board
+ent-CriminalRecordsComputerCircuitboard = criminal records computer board
+    .desc = A computer printed circuit board for a criminal records computer.
 
 ent-StationRecordsComputerCircuitboard = employment records computer board
     .desc = A computer printed circuit board for a employment records computer.

--- a/Resources/Prototypes/_DV/Reagents/medicine.yml
+++ b/Resources/Prototypes/_DV/Reagents/medicine.yml
@@ -47,7 +47,7 @@
   id: UnholyWater # going to be renamed later alongside holy water
   name: reagent-name-unholy-water
   group: Toxins
-  desc: reagent-name-unholy-water
+  desc: reagent-desc-unholy-water
   physicalDesc: reagent-physical-desc-menacing
   flavor: UnholyWater
   color: "#1614143d"

--- a/Resources/Prototypes/_Goobstation/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/_Goobstation/Recipes/Lathes/electronics.yml
@@ -11,31 +11,39 @@
 - type: latheRecipe
   parent: BaseGoldCircuitboardRecipe
   id: RoboticArmCircuitboard
-  icon:
-    sprite: _Goobstation/Structures/Machines/robotic_arm.rsi
-    state: icon
+  # Begin DeltaV Removal - Use the circuit board icon instead
+  # icon:
+  #   sprite: _Goobstation/Structures/Machines/robotic_arm.rsi
+  #   state: icon
+  # End DeltaV Removal
   result: RoboticArmCircuitboard
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe
   id: ConstructorCircuitboard
-  icon:
-    sprite: _Goobstation/Structures/Machines/constructor.rsi
-    state: icon
+  # Begin DeltaV Removal - Same as above
+  # icon:
+    # sprite: _Goobstation/Structures/Machines/constructor.rsi
+    # state: icon
+  # End DeltaV Removal
   result: ConstructorCircuitboard
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe
   id: StorageBinCircuitboard
-  icon:
-    sprite: _Goobstation/Structures/Machines/storage_bin.rsi
-    state: icon
+  # Begin DeltaV Removal - Same as above
+  # icon:
+    # sprite: _Goobstation/Structures/Machines/storage_bin.rsi
+    # state: icon
+  # End DeltaV Removal
   result: StorageBinCircuitboard
 
 - type: latheRecipe
   parent: BaseCircuitboardRecipe
   id: InteractorCircuitboard
-  icon:
-    sprite: _Goobstation/Structures/Machines/interactor.rsi
-    state: icon
+  # Begin DeltaV Removal - Same as above
+  # icon:
+    # sprite: _Goobstation/Structures/Machines/interactor.rsi
+    # state: icon
+  # End DeltaV Removal
   result: InteractorCircuitboard


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Changed the Security Records Computer Board to Criminal Records.
Changed the Factorio machine boards to using the board icon instead of the finished machine in the lathe.
Changed the unholy water description to actually work.

## Why / Balance
Fixing #4410, #4406 and #4403

## Technical details
Just yml and ftl fixes.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed the criminal records computer board being called "security records"
- fix: Fixed robotic arms (and other automation machines) icons in the circuit lathe.
- fix: Fixed unholy water's guidebook description.