### PR TITLE
Buff ifrit for real this time

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/familiars.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/familiars.yml
@@ -49,7 +49,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 120
+        damage: 150
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -129,23 +129,24 @@
   - type: Welder
     fuelReagent: Phlogiston
     tankSafe: true
-#    welderOnSounds:
-#      collection: WelderIfritHandOn
-#    welderOffSounds:
-#      collection: WelderIfritHandOff
-#  - type: Tool
-#    useSound:
-#      collection: WelderIfritHand
-#  - type: MeleeWeapon
-#    soundHit:
-#      collection: WelderIfritHand
-# TODO some way to give the MeleeWeapon a separate soundHit for when it's on,
-# similar to EnergySword. will have to go in ToolSystem.Welder.cs
-# for now, just make it sound like it's on fire no matter what because it
-# sounds cooler than the default fizzling noise.
+  - type: ItemToggleMeleeWeapon
+    activatedSoundOnHit:
+      path: /Audio/Weapons/Guns/Hits/energy_meat1.ogg
+      params:
+        variation: 0.250
+    activatedSoundOnHitNoDamage:
+      path: /Audio/Weapons/Guns/Hits/energy_meat1.ogg
+      params:
+        variation: 0.250
+    deactivatedSoundOnHitNoDamage:
+      collection: MetalThud
+    activatedDamage:
+        types:
+            Heat: 15
   - type: MeleeWeapon
-    soundHit:
-      path: /Audio/Items/welder.ogg
+    damage:
+      types:
+        Blunt: 12
   - type: SolutionRegeneration
     solution: Welder
     generated:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Buffed ifrit but for real this time

## Why / Balance
So the #4570 Ifrit buff wasn't real because they:
Had a damage trigger to destroy at 120 damage
Didn't use actual entity damage to attack, they use ifrit hands (resprited welders) to do everything

So both health buff or damage buff were a lie
Also we can indeed make it have a different hit sound when it's on now, so i did that and removed the comment from ancient times (rip)



## Media
Lazy
