### PR TITLE
Fixes mime survival box spawns

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -97,7 +97,7 @@
 - type: loadout
   id: EmergencyOxygenMime
   effects:
-  - !type:GroupLoadoutEffect
+  - !type:SpeciesLoadoutEffect
     proto: OxygenBreatherMime
   storage:
     back:

--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -86,6 +86,17 @@
     - Dwarf
     - Human
     - Reptilian
+    # Begin DeltaV additions
+    - Felinid
+    - Harpy
+    - Oni
+    - Vulpkanin
+    - Rodentia
+    - Chitinid
+    - Thaven
+    - Kitsune
+    - Avali
+    # End DeltaV additions
 
 - type: loadoutEffectGroup
   id: OxygenBreatherMimeMoth
@@ -97,7 +108,7 @@
 - type: loadout
   id: EmergencyOxygenMime
   effects:
-  - !type:SpeciesLoadoutEffect
+  - !type:GroupLoadoutEffect
     proto: OxygenBreatherMime
   storage:
     back:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixed some mimes not spawning with survival boxes.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #4766 I hope.
Delta-V specific species that breathe oxygen weren't getting their survival boxes after the upstream merge, every other species was fine.
## Technical details
<!-- Summary of code changes for easier review. -->
Don't know what changed behind the scenes so I copied the OxygenBreather stuff to OxygenBreatherMime and it worked.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
God I hope not.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- fix: Fixed certain species not starting with a survival box when joining as a mime.

