### PR TITLE
Spillable Censer

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Objects/censer.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Objects/censer.yml
@@ -51,6 +51,8 @@
           Quantity: 50
         maxVol: 50
   - type: ItemTogglePointLight
+  - type: Spillable
+    solution: Censer
   - type: ToggleableVisuals
     spriteLayer: flame
     inhandVisuals:


### PR DESCRIPTION
Spillable Censer

## About the PR
Added the "Spill Liquid" option to the censer to prevent it getting soft-locked.

Fixes https://github.com/DeltaV-Station/Delta-v/issues/4240
by allowing the holy water to be removed.

## Why / Balance
If filled with the incorrect liquid it can get broken requiring admins to respawn the item before it can be used to purge cult influence.

## Technical details
Minor yml change

## Media
<img width="539" height="513" alt="image" src="https://github.com/user-attachments/assets/0fdf5453-5f13-4e2f-9982-8ab304f6e9bc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
:cl:
- fix: Censer is now spillable to prevent cult soft-lock
