### PR TITLE
Update Apoapsis and Periapsis Server Descriptions

### DIFF
--- a/Resources/ConfigPresets/DeltaV/apoapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/apoapsis.toml
@@ -1,6 +1,10 @@
 [game]
 hostname         = "[EN][MRP] Delta-v (Ψ) | Apoapsis [US East 1]"
 soft_max_players = 100
+desc = """\
+This server focuses on shifts with higher population, shorter length, and gameplay centered around station-ending crises and antagonists.\
+A medium roleplay fork based around the mysterious Noösphere, featuring unique content, custom maps, new species and a revamped science department.\
+"""
 
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"

--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -1,6 +1,10 @@
 [game]
 hostname           = "[EN][MRP] Delta-v (Ψ) | Periapsis [US East 2]"
 soft_max_players   = 60
+desc = """\
+This server focuses on shifts with lower population, greater length, and a calmer atmosphere to foster character-driven roleplay.\
+A medium roleplay fork based around the mysterious Noösphere, featuring unique content, custom maps, new species and a revamped science department.\
+"""
 
 [vote]
 preset_enabled = true


### PR DESCRIPTION
## About the PR
Changed server descriptions in Apoapsis and Periapsis ConfigPresets. Descriptions retain previous description, however are now prefaced with description of intended culture/tone of rounds on each server.

## Why / Balance
This change came after much discussion about shorter rounds, higher chaos factor, and the net negative impact these have had on roleplay quality.

Each time this topic has come up, it is mentioned--and the general consensus has been--that Apoapsis is meant for shorter, more chaotic shifts, and Periapsis is meant for longer, calmer shifts.

Without some indication of this in the server browser, however, the average new player tends to perceive Periapsis as the "overflow server" for Apoapsis. This in turn lead to other issues in Periapsis, the breakdown of which is outside the scope of this pull request.

This change would address this misconception by making it clear at the "first point of contact" for a newer player that these servers are meant to have their own identities, not to simply be a "main server" and "overflow server" respectively.

## Technical details
+ Added "desc" property to Apoapsis.toml; New description details focus on shorter, more chaotic shifts.
+ Added "desc" property to Periapsis.toml; New description details focus on longer, calmer shifts.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
N/A