### PR TITLE
Make the Bible protect BibleUsers when held

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.Relay.cs
@@ -1,6 +1,8 @@
+using Content.Shared.Armor; // DeltaV - Addition of HandHeldArmor
 using Content.Shared.Atmos;
 using Content.Shared.Camera;
 using Content.Shared.Cuffs;
+using Content.Shared.Damage; // DeltaV End - Addition of HandHeldArmor
 using Content.Shared.Hands.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Projectiles;
@@ -16,6 +18,10 @@ public abstract partial class SharedHandsSystem
         SubscribeLocalEvent<HandsComponent, GetEyeOffsetRelayedEvent>(RelayEvent);
         SubscribeLocalEvent<HandsComponent, GetEyePvsScaleRelayedEvent>(RelayEvent);
         SubscribeLocalEvent<HandsComponent, RefreshMovementSpeedModifiersEvent>(RelayEvent);
+        // DeltaV Start - Addition of HandHeldArmor
+        SubscribeLocalEvent<HandsComponent, CoefficientQueryEvent>(RelayEvent);
+        SubscribeLocalEvent<HandsComponent, DamageModifyEvent>(RelayEvent);
+        // DeltaV End - Addition of HandHeldArmor
 
         // By-ref events.
         SubscribeLocalEvent<HandsComponent, ExtinguishEvent>(RefRelayEvent);

--- a/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
+++ b/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class HandHeldArmorComponent : Component
     /// The Entity holding the handheld armor.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public EntityUid Holder;
+    public EntityUid? Holder;
 
     /// <summary>
     /// The damage reduction

--- a/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
+++ b/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
@@ -1,0 +1,72 @@
+﻿using Content.Shared._DV.Armor.Systems;
+using Content.Shared.Damage;
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Armor.Components;
+
+/// <summary>
+/// Used for armor that can be held in your hands.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(HandHeldArmorSystem))]
+public sealed partial class HandHeldArmorComponent : Component
+{
+    /// <summary>
+    /// The Entity holding the handheld armor.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid Holder;
+
+    /// <summary>
+    /// The damage reduction
+    /// </summary>
+    [DataField(required: true), AutoNetworkedField]
+    public DamageModifierSet Modifiers;
+
+    /// <summary>
+    /// A multiplier applied to the calculated point value
+    /// to determine the monetary value of the armor
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float PriceMultiplier = 1;
+
+    /// <summary>
+    /// If true, you can examine the armor to see the protection. If false, the verb won't appear.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ShowArmorOnExamine = true;
+
+    /// <summary>
+    /// DeltaV - Gets the effective stamina melee damage coefficient, based on the armor's blunt protection.
+    /// </summary>
+    [ViewVariables]
+    public float StaminaMeleeDamageCoefficient => Modifiers.Coefficients.GetValueOrDefault("Blunt", 1.0f);
+
+    /// <summary>
+    /// The required components for the held armor to be active while held.
+    /// </summary>
+    /// <example>A Bible only protects the holder if they have the BibleUserComponent.</example>
+    /// <remarks>No whitelist check when null.</remarks>
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+
+    /// <summary>
+    /// The Loc string for the message shown in the armor examination if the user fails the whitelist requirements.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? WhitelistFailMessage;
+
+    /// <summary>
+    /// Components for the held armor to be inactive while held.
+    /// </summary>
+    /// <example>A clown with the clumsy cannot make use of a parrying dagger.</example>
+    /// <remarks>No blacklist check when null.</remarks>
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Blacklist;
+
+    /// <summary>
+    /// The Loc string for the message shown in the armor examination if the user fails the blacklist requirements.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? BlacklistFailMessage;
+}

--- a/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
+++ b/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._DV.Armor.Systems;
+using Content.Shared._DV.Armor.Systems;
 using Content.Shared.Damage;
 using Content.Shared.Whitelist;
 using Robust.Shared.GameStates;

--- a/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
+++ b/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
@@ -1,0 +1,146 @@
+﻿using Content.Shared._DV.Armor.Components;
+using Content.Shared.Armor;
+using Content.Shared.Damage;
+using Content.Shared.Examine;
+using Content.Shared.Hands;
+using Content.Shared.Verbs;
+using Content.Shared.Whitelist;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._DV.Armor.Systems;
+
+/// <summary>
+///     This handles logic relating to <see cref="HeldArmorComponent" />
+/// </summary>
+public sealed class HandHeldArmorSystem : EntitySystem
+{
+    [Dependency] private readonly ExamineSystemShared _examine = default!;
+    [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HandHeldArmorComponent, GotEquippedHandEvent>(OnHandEquipped);
+        SubscribeLocalEvent<HandHeldArmorComponent, HeldRelayedEvent<CoefficientQueryEvent>>(OnCoefficientQuery);
+        SubscribeLocalEvent<HandHeldArmorComponent, HeldRelayedEvent<DamageModifyEvent>>(OnDamageModify);
+        SubscribeLocalEvent<HandHeldArmorComponent, GetVerbsEvent<ExamineVerb>>(OnHeldArmorVerbExamine);
+    }
+
+    private void OnHandEquipped(Entity<HandHeldArmorComponent> armor, ref GotEquippedHandEvent args)
+    {
+        armor.Comp.Holder = args.User; // So we can check the whitelists later. The events actually don't carry over the user.
+    }
+
+    private void OnCoefficientQuery(Entity<HandHeldArmorComponent> armor, ref HeldRelayedEvent<CoefficientQueryEvent> args)
+    {
+        if (_whitelist.IsWhitelistFail(armor.Comp.Whitelist, armor.Comp.Holder) // If they pass the lists, add the coefficients.
+            || _whitelist.IsBlacklistPass(armor.Comp.Blacklist, armor.Comp.Holder))
+            return;
+
+        foreach (var armorCoefficient in armor.Comp.Modifiers.Coefficients)
+        {
+            args.Args.DamageModifiers.Coefficients[armorCoefficient.Key] =
+                args.Args.DamageModifiers.Coefficients.TryGetValue(armorCoefficient.Key, out var coefficient)
+                ? coefficient * armorCoefficient.Value
+                : armorCoefficient.Value;
+        }
+    }
+
+    private void OnDamageModify(Entity<HandHeldArmorComponent> armor, ref HeldRelayedEvent<DamageModifyEvent> args)
+    {
+        if (_whitelist.IsWhitelistFail(armor.Comp.Whitelist, armor.Comp.Holder) // If they pass the lists, add the coefficients.
+            || _whitelist.IsBlacklistPass(armor.Comp.Blacklist, armor.Comp.Holder))
+            return;
+
+        args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, armor.Comp.Modifiers);
+    }
+
+    private void OnHeldArmorVerbExamine(Entity<HandHeldArmorComponent> armor, ref GetVerbsEvent<ExamineVerb> args)
+    {
+        if (!args.CanInteract
+            || !args.CanAccess
+            || !armor.Comp.ShowArmorOnExamine)
+            return;
+
+        FormattedMessage examineMarkup;
+
+        // If the user is blacklisted or not whitelisted, show what they need. Otherwise, show resistance values.
+        if (_whitelist.IsWhitelistPassOrNull(armor.Comp.Whitelist, args.User)
+            && _whitelist.IsBlacklistFailOrNull(armor.Comp.Blacklist, args.User))
+        {
+            examineMarkup = GetHeldArmorExamine(armor);
+
+            var ev = new ArmorExamineEvent(examineMarkup);
+            RaiseLocalEvent(armor, ref ev);
+        }
+        else
+            examineMarkup = GetHeldArmorFailExamine(armor);
+
+        _examine.AddDetailedExamineVerb(args, armor, examineMarkup,
+            Loc.GetString("armor-examinable-verb-text"), "/Textures/Interface/VerbIcons/dot.svg.192dpi.png",
+            Loc.GetString("armor-examinable-verb-message"));
+    }
+
+    private FormattedMessage GetHeldArmorExamine(HandHeldArmorComponent armor)
+    {
+        var msg = new FormattedMessage();
+        msg.AddMarkupOrThrow(Loc.GetString("held-armor-examine"));
+
+        foreach (var coefficientArmor in armor.Modifiers.Coefficients) // DeltaV
+        {
+            msg.PushNewline();
+
+            var armorType = Loc.GetString("armor-damage-type-" + coefficientArmor.Key.ToLower());
+            msg.AddMarkupOrThrow(Loc.GetString("armor-coefficient-value",
+                ("type", armorType),
+                ("value", MathF.Round((1f - coefficientArmor.Value) * 100, 1))
+            ));
+        }
+
+        foreach (var flatArmor in armor.Modifiers.FlatReduction) // DeltaV
+        {
+            msg.PushNewline();
+
+            var armorType = Loc.GetString("armor-damage-type-" + flatArmor.Key.ToLower());
+            msg.AddMarkupOrThrow(Loc.GetString("armor-reduction-value",
+                ("type", armorType),
+                ("value", flatArmor.Value)
+            ));
+        }
+
+        // Begin DeltaV Additions - Add melee stamina resistance information if it has any
+        if (!MathHelper.CloseTo(armor.StaminaMeleeDamageCoefficient, 1.0f))
+        {
+            msg.PushNewline();
+            var reduction = (1 - armor.StaminaMeleeDamageCoefficient) * 100;
+            msg.AddMarkupOrThrow(Loc.GetString("armor-stamina-melee-coefficient-value",
+                ("value", MathF.Round(reduction, 1))
+            ));
+        }
+        // End DeltaV
+
+        return msg;
+    }
+
+    private FormattedMessage GetHeldArmorFailExamine(HandHeldArmorComponent armor)
+    {
+        var msg = new FormattedMessage();
+        msg.AddMarkupOrThrow(Loc.GetString("held-armor-fail-examine"));
+
+        if (armor.WhitelistFailMessage != null)
+        {
+            msg.PushNewline();
+            msg.AddMarkupOrThrow(Loc.GetString("held-armor-whitelist-fail", ("reason", Loc.GetString(armor.WhitelistFailMessage))));
+        }
+
+        if (armor.BlacklistFailMessage != null)
+        {
+            msg.PushNewline();
+            msg.AddMarkupOrThrow(Loc.GetString("held-armor-blacklist-fail", ("reason", Loc.GetString(armor.BlacklistFailMessage))));
+        }
+
+        return msg;
+    }
+}

--- a/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
+++ b/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
@@ -90,7 +90,7 @@ public sealed class HandHeldArmorSystem : EntitySystem
         var msg = new FormattedMessage();
         msg.AddMarkupOrThrow(Loc.GetString("held-armor-examine"));
 
-        foreach (var coefficientArmor in armor.Modifiers.Coefficients) // DeltaV
+        foreach (var coefficientArmor in armor.Modifiers.Coefficients)
         {
             msg.PushNewline();
 
@@ -112,7 +112,6 @@ public sealed class HandHeldArmorSystem : EntitySystem
             ));
         }
 
-        // Begin DeltaV Additions - Add melee stamina resistance information if it has any
         if (!MathHelper.CloseTo(armor.StaminaMeleeDamageCoefficient, 1.0f))
         {
             msg.PushNewline();
@@ -121,7 +120,6 @@ public sealed class HandHeldArmorSystem : EntitySystem
                 ("value", MathF.Round(reduction, 1))
             ));
         }
-        // End DeltaV
 
         return msg;
     }

--- a/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
+++ b/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
@@ -35,8 +35,9 @@ public sealed class HandHeldArmorSystem : EntitySystem
 
     private void OnCoefficientQuery(Entity<HandHeldArmorComponent> armor, ref HeldRelayedEvent<CoefficientQueryEvent> args)
     {
-        if (_whitelist.IsWhitelistFail(armor.Comp.Whitelist, armor.Comp.Holder) // If they pass the lists, add the coefficients.
-            || _whitelist.IsBlacklistPass(armor.Comp.Blacklist, armor.Comp.Holder))
+        if (!armor.Comp.Holder.HasValue
+            || _whitelist.IsWhitelistFail(armor.Comp.Whitelist, armor.Comp.Holder.Value) // If they pass the lists, add the coefficients.
+            || _whitelist.IsBlacklistPass(armor.Comp.Blacklist, armor.Comp.Holder.Value))
             return;
 
         foreach (var armorCoefficient in armor.Comp.Modifiers.Coefficients)

--- a/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
+++ b/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._DV.Armor.Components;
+using Content.Shared._DV.Armor.Components;
 using Content.Shared.Armor;
 using Content.Shared.Damage;
 using Content.Shared.Examine;

--- a/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
+++ b/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
@@ -50,8 +50,9 @@ public sealed class HandHeldArmorSystem : EntitySystem
 
     private void OnDamageModify(Entity<HandHeldArmorComponent> armor, ref HeldRelayedEvent<DamageModifyEvent> args)
     {
-        if (_whitelist.IsWhitelistFail(armor.Comp.Whitelist, armor.Comp.Holder) // If they pass the lists, add the coefficients.
-            || _whitelist.IsBlacklistPass(armor.Comp.Blacklist, armor.Comp.Holder))
+        if (!armor.Comp.Holder.HasValue
+            || _whitelist.IsWhitelistFail(armor.Comp.Whitelist, armor.Comp.Holder.Value) // If they pass the lists, add the coefficients.
+            || _whitelist.IsBlacklistPass(armor.Comp.Blacklist, armor.Comp.Holder.Value))
             return;
 
         args.Args.Damage = DamageSpecifier.ApplyModifierSet(args.Args.Damage, armor.Comp.Modifiers);

--- a/Resources/Locale/en-US/_DV/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/_DV/armor/armor-examine.ftl
@@ -1,3 +1,10 @@
 armor-stamina-projectile-coefficient-value = - [color=yellow]Stamina projectile[/color] damage reduced by [color=lightblue]{$value}%[/color].
 armor-stamina-melee-coefficient-value = - [color=yellow]Stamina melee[/color] damage reduced by [color=lightblue]{$value}%[/color].
 armor-damage-type-shadow = Shadow
+
+held-armor-examine = [color=cyan]Holding[/color] it provides the following protection:
+
+held-armor-fail-examine = You do not pass the following requirements to profit from its protection:
+held-armor-whitelist-fail = You are not [color=yellow]{$reason}[/color].
+held-armor-blacklist-fail = You are [color=red]{$reason}[/color].
+

--- a/Resources/Locale/en-US/_DV/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/_DV/armor/armor-examine.ftl
@@ -8,3 +8,4 @@ held-armor-fail-examine = You do not pass the following requirements to profit f
 held-armor-whitelist-fail = You are not [color=yellow]{$reason}[/color].
 held-armor-blacklist-fail = You are [color=red]{$reason}[/color].
 
+held-armor-bible-user-fail = faithful

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -58,8 +58,21 @@
     - Book
   - type: StealTarget
     stealGroup: Bible
-  - type: CollisionWake # DeltaV
+  # Begin DeltaV Additions
+  - type: CollisionWake
     enabled: false
+  - type: HandHeldArmor # Holding the Bible protects you
+    modifiers:
+      coefficients:
+        Cold: 0.5
+        Asphyxiation: 0.5
+        Holy: 0.5
+        Shadow: 0.5
+    whitelist:
+      components:
+        - BibleUser # Only if you're the Chaplain or Mystagogue
+    whitelistFailMessage: held-armor-bible-user-fail
+  # End DeltaV Additions
 
 - type: entity
   parent: [Bible, BaseSyndicateContraband]

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -64,10 +64,10 @@
   - type: HandHeldArmor # Holding the Bible protects you
     modifiers:
       coefficients:
-        Cold: 0.5
-        Asphyxiation: 0.5
-        Holy: 0.5
-        Shadow: 0.5
+        Cold: 0.7
+        Asphyxiation: 0.7
+        Holy: 0.3
+        Shadow: 0.3
     whitelist:
       components:
         - BibleUser # Only if you're the Chaplain or Mystagogue


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I made the bible protect the Chaplain from Cultist Damage and Metaphysical damage when held.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Chaplain should be a menace to cultists and anything metaphysically related.
Though they are easily cut down. Now, when they hold the bible, they will receive half as much unholy/holy/cold/asphyx damage.
They can reliable engage into a skia and cultist might need to stun a chaplain rather than murder them, unless they get the drop on them when they aren't holding the bible.

There is one annoying bug where they also take half damage from having no air, but I'll PR a fix upstream today. Not having air in your lungs should probably circumvent resistances.

I've got some more buffs in mind for Epistemics. Such as making the bible upgradable via an altar interaction, and giving the Mantis' jacket a psionically insulated jacket as well as a visibile range to their metapsionic pulse.
## Technical details
<!-- Summary of code changes for easier review. -->
Added HandHeldArmorSystem and the respective Component.
Whenever someone gets hit, it'll check a whitelist if they have the sufficient components and then reduce damages.
A few YML changes.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="671" height="291" alt="grafik" src="https://github.com/user-attachments/assets/2463941a-35c7-4c07-a7b3-9ccf779b31e5" />
<img width="652" height="385" alt="grafik" src="https://github.com/user-attachments/assets/a572ae23-162a-4084-931e-b9ed6e9f35a4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The faithful rejoice! Your deity has chosen to to protect you as long as you hold your religious tome!
