### PR TITLE
Make Anomaly particle shuffle happen after triggering effects

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.cs
+++ b/Content.Server/Anomaly/AnomalySystem.cs
@@ -129,6 +129,9 @@ public sealed partial class AnomalySystem : SharedAnomalySystem
             if (_random.Prob(anomaly.Comp.Continuity))
                 SetBehavior(anomaly, GetRandomBehavior());
         }
+
+        var ev = new AnomalyAffectedByParticleEvent(anomaly, args.OtherEntity);
+        RaiseLocalEvent(anomaly, ref ev);
     }
 
     /// <summary>

--- a/Content.Server/Anomaly/Effects/ShuffleParticlesAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/ShuffleParticlesAnomalySystem.cs
@@ -1,9 +1,9 @@
 using Content.Server.Anomaly.Components;
 using Content.Shared.Anomaly.Components;
-using Robust.Shared.Physics.Events;
 using Robust.Shared.Random;
 
 namespace Content.Server.Anomaly.Effects;
+
 public sealed class ShuffleParticlesAnomalySystem : EntitySystem
 {
     [Dependency] private readonly AnomalySystem _anomaly = default!;
@@ -12,19 +12,16 @@ public sealed class ShuffleParticlesAnomalySystem : EntitySystem
     public override void Initialize()
     {
         SubscribeLocalEvent<ShuffleParticlesAnomalyComponent, AnomalyPulseEvent>(OnPulse);
-        SubscribeLocalEvent<ShuffleParticlesAnomalyComponent, StartCollideEvent>(OnStartCollide);
+        SubscribeLocalEvent<ShuffleParticlesAnomalyComponent, AnomalyAffectedByParticleEvent>(OnAffectedByParticle);
     }
 
-    private void OnStartCollide(Entity<ShuffleParticlesAnomalyComponent> ent, ref StartCollideEvent args)
+    private void OnAffectedByParticle(Entity<ShuffleParticlesAnomalyComponent> ent, ref AnomalyAffectedByParticleEvent args)
     {
-        if (!TryComp<AnomalyComponent>(ent, out var anomaly))
-            return;
-
-        if (!HasComp<AnomalousParticleComponent>(args.OtherEntity))
+        if (!TryComp<AnomalyComponent>(ent, out var anomalyComp))
             return;
 
         if (ent.Comp.ShuffleOnParticleHit && _random.Prob(ent.Comp.Prob))
-            _anomaly.ShuffleParticlesEffect((ent, anomaly));
+            _anomaly.ShuffleParticlesEffect((args.Anomaly, anomalyComp));
     }
 
     private void OnPulse(Entity<ShuffleParticlesAnomalyComponent> ent, ref AnomalyPulseEvent args)

--- a/Content.Shared/Anomaly/Components/AnomalousParticleComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalousParticleComponent.cs
@@ -1,7 +1,4 @@
-using Content.Shared.Anomaly;
-using Content.Shared.Anomaly.Components;
-
-namespace Content.Server.Anomaly.Components;
+namespace Content.Shared.Anomaly.Components;
 
 /// <summary>
 /// This is used for projectiles which affect anomalies through colliding with them.

--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -336,3 +336,10 @@ public readonly record struct AnomalyHealthChangedEvent(EntityUid Anomaly, float
 /// </summary>
 [ByRefEvent]
 public readonly record struct AnomalyBehaviorChangedEvent(EntityUid Anomaly, ProtoId<AnomalyBehaviorPrototype>? Old, ProtoId<AnomalyBehaviorPrototype>? New);
+
+/// <summary>
+/// Event of anomaly being affected by exotic particle.
+/// Is raised when particle collides with artifact.
+/// </summary>
+[ByRefEvent]
+public record struct AnomalyAffectedByParticleEvent(EntityUid Anomaly, EntityUid Particle);


### PR DESCRIPTION
## About the PR
Supercedes #4659
Cherry-pick of upstream PR https://github.com/space-wizards/space-station-14/pull/40624

## Why / Balance
See previous PR

## Technical details
Refactors the anomaly triggering into a separate event

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Impermanent anomalies now trigger the scanned effect instead of the newly generated one
