### PR TITLE
resync _wiki

### DIFF
--- a/.wiki/_DV/Laws/SpaceLaw.txt
+++ b/.wiki/_DV/Laws/SpaceLaw.txt
@@ -8,7 +8,7 @@ It is highly recommended to read the '''[[Standard Operating Procedure|Standard 
 * '''[[Standard Operating Procedure#Entity Definitions|Employee]]:''' An entity who has an employment contract with a Company.
 * '''[[Standard Operating Procedure#Security Jurisdiction|Security Jurisdiction]]:''' Station law enforcement officers are bound by Space Law; they cannot operate outside of standard accessible areas, or perform searches, unless such action is allowed by either Alert Procedure or a valid warrant.
 * '''[[Standard Operating Procedure#Detainment and Arrest|Detainment & Arrest]]:''' Members of law enforcement may detain entities under '''[[Standard Operating Procedure#Probable Cause|Probable Cause]]''' of criminal activity. These detainees must be informed of the crime they are suspected of committing, and may be moved to a secure location and/or restrained while law enforcement determine if a crime was committed. Such detention should last no longer than five minutes. Any entity may be arrested, during which they are restrained, informed of their charges, and taken to the brig for search and processing under '''[[Standard Operating Procedure#Brig Procedure|Brig Procedure]]'''.
-* '''[[Standard Operating Procedure#Sentencing|Sentencing]]:''' Any member of law enforcement is allowed to pass sentence on Misdemeanor, Felony, and Grand Felony charges. The Prosecutor is allowed to adjust such sentences, within reason.
+* '''[[Standard Operating Procedure#Sentencing|Sentencing]]:''' Any member of law enforcement is allowed to pass sentence on Misdemeanor, Felony, and Grand Felony charges. The Chief Justice, or in their absence, the Head of Security are allowed to pass sentence on all Charges.
 * '''[[Standard Operating Procedure#Treatment of Prisoners|Treatment of Prisoners]]:''' Prisoners must be provided with food, water, clothing, free movement within the brig, adequate medical care, access to the Common and Prison radio channels, and moral, spiritual, or legal counseling if requested and available. If the brig becomes uninhabitable, prisoners must be securely and safely relocated to another area until the brig is functional once more. Prisoners sentenced to Extended Confinement have additional rights and firmer restrictions that must be upheld by law enforcement officials.
 * '''[[Standard Operating Procedure#Paroles and Pardons|Paroles & Pardons]]:''' Parole may be offered under the discretion of the Warden, Head of Security, or CO. A parole hearing requires only a Judge, as discussed within Trial Procedure. Pardons may be issued by the arresting officer, the Judge of a trial, by the Warden (to those within the permanent brig), or by the CO, when deemed in the best interest of the crew or vessel, or when the circumstances of the crime warrant suspension of sentence.
 * '''[[Standard Operating Procedure#Pressing Charges|Pressing Charges]]:''' Any Employee may press charges against any other entity. Individuals may only be charged with a crime if it can be proveny beyond reasonable doubt that they have committed the crime.
@@ -26,7 +26,7 @@ Use this to quickly find the Crime Code Numbers.
 
 Crime codes are organized into four Category Codes (_XX) as listed below, with the most severe crimes being given the highest Severity Codes (x__). The sentencing officer or Judge should use discretion, and not charge an entity with two similar crimes for a singular offense.
 
-For example, an attack upon a Employee which causes them to die of their injuries is Murder, not Assault AND Murder. Likewise, an entity should not be charged for both Possession AND Grand Possession on a singular Controlled Item held without proper authorization.
+For example, an attack upon an Employee which causes them to die of their injuries is Murder, not Assault AND Murder. Likewise, an entity should not be charged for both Possession AND Grand Possession on a singular Controlled Item held without proper authorization.
 
 {| style='text-align:center; border:solid 1px black' cellspacing=0
 ! style="border: 1px solid black; width:5%" | Code
@@ -158,7 +158,7 @@ Sentencing modifiers are to be applied by the sentencing officer, judge, or arbi
 | style="border: 1px solid black;" | [[File:SL_Murder.png]]
 ! style="border: 1px solid black;" | Murder
 | style="border: 1px solid black;" | Capital
-| style="border: 1px solid black;" | To maliciously commit an act resulting in the death of a Employee, with reckless indifference to their life.
+| style="border: 1px solid black;" | To maliciously commit an act resulting in the death of an Employee, with reckless indifference to their life.
 |-
 | style="border: 1px solid black;" | 402
 | style="border: 1px solid black;" | [[File:SL_Terrorism.png]]
@@ -176,7 +176,7 @@ Sentencing modifiers are to be applied by the sentencing officer, judge, or arbi
 | style="border: 1px solid black;" | [[File:SL_Decorporealisation.png]]
 ! style="border: 1px solid black;" | '''Prevention of Revival'''
 | style="border: 1px solid black;" | Capital
-| style="border: 1px solid black;" | To commit an act that prevents the revival of a Employee by standard medical care following their death.
+| style="border: 1px solid black;" | To commit an act that prevents the revival of an Employee by standard medical care following their death.
 |-
 | style="border: 1px solid black;" | 405
 | style="border: 1px solid black;" | [[File:SL_Sedition.png]]
@@ -204,7 +204,7 @@ Sentencing modifiers are to be applied by the sentencing officer, judge, or arbi
 |style= "border:1px solid black;"| [[File:SL_Manslaughter.png]]
 |style= "border:1px solid black;"| Manslaughter
 |style= "border:1px solid black;"| 16 minutes
-|style= "border:1px solid black;"| To act without malice in a manner which, directly or indirectly, leads to the death of a Employee.
+|style= "border:1px solid black;"| To act without malice in a manner which, directly or indirectly, leads to the death of an Employee.
 |-
 |style= "border:1px solid black;"| 302
 |style= "border:1px solid black;"| [[File:SL_Kidnapping.png]]
@@ -262,7 +262,7 @@ Sentencing modifiers are to be applied by the sentencing officer, judge, or arbi
 | style="border: 1px solid black;" | [[File:SL_Assault.png]]
 ! style="border: 1px solid black;" | {{anchor|Assault}}Assault
 | style="border: 1px solid black;" | 10 minutes
-| style="border: 1px solid black;" | To cause physical harm or to effect unwanted physical contact on a Employee, without the apparent intent to kill them, or to threaten such actions with both capability and intent to do so.
+| style="border: 1px solid black;" | To cause physical harm or to effect unwanted physical contact on an Employee, without the apparent intent to kill them, or to threaten such actions with both capability and intent to do so.
 |-
 | style="border: 1px solid black;" | 202
 | style="border: 1px solid black;" | [[File:SL_BreakingAndEntering.png]]

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -6,7 +6,7 @@ The terms specified below are defined for further use within the procedures.
 :*Captain: The officer legally appointed by NanoTrasen as Commanding Officer of the station. This title is only transferable by Central Command.
 :*Commanding Officer / CO: An officer appointed to lead the station and its Command department, whether it be the Captain by NanoTrasen, or an Acting CO by Station Command.
 :* Command Staff/Station Command: Members of the Command department who lead a department aboard the station.
-:* Crew: All Employees employed by Station Command, or by NT to reside on the station and perform an established function therein. This includes any Employee listed on the Crew Manifest or issued a functional NT identification and access card. Employees imprisoned by NT, along with those imprisoned during the course of a shift for violations of Space Law, are considered Crew.
+:* Crew: All Employees employed by Station Command, or by NT to reside on the station and perform an established function therein. This includes any Employee listed on the Crew Manifest or issued a functional NT identification and access card. Individuals imprisoned by NT, along with those imprisoned during the course of a shift for violations of Space Law, are considered Crew.
 :* Judge: An individual legally appointed to preside over a hearing, as specified within Hearing Procedure.
 :* Detainee: Any Employee whose free movement has been curtailed by law enforcement on suspicion of criminal activity. They have not, however, been officially charged with a crime.
 :* Arrestee: Any Employee who has been formally charged with a crime.
@@ -24,34 +24,34 @@ Any individual with a distinct existence. Entities may also encompass a pluralit
 == Pet ==
 Any Entity that is provided to NanoTrasen Space Stations- either through the station's Logistics Department, or brought on board by the crew- for the purposes of emotional support. Any harm against such a Pet may render the offender liable to the crime of Animal Cruelty.
 Examples of Pets include, but are not limited to:
-- Renault the Fox
-- Smile the Rainbow Slime
-- Laika the Guard Dog
-- Silvia the Medical Cobra
-- a corgi, purchased by Station Logistics
-- hand-held "personal AI" devices
+:* Renault the Fox
+:* Smile the Rainbow Slime
+:* Laika the Guard Dog
+:* Silvia the Medical Cobra
+:* a corgi, purchased by Station Logistics
+:* hand-held "personal AI" devices
 
 == Synthetic ==
 Any Entity consisting primarily of non-organic matter, designed and/or constructed by NanoTrasen or its Employees for the purpose of performing tasks aboard a Space Station. Synthetics are bound by software limitations, typically referred to as Synthetic or Silicon Laws, and physically incorporated into their chassis. Any damage to a Synthetic- including un-authorized modification of their Laws- may leave the offender liable to charges of Sabotage. Irrevocable destruction of a Synthetic may leave the offender liable to the crime of Grand Sabotage.
 Examples of Synthetics include, but are not limited to:
-- Crew-constructed Cyborgs
-- The Station AI
-- Positronic Brains
+:* Crew-constructed Cyborgs
+:* The Station AI
+:* Positronic Brains
 
 == Employee ==
 Any Entity who has a contract with NanoTrasen.
 Typically, these individuals possess all of the following:
-- A communications headset (or similar communications capability) outfitted with encryption keys relevant to their assigned job function.
-- An ID card with their name and job function, pre-programmed with door access relevant to aforementioned job function.
-- Company-approved attire for an individual of their job function.
+:* A communications headset (or similar communications capability) outfitted with encryption keys relevant to their assigned job function.
+:* An ID card with their name and job function, pre-programmed with door access relevant to aforementioned job function.
+:* Company-approved attire for an individual of their job function.
 In situations where an individual lacks one or more of these items, law enforcement officials are encouraged to use their best judgement, and mitigate any risk of liability to charges of Endangerment or Abuse of Power.
 Harm or death of an Employee may leave the offender liable to the crimes of Assault, Manslaughter, or even Murder.
 Examples of Employees include, but are not limited to:
-- All crew present on the Space Station, including those who are removed from cryogenic stasis during the course of a shift.
-- Any crewmate arriving from a different NanoTrasen Space Station, due to navigation errors, disasters, or similar.
-- Individuals imprisoned by NT, along with those imprisoned during the course of a shift for violations of Space Law.
-- Any and all members of NanoTrasen Central Command, including Emergency Response Team soldiers and Central Commanders.
-  - In cases where there is reasonable doubt as to the identity of a member of Central Command, the Commanding Officer is encouraged to request clarity from Central Command themselves.
+:* All crew present on the Space Station, including those who are removed from cryogenic stasis during the course of a shift.
+:* Any crewmate arriving from a different NanoTrasen Space Station, due to navigation errors, disasters, or similar.
+:* Individuals imprisoned by NT, along with those imprisoned during the course of a shift for violations of Space Law.
+:* Any and all members of NanoTrasen Central Command, including Emergency Response Team soldiers and Central Commanders.
+In cases where there is reasonable doubt as to the identity of a member of Central Command, the Commanding Officer is encouraged to request clarity from Central Command themselves.
 
 Any Employees that are fired by Station Command are still considered Employees until Central Command can confirm their contract termination.
 
@@ -61,7 +61,6 @@ Provisional Employees are a special subcategory of Employee. During the course o
 In such a case, the Head of Personnel must create a document listing the Provisional Employee's name and assigned job function, along with any physical features deemed necessary to identify them. This must be signed and stamped (where applicable) by the Head of Personnel, their relevant departmental head, and the Provisional Employee. A copy must be kept within the Head of Personnel's records, and with the Provisional Employee if possible.
 
 Provisional Employees serve "at will", and may have their employment revoked at any time by Central or Station Command authorities.
-
 =Controlled Items, Substances, & Areas=
 
 == Controlled Items ==
@@ -179,6 +178,7 @@ Common HSAs for commercial and military vessels are as follows:
 * Gravity Generation\Life Support\Engine Rooms
 * Telecommunications\Telemetry
 * Permanent Brig\Holding Cells
+
 
 =Commanding Officer=
 ==Captain’s Authority==


### PR DESCRIPTION
fix cepes typos, fix one outdated thing

## Why / Balance
'an' employee
wiki uses :* not -

**Changelog**
no
