### PR TITLE
ANNIHILATE rod of animation

### DIFF
--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -265,18 +265,18 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- # type: listing # DeltaV - Commented out
-  # id: SpellbookStaffAnimation
-  # name: spellbook-staff-animation-name
-  # description: spellbook-staff-animation-description
-  # productEntity: AnimationStaff
-  # cost:
-  #  WizCoin: 3
-  # categories:
-  # - SpellbookEquipment
-  # conditions:
-  # - !type:ListingLimitedStockCondition
-  #  stock: 1
+#- type: listing # DeltaV - Commented out
+#  id: SpellbookStaffAnimation
+#  name: spellbook-staff-animation-name
+#  description: spellbook-staff-animation-description
+#  productEntity: AnimationStaff
+#  cost:
+#   WizCoin: 3
+#  categories:
+#  - SpellbookEquipment
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
 # Event
 - type: listing

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -265,18 +265,18 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- type: listing
-  id: SpellbookStaffAnimation
-  name: spellbook-staff-animation-name
-  description: spellbook-staff-animation-description
-  productEntity: AnimationStaff
-  cost:
-    WizCoin: 3
-  categories:
-  - SpellbookEquipment
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+- # type: listing # DeltaV - Commented out
+  # id: SpellbookStaffAnimation
+  # name: spellbook-staff-animation-name
+  # description: spellbook-staff-animation-description
+  # productEntity: AnimationStaff
+  # cost:
+  #  WizCoin: 3
+  # categories:
+  # - SpellbookEquipment
+  # conditions:
+  # - !type:ListingLimitedStockCondition
+  #  stock: 1
 
 # Event
 - type: listing


### PR DESCRIPTION
## About the PR
rod of animation is GONE (from the wizard's grimoire)

## Why / Balance
the rod of animations pretty busted and can animate things surely not intended to be animated (but that's outside the scope of my experience)

## Technical details
comments out a few lines in the wizard's grimoire
something something git/codebase newbie, surely I did this ~~wrong~~ right!

## Media
<img width="679" height="39" alt="image" src="https://github.com/user-attachments/assets/cb5f63a8-7ccc-42b1-8019-6c64cda6c59a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
lightly modifies an upstream file by commenting out a few lines
:cl:
- remove: Wizards left their rod of animation back home. Woops!