### PR TITLE
Map Edits: Arena

### DIFF
--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_uclb.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_uclb.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 260.2.0
+  engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/29/2025 02:00:07
-  entityCount: 1519
+  time: 11/23/2025 07:03:07
+  entityCount: 1538
 maps: []
 grids:
 - 1
@@ -673,6 +673,8 @@ entities:
       - 436
       - 1225
       - 483
+    - type: Fixtures
+      fixtures: {}
   - uid: 1294
     components:
     - type: Transform
@@ -695,6 +697,8 @@ entities:
       - 1195
       - 1194
       - 1099
+    - type: Fixtures
+      fixtures: {}
   - uid: 1295
     components:
     - type: Transform
@@ -708,6 +712,8 @@ entities:
       - 1297
       - 1282
       - 1103
+    - type: Fixtures
+      fixtures: {}
   - uid: 1296
     components:
     - type: Transform
@@ -729,6 +735,8 @@ entities:
       - 440
       - 1281
       - 1293
+    - type: Fixtures
+      fixtures: {}
   - uid: 1304
     components:
     - type: Transform
@@ -742,6 +750,8 @@ entities:
       - 380
       - 1101
       - 1277
+    - type: Fixtures
+      fixtures: {}
   - uid: 1305
     components:
     - type: Transform
@@ -774,6 +784,8 @@ entities:
       - 162
       - 637
       - 1092
+    - type: Fixtures
+      fixtures: {}
   - uid: 1306
     components:
     - type: Transform
@@ -788,6 +800,8 @@ entities:
       - 1363
       - 1382
       - 1380
+    - type: Fixtures
+      fixtures: {}
   - uid: 1308
     components:
     - type: Transform
@@ -804,6 +818,8 @@ entities:
       - 1260
       - 1382
       - 1381
+    - type: Fixtures
+      fixtures: {}
   - uid: 1313
     components:
     - type: Transform
@@ -828,6 +844,8 @@ entities:
       - 436
       - 1328
       - 1317
+    - type: Fixtures
+      fixtures: {}
   - uid: 1330
     components:
     - type: Transform
@@ -840,6 +858,8 @@ entities:
       - 912
       - 1181
       - 1075
+    - type: Fixtures
+      fixtures: {}
   - uid: 1335
     components:
     - type: Transform
@@ -853,6 +873,8 @@ entities:
       - 1232
       - 1500
       - 1501
+    - type: Fixtures
+      fixtures: {}
   - uid: 1388
     components:
     - type: Transform
@@ -875,6 +897,8 @@ entities:
       - 474
       - 475
       - 1349
+    - type: Fixtures
+      fixtures: {}
   - uid: 1389
     components:
     - type: Transform
@@ -895,6 +919,8 @@ entities:
       - 1349
       - 1387
       - 1352
+    - type: Fixtures
+      fixtures: {}
   - uid: 1406
     components:
     - type: Transform
@@ -908,6 +934,8 @@ entities:
       - 1360
       - 1404
       - 1401
+    - type: Fixtures
+      fixtures: {}
 - proto: AirCanister
   entities:
   - uid: 805
@@ -1265,39 +1293,69 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 9.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 514
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 516
     components:
     - type: Transform
       pos: 9.5,-2.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 521
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-17.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 525
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 526
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 854
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1524
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-12.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1528
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 13.5,-13.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: AtmosDeviceFanDirectional
   entities:
   - uid: 323
@@ -1408,6 +1466,8 @@ entities:
     - type: Transform
       pos: 2.5,-16.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: BedsheetMedical
   entities:
   - uid: 733
@@ -2996,6 +3056,61 @@ entities:
     - type: Transform
       pos: 5.5,-17.5
       parent: 1
+  - uid: 1525
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 1
+  - uid: 1526
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 1527
+    components:
+    - type: Transform
+      pos: 5.5,-12.5
+      parent: 1
+  - uid: 1529
+    components:
+    - type: Transform
+      pos: 9.5,-10.5
+      parent: 1
+  - uid: 1530
+    components:
+    - type: Transform
+      pos: 10.5,-10.5
+      parent: 1
+  - uid: 1531
+    components:
+    - type: Transform
+      pos: 11.5,-10.5
+      parent: 1
+  - uid: 1532
+    components:
+    - type: Transform
+      pos: 12.5,-10.5
+      parent: 1
+  - uid: 1533
+    components:
+    - type: Transform
+      pos: 12.5,-11.5
+      parent: 1
+  - uid: 1534
+    components:
+    - type: Transform
+      pos: 12.5,-12.5
+      parent: 1
+  - uid: 1535
+    components:
+    - type: Transform
+      pos: 12.5,-13.5
+      parent: 1
+  - uid: 1536
+    components:
+    - type: Transform
+      pos: 13.5,-13.5
+      parent: 1
 - proto: Carpet
   entities:
   - uid: 695
@@ -4055,18 +4170,24 @@ entities:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-- proto: ClosetWallOrangeFilled
+    - type: Fixtures
+      fixtures: {}
+- proto: ClosetWallWardrobePrisonFilled
   entities:
   - uid: 1471
     components:
     - type: Transform
       pos: 14.5,-8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1475
     components:
     - type: Transform
       pos: 15.5,-8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ClothingHandsGlovesBoxingBlue
   entities:
   - uid: 212
@@ -4098,7 +4219,7 @@ entities:
     - type: Transform
       pos: -2.6044517,1.7804337
       parent: 1
-- proto: ClothingNeckHeadphones
+- proto: ClothingMultipleHeadphones
   entities:
   - uid: 1345
     components:
@@ -4176,6 +4297,8 @@ entities:
     - type: Transform
       pos: 12.5,-14.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: DisposalBend
   entities:
   - uid: 393
@@ -4493,26 +4616,36 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 636
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 850
     components:
     - type: Transform
       pos: 5.5,-19.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1053
     components:
     - type: Transform
       pos: 9.5,-18.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1078
     components:
     - type: Transform
       pos: -3.5,-12.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: filingCabinetRandom
   entities:
   - uid: 775
@@ -4783,6 +4916,28 @@ entities:
     components:
     - type: Transform
       pos: 9.5,-10.5
+      parent: 1
+- proto: FloorChasmEntity
+  entities:
+  - uid: 1520
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 1521
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 1522
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 1523
+    components:
+    - type: Transform
+      pos: 4.5,6.5
       parent: 1
 - proto: FloorDrain
   entities:
@@ -7150,6 +7305,23 @@ entities:
     - type: Transform
       pos: 4.5,-15.5
       parent: 1
+- proto: LockerWallEvacRepairFilled
+  entities:
+  - uid: 1537
+    components:
+    - type: Transform
+      pos: -1.5,-20.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1538
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: Matchbox
   entities:
   - uid: 1193
@@ -7221,6 +7393,8 @@ entities:
     - type: Transform
       pos: 10.5,0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: NitrogenCanister
   entities:
   - uid: 807
@@ -7338,6 +7512,8 @@ entities:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PosterLegitBotanyFood
   entities:
   - uid: 1422
@@ -7345,6 +7521,8 @@ entities:
     - type: Transform
       pos: -2.5,-5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: PottedPlantRandom
   entities:
   - uid: 229
@@ -7922,36 +8100,50 @@ entities:
     - type: Transform
       pos: 11.5,-14.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1434
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1437
     components:
     - type: Transform
       pos: 8.5,-18.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1442
     components:
     - type: Transform
       pos: -7.5,-1.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1444
     components:
     - type: Transform
       pos: 10.5,-2.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1451
     components:
     - type: Transform
       pos: -6.5,8.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1454
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: ShuttleWindow
   entities:
   - uid: 2
@@ -8842,16 +9034,22 @@ entities:
     - type: Transform
       pos: 11.5,0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1031
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
   - uid: 1036
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
+    - type: Fixtures
+      fixtures: {}
 - proto: WallShuttle
   entities:
   - uid: 4
@@ -9732,6 +9930,9 @@ entities:
     - type: Transform
       pos: 4.121771,6.791744
       parent: 1
+    missingComponents:
+    - Item
+    - Pullable
 - proto: WeldingFuelTankFull
   entities:
   - uid: 1184

--- a/Resources/Prototypes/Maps/arena.yml
+++ b/Resources/Prototypes/Maps/arena.yml
@@ -61,7 +61,7 @@
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 2 ]
             Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 2, 2 ]
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 1, 2 ]
           #science

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
@@ -130,3 +130,20 @@
     - id: ClothingShoesBootsSecurityMagboots
     - id: OxygenTankFilled
     - id: ClothingMaskBreath
+
+- type: entity
+  parent: GunSafeBaseSecure
+  id: GunSafeNonLethalShotgun
+  name: non-lethal shotgun safe
+  suffix: Security, Locked
+  components:
+  - type: AccessReader
+    access: [["Security"]]
+  - type: StorageFill
+    contents:
+    - id: WeaponShotgunKammererNonLethal
+      amount: 2
+    - id: BoxBeanbag
+      amount: 2
+    - id: BoxShotgunPractice
+      amount: 2

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
@@ -9,7 +9,7 @@
   - type: Transform
     anchored: false
   - type: Sprite
-    sprite: Objects/Weapons/Melee/claymore.rsi #change to katana
+    sprite: Objects/Weapons/Melee/claymore.rsi
     layers:
     - state: icon
   - type: EntityTableSpawner

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
@@ -1,0 +1,57 @@
+- type: entity
+  parent: MarkerBase
+  id: ArenaGladiatorWeaponSpawner
+  name: Gladiator Weapon Spawner
+  suffix: Do Not Map
+  placement:
+    mode: PlaceFree
+  components:
+  - type: Transform
+    anchored: false
+  - type: Sprite
+    sprite: Objects/Weapons/Melee/claymore.rsi #change to katana
+    layers:
+    - state: icon
+  - type: EntityTableSpawner
+    offset: 0
+    table: !type:GroupSelector
+      children:
+      - id: FireAxe
+      - id: Chainsaw
+      - id: CombatKnife
+      - id: Machete
+      - !type:GroupSelector
+        children:
+        - id: Katana
+        - id: Claymore
+        - id: Cutlass
+      - !type:GroupSelector
+        children:
+        - id: Spear
+        - id: SpearReinforced
+          weight: 2
+        - id: SpearPlasma
+        - id: SpearUranium
+        - id: SpearBone
+      #Ranged
+      - !type:GroupSelector
+        children:
+        - id: Bola
+        - id: ThrowingStar
+          amount: !type:RangeNumberSelector
+            range: 5, 10
+        - !type:AllSelector
+          children:
+          - id: BowImprovised
+          - id: ClothingBeltQuiver
+          - !type:GroupSelector
+            rolls: 16
+            children:
+            - id: ArrowRegular
+              prob: 0.8
+            - id: ArrowImprovised
+              prob: 0.9
+            - id: ArrowImprovisedPlasma
+              prob: 0.7
+            - id: ArrowImprovisedUranium
+              prob: 0.6


### PR DESCRIPTION
## About the PR
- Swapped in sentry turrets in AI
- Added prisoner intercom
- Added chefvend in perma
- Added archivist locker and some basic display stands
- Added LO's suit storage
- Added a couple new maint rooms/jani closet
- Added a space cleaner dispenser in jani man office
- Swapped all bedroom lights to be warm lights
- Adds a non-lethal shotgun cabinet entity and places in tier 1 armory
- Adds proper shotgun cabinets in tier 2 armory
- Adjusts all double external airlocks to use logic gates
- Adds a cryo bed in gladiator room
- Adds a new gladiator weapon spawner
- Fixes the Robotech in robotics was a vendomat
- Fixes vent rotated wrong way in nitrogen lounge
- Changes library cameras to epi cameras
- Increases number of musician slots from 1->2

NTES UCLB
- Adds repair closets
- Adds Fun!


## Why / Balance
👊

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
MAPS:
- add: Arena: Updated with AI turrets and Archivist tools
- tweak: Arena: Gladiator gets some new toys 
- tweak: Arena: Increased musician slots from 1 to 2
