### PR TITLE
Hotfix: Some chapel airlocks use wrong wires and suffix

### DIFF
--- a/Resources/Migrations/deltaMigrations.yml
+++ b/Resources/Migrations/deltaMigrations.yml
@@ -190,3 +190,6 @@ Oilpack1: null
 
 # 2025-10-11
 ClosetWallOrangeFilled: ClosetWallWardrobePrisonFilled
+
+# 2025-11-19
+AirlockChapelStandardGlassLocked: AirlockChapelGlassLocked

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/access.yml
@@ -612,6 +612,7 @@
   parent: AirlockStandardGlass
   id: AirlockChapelStandardGlassLocked
   suffix: Chapel, Locked
+  categories: [ HideSpawnMenu ] # DeltaV - Chapel is Epistemics and redundant
   components:
   - type: ContainerFill
     containers:
@@ -952,6 +953,7 @@
 - type: entity
   parent: AirlockMaintRnDLocked # DeltaV - Chapel is in Epistemics
   id: AirlockMaintChapelLocked
+  suffix: Chapel, Locked
   components:
   - type: Sprite
     sprite: _DV/Structures/Doors/Airlocks/Standard/maint.rsi # DeltaV - Changed to our sprites

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/windoor.yml
@@ -80,6 +80,10 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsChapel ]
+  # DeltaV - Add epistemics wires
+  - type: Wires 
+    layoutId: AirlockScience
+  # Delta V - End
 
 - type: entity
   parent: WindoorServiceLocked
@@ -221,7 +225,7 @@
     layoutId: AirlockCargo
 
 - type: entity
-  parent: WindoorSecure
+  parent: WindoorSecureScienceLocked # DeltaV - Epistemics wires
   id: WindoorSecureChapelLocked
   suffix: Chapel, Locked
   components:


### PR DESCRIPTION
## About the PR
- Fixes chapel airlocks and windoors
- Fixes #4680 


## Why / Balance
Fix

## Technical details
n/a

## Media
<img width="420" height="92" alt="Screenshot 2025-11-19 125135" src="https://github.com/user-attachments/assets/c13f65e0-7354-4a39-834e-b305eb973fa5" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
