### PR TITLE
Remove Siphon Damage

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs
@@ -98,9 +98,9 @@ public sealed class CosmicSiphonSystem : EntitySystem
         uid.Comp.EntropyStored += siphonQuantity;
         uid.Comp.EntropyBudget += siphonQuantity;
         Dirty(uid, uid.Comp);
-        _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(target, "EntropicDegen", TimeSpan.FromSeconds(_random.Next(21) + 40), true); //40-60 seconds, 4-6 cold damage per siphon
         if (_cosmicCult.EntityIsCultist(target))
         {
+            _statusEffects.TryAddStatusEffect<CosmicEntropyDebuffComponent>(target, "EntropicDegen", TimeSpan.FromSeconds(_random.Next(21) + 40), true); //40-60 seconds, 4-6 cold damage per siphon
             _popup.PopupEntity(Loc.GetString("cosmicability-siphon-cultist-success", ("target", Identity.Entity(target, EntityManager))), uid, uid);
         }
         else

--- a/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Actions/cosmiccult.actions.yml
@@ -2,7 +2,7 @@
   parent: BaseAction
   id: ActionCosmicSiphon
   name: Siphon Entropy
-  description: Silently siphon entropy from your target, dealing some damage in the process.
+  description: Silently siphon entropy from your target.
   components:
   - type: Action
     useDelay: 30


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Moved the Siphon damage to only be done if the target is a cultist. Siphon doesn't work on cultists currently, but if it will, it'll damage the cultists.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This damage mechanic served absolutely nothing but to enable metagaming.

As the target, you can do /nothing/ with that information. You don't know the cultist exists. But you as the player know.
There is no instance where this isn't true, unless the cultist, for whatever reason, decides to siphon from the Captain or Mantis (MG and Chaplain cannot be siphoned).

Why have it? Just being on a standard bed cures the cold, so it doesn't prevent using one crewmember as a entrophy mine.
It just OOCly tells you "Hey, this is cultist gamemode, the person you just met is a cultist, but you can't do anything about that information, sucks to suck lmao"
## Technical details
<!-- Summary of code changes for easier review. -->
Moved one text line and changed the action text to accurately represent that it does no damage anymore.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Removed the Damage caused by Cosmic Siphoning. 