### PR TITLE
remove species locks in uplink store

### DIFF
--- a/Resources/Locale/en-US/_DV/store/uplink/implants.ftl
+++ b/Resources/Locale/en-US/_DV/store/uplink/implants.ftl
@@ -1,5 +1,5 @@
-uplink-bionic-syrinx-implanter-name = Bionic Syrinx Implanter
-uplink-bionic-syrinx-implanter-desc = An implant that enhances a harpy's natural talent for mimicry to let you adjust your voice to whoever you can think of.
+uplink-bionic-syrinx-implanter-name = Bionic Larynx Implanter
+uplink-bionic-syrinx-implanter-desc = A laryngeal implant that lets you adjust your voice to whoever you can think of.
 
 uplink-syndicate-radio-implanter-name = Syndicate Radio Implanter
 uplink-syndicate-radio-implanter-desc = A cranial implant that lets you talk on the Syndicate radio channel (use :t).

--- a/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
@@ -10,10 +10,6 @@
     Telecrystal: 10
   categories:
   - UplinkWeaponry
-  conditions:
-  - !type:BuyerSpeciesCondition
-    whitelist:
-    - Oni
 
 - type: listing
   id: UplinkRickenbacker
@@ -44,10 +40,6 @@
     Telecrystal: 6
   categories:
   - UplinkWearables
-  conditions:
-  - !type:BuyerSpeciesCondition
-    whitelist:
-    - Oni
   - !type:BuyerWhitelistCondition
     blacklist:
       components:

--- a/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/uplink_catalog.yml
@@ -40,6 +40,7 @@
     Telecrystal: 6
   categories:
   - UplinkWearables
+  conditions:
   - !type:BuyerWhitelistCondition
     blacklist:
       components:

--- a/Resources/Prototypes/_DV/Catalog/Uplink/implants.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/implants.yml
@@ -11,9 +11,6 @@
   categories:
   - UplinkImplants
   conditions:
-  - !type:BuyerSpeciesCondition
-    whitelist:
-    - Harpy
   - !type:BuyerWhitelistCondition
     blacklist:
       components:

--- a/Resources/Prototypes/_DV/Catalog/Uplink/implants.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/implants.yml
@@ -2,7 +2,7 @@
   id: UplinkBionicSyrinxImplanter
   name: uplink-bionic-syrinx-implanter-name
   description: uplink-bionic-syrinx-implanter-desc
-  productEntity: BionicSyrinxImplanter
+  productEntity: BionicVoiceMaskImplanter
   discountCategory: usualDiscounts
   discountDownTo:
     Telecrystal: 1


### PR DESCRIPTION

## About the PR
remove species whitelist from:
kanabou, samurai armor, larynx implant

## Why / Balance
larynx implant 2tc because voicemask is 1tc

**Changelog**
:cl:
- tweak: Larynx Implants are now purchaseable in the uplink for all species
- tweak: Kanabou are now purchaseable in the uplink for all species
- tweak: Samurai armors are now purchaseable in the uplink for all species

