### PR TITLE
Fix ClothingSpeedModifier getting applied twice

### DIFF
--- a/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
+++ b/Content.Shared/Clothing/ClothingSpeedModifierSystem.cs
@@ -60,6 +60,8 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
         if (!_toggle.IsActivated(uid))
             return;
 
+        if (component.Standing != null && !_standing.IsMatchingState(args.Owner, component.Standing.Value))
+            return;
 
         // DeltaV Start - Introduce ClothingSlowResistance to Species
         if (_container.TryGetContainingContainer((uid, null), out var container))
@@ -74,11 +76,6 @@ public sealed class ClothingSpeedModifierSystem : EntitySystem
             args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
         }
         // DeltaV End - Introduce ClothingSlowResistance to Species
-
-        if (component.Standing != null && !_standing.IsMatchingState(args.Owner, component.Standing.Value))
-            return;
-
-        args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);
     }
 
     private void OnClothingVerbExamine(EntityUid uid, ClothingSpeedModifierComponent component, GetVerbsEvent<ExamineVerb> args)


### PR DESCRIPTION
## About the PR
Fixes https://github.com/DeltaV-Station/Delta-v/issues/4745
Caused by unfortunate merge conflict resolution in upstream merge

## Why / Balance
bugfix

## Technical details
We replaced `args.Args.ModifySpeed(component.WalkModifier, component.SprintModifier);` with a conditional for Oni
During upmerge that was moved to above a new check that would stop the effects if standing is required but player is crawling

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- fix: Fixed clothing slowdowns being applied twice
