### PR TITLE
Admin Bag

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
+++ b/Resources/Prototypes/Roles/Jobs/Fun/misc_startinggear.yml
@@ -136,7 +136,7 @@
 - type: startingGear
   id: MobAghostGear
   equipment:
-    back: ClothingBackpackSatchelHolding
+    back: AdminSatchelofHolding # DeltaV
     id: AdminPDA
     belt: AdminToolbelt
   storage:

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/admin.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/admin.yml
@@ -1,0 +1,11 @@
+- type: entity
+  id: AdminSatchelofHolding
+  parent: ClothingBackpackSatchelHolding
+  name: admin satchel of holding
+  description: A satchel of holding... for admins! Now with 100% less shards of broken glass!
+  suffix: Admin
+  components:
+  - type: ExplosionResistance
+    damageCoefficient: 0
+  - type: Tag
+    tags: [] # ignore "WhitelistChameleon" tag


### PR DESCRIPTION
## About the PR
Added 100% explosion resistant bag for admins.

## Why / Balance
If an explosion happens and an aghost is in it, anything breakable (i.e. glass) will break and shards of glass will be everywhere. Same with any grenades in their bag, but that can hurt players too.

## Technical details
Yaml

## Media
<img width="444" height="149" alt="image" src="https://github.com/user-attachments/assets/0172cde0-3e75-46b3-bf13-498bf10a9de6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Doesn't need one.
