### PR TITLE
Give Gamblagator passive radiation

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -393,7 +393,7 @@
     - entity_storage
   - type: StaticPrice
     price: 660
-    # Begin DeltaV additions - adjusted the health of gun safes to be 50 health stronger than LockerBaseSecure
+    # Begin DeltaV additions - adjusted the health of gun safes to be 50 health stronger than LockerBaseSecure. Safes now protect from radiation, like the Gamblagator.
   - type: Destructible
     thresholds:
     - trigger:
@@ -402,6 +402,8 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: RadiationBlockingContainer
+    resistance: 3
     # End DeltaV additions
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -492,6 +492,8 @@
     slots:
     - Back
   - type: AmmoCounter
+  - type: RadiationSource
+    intensity: 1.5
   - type: Gun
     fireRate: 0.7
     selectedMode: SemiAuto


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Gamblagators now emit radiation to everyone around them, about 1.5 max rads. Gun Safes now also protect from radiation.

## Why / Balance
Direction wanted to give some downside to a super weapon, to dissuade people from using it for every medium antag and only to use in a emergency situation. Dropping this or being near someone who has it equipped, is now a health hazard.

The radiation radius is about 3 tiles.

Tested out armors and damages. This is in context of the user having the weapon in their inventory, are human and will crit once they reach 100 damage:
- A regular secoff who has no radiation resistance: 1 minute and 6 seconds (1.5 damage each second)
- A secoff in a combat hardsuit/HOS hardsuit: ~1 minute and 30 seconds (1.12 damage each second)
- Warden hardsuit: ~ 1 minute and 35 seconds (1.05 damage each second)
- bloodred hardsuit: ~ 2 minutes and 17 seconds (0.75 damage each second)
- commander bloodred hardsuit: ~ 4 minutes and 37 seconds (0.37 each second)
- engineer hardsuit: ~ 23 minutes (0.07 damage each second)
- thermal hardsuit: ~ 2 hours and 47 minutes (0.01 damage each second)
- CE hardsuit/radiation suit: ~ practically immune


## Technical details
Yml code changes. Had to fiddle with upstream safe code in lockers.yml

## Media
<img width="299" height="185" alt="image" src="https://github.com/user-attachments/assets/7640f32a-25a8-4f47-b741-26a7da6e2256" />

<img width="128" height="173" alt="image" src="https://github.com/user-attachments/assets/92b5a951-b6cd-4df2-a0e3-1b8874254624" />

<img width="127" height="173" alt="image" src="https://github.com/user-attachments/assets/2d6a1c39-072e-4bad-8dee-f77bf4a73159" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Might've commented something wrong in the upstream file.

**Changelog**
:cl:
- add: Due to a budget cuts, Gamblagators now emit radiation to their surroundings. Make sure to have radiation protection before opening that safe!
- add: Safes are now leadlined and protect any contents from emitting radiation to their surrounding areas.
