### PR TITLE
Buff Zombies

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -221,7 +221,7 @@ public sealed partial class ZombieSystem
         _bloodstream.ChangeBloodReagent(target, zombiecomp.NewBloodReagent);
 
         //This is specifically here to combat insuls, because frying zombies on grilles is funny as shit.
-        _inventory.TryUnequip(target, "gloves", true, true);
+        //_inventory.TryUnequip(target, "gloves", true, true); // DeltaV - Buff Zombies
         //Should prevent instances of zombies using comms for information they shouldnt be able to have.
         _inventory.TryUnequip(target, "ears", true, true);
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -27,7 +27,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
-using Content.Shared.Zombies;
+using Content.Shared.Zombies; // DeltaV - Buff Zombies
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -27,6 +27,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Zombies;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Map;
@@ -315,7 +316,8 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
         // Use hands clothing if applicable.
         if (_inventory.TryGetSlotEntity(entity, "gloves", out var gloves) &&
-            TryComp<MeleeWeaponComponent>(gloves, out var glovesMelee))
+            TryComp<MeleeWeaponComponent>(gloves, out var glovesMelee)
+            && !HasComp<ZombieComponent>(entity)) // DeltaV - Zombies don't lose gloves, but also shouldn't use them for combat over their bite.
         {
             weaponUid = gloves.Value;
             melee = glovesMelee;

--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -115,8 +115,10 @@ public sealed partial class ZombieComponent : Component
             { "Blunt", -0.4 },
             { "Slash", -0.2 },
             { "Piercing", -0.2 },
-            { "Heat", -0.02 },
-            { "Shock", -0.02 }
+            // DeltaV Start - Buff Zombies
+            { "Heat", -0.2 }, // Was -0.02
+            { "Shock", -0.2 } // Was -0.02
+            // DeltaV End - Buff Zombies
         }
     };
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I made Zombies heal Shock and Burn damage as quickly as they heal Pierce and Slash.
I also made them not lose their gloves upon zombification.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Zombies need a few loving touches. Especially given that my other [PR seeks to remove the interaction of zombification disabling the limbs](https://github.com/DeltaV-Station/Delta-v/pull/4584).
But even without that PR, zombies kinda always get shutdown easily by Security.
And it felt incredibly bad to be lying down in critical state for straight up half an hour (No hyperbole) to heal 80 heat damage.

They're still weak to heat. They don't heal heat damage on bite (Yes, they heal themselves when biting something else), and take more heat damage as they have a vulnerability to heat damage.

I've also removed the interaction of them losing their gloves. Zombified Security personnel remained insulated, so why shouldn't Engineers or IIs that managed to get insulated gloves?
I still kept the radio falling off, because that just invites metagaming. And contrary to popular belief, we shouldn't trust people to not metagame, and just prevent metagaming like smort people. (*cough* Cult deals cold damage on syphoning, immediately inviting metagaming *cough*)
## Technical details
<!-- Summary of code changes for easier review. -->
Outcommented a line and increased two numbers tenfold.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Interdyne, a rival company, scores a research-breakthrough, causing dead cells to regenerate burnt tissue quicker - But is that a good thing..? (Zombies heal Heat & Shock Damage quicker, but they still take more damage of it.)
- tweak: Upon zombification, zombies don't discard their gloves to show off their green nail polish anymore.