### PR TITLE
MMI fix part two

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -47,8 +47,8 @@
           - Brain
         blacklist: # DeltaV
           components:
-          - BorgBrain
-          - MMI
+          - BorgBrain # DeltaV - prevents PB in MMI
+          - MMI # DeltaV - prevents MMI in MMI
           - Unborgable
   - type: ContainerContainer
     containers:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/mmi.yml
@@ -47,6 +47,8 @@
           - Brain
         blacklist: # DeltaV
           components:
+          - BorgBrain
+          - MMI
           - Unborgable
   - type: ContainerContainer
     containers:


### PR DESCRIPTION
## About the PR
Missed the part where i enabled the option to insert MMI or PB into MMI

## Why / Balance
Prevents from inserting PB and MMI into MMI

## Technical details
2 new blacklist components in mmi.

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Surely nothing breaks :clueless:

**Changelog**

:cl:
- fix: No more MMInception. The Positronic Brain and MMI can no longer be inserted into the MMI.
