### PR TITLE
Ensure laika can also wear the K9 armour

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -53,6 +53,7 @@
     - CannotSuicide
     - VimPilot
     - DoorBumpOpener
+    - K9
   - type: StealTarget
     stealGroup: AnimalSecurity # DeltaV - Adjusts because we have multiple possible sec animals
   - type: Temperature


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Bad testing on https://github.com/DeltaV-Station/Delta-v/pull/4514 meant that Secdogs can wear the armour, but not Laika. I assumed that Tags were inherited along with the parent, but that doesn't seem to be the case.

## Why / Balance
n/a

## Technical details
I am but a humble YAML amateur who makes mistakes, please look kindly on me

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Laika can now indeed wear K9 armour again
