### PR TITLE
feat: Secured Shock Collar

### DIFF
--- a/Content.Server/_DV/Clothing/ShockOnUnequipSystem.cs
+++ b/Content.Server/_DV/Clothing/ShockOnUnequipSystem.cs
@@ -1,0 +1,34 @@
+using Content.Server.Electrocution;
+using Content.Shared._DV.Clothing.Components;
+using Content.Shared._DV.Clothing.Systems;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Inventory;
+using Content.Shared.Inventory.Events;
+
+namespace Content.Server._DV.Clothing;
+
+/// <summary>
+///     This system implements electrocution for ShockOnUnequipComponent.
+/// </summary>
+public sealed class ShockOnUnequipSystem : SharedShockOnUnequipSystem
+{
+    [Dependency] private readonly ElectrocutionSystem _electrocutionSystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ShockOnUnequipComponent, BeingUnequippedAttemptEvent>(OnUnequipAttempt);
+    }
+
+    private void OnUnequipAttempt(Entity<ShockOnUnequipComponent> entity, ref BeingUnequippedAttemptEvent args)
+    {
+        if (TryComp<ClothingComponent>(entity, out var clothing) && (clothing.Slots & args.SlotFlags) == SlotFlags.NONE)
+            return;
+
+        var wasStunned = _electrocutionSystem.TryDoElectrocution(args.Unequipee, args.Equipment, entity.Comp.Damage, entity.Comp.Duration, true);
+        if (wasStunned)
+        {
+            args.Cancel();
+        }
+    }
+}

--- a/Content.Server/_DV/Clothing/ShockOnUnequipSystem.cs
+++ b/Content.Server/_DV/Clothing/ShockOnUnequipSystem.cs
@@ -1,6 +1,8 @@
 using Content.Server.Electrocution;
 using Content.Shared._DV.Clothing.Components;
 using Content.Shared._DV.Clothing.Systems;
+using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
@@ -13,6 +15,8 @@ namespace Content.Server._DV.Clothing;
 public sealed class ShockOnUnequipSystem : SharedShockOnUnequipSystem
 {
     [Dependency] private readonly ElectrocutionSystem _electrocutionSystem = default!;
+    [Dependency] private readonly AccessReaderSystem _accessReaderSystem = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -24,6 +28,11 @@ public sealed class ShockOnUnequipSystem : SharedShockOnUnequipSystem
     {
         if (TryComp<ClothingComponent>(entity, out var clothing) && (clothing.Slots & args.SlotFlags) == SlotFlags.NONE)
             return;
+
+        if (entity.Comp.UseAccess && _accessReaderSystem.IsAllowed(args.Unequipee, args.Equipment))
+        {
+            return;
+        }
 
         var wasStunned = _electrocutionSystem.TryDoElectrocution(args.Unequipee, args.Equipment, entity.Comp.Damage, entity.Comp.Duration, true);
         if (wasStunned)

--- a/Content.Server/_DV/Clothing/ShockOnUnequipSystem.cs
+++ b/Content.Server/_DV/Clothing/ShockOnUnequipSystem.cs
@@ -1,7 +1,6 @@
 using Content.Server.Electrocution;
 using Content.Shared._DV.Clothing.Components;
 using Content.Shared._DV.Clothing.Systems;
-using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Clothing.Components;
 using Content.Shared.Inventory;

--- a/Content.Shared/_DV/Clothing/Components/ShockOnUnequipComponent.cs
+++ b/Content.Shared/_DV/Clothing/Components/ShockOnUnequipComponent.cs
@@ -1,0 +1,23 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Clothing.Components;
+
+/// <summary>
+///     Electrocutes players attempting to unequip clothes that have this component.
+/// </summary>
+[RegisterComponent]
+[NetworkedComponent]
+public sealed partial class ShockOnUnequipComponent : Component
+{
+    /// <summary>
+    /// The damage dealt to someone trying to unequip the item without insulation.
+    /// </summary>
+    [DataField]
+    public int Damage = 5;
+
+    /// <summary>
+    /// The duration of the shock dealt to someone trying to unequip the item without insulation.
+    /// </summary>
+    [DataField]
+    public TimeSpan Duration = TimeSpan.FromSeconds(2);
+}

--- a/Content.Shared/_DV/Clothing/Components/ShockOnUnequipComponent.cs
+++ b/Content.Shared/_DV/Clothing/Components/ShockOnUnequipComponent.cs
@@ -4,6 +4,7 @@ namespace Content.Shared._DV.Clothing.Components;
 
 /// <summary>
 ///     Electrocutes players attempting to unequip clothes that have this component.
+///     Use AccessReaderComponent to stop shocking characters with certain access.
 /// </summary>
 [RegisterComponent]
 [NetworkedComponent]
@@ -20,4 +21,10 @@ public sealed partial class ShockOnUnequipComponent : Component
     /// </summary>
     [DataField]
     public TimeSpan Duration = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// If true, only shock unequipping entity if lacking access specified in AccessReader component.
+    /// </summary>
+    [DataField]
+    public bool UseAccess = true;
 }

--- a/Content.Shared/_DV/Clothing/Systems/SharedShockOnUnequipSystem.cs
+++ b/Content.Shared/_DV/Clothing/Systems/SharedShockOnUnequipSystem.cs
@@ -11,6 +11,7 @@ public abstract class SharedShockOnUnequipSystem : EntitySystem
 
         SubscribeLocalEvent<ShockOnUnequipComponent, ExaminedEvent>(OnExamined);
     }
+
     private void OnExamined(Entity<ShockOnUnequipComponent> selfUnremovableClothing, ref ExaminedEvent args)
     {
         args.PushMarkup(Loc.GetString("shock-on-unequip-examine"));

--- a/Content.Shared/_DV/Clothing/Systems/SharedShockOnUnequipSystem.cs
+++ b/Content.Shared/_DV/Clothing/Systems/SharedShockOnUnequipSystem.cs
@@ -1,0 +1,18 @@
+using Content.Shared._DV.Clothing.Components;
+using Content.Shared.Examine;
+
+namespace Content.Shared._DV.Clothing.Systems;
+
+public abstract class SharedShockOnUnequipSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ShockOnUnequipComponent, ExaminedEvent>(OnExamined);
+    }
+    private void OnExamined(Entity<ShockOnUnequipComponent> selfUnremovableClothing, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("shock-on-unequip-examine"));
+    }
+}

--- a/Resources/Locale/en-US/_DV/components/shock-on-unequip-component.ftl
+++ b/Resources/Locale/en-US/_DV/components/shock-on-unequip-component.ftl
@@ -1,0 +1,1 @@
+shock-on-unequip-examine = This cannot be removed without insulated gloves.

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
@@ -21,6 +21,9 @@
   - type: ShockOnUnequip
     damage: 10
     duration: 3
+  - type: AccessReader
+    access:
+    - - Security
   - type: ShockOnTrigger
     damage: 5
     duration: 3

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
@@ -18,6 +18,9 @@
     slots:
     - neck
   - type: SelfUnremovableClothing
+  - type: ShockOnUnequip
+    damage: 10
+    duration: 3
   - type: ShockOnTrigger
     damage: 5
     duration: 3


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Implements ShockOnUnequip component and adds it to the shock collar. The collar now electrocutes characters that attempt to remove it with configurable damage and duration, if they lack the required access (in case of the collar: Security). Since the system uses the AccessReader component, the collar can be reconfigured just like doors using the Access Configurator.

## Why / Balance
Stop Permas from removing the collar as soon as the guard leaves. [Requested in #wyci-suggestions](https://discord.com/channels/968983104247185448/1419786773571178650)

## Technical details
Implemented new ShockOnUnequip Component with accompanying System. Uses ElectrocutionSystem to electrocute the unequipping entity. Component also adds Examine text. Optionally, uses AccessReaderSystem to check access.

## Media
Initial version:

https://github.com/user-attachments/assets/2276d6a4-d867-48b4-988e-771ed554384c

Updated, with access check:

https://github.com/user-attachments/assets/f2c8736c-2486-4e31-a77c-4f604647e61e

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: DisposableCrewmember42
- tweak: Shock collars are now secured. Those without access will be shocked, so smuggle insuls into perma!