### PR TITLE
Fix Transmutes taking transmuted objects

### DIFF
--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicTransmuteSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicTransmuteSystem.cs
@@ -44,7 +44,8 @@ public sealed class CosmicTransmuteSystem : EntitySystem
         var tgtpos = Transform(uid).Coordinates;
         var possibleTargets = GatherEntities(uid);
         var target = _random.Pick(possibleTargets);
-        if (!TryComp<CosmicTransmutableComponent>(target, out var comp)) return;
+        if (!TryComp<CosmicTransmutableComponent>(target, out var comp))
+            return;
         Spawn(comp.TransmutesTo, tgtpos);
         QueueDel(target);
     }
@@ -57,7 +58,7 @@ public sealed class CosmicTransmuteSystem : EntitySystem
     {
         _entities.Clear();
         _lookup.GetEntitiesInRange(Transform(ent).Coordinates, ent.Comp.TransmuteRange, _entities);
-        _entities.RemoveWhere(item => !TryComp<CosmicTransmutableComponent>(item, out var comp) || comp.RequiredGlyphType != MetaData(ent).EntityPrototype!.ID);
+        _entities.RemoveWhere(item => !TryComp<CosmicTransmutableComponent>(item, out var comp) || comp.RequiredGlyphType != MetaData(ent).EntityPrototype!.ID || HasComp<CosmicEquipmentComponent>(item));
         return _entities;
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
The glyphs that make weaponry or armor do not take already transmuted objects anymore.
Example: You transmute a shiv into a sword, and then want to transmute another shiv into another sword.
However, the first Sword is consumed instead. Now, the second shiv will be used instead.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix.
## Technical details
<!-- Summary of code changes for easier review. -->
One line in the check for what is eligible for transmutation.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Cultists: Transmutating Objects will no longer use already transmutated objects!