### PR TITLE
remove particle impermenance

### DIFF
--- a/Resources/Prototypes/Anomaly/behaviours.yml
+++ b/Resources/Prototypes/Anomaly/behaviours.yml
@@ -16,15 +16,15 @@
   #Hard
     Fast: 0.5
     Strenght: 0.5
-    Inconstancy: 0.5
-    InconstancyParticle: 0.5
+    #Inconstancy: 0.5 DeltaV - Disabled for now
+    #InconstancyParticle: 0.5 DeltaV - Disabled for now
     FullUnknown: 0.5
     Jumping: 0.3
     Invisibility: 0.5
   #Complex
     FastUnknown: 0.2
     JumpingUnknown: 0.1
-    InconstancyParticleUnknown: 0.1
+    #InconstancyParticleUnknown: 0.1 DeltaV - Disabled for now
     InvisibilityJumping: 0.1
 
 
@@ -62,7 +62,7 @@
   description: anomaly-behavior-delayed-force
   pulseFrequencyModifier: 2
   pulsePowerModifier: 2
-  
+
 - type: anomalyBehavior
   id: Rapid
   earnPointModifier: 1.15
@@ -95,7 +95,7 @@
   earnPointModifier: 0.8
   particleSensivity: 0.5
   description: anomaly-behavior-nonsensivity
-  
+
 - type: anomalyBehavior
   id: Sensivity
   earnPointModifier: 1.2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
I don't know what specifically changed it, but particle impermanence now uses the effect of the _rerolled_ particle as opposed to the particle effect that was there when it was hit. when that is then applied to an infectious anomaly that is currently inside of someone, it basically gives them two options to either roll the dice and explode, or to get themselves killed. getting themselves killed, in this case, actually ends up being the safer option now. suicide roleplay is against the rules for a reason, but rather then punishing people for taking the method that is safest for everyone, I'm just disabling it until I figure out how to change it back.

## Why / Balance
not a good mechanic for our server, we have that kind of roleplay banned for a reason

## Technical details
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- remove: anomalies don't seem to be randomly changing their particles anymore, for now at least.

