### PR TITLE
Made Zombie bites deal only one DamageType

### DIFF
--- a/Content.Shared/Zombies/ZombieComponent.cs
+++ b/Content.Shared/Zombies/ZombieComponent.cs
@@ -148,9 +148,11 @@ public sealed partial class ZombieComponent : Component
     {
         DamageDict = new()
         {
-            { "Slash", 13 },
-            { "Piercing", 7 },
-            { "Structural", 10 }
+            // Delta-V Start - Shifting Piercing Damage to Slash.
+            { "Slash", 20 }, // Was 13.
+            //{ "Piercing", 7 }, // Removed, so a durathread vest properly protects against it now.
+            { "Structural", 15 } // Was 10.
+            // Delta-V End - Shifting Piercing Damage to Slash.
         }
     };
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Shifted the 7 Piercing Damage from Zombies to Slash.
Added 5 Structural Damage.
Previous Damage: 13 Slash, 7 Piercing, 10 Structural.
Proposed Damage: 20 Slash, 15 Structural.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A mixture of Slash/Blunt & Piercing is hard to properly protect without just putting on the hardsuit with a 40% all-round brute protection.
Shields suffer from this especially.

Wearing just a Durathread vest, a bite originally dealt 14.1 Damage.
Now, it'll only deal 12 Damage. 

However, Slash is better as a Damage Type, causing more bleeding stacks than Piercing. In addition, to counteract the nerf, I've chosen to up their Structural by 50%. 
## Technical details
<!-- Summary of code changes for easier review. -->
Simple C# Changes.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Zombies now deal solely Slash with their bites!