### PR TITLE
Ensure grappled entities cleanup grapples when they crit/die

### DIFF
--- a/Content.Server/_DV/Grappling/EntitySystems/GrapplingSystem.cs
+++ b/Content.Server/_DV/Grappling/EntitySystems/GrapplingSystem.cs
@@ -57,6 +57,7 @@ public sealed partial class GrapplingSystem : SharedGrapplingSystem
         SubscribeLocalEvent<GrapplerComponent, EscapeGrappleAlertEvent>(OnEscapeGrapplerAlert);
         SubscribeLocalEvent<GrapplerComponent, MobStateChangedEvent>(OnGrapplerStateChanged);
 
+        SubscribeLocalEvent<GrappledComponent, MobStateChangedEvent>(OnGrappledStateChanged);
         SubscribeLocalEvent<GrappledComponent, MoveInputEvent>(OnGrappledMove);
         SubscribeLocalEvent<GrappledComponent, GrappledEscapeDoAfter>(OnEscapeDoAfter);
         SubscribeLocalEvent<GrappledComponent, EscapeGrappleAlertEvent>(OnEscapeGrappledAlert);
@@ -422,6 +423,24 @@ public sealed partial class GrapplingSystem : SharedGrapplingSystem
             args.NewMobState == MobState.Dead)
         {
             ReleaseGrapple(grappler.AsNullable(), manualRelease: true);
+        }
+    }
+
+    /// <summary>
+    /// Handles when a grappled entity enters crit or dies while being held by a grappler, releasing the
+    /// grappler for them.
+    /// </summary>
+    /// <param name="grappled">Grappled entity which has entered crit or death.</param>
+    /// <param name="args">Args for the event.</param>
+    private void OnGrappledStateChanged(Entity<GrappledComponent> grappled, ref MobStateChangedEvent args)
+    {
+        if (grappled.Comp.Grappler == EntityUid.Invalid)
+            return;
+
+        if (args.NewMobState == MobState.Critical ||
+            args.NewMobState == MobState.Dead)
+        {
+            ReleaseGrapple(grappled.Comp.Grappler, manualRelease: true);
         }
     }
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixes an issue where killing the target currently grappled by Laika forces her to be stuck in a grappled state.

## Why / Balance
Laika shouldn't get stuck

## Technical details
Somehow forgot to check the mob state of the grappled target, silly me

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Killing the grappled target of a grappler no longer causes them to be stuck forever
