### PR TITLE
Archivist closet

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -69,6 +69,9 @@
           components:
           - MachineBoard
           - ComputerBoard
+        blacklist: # DeltaV
+          tags:
+          - DisplayCaseBoard
   - type: AutomationSlots # Goobstation
     slots:
     - !type:AutomatedItemSlot

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
@@ -15,3 +15,6 @@
     - id: ClothingUniformJumpskirtLibrarian
     - id: ClothingShoesBootsLaceup
     - id: ClothingEyesGlasses
+    - id: ArtifactDisplayCaseMachineCircuitBoard
+      amount: 1
+      maxAmount: 3

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
@@ -1,0 +1,15 @@
+- type: entity
+  id: LockerArchivistFilled
+  suffix: Filled
+  parent: LockerArchivist
+  components:
+  - type: StorageFill
+    contents:
+    - id: BookRestorationKit
+    - id: LuxuryPen
+    - id: Paper
+      amount: 5
+    - id: ClothingUniformJumpsuitLibrarian
+    - id: ClothingUniformJumpskirtLibrarian
+    - id: ClothingShoesBootsLaceup
+    - id: ClothingEyesGlasses

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/science.yml
@@ -9,6 +9,8 @@
     - id: LuxuryPen
     - id: Paper
       amount: 5
+    - id: BookRandom
+      amount: 3
     - id: ClothingUniformJumpsuitLibrarian
     - id: ClothingUniformJumpskirtLibrarian
     - id: ClothingShoesBootsLaceup

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/CircuitBoards/Machine/displaycase.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/CircuitBoards/Machine/displaycase.yml
@@ -16,3 +16,6 @@
       Artifact:
         amount: 1
         defaultPrototype: SimpleXenoArtifactItem
+  - type: Tag
+    tags:
+      - DisplayCaseBoard

--- a/Resources/Prototypes/_DV/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -167,3 +167,13 @@
   components:
   - type: AccessReader
     access: [["SyndicateAgent"]]
+
+- type: entity
+  parent: LockerForensicMantis
+  id: LockerArchivist
+  name: archivist's cabinet
+  suffix: Empty
+  description: You'll never know what's inside until you collapse the quantum superposition of all possible mysteries.
+  components:
+  - type: AccessReader
+    access: [["Library"]]

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -197,3 +197,6 @@
 
 - type: Tag
   id: AncientBookDamagedRare
+
+- type: Tag
+  id: DisplayCaseBoard


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
adds a closet for archivist. requested by mappers. also now fixes an exploit with display cases that lets people get cheap artifacts by blacklisting the display case board from the flatpacker.

## Why / Balance
mapping stuff. is just a closet, has a spare book restoration kit, a spare pen, a change of clothes, some paper, and some books, as well as 1-3 display case boards.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Archivists now have a place to store their stuff.
