### PR TITLE
xenoarch: remove impossible artifact trigger combinations

### DIFF
--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
@@ -53,8 +53,14 @@ public sealed partial class XenoArtifactSystem
             var triggerId = RobustRandom.Pick(weightsByTriggersLeft);
             weightsByTriggersLeft.Remove(triggerId);
             var trigger = PrototypeManager.Index<XenoArchTriggerPrototype>(triggerId);
-            if (_entityWhitelist.IsWhitelistFail(trigger.Whitelist, ent))
+            // DeltaV - start of TriggerBlacklist
+            if (
+                _entityWhitelist.IsWhitelistFail(trigger.Whitelist, ent)
+                || (trigger.TriggerBlacklist != null && triggerPool.Any(otherTrigger => trigger.TriggerBlacklist.Contains(otherTrigger.ID)))
+                || (triggerPool.Any(otherTrigger => otherTrigger.TriggerBlacklist != null && otherTrigger.TriggerBlacklist.Contains(triggerId)))
+            )
                 continue;
+            // DeltaV - end of TriggerBlacklist
 
             triggerPool.Add(trigger);
         }

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
@@ -53,10 +53,11 @@ public sealed partial class XenoArtifactSystem
             var triggerId = RobustRandom.Pick(weightsByTriggersLeft);
             weightsByTriggersLeft.Remove(triggerId);
             var trigger = PrototypeManager.Index<XenoArchTriggerPrototype>(triggerId);
+            if (_entityWhitelist.IsWhitelistFail(trigger.Whitelist, ent))
+                continue;
             // DeltaV - start of TriggerBlacklist
             if (
-                _entityWhitelist.IsWhitelistFail(trigger.Whitelist, ent)
-                || (trigger.TriggerBlacklist != null && triggerPool.Any(otherTrigger => trigger.TriggerBlacklist.Contains(otherTrigger.ID)))
+                (trigger.TriggerBlacklist != null && triggerPool.Any(otherTrigger => trigger.TriggerBlacklist.Contains(otherTrigger.ID)))
                 || triggerPool.Any(otherTrigger => otherTrigger.TriggerBlacklist != null && otherTrigger.TriggerBlacklist.Contains(triggerId))
             )
                 continue;

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.ProcGen.cs
@@ -57,7 +57,7 @@ public sealed partial class XenoArtifactSystem
             if (
                 _entityWhitelist.IsWhitelistFail(trigger.Whitelist, ent)
                 || (trigger.TriggerBlacklist != null && triggerPool.Any(otherTrigger => trigger.TriggerBlacklist.Contains(otherTrigger.ID)))
-                || (triggerPool.Any(otherTrigger => otherTrigger.TriggerBlacklist != null && otherTrigger.TriggerBlacklist.Contains(triggerId)))
+                || triggerPool.Any(otherTrigger => otherTrigger.TriggerBlacklist != null && otherTrigger.TriggerBlacklist.Contains(triggerId))
             )
                 continue;
             // DeltaV - end of TriggerBlacklist

--- a/Content.Shared/Xenoarchaeology/Artifact/Prototypes/XenoArchTriggerPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Prototypes/XenoArchTriggerPrototype.cs
@@ -25,6 +25,14 @@ public sealed partial class XenoArchTriggerPrototype : IPrototype
     [DataField]
     public EntityWhitelist? Whitelist;
 
+    // DeltaV - start of TriggerBlacklist
+    /// <summary>
+    /// Triggers that CANNOT appear on the same artifact as this trigger.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<XenoArchTriggerPrototype>>? TriggerBlacklist;
+    // DeltaV - end of TriggerBlacklist
+
     /// <summary>
     /// List of components that represent ways to trigger node.
     /// </summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/Prototypes/XenoArchTriggerPrototype.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Prototypes/XenoArchTriggerPrototype.cs
@@ -25,13 +25,11 @@ public sealed partial class XenoArchTriggerPrototype : IPrototype
     [DataField]
     public EntityWhitelist? Whitelist;
 
-    // DeltaV - start of TriggerBlacklist
     /// <summary>
-    /// Triggers that CANNOT appear on the same artifact as this trigger.
+    /// DeltaV - Triggers that CANNOT appear on the same artifact as this trigger.
     /// </summary>
     [DataField]
-    public List<ProtoId<XenoArchTriggerPrototype>>? TriggerBlacklist;
-    // DeltaV - end of TriggerBlacklist
+    public HashSet<ProtoId<XenoArchTriggerPrototype>>? TriggerBlacklist;
 
     /// <summary>
     /// List of components that represent ways to trigger node.

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -40,7 +40,7 @@
 - type: xenoArchTrigger
   id: TriggerHeat
   tip: xenoarch-trigger-tip-heat
-  triggerBlacklist: # DeltaV
+  triggerBlacklist: # DeltaV - add blacklist for difficult trigger combinations
   - TriggerCold # two different temperature triggers on the same node is doable (frezon + welding), but silly
   components:
   - type: XATTemperature
@@ -58,7 +58,7 @@
 - type: xenoArchTrigger
   id: TriggerCold
   tip: xenoarch-trigger-tip-cold
-  triggerBlacklist: # DeltaV
+  triggerBlacklist: # DeltaV - add blacklist for difficult trigger combinations
   - TriggerHeat # two different temperature triggers on the same node is doable (frezon + welding), but silly
   components:
   - type: XATTemperature
@@ -159,7 +159,7 @@
 - type: xenoArchTrigger
   id: TriggerPressureHigh
   tip: xenoarch-trigger-tip-pressure-high
-  triggerBlacklist: # DeltaV
+  triggerBlacklist: # DeltaV - add blacklist for difficult trigger combinations
   - TriggerPressureLow # two different pressure triggers on the same node is too difficult to complete
   components:
   - type: XATPressure
@@ -168,7 +168,7 @@
 - type: xenoArchTrigger
   id: TriggerPressureLow
   tip: xenoarch-trigger-tip-pressure-low
-  triggerBlacklist: # DeltaV
+  triggerBlacklist: # DeltaV - add blacklist for difficult trigger combinations
   - TriggerPressureHigh # two different pressure triggers on the same node is too difficult to complete
   components:
   - type: XATPressure

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -40,6 +40,8 @@
 - type: xenoArchTrigger
   id: TriggerHeat
   tip: xenoarch-trigger-tip-heat
+  triggerBlacklist: # DeltaV
+  - TriggerCold # two different temperature triggers on the same node is doable (frezon + welding), but silly
   components:
   - type: XATTemperature
     targetTemperature: 373
@@ -56,6 +58,8 @@
 - type: xenoArchTrigger
   id: TriggerCold
   tip: xenoarch-trigger-tip-cold
+  triggerBlacklist: # DeltaV
+  - TriggerHeat # two different temperature triggers on the same node is doable (frezon + welding), but silly
   components:
   - type: XATTemperature
     targetTemperature: 255
@@ -155,6 +159,8 @@
 - type: xenoArchTrigger
   id: TriggerPressureHigh
   tip: xenoarch-trigger-tip-pressure-high
+  triggerBlacklist: # DeltaV
+  - TriggerPressureLow # two different pressure triggers on the same node is too difficult to complete
   components:
   - type: XATPressure
     maxPressureThreshold: 385
@@ -162,6 +168,8 @@
 - type: xenoArchTrigger
   id: TriggerPressureLow
   tip: xenoarch-trigger-tip-pressure-low
+  triggerBlacklist: # DeltaV
+  - TriggerPressureHigh # two different pressure triggers on the same node is too difficult to complete
   components:
   - type: XATPressure
     minPressureThreshold: 50


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Blacklisted artifacts from having undesired trigger combinations, such as "Low Pressure + High Pressure", or "Low Temperature + High Temperature".

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This was a common criticism of the new xenoarch system, when discussing the system in https://github.com/DeltaV-Station/Delta-v/pull/4640

While technically doable (frezon+welding will give both temperature triggers, and just "be fast" to do the pressure combination), these are impractical trigger combinations.

## Merging

The new xenoarch system might be reverted soon, in https://github.com/DeltaV-Station/Delta-v/pull/4640 . Merging this before that would cause merge conflicts. 

I'm posting this PR for two reasons: 1. in case we decide to postpone the revert, and also 2. for our reference if we revisit the system in the future.

## Technical details
<!-- Summary of code changes for easier review. -->

The way this *actually* works is it blacklists the two triggers from appearing on the same artifact, not just on the same node. Limiting it to the same node would be doable in the code, but way more complicated / hard to review and maintain. Happy to discuss that approach though.

Recommended review order:
- `XenoArchTriggerPrototype.cs`
- `triggers.yml`
- `XenoArtifactSystem.ProcGen.cs`

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Difficult to demonstrate visually. I tested it by adding a log-statement in the if-statement, giving details when the blacklist triggered. It does work as intended, blocking one or the other trigger when one of the pair is already present (spawned lots of artifacts to test).

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: "Impossible" arti trigger combinations (like low+high pressure) will no longer appear on artifacts.

