### PR TITLE
Make rat servants edible

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -210,7 +210,6 @@
     - map: [ "enum.DamageStateVisualLayers.BaseUnshaded"]
       state: eyes
       shader: unshaded
-
   - type: SpriteMovement
     movementLayers:
       movement:
@@ -316,6 +315,15 @@
     - MinorAntagonists
   - type: FelinidFood # Nyanotrasen - Felinid, ability to eat rat, see Content.Server/Nyanotrasen/Abilities/Felinid/FelinidSystem.cs
   - type: Food
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        reagents:
+        - ReagentId: UncookedAnimalProteins
+          Quantity: 3
+  - type: FlavorProfile
+    flavors:
+    - meaty
   - type: Item
     size: Tiny # Delta V - Make them edible and pickable.
   - type: FireVisuals

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -315,6 +315,7 @@
     - MinorAntagonists
   - type: FelinidFood # Nyanotrasen - Felinid, ability to eat rat, see Content.Server/Nyanotrasen/Abilities/Felinid/FelinidSystem.cs
   - type: Food
+  # Begin DeltaV - Make them edible and grabbable
   - type: SolutionContainerManager
     solutions:
       food:
@@ -325,7 +326,8 @@
     flavors:
     - meaty
   - type: Item
-    size: Tiny # Delta V - Make them edible and pickable.
+    size: Tiny
+  # End DeltaV - Make them edible and grabbable
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning


### PR DESCRIPTION
## About the PR
fixes #4491 

## Why / Balance
Consistency

## Technical details
Add flavor and nutrition to rat servants, copied from mice

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Rat servants are now edible. Yum...
