### PR TITLE
Fixed colossus stamina issues

### DIFF
--- a/Content.Shared/Damage/Components/StaminaResistanceComponent.cs
+++ b/Content.Shared/Damage/Components/StaminaResistanceComponent.cs
@@ -35,4 +35,16 @@ public sealed partial class StaminaResistanceComponent : Component
     /// </summary>
     [DataField]
     public LocId Examine = "armor-stamina-projectile-coefficient-value"; // DeltaV
+
+
+    /// <summary>
+    /// DeltaV - Whether or not this includes melee resistance. By default, DeltaV assigns melee stamina resistance to
+    /// blunt damage, but if this is set to true, it was override that and use the stamina resistance value.
+    ///
+    /// If this is true, then the stamina resistance will double-dip with any blunt resistance, since stamina damage due to
+    /// blunt damage is calculated after blunt resistance is applied. Basically, use this when you want to make something even
+    /// resistant or even immune to melee stamina damage.
+    /// </summary>
+    [DataField]
+    public bool MeleeResistance = false;
 }

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.Resistance.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.Resistance.cs
@@ -16,7 +16,7 @@ public partial class SharedStaminaSystem
 
     private void OnGetResistance(Entity<StaminaResistanceComponent> ent, ref BeforeStaminaDamageEvent args)
     {
-        if (!args.FromMelee) // DeltaV - StaminaResistance is only for disablers etc, blunt armor is for resisting batong
+        if (!args.FromMelee || ent.Comp.MeleeResistance) // DeltaV - StaminaResistance is only for disablers etc, blunt armor is for resisting baton. <- WHO THOUGHT THIS WAS A GOOD IDEA?
             args.Value *= ent.Comp.DamageCoefficient;
     }
 

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -546,7 +546,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             // If the target has stamina and is taking blunt damage, they should also take stamina damage based on their blunt to stamina factor
             if (damageResult.DamageDict.TryGetValue("Blunt", out var bluntDamage))
             {
-
                 //DeltaV - No Stamina Resistance Doubledipping, unless we want to.
                 var ignoreResist = true;
                 if (TryComp<StaminaResistanceComponent>(target, out var staminaResist))
@@ -716,7 +715,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
 
                     _stamina.TakeStaminaDamage(entity, (bluntDamage * component.BluntStaminaDamageFactor).Float(), visual: false, source: user, with: meleeUid == user ? null : meleeUid, ignoreResist: ignoreResist);
                     // END DeltaV
-
                 }
 
                 appliedDamage += damageResult;

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Administration.Components;
 using Content.Shared.Administration.Logs;
 using Content.Shared.CombatMode;
 using Content.Shared.Damage;
+using Content.Shared.Damage.Components; // DeltaV - Melee Stamina Resistance Override
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
@@ -545,7 +546,14 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             // If the target has stamina and is taking blunt damage, they should also take stamina damage based on their blunt to stamina factor
             if (damageResult.DamageDict.TryGetValue("Blunt", out var bluntDamage))
             {
-                _stamina.TakeStaminaDamage(target.Value, (bluntDamage * component.BluntStaminaDamageFactor).Float(), visual: false, source: user, with: meleeUid == user ? null : meleeUid, ignoreResist: true); // DeltaV - No Stamina Resistance Doubledipping
+
+                //DeltaV - No Stamina Resistance Doubledipping, unless we want to.
+                var ignoreResist = true;
+                if (TryComp<StaminaResistanceComponent>(target, out var staminaResist))
+                    ignoreResist = !staminaResist.MeleeResistance;
+
+                _stamina.TakeStaminaDamage(target.Value, (bluntDamage * component.BluntStaminaDamageFactor).Float(), visual: false, source: user, with: meleeUid == user ? null : meleeUid, ignoreResist: ignoreResist);
+                // END DeltaV
             }
 
             if (meleeUid == user)
@@ -701,7 +709,14 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
                 // If the target has stamina and is taking blunt damage, they should also take stamina damage based on their blunt to stamina factor
                 if (damageResult.DamageDict.TryGetValue("Blunt", out var bluntDamage))
                 {
-                    _stamina.TakeStaminaDamage(entity, (bluntDamage * component.BluntStaminaDamageFactor).Float(), visual: false, source: user, with: meleeUid == user ? null : meleeUid, ignoreResist: true); // DeltaV - No Stamina Resistance Doubledipping
+                    //DeltaV - No Stamina Resistance Doubledipping, unless we want to.
+                    var ignoreResist = true;
+                    if (TryComp<StaminaResistanceComponent>(entity, out var staminaResist))
+                        ignoreResist = !staminaResist.MeleeResistance;
+
+                    _stamina.TakeStaminaDamage(entity, (bluntDamage * component.BluntStaminaDamageFactor).Float(), visual: false, source: user, with: meleeUid == user ? null : meleeUid, ignoreResist: ignoreResist);
+                    // END DeltaV
+
                 }
 
                 appliedDamage += damageResult;

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -12,6 +12,8 @@
   - type: AntagImmune
   - type: StaminaResistance
     damageCoefficient: 0 # No more stunning colossi
+    worn: false
+    meleeResistance: true
   - type: Sprite
     drawdepth: Mobs
     sprite: _DV/CosmicCult/Mobs/colossus.rsi
@@ -167,7 +169,6 @@
   - type: StatusEffects
     allowed:
     - Stutter
-    - Stun
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
     channels:


### PR DESCRIPTION
## About the PR
Added additional melee resistance property to `StaminaResistanceComponent`, since we ignore stamina resistance on melee hits due to #4419. If this property is true, it basically double-dips stamina resistance on melee hits. But since this property is false, it should only affect entities that require additional stamina resistance.

## Why / Balance
Fixes #4559

## Technical details
Added a `MeleeResistance` boolean to `StaminaResistanceComponent` that is false by default (so things work like normal). SharedStaminaSystem will check that if its true and apply the resistance value.

Then I tested with a baton that was off and saw that stamina damage was still happening (from the blunt damage), so I had to modify if we ignore stamina resistance during the `TakeStaminaDamage` call. It checks for the `StaminaResistanceComponent`, and if it finds it, it will use the inverse of the `MeleeResistance` component. 

## Media
(Colossus POV btw)

https://github.com/user-attachments/assets/5b4b5339-c9c6-4925-8a0f-358f471cb806

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Colossi no longer take stamina damage from melee weapons.

