### PR TITLE
Security Roundstart gloves

### DIFF
--- a/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
@@ -119,7 +119,7 @@ loadout-group-head-of-security-shoes = Head of Security shoes
 
 loadout-group-security-cadet-head = Security Cadet head
 loadout-group-security-neck = Security neck
-loadout-group-security-gloves = Security Gloves
+loadout-group-security-gloves = Security gloves
 
 loadout-group-brig-medic-head = Corpsman head
 loadout-group-brig-medic-jumpsuit = Corpsman jumpsuit

--- a/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
@@ -119,6 +119,7 @@ loadout-group-head-of-security-shoes = Head of Security shoes
 
 loadout-group-security-cadet-head = Security Cadet head
 loadout-group-security-neck = Security neck
+loadout-group-security-gloves = Security Gloves
 
 loadout-group-brig-medic-head = Corpsman head
 loadout-group-brig-medic-jumpsuit = Corpsman jumpsuit

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -381,7 +381,6 @@
   - SecurityBackpack
   - SecurityBelt
   - HeadofSecurityOuterClothingDeltaV # DeltaV - Switched to DeltaV version, was HeadofSecurityOuterClothing
-  - SecurityGloves # DeltaV - Security can start with gloves
   - HeadofSecurityShoes # DeltaV - winter boots
   - SurvivalSecurity
   - Trinkets
@@ -435,7 +434,6 @@
   - DetectiveJumpsuitDeltaV # DeltaV - Replaced with DeltaV version, was DetectiveJumpsuit
   - SecurityBackpack
   - DetectiveOuterClothingDeltaV # DeltaV - Replaced with DeltaV version, was DetectiveOuterClothing
-  - SecurityGloves # DeltaV - Security can start with gloves
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -381,6 +381,7 @@
   - SecurityBackpack
   - SecurityBelt
   - HeadofSecurityOuterClothingDeltaV # DeltaV - Switched to DeltaV version, was HeadofSecurityOuterClothing
+  - SecurityGloves # DeltaV - Security can start with gloves
   - HeadofSecurityShoes # DeltaV - winter boots
   - SurvivalSecurity
   - Trinkets
@@ -398,6 +399,7 @@
   - SecurityBackpack
   - SecurityBelt
   - WardenOuterClothingDeltaV # DeltaV - Switched to DeltaV version, was WardenOuterClothing
+  - SecurityGloves # DeltaV - Security can start with gloves
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
@@ -414,6 +416,7 @@
   - SecurityJumpsuit
   - SecurityBackpack
   - SecurityOuterClothingDeltaV # DeltaV - Switched to DeltaV version, was SecurityOuterClothing
+  - SecurityGloves # DeltaV - Security can start with gloves
   - SecurityShoes
   - SecurityPDA
   - SecurityBelt
@@ -432,6 +435,7 @@
   - DetectiveJumpsuitDeltaV # DeltaV - Replaced with DeltaV version, was DetectiveJumpsuit
   - SecurityBackpack
   - DetectiveOuterClothingDeltaV # DeltaV - Replaced with DeltaV version, was DetectiveOuterClothing
+  - SecurityGloves # DeltaV - Security can start with gloves
   - SecurityShoes
   - SurvivalSecurity
   - Trinkets
@@ -445,6 +449,7 @@
   groups:
   - SecurityHead # DeltaV
   - SecurityNeck # DeltaV
+  - SecurityGloves # DeltaV - Security can start with gloves
   - SecurityCadetJumpsuit
   - SecurityBackpack
   - SurvivalSecurity

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -35,6 +35,7 @@
   - PrisonGuardJumpsuit
   - SecurityBackpack
   - SecurityOuterClothingDeltaV # DeltaV - Switched to DeltaV version, was SecurityOuterClothing
+  - SecurityGloves # DeltaV - Security can start with gloves
   - SecurityShoes
   - SecurityBelt
   - SurvivalSecurity

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
@@ -122,3 +122,15 @@
   id: SecurityPoncho
   equipment:
     neck: ClothingNeckCWPSec
+
+# Gloves
+
+- type: loadout
+  id: SecurityClothingHandsGlovesColorBlack
+  equipment:
+    gloves: ClothingHandsGlovesColorBlack
+
+- type: loadout
+  id: SecurityClothingHandsGlovesFingerless
+  equipment:
+    gloves: ClothingHandsGlovesFingerless

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -393,6 +393,15 @@
   - SecurityFirearmSpeedLoaderSpecialRubber
   - SecurityFirearmSpeedLoaderSpecial
 
+## Security Gloves
+- type: loadoutGroup
+  id: SecurityGloves
+  name: loadout-group-security-gloves
+  minLimit: 0
+  loadouts:
+  - ClothingHandsGlovesColorBlack
+  - ClothingHandsGlovesFingerless
+
 ## Security Officer
 - type: loadoutGroup
   id: SecurityNeck

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -399,8 +399,8 @@
   name: loadout-group-security-gloves
   minLimit: 0
   loadouts:
-  - ClothingHandsGlovesColorBlack
-  - ClothingHandsGlovesFingerless
+  - SecurityClothingHandsGlovesColorBlack
+  - SecurityClothingHandsGlovesFingerless
 
 ## Security Officer
 - type: loadoutGroup


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Let's security pick gloves in the loadouts. Only affects security jobs that don't start with gloves already (Secoff, cadet, warden, prison guard)
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Small QOL. Black gloves are easily accessible, not really limited and some other jobs (bartender) already start with them. 
This saves secoffs a couple clicks
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="796" height="398" alt="Screenshot 2025-11-26 021513" src="https://github.com/user-attachments/assets/a7c2e0cc-d7ae-46c5-90cc-1373915fd800" />
"Gloves" is lowercase now to match the other options but you get it

## Breaking Changes
**Changelog**

:cl:
- add: Security now has gloves in loadouts
