### PR TITLE
xenoarch: make commonly-conflicting atmos triggers appear less often

### DIFF
--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -3,6 +3,10 @@
   weights:
     TriggerMetapsionic: 1 # DeltaV
     TriggerMusic: 1
+    # DeltaV - make less frequent
+    #TriggerHeat: 1
+    #TriggerCold: 0.5
+    #TriggerNoOxygen: 1
     TriggerHeat: 0.5
     TriggerCold: 0.25
     TriggerNoOxygen: 0.5
@@ -14,6 +18,9 @@
     TriggerAmmonia: 0.1
     TriggerFrezon: 0.1
     TriggerRadiation: 1
+    # DeltaV - make less frequent
+    #TriggerPressureHigh: 0.5
+    #TriggerPressureLow: 1
     TriggerPressureHigh: 0.25
     TriggerPressureLow: 0.5
     TriggerExamine: 1

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -3,9 +3,9 @@
   weights:
     TriggerMetapsionic: 1 # DeltaV
     TriggerMusic: 1
-    TriggerHeat: 1
-    TriggerCold: 0.5
-    TriggerNoOxygen: 1
+    TriggerHeat: 0.5
+    TriggerCold: 0.25
+    TriggerNoOxygen: 0.5
     TriggerWater: 1
     TriggerCO2: 0.5
     TriggerPlasma: 0.5
@@ -14,8 +14,8 @@
     TriggerAmmonia: 0.1
     TriggerFrezon: 0.1
     TriggerRadiation: 1
-    TriggerPressureHigh: 0.5
-    TriggerPressureLow: 1
+    TriggerPressureHigh: 0.25
+    TriggerPressureLow: 0.5
     TriggerExamine: 1
     TriggerBruteDamage: 1
     #TriggerInteraction: 1 #this one interferes with activating artifact AND brute dmg!


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Reduced the likelihood of the following artifact node triggers by ~half:
- `Low-oxygen environment` (reduce oxygen presence to ~10% or less)
- `High Pressure` (> 385 kPa)
- `Low Pressure` (< 50 kPa)
- `Heat` (> 100 C, or deal Heat damage - hit with a welding tool)
- `Cold` (< -20 C, or deal Cold damage - not sure how you do that)

That is, each of the above are roughly half as less likely to appear in any given artifact.

Related: a separate PR makes sure that certain "impossible" combinations of these don't show up. That's a separate thing: https://github.com/DeltaV-Station/Delta-v/pull/4740

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This is related to a common criticism of the new xenoarch system, when discussing the system in https://github.com/DeltaV-Station/Delta-v/pull/4640

The new xenoarch system has the brand new feature that: **simultaneously activating two different, unrelated nodes in the tree will cause NEITHER of them to unlock**. The idea is that you have to create isolated conditions: trigger one, but avoid triggering others. It's an intended challenge.

However, people have been really struggling with these atmos ones. (e.g. opening the arti room blast doors creates low-oxygen AND low pressure AND Cold)

The broader concept here is that "scientists are generally not expected to have a detailed understanding of the atmos system and pumping infrastructure". For some of these triggers, a good atmos understanding (or an engi department that is free enough to send an atmos tech over) is necessary to isolate the effects.

Reducing the difficulty of these triggers (by reducing their frequency) may or may not be something you agree with. This is a balance change, and I defer to Direction to make the decision about where this should land.

## Technical details
<!-- Summary of code changes for easier review. -->

`Weights = Weights / 2`

## Merging

The new xenoarch system might be reverted soon, in https://github.com/DeltaV-Station/Delta-v/pull/4640 . Merging this before that would cause merge conflicts.

I'm posting this PR for two reasons: 1. in case we decide to postpone the revert, and also 2. for our reference if we revisit the system in the future.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

N/A

Only test I did was spawning a bunch of artifacts and verified no error messages or anything popped up.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The more difficult atmos triggers on artifacts (low O2, heat, cold, low pressure, high pressure) will show up less frequently.

