### PR TITLE
Supersynth hours 200 -> 50

### DIFF
--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobMusician
-      time: 180000 # Delta-V - 50 hours
+      time: 180000 # Delta-V - 50 hours, was 10
   storage:
     back:
     - SuperSynthesizerInstrument #Delta-V - Supersynth spawns in backpack if chosen as trinket.

--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
@@ -6,7 +6,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobMusician
-      time: 720000 #Delta-V - 10hr originally, but changed to 200 for delta-V because I want the musicians to suffer.
+      time: 180000 # Delta-V - 50 hours
   storage:
     back:
     - SuperSynthesizerInstrument #Delta-V - Supersynth spawns in backpack if chosen as trinket.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Supersynth now needs 50 hours to unlock, instead of 200

## Why / Balance
Expecting somebody to play 200 hours of a *singular role* is both unrealistic and, frankly, unhealthy. Surprisingly, some SS14 players have lives, and shouldn't be expected nor should be encouraged to grind 200 hours in this game for an important item. Plus, many forms of learning how to be a better musician (making your own MIDIs, setting up external software) take place outside of the game anyways

IMO, supersynths should be musician-only as well (like [on starlight](https://github.com/ss14Starlight/space-station-14/pull/1728)), seeing as musicians should be the role that is categorically more well-equipped to play music. doesn't feel right as a musician for the passenger right next to you to have a better instrument because they happened to have more hours then you. time-gated important items are just eeeh overall. but take that with a grain of salt, not included in the PR.

[long-winded forum discussion](https://discord.com/channels/968983104247185448/1441554471003099146)

## Technical details
yaml op

## Media
<img width="928" height="102" alt="image" src="https://github.com/user-attachments/assets/1dd96802-a4fb-4a99-9f4f-c65ff7262dcd" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Super Synthesizer now only requires 50 musician hours to unlock as a trinket.
