### PR TITLE
MASSIVELY buff Random Animation

### DIFF
--- a/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/RandomAnimationRuleComponent.cs
@@ -6,14 +6,14 @@ namespace Content.Server._DV.StationEvents.Components;
 public sealed partial class RandomAnimationRuleComponent : Component
 {
     [DataField]
-    public int MinAnimates = 7;
+    public int MinAnimates = 40;
 
     [DataField]
-    public int MaxAnimates = 10;
+    public int MaxAnimates = 60;
 
     [DataField]
-    public float MinTime = 7f;
+    public float MinTime = 15f;
 
     [DataField]
-    public float MaxTime = 15f;
+    public float MaxTime = 30f;
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Random animation minimum/maximum objects raised from 7/10 -> **40/60** (!!!)
Animation time raised from 7/15 -> 15/30

## Why / Balance
I have literally never seen this event trigger. Ever. Nobody even knows it exists. My current theory is that 99% of the time it triggers, it's on Elegance or something and it just picks up random trash in maints and nobody sees it and it immediately dies out with nobody the wiser.

With this change, there's a GOOD chance that multiple people will get attacked on large maps like Elegance. On SMALLER maps, every department will have a small nightmare for about 15-30 seconds, which I believe is ideal.

On Dev, you get hunted by basically everything that's not nailed down :)

(in theory, at least, on release config it's a bit wacky)

## Technical details
could probably update it in the yaml but it's never ever going to be used anywhere else so might as well just mess with the component

have only tested on debug, not sure if release spawns trash differently, will test Later:tm:
ok on Release even on Glacier it's a bit rare to see anything actually happen from any singular location but. still a hell of a lot better then it was

## Media
<img width="294" height="240" alt="image" src="https://github.com/user-attachments/assets/bb1301ae-77b0-412c-87eb-0cfa8dcddcbf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The random animation glimmer event is now a LOT more scary.
