### PR TITLE
Ditch yamltainer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,10 +9,6 @@
 # Server config files
 /Resources/ConfigPresets/ @Toby222
 
-# YML files
-/Resources/*.yml @DeltaV-Station/yaml-maintainers
-/Resources/**/*.yml @DeltaV-Station/yaml-maintainers
-
 # Sprites - Direction in lack of art director
 /Resources/Textures/ @DeltaV-Station/direction
 


### PR DESCRIPTION
## About the PR
Removes yamltainer from code owners, leaving only normal maintainers

## Why / Balance
Team literally doesn't exist anymore

## Technical details
/

## Media

## Requirements
All github changes are YOLO
~~- [ ] I have tested all added content and changes.~~
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
/