### PR TITLE
Oracle "offer item" context menu verb

### DIFF
--- a/Resources/Locale/en-US/_DV/verbs/verb-system.ftl
+++ b/Resources/Locale/en-US/_DV/verbs/verb-system.ftl
@@ -1,0 +1,3 @@
+# verb categories & common verbs. These appear across multiple systems, so they may as well go here.
+
+verb-categories-oracle-insert-desired = Offer


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Add a right-click option to "Offer" the currently held item to the oracle - does the same thing as left-clicking on the oracle.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixes https://github.com/DeltaV-Station/Delta-v/issues/4096

Some items like the holofan can't be submitted without a right-click option, because left-clicking does an action.

## Technical details
<!-- Summary of code changes for easier review. -->

Mimicked the verb code patterns of SharedDisposalUnitSystem.

Added a new VerbCategory like how `TimerSystem.OnUse.cs` does.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

<img width="729" height="688" alt="image" src="https://github.com/user-attachments/assets/b9eb8210-109a-4141-a5ea-fb849c544bdc" />


https://github.com/user-attachments/assets/5f42ac1b-53ae-49a4-94c6-1f942ebfb6ec



## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Oracle can now accept holofan projector and other tools through right-click menu action

