### PR TITLE
Fractured Form Sleep Patch

### DIFF
--- a/Content.Server/_DV/Abilities/Psionics/FracturedFormPowerSystem.cs
+++ b/Content.Server/_DV/Abilities/Psionics/FracturedFormPowerSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Preferences;
 using Content.Shared.Psionics.Events;
+using Content.Shared.SSDIndicator;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
@@ -117,6 +118,12 @@ public sealed class FracturedFormPowerSystem : SharedFracturedFormPowerSystem
             if (!HasComp<SleepingComponent>(uid) && !HasComp<FracturedFormPowerComponent>(uid))
             {
                 _sleeping.TrySleeping(uid);
+            }
+
+            if (TryComp<SSDIndicatorComponent>(uid, out var ssd) && ssd.IsSSD)
+            {
+                // Ensure the body isn't forcesleep'd by the SSD system.
+                ssd.IsSSD = false;
             }
         }
     }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixes a bug with Fractured Forms making you unable to swap body.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, when a spare body is left for longer than 10 mintues without swapping into it, the SSD system gives it a `ForcedSleepingComponent`, which makes sense for the general case, but prevents switching.

## Technical details
<!-- Summary of code changes for easier review. -->
Marked the `SSDIndicatorComponent` as not `IsSSD` on spare bodies, preventing force sleeping.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fractured Form bodies no-longer get stuck when left too long
