### PR TITLE
Fix Gladiator having wrong headset

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/gladiator.yml
@@ -19,7 +19,7 @@
   id: NyanoGladiatorGear
   equipment:
     id: GladiatorPDA
-    ears: ClothingHeadsetGrey
+    ears: ClothingHeadsetPrison
   #any other possessions, spawn in cell
 
 - type: chameleonOutfit
@@ -27,6 +27,6 @@
   job: Gladiator
   equipment:
     id: GladiatorPDA
-    ears: ClothingHeadsetGrey
+    ears: ClothingHeadsetPrison
     jumpsuit: ClothingUniformJumpsuitGladiator
     outerClothing: ClothingOuterArmorGladiator


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
Allows them to communicate with guards

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- fix: Fixed gladiators now spawn with a prisoner headset
