### PR TITLE
Fixed Kitsune needing to confirm reverting back to human form

### DIFF
--- a/Resources/Prototypes/Actions/polymorph.yml
+++ b/Resources/Prototypes/Actions/polymorph.yml
@@ -4,8 +4,8 @@
   name: Revert
   description: Revert back into your original form.
   components:
-  - type: ConfirmableAction
-    popup: revert-polymorph-action-popup
+  #- type: ConfirmableAction # DeltaV - Don't ask for confirmation, affects Kitsune Foxes reverting
+  #  popup: revert-polymorph-action-popup
   - type: InstantAction
     event: !type:RevertPolymorphActionEvent
 


### PR DESCRIPTION
Upstream merge bug

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Comments out the polymorph revert confirmation.

## Why / Balance
Fix

## Technical details
n/a

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Kitsune no longer need to confirm that they would like to revert back to human form.
