### PR TITLE
Add an experimental rcd and air gernade to ce's locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -176,10 +176,11 @@
     - id: ClothingHeadsetAltEngineering
     - id: DoorRemoteEngineering
     - id: CargoRequestEngineeringComputerCircuitboard
-    - id: RCD
+    - id: RCDRecharging # DeltaV (Untell ce can get there own rcd agian)
     - id: RCDAmmo
     - id: RubberStampCE
     - id: MetalFoamGrenade
+    - id: AirGrenade # DeltaV
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable


### PR DESCRIPTION
## About the PR
Added the experimental rcd and a air grenade to ce locker round start

## Why / Balance
Ce use to be the only one with a rcd so until ce gets there own rcd again they should have a better rcd then the rest of eng since there the ce. Also added a air grenade to ce locker so they can have it like atmos and so they dont steal one from a atmos locker

## Technical details
Changed the rcd to the experimental one and added one air grenade

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**

:cl:

- tweak: Added an experimental RCD and air grenade to chief engineer's locker

