### PR TITLE
Make crawl speed depend on your free hand count (#41458)

### DIFF
--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -11,6 +11,7 @@ public abstract partial class SharedHandsSystem
     private void InitializeEventListeners()
     {
         SubscribeLocalEvent<HandsComponent, GetStandUpTimeEvent>(OnStandupArgs);
+        SubscribeLocalEvent<HandsComponent, KnockedDownRefreshEvent>(OnKnockedDownRefresh);
     }
 
     /// <summary>
@@ -27,5 +28,18 @@ public abstract partial class SharedHandsSystem
             return;
 
         time.DoAfterTime *= (float)ent.Comp.Count / (hands + ent.Comp.Count);
+    }
+
+    private void OnKnockedDownRefresh(Entity<HandsComponent> ent, ref KnockedDownRefreshEvent args)
+    {
+        var freeHands = CountFreeHands(ent.AsNullable());
+        var totalHands = GetHandCount(ent.AsNullable());
+
+        // Can't crawl around without any hands.
+        // Entities without the HandsComponent will always have full crawling speed.
+        if (totalHands == 0)
+            args.SpeedModifier = 0f;
+        else
+            args.SpeedModifier *= (float)freeHands / totalHands;
     }
 }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -39,7 +39,17 @@ public abstract partial class SharedHandsSystem
         // Entities without the HandsComponent will always have full crawling speed.
         if (totalHands == 0)
             args.SpeedModifier = 0f;
-        else
-            args.SpeedModifier *= (float)freeHands / totalHands;
+        // DeltaV - hand free = 75% movespeed, no hands free = 50% movespeed
+        else if (totalHands > freeHands)
+        {
+            // For some reason, this feels a bit dirty
+            // 0 free hands out of 1 total hands = (1-(1-0)*.50) = 50% move speed
+            // 1 free hand out of 2 total hands = (1-(2-1)*.25) = 75% move speed
+            // 1 free hand out of 4 total hands = (1-(4-1)*.125) = 62.5% move speed
+            // 6 free hands out of 10 total hands hands = (1-(10-6)*0.05) = 80% move speed
+            var reductionPerHand = 1 / totalHands * 2;
+            args.SpeedModifier = (float)Math.Clamp(1 - (totalHands - freeHands) * reductionPerHand, 0.5, 1.0);
+        }
+        // END DeltaV
     }
 }

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -39,7 +39,7 @@ public abstract partial class SharedHandsSystem
         // Entities without the HandsComponent will always have full crawling speed.
         if (totalHands == 0)
             args.SpeedModifier = 0f;
-        // DeltaV - hand free = 75% movespeed, no hands free = 50% movespeed
+        // DeltaV - 1 hand free = 75% movespeed, no hands free = 50% movespeed
         else if (totalHands > freeHands)
         {
             // For some reason, this feels a bit dirty

--- a/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
+++ b/Content.Shared/Hands/EntitySystems/SharedHandsSystem.EventListeners.cs
@@ -43,12 +43,12 @@ public abstract partial class SharedHandsSystem
         else if (totalHands > freeHands)
         {
             // For some reason, this feels a bit dirty
-            // 0 free hands out of 1 total hands = (1-(1-0)*.50) = 50% move speed
-            // 1 free hand out of 2 total hands = (1-(2-1)*.25) = 75% move speed
-            // 1 free hand out of 4 total hands = (1-(4-1)*.125) = 62.5% move speed
-            // 6 free hands out of 10 total hands hands = (1-(10-6)*0.05) = 80% move speed
-            var reductionPerHand = 1 / totalHands * 2;
-            args.SpeedModifier = (float)Math.Clamp(1 - (totalHands - freeHands) * reductionPerHand, 0.5, 1.0);
+            // 0 free hands out of 1 total hands = (1-(1-0)*.50) = 50% additional reduction to current move speed mod
+            // 1 free hand out of 2 total hands = (1-(2-1)*.25) = 75%
+            // 1 free hand out of 4 total hands = (1-(4-1)*.125) = 62.5% 
+            // 6 free hands out of 10 total hands hands = (1-(10-6)*0.05) = 80% 
+            var reductionPerHand = 1f / (totalHands + totalHands);
+            args.SpeedModifier *= (float)Math.Clamp(1f - (totalHands - freeHands) * reductionPerHand, 0.5, 1.0);
         }
         // END DeltaV
     }

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -6,6 +6,7 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Gravity;
+using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Input;
 using Content.Shared.Movement.Events;
@@ -53,7 +54,7 @@ public abstract partial class SharedStunSystem
         SubscribeLocalEvent<KnockedDownComponent, BuckleAttemptEvent>(OnBuckleAttempt);
         SubscribeLocalEvent<KnockedDownComponent, StandAttemptEvent>(OnStandAttempt);
 
-        // Updating movement a friction
+        // Updating movement and friction
         SubscribeLocalEvent<KnockedDownComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshKnockedSpeed);
         SubscribeLocalEvent<KnockedDownComponent, RefreshFrictionModifiersEvent>(OnRefreshFriction);
         SubscribeLocalEvent<KnockedDownComponent, TileFrictionEvent>(OnKnockedTileFriction);
@@ -65,6 +66,9 @@ public abstract partial class SharedStunSystem
         SubscribeLocalEvent<CrawlerComponent, KnockedDownRefreshEvent>(OnKnockdownRefresh);
         SubscribeLocalEvent<CrawlerComponent, DamageChangedEvent>(OnDamaged);
         SubscribeLocalEvent<KnockedDownComponent, WeightlessnessChangedEvent>(OnWeightlessnessChanged);
+        SubscribeLocalEvent<KnockedDownComponent, DidEquipHandEvent>(OnHandEquipped);
+        SubscribeLocalEvent<KnockedDownComponent, DidUnequipHandEvent>(OnHandUnequipped);
+        SubscribeLocalEvent<KnockedDownComponent, HandCountChangedEvent>(OnHandCountChanged);
         SubscribeLocalEvent<GravityAffectedComponent, KnockDownAttemptEvent>(OnKnockdownAttempt);
         SubscribeLocalEvent<GravityAffectedComponent, GetStandUpTimeEvent>(OnGetStandUpTime);
 
@@ -365,7 +369,7 @@ public abstract partial class SharedStunSystem
 
     private void OnForceStandup(ForceStandUpEvent msg, EntitySessionEventArgs args)
     {
-        if (args.SenderSession.AttachedEntity is not {} user)
+        if (args.SenderSession.AttachedEntity is not { } user)
             return;
 
         ForceStandUp(user);
@@ -507,6 +511,30 @@ public abstract partial class SharedStunSystem
         RemCompDeferred<KnockedDownComponent>(entity);
     }
 
+    private void OnHandEquipped(Entity<KnockedDownComponent> entity, ref DidEquipHandEvent args)
+    {
+        if (GameTiming.ApplyingState)
+            return; // The result of the change is already networked separately in the same game state
+
+        RefreshKnockedMovement(entity);
+    }
+
+    private void OnHandUnequipped(Entity<KnockedDownComponent> entity, ref DidUnequipHandEvent args)
+    {
+        if (GameTiming.ApplyingState)
+            return; // The result of the change is already networked separately in the same game state
+
+        RefreshKnockedMovement(entity);
+    }
+
+    private void OnHandCountChanged(Entity<KnockedDownComponent> entity, ref HandCountChangedEvent args)
+    {
+        if (GameTiming.ApplyingState)
+            return; // The result of the change is already networked separately in the same game state
+
+        RefreshKnockedMovement(entity);
+    }
+
     private void OnKnockdownAttempt(Entity<GravityAffectedComponent> entity, ref KnockDownAttemptEvent args)
     {
         // Directed, targeted moth attack.
@@ -567,6 +595,7 @@ public abstract partial class SharedStunSystem
 
         ent.Comp.SpeedModifier = ev.SpeedModifier;
         ent.Comp.FrictionModifier = ev.FrictionModifier;
+        Dirty(ent);
 
         _movementSpeedModifier.RefreshMovementSpeedModifiers(ent);
         _movementSpeedModifier.RefreshFrictionModifiers(ent);


### PR DESCRIPTION
Upstream nerf that looks cool

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
https://github.com/space-wizards/space-station-14/pull/41458

Modified that cherry-pick by limiting the max penalty due to lack of free hands to 50%
```c#
var reductionPerHand = 1f / (totalHands + totalHands);
args.SpeedModifier *= (float)Math.Clamp(1f - (totalHands - freeHands) * reductionPerHand, 0.5, 1.0);
```

### Math (This percentage is in addition to the current SpeedModifier)
* 0 free hands out of 1 total hands = (1-(1-0)*.50) = 50% additional reduction to current move speed mod
* 1 free hand out of 2 total hands = (1-(2-1)*.25) = 75%
* 1 free hand out of 4 total hands = (1-(4-1)*.125) = 62.5% 
* 6 free hands out of 10 total hands = (1-(10-6)*0.05) = 80% 



Supersedes #4746

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Upstream neat things.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: ShepardToTheStars, slarticodefast
- tweak: Crawling speed now depends on the number of free hands you have.
