### PR TITLE
xenoarch: arti effect happens faster, for more fun danger

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -78,18 +78,14 @@ public sealed partial class XenoArtifactComponent : Component
     [DataField]
     public TimeSpan UnlockStateRefractory = TimeSpan.FromSeconds(5);
 
-    // DeltaV - start of faster unlock effect
-
     /// <summary>
-    /// If set, will overwrite the unlocking state time remaining as soon as a node is ready to unlock (triggers are met).
+    /// DeltaV - If set, will overwrite the unlocking state time remaining as soon as a node is ready to unlock (triggers are met).
     ///   (why: letting the timer run out naturally makes artifacts less dangerous, since scientists have lots of time to run away)
     /// If null, the unlock time will just run its course naturally.
     /// </summary>
     [DataField]
     public TimeSpan? UnlockCompleteDuration = TimeSpan.FromSeconds(0.7);
     
-    // DeltaV - end of faster unlock effect
-
     /// <summary>
     /// When next unlock session can be triggered.
     /// </summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -78,6 +78,18 @@ public sealed partial class XenoArtifactComponent : Component
     [DataField]
     public TimeSpan UnlockStateRefractory = TimeSpan.FromSeconds(5);
 
+    // DeltaV - start of faster unlock effect
+
+    /// <summary>
+    /// If set, will overwrite the unlocking state time remaining as soon as a node is ready to unlock (triggers are met).
+    ///   (why: letting the timer run out naturally makes artifacts less dangerous, since scientists have lots of time to run away)
+    /// If null, the unlock time will just run its course naturally.
+    /// </summary>
+    [DataField]
+    public TimeSpan? UnlockCompleteDuration = TimeSpan.FromSeconds(0.7);
+    
+    // DeltaV - end of faster unlock effect
+
     /// <summary>
     /// When next unlock session can be triggered.
     /// </summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
@@ -91,9 +91,12 @@ public abstract partial class SharedXenoArtifactSystem
         if (node != null && unlockingComp.TriggeredNodeIndexes.Add(GetIndex(ent, node.Value)))
         {
             // DeltaV - start of faster unlock effect
-            if (ent.Comp.UnlockCompleteDuration != null && TryGetNodeFromUnlockState((ent.Owner, unlockingComp, ent.Comp), out var unlockingNode))
+            if (
+                ent.Comp.UnlockCompleteDuration is {} completeDuration 
+                && TryGetNodeFromUnlockState((ent.Owner, unlockingComp, ent.Comp), out var unlockingNode)
+            )
             {
-                unlockingComp.EndTime = _timing.CurTime + ent.Comp.UnlockCompleteDuration.Value;
+                unlockingComp.EndTime = _timing.CurTime + completeDuration;
             }
             // DeltaV - end of faster unlock effect
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
@@ -90,6 +90,13 @@ public abstract partial class SharedXenoArtifactSystem
 
         if (node != null && unlockingComp.TriggeredNodeIndexes.Add(GetIndex(ent, node.Value)))
         {
+            // DeltaV - start of faster unlock effect
+            if (ent.Comp.UnlockCompleteDuration != null && TryGetNodeFromUnlockState((ent.Owner, unlockingComp, ent.Comp), out var unlockingNode))
+            {
+                unlockingComp.EndTime = _timing.CurTime + ent.Comp.UnlockCompleteDuration.Value;
+            }
+            // DeltaV - end of faster unlock effect
+
             Dirty(ent, unlockingComp);
         }
     }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Shortened the delay between 
1. a scientist triggering the final trigger of an arti node, and 
2. the node unlocking/the effect happening.

The delay before this PR was ~5-10 seconds (it varied depending on how fast you did the triggers). Now, it is a fixed 0.7 seconds.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This was a common criticism of the new xenoarch system, when discussing the system in https://github.com/DeltaV-Station/Delta-v/pull/4640

The delay was very long, meaning you had plenty of time to run away before the effect triggered. If the effect was "spawn dangerous fauna" or "explode" or something else, you'd have plenty of time to dodge it. People liked the high danger of the old xenoarch system, so let's bring some of it back!

## Merging

The new xenoarch system might be reverted soon, in https://github.com/DeltaV-Station/Delta-v/pull/4640 . Merging this before that would cause merge conflicts.

I'm posting this PR for two reasons: 1. in case we decide to postpone the revert, and also 2. for our reference if we revisit the system in the future.

## Technical details
<!-- Summary of code changes for easier review. -->

How it worked before: every trigger that occurs adds time to the "unlocking phase" timer. When that timer runs out, the unlocking checks occur; if they find a node that was triggered, it's unlocked.

How it works now: The same, but also every time a trigger occurs, all the standard unlocking checks are run as well. If they succeed, then the remaining time in the unlocking phase is set to the short 0.7 seconds time.

0.7 seconds was chosen because it's:
- Short enough that you can't run away
- Not instant, so there isn't too much happening visually on the screen at once
- Long enough that other conflicting triggers present (e.g. low oxygen + low pressure) can still occur consistently. (setting the timer to zero would probably cause intermittent / glitchy triggering)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Demo: artifact will `Create Hostile Fish` after triggers `Water` and `Blood`. See:
- Splash with Water, the first trigger
- Popup says "artifact begins to shift", indicating the start of the unlocking time
- Plenty of time is given to do the second trigger
- Splash with Blood
- A very short time later (0.7s), "the artifact is permanently changed", and the fish spawns
  - This would've been a lot longer before this PR; you'd have to wait for the rest of the unlocking phase timer to drain

https://github.com/user-attachments/assets/6d8fa5fc-737e-43ef-8194-e45c7d72397d

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Artifacts now activate much faster after you successfully perform their triggers. More danger = more fun
