### PR TITLE
make slips scary again

### DIFF
--- a/Content.Shared/Slippery/SlipperyComponent.cs
+++ b/Content.Shared/Slippery/SlipperyComponent.cs
@@ -56,7 +56,7 @@ namespace Content.Shared.Slippery
         /// How many seconds the mob will be stunned for.
         /// </summary>
         [DataField]
-        public TimeSpan StunTime = TimeSpan.FromSeconds(0.5);
+        public TimeSpan StunTime = TimeSpan.FromSeconds(1.5); // DeltaV - buff slips
 
         /// <summary>
         /// How many seconds the mob will be knocked down for.

--- a/Content.Shared/Slippery/SlipperySystem.cs
+++ b/Content.Shared/Slippery/SlipperySystem.cs
@@ -132,7 +132,7 @@ public sealed class SlipperySystem : EntitySystem
         if (!knockedDown)
         {
             // Status effects should handle a TimeSpan of 0 properly...
-            _stun.TryUpdateStunDuration(other, component.SlipData.StunTime);
+            _stun.TryUpdateStunDuration(other, component.SlipData.KnockdownTime); // DeltaV - buff slips
 
             // Don't make a new status effect entity if the entity wouldn't do anything
             if (!MathHelper.CloseTo(component.SlipData.SlipFriction, 1f))

--- a/Content.Shared/Slippery/SlipperySystem.cs
+++ b/Content.Shared/Slippery/SlipperySystem.cs
@@ -132,7 +132,7 @@ public sealed class SlipperySystem : EntitySystem
         if (!knockedDown)
         {
             // Status effects should handle a TimeSpan of 0 properly...
-            _stun.TryUpdateStunDuration(other, component.SlipData.KnockdownTime); // DeltaV - buff slips
+            _stun.TryUpdateStunDuration(other, component.SlipData.StunTime);
 
             // Don't make a new status effect entity if the entity wouldn't do anything
             if (!MathHelper.CloseTo(component.SlipData.SlipFriction, 1f))

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/soap.yml
@@ -130,6 +130,7 @@
   - type: Slippery
     staminaDamage: 50
     slipData:
+      stunTime: 3 # DeltaV - buff slips
       knockdownTime: 3
       launchForwardsMultiplier: 3
   - type: Item
@@ -228,6 +229,7 @@
   - type: Slippery
     staminaDamage: 50
     slipData:
+      stunTime: 5.0 # DeltaV - buff slips
       knockdownTime: 5.0
       launchForwardsMultiplier: 3.0
   - type: Item


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
upstream merge giga-nerfed slips so that they don't actually stun you for longer then 0.5 seconds and you can just immediately pick your items back up and it sucks. now you get stunned for however long you get knocked down. awesome

## Why / Balance
clown major

friction is kinda a bit weird right now with it, but :idk:

## Technical details
either I do this, or I go to every single prototype that's slippery and modify the values here. each solution is equally mediocre, so up to the maints

## Media

https://github.com/user-attachments/assets/a876c958-51bd-4cee-b8c1-6b6f4cf32508




## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Slipping is now scary again, and will stun you for a while. Beware of the clown.
