### PR TITLE
new round in periapsis pingable discord role

### DIFF
--- a/Resources/ConfigPresets/DeltaV/periapsis.toml
+++ b/Resources/ConfigPresets/DeltaV/periapsis.toml
@@ -27,5 +27,8 @@ enabled = true
 [hub]
 tags = "lang:en-US,region:am_n_e,rp:med,no_tag_infer"
 
+[discord]
+round_end_role=1440055204451188847
+
 [debug]
 pow3r_disable_parallel = false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
pings the discord role whenever a new round of peri is starting

## Why / Balance
community wants it
make peri alive again

## Technical details
honestly have no clue what i'm doing, i'm just making this into pr
read the "add discord role for periapsis players" in #community-feedback

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- add: Periapsis now pings a specific discord role whenever a new round is starting. 

