### PR TITLE
Allow base secdogs to wear K9 armour

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/animals.yml
@@ -181,6 +181,7 @@
     tags:
     - DoorBumpOpener
     - VimPilot
+    - K9
   - type: Vocal
     sounds:
       Unsexed: MobDog

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -53,7 +53,6 @@
     - CannotSuicide
     - VimPilot
     - DoorBumpOpener
-    - K9
   - type: StealTarget
     stealGroup: AnimalSecurity # DeltaV - Adjusts because we have multiple possible sec animals
   - type: Temperature


### PR DESCRIPTION

## About the PR
Allows crate based secdogs to also wear K9 armour.

## Why / Balance
Laika shouldn't be the only dog able to wear it!

## Technical details
YAML Warrior

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Enabled any/all sec dogs to wear K9 armour
