### PR TITLE
ERT Selectable loadouts 

### DIFF
--- a/Resources/Locale/en-US/_DV/ERTBox/sets.ftl
+++ b/Resources/Locale/en-US/_DV/ERTBox/sets.ftl
@@ -1,0 +1,16 @@
+ert-box-bulldog-name = Bulldog
+ert-box-bulldog-description =
+    A 12 gauge magazine-fed auto-shotgun, taken from a defeated Nuclear Commander.
+    Comes with a loaded viper and a spare mag.
+
+ert-box-energy-carbine-name = IK-60
+ert-box-energy-carbine-description =
+    A standard issue energy carbine used by NanoTrasen Navy.
+    Comes with an IK-60 and three energy magazines.
+
+ert-box-wt550-name = WT550
+ert-box-wt550-description =
+    A one handed submachine gun, chambered in .35.
+    A versatile close to medium range weapon.
+    Comes with 3 spare magazines.
+

--- a/Resources/Locale/en-US/_DV/ERTBox/sets.ftl
+++ b/Resources/Locale/en-US/_DV/ERTBox/sets.ftl
@@ -13,4 +13,3 @@ ert-box-wt550-description =
     A one handed submachine gun, chambered in .35.
     A versatile close to medium range weapon.
     Comes with 3 spare magazines.
-

--- a/Resources/Prototypes/_DV/Catalog/ertbox.yml
+++ b/Resources/Prototypes/_DV/Catalog/ertbox.yml
@@ -1,0 +1,35 @@
+- type: thiefBackpackSet
+  id: Bulldog
+  name: ert-box-bulldog-name
+  description: ert-box-bulldog-description
+  sprite:
+    sprite: Objects/Weapons/Guns/Shotguns/bulldog.rsi
+    state: icon
+  content:
+  - WeaponShotgunBulldog
+
+- type: thiefBackpackSet
+  id: EnergyCarbine
+  name: ert-box-energy-carbine-name
+  description: ert-box-energy-carbine-description
+  sprite:
+    sprite: _DV/Objects/Weapons/Guns/Rifles/lasercarbineert.rsi
+    state: icon
+  content:
+  - WeaponRifleLaserERT
+  - MagazineLaser
+  - MagazineLaser
+  - MagazineLaser
+
+- type: thiefBackpackSet
+  id: SubMachineGun
+  name: ert-box-wt550-name
+  description: ert-box-wt550-description
+  sprite:
+    sprite: Objects/Weapons/Guns/SMGs/wt550.rsi
+    state: icon
+  content:
+  - WeaponSubMachineGunWt550
+  - MagazinePistolSubMachineGunTopMounted
+  - MagazinePistolSubMachineGunTopMounted
+  - MagazinePistolSubMachineGunTopMounted

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/ert_box.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/ert_box.yml
@@ -1,0 +1,15 @@
+- type: entity
+  parent: ToolboxThief
+  id: ERTBox
+  name: ERT Box
+  description: Your designated gear. Though you were in a such a rush to deploy, that you forgot what you brought with you!
+  components:
+#  - type: Sprite
+#    sprite: Objects/Tools/Toolboxes/toolbox_thief.rsi
+#    state: icon
+  - type: ThiefUndeterminedBackpack
+    maxSelectedSets: 1
+    possibleSets:
+    - Bulldog
+    - EnergyCarbine
+    - SubMachineGun


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds undetermined kits to ERT classes, ranging from primaries, secondaries and utility items.

## Why / Balance
Noticed a trend where eventers would sometimes change loadouts or give units something extra before deployment. Got annoyed at the inconsistencies with their deployment and some of their weapon selections, so wanted to give our units options before going in.

This will probably be changed rapidly as it goes, but just wanted to post it here as a reminder for myself.

## Technical details
Most of the code is from thief satchel stuff, but i'm probably going to make a specific version for ERT

## Media
<img width="347" height="148" alt="image" src="https://github.com/user-attachments/assets/76e20d22-5538-4d63-bc41-2f83e161b361" />
<img width="608" height="500" alt="image" src="https://github.com/user-attachments/assets/595cb4a7-1232-4b39-80e1-0f5d158adf10" />

## Todo
- [ ] Make class specific ERT loadouts for primaries
- [ ] Make class specific ERT loadouts for secondaries.
- [ ] Make class specific ERT loadouts for utility.
- [ ] Have someone sprite the funny box.
- [ ] Do some C# stuff, for the bag logic and naming (mostly around ThiefUndeterminedBackpack systems)

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: In order to reduce deployment time and increase combat effectiveness, NanoTrasen has designated special kits for ERT teams. They can now select their primary, secondary and a utility option.

