### PR TITLE
Fix NT-3

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -404,7 +404,7 @@ public abstract partial class SharedGunSystem : EntitySystem
         var shooterEv = new ShooterImpulseEvent();
         RaiseLocalEvent(user, ref shooterEv);
 
-        if (shooterEv.Push)
+        if (shooterEv.Push && !shooterEv.CannotBePushed) // DeltaV - Bipods stop you from being moved by recoil.
             CauseImpulse(fromCoordinates, toCoordinates.Value, user, userPhysics);
     }
 
@@ -662,6 +662,7 @@ public record struct GunShotEvent(EntityUid User, List<(EntityUid? Uid, IShootab
 public record struct ShooterImpulseEvent()
 {
     public bool Push;
+    public bool CannotBePushed; // DeltaV - Bipods stop you from being moved by recoil.
 };
 
 public enum EffectLayers : byte

--- a/Content.Shared/_DV/Weapons/Ranged/Systems/SharedGunSystem.Bipod.cs
+++ b/Content.Shared/_DV/Weapons/Ranged/Systems/SharedGunSystem.Bipod.cs
@@ -26,8 +26,10 @@ public abstract partial class SharedGunSystem
 
         SubscribeLocalEvent<GunBipodComponent, GunRefreshModifiersEvent>(OnGunRefreshModifiers);
         SubscribeLocalEvent<GunBipodComponent, BipodSetupFinishedEvent>(SetupBipod);
-        SubscribeLocalEvent<GunBipodComponent, ShotAttemptedEvent>(OnShotAttempted);
         SubscribeLocalEvent<IsUsingBipodComponent, MoveEvent>(OnMove);
+
+        SubscribeLocalEvent<GunBipodComponent, ShotAttemptedEvent>(OnShotAttempted);
+        SubscribeLocalEvent<IsUsingBipodComponent, ShooterImpulseEvent>(OnImpulse);
     }
 
     private void OnMapInit(Entity<GunBipodComponent> weapon, ref MapInitEvent args)
@@ -188,8 +190,13 @@ public abstract partial class SharedGunSystem
     private void OnShotAttempted(Entity<GunBipodComponent> ent, ref ShotAttemptedEvent args)
     {
         // This is true when the bipod is being set up - Preventing the gun from shooting.
-        if (Timing.CurTime < ent.Comp.BipodSetupTime + ent.Comp.SetupDelay)
+        if (Timing.CurTime < ent.Comp.BipodSetupTime + ent.Comp.SetupDelay + TimeSpan.FromSeconds(0.1))
             args.Cancel();
+    }
+
+    private void OnImpulse(Entity<IsUsingBipodComponent> bipodUser, ref ShooterImpulseEvent args)
+    {
+        args.CannotBePushed = true;
     }
 }
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Made it unable to push the user if the bipod is enabled.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix. The push disables the bipod, making the bipod unusable.
## Technical details
<!-- Summary of code changes for easier review. -->
Added a check if the gun user can be pushed.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Shooting the NT-3 does not disable the bipod anymore via recoil!