### PR TITLE
make guns cheaper

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -168,7 +168,7 @@
   discountDownTo:
     Telecrystal: 4 # DeltaV - was 6
   cost:
-    Telecrystal: 8 # DeltaV - was 12 changed because the Hristov is REALLY bad
+    Telecrystal: 9 # DeltaV - was 12 changed because the Hristov is REALLY bad
   categories:
   - UplinkWeaponry
 
@@ -236,7 +236,7 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledLMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 10 # DeltaV - Was 8
+    Telecrystal: 12 # DeltaV - Was 8
   cost:
     Telecrystal: 28 # DeltaV - Was 12
   categories:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -8,9 +8,9 @@
   productEntity: WeaponPistolViper
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 3 # DeltaV - was 2
+    Telecrystal: 2
   cost:
-    Telecrystal: 4 # DeltaV - was 3
+    Telecrystal: 3
   categories:
   - UplinkWeaponry
 
@@ -21,7 +21,7 @@
   productEntity: WeaponRevolverPython # DeltaV - No longer loaded with AP by default
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 3 # DeltaV - was 2
+    Telecrystal: 2
   cost:
     Telecrystal: 4
   categories:
@@ -35,9 +35,9 @@
   productEntity: WeaponPistolCobra
   discountCategory: rareDiscounts
   discountDownTo:
-    Telecrystal: 3 # DeltaV - was 2
+    Telecrystal: 2
   cost:
-    Telecrystal: 6 # DeltaV - was 4
+    Telecrystal: 4
   categories:
   - UplinkWeaponry
 
@@ -166,9 +166,9 @@
   productEntity: BriefcaseSyndieSniperBundleFilled
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 5 # DeltaV - was 6
+    Telecrystal: 4 # DeltaV - was 6
   cost:
-    Telecrystal: 10 # DeltaV - was 12 changed because the Hristov is REALLY bad
+    Telecrystal: 8 # DeltaV - was 12 changed because the Hristov is REALLY bad
   categories:
   - UplinkWeaponry
 
@@ -180,9 +180,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledSMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 10
+    Telecrystal: 8
   cost:
-    Telecrystal: 20 # DeltaV - was 17
+    Telecrystal: 15 # DeltaV - was 17
   categories:
   - UplinkWeaponry
 
@@ -208,9 +208,9 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledShotgun
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 12
+    Telecrystal: 8
   cost:
-    Telecrystal: 22 # DeltaV - was 20
+    Telecrystal: 15 # DeltaV - was 20
   categories:
   - UplinkWeaponry
 
@@ -236,7 +236,7 @@
   productEntity: ClothingBackpackDuffelSyndicateFilledLMG
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 20 # DeltaV - Was 8
+    Telecrystal: 10 # DeltaV - Was 8
   cost:
     Telecrystal: 28 # DeltaV - Was 12
   categories:


### PR DESCRIPTION

## About the PR
partially reverts #3509
viper to 3 from 4
cobra to 4 from 6 (who spends 6tc on a cobra seriously)
hristov to 8 from 10
c20 to 15 from 20
bulldog to 15 from 22
l6 discount to 10 from 20

## Why / Balance
guns are fun. rifles should not be de facto nukie exclusive. shooting someone leaves evidence, is loud, and is a very kinetic way of solving your problems. it also lets sec do their job. fun for at least 2 out of 3 participants.

**Changelog**
:cl:
- tweak: guns are now cheaper, write a proper CL later :godo:

