### PR TITLE
Fix dV winter coats having the wrong parent

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -1,13 +1,8 @@
 - type: entity
   abstract: true
-  parent: [ClothingOuterStorageBase, AllowSuitStorageClothing]
+  parent: ClothingOuterWinterCoat
   id: ClothingOuterArmoredWinterCoat
   components:
-  - type: TemperatureProtection
-    heatingCoefficient: 1.1
-    coolingCoefficient: 0.1
-  - type: Item
-    size: Normal
   - type: Armor
     modifiers:
       coefficients:
@@ -15,21 +10,6 @@
         Slash: 0.75
         Piercing: 0.75
         Heat: 0.75
-  - type: Food
-    requiresSpecialDigestion: true
-  - type: SolutionContainerManager
-    solutions:
-      food:
-        maxVol: 30
-        reagents:
-        - ReagentId: Fiber
-          Quantity: 30
-  - type: Tag
-    tags:
-    - ClothMade
-    - WhitelistChameleon
-  - type: StaticPrice
-    price: 50
 
 - type: entity
   abstract: true


### PR DESCRIPTION
## About the PR
Reparent armored winter coats so they get the zombie infection protection and other stuff

## Why / Balance
Consistency with all other winter coats

## Technical details
Change parent of ClothingOuterArmoredWinterCoat

## Media

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- fix: All winter clothing now properly protects against zombies