### PR TITLE
Add an option for ore box to dump out ores.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -8,7 +8,7 @@
     price: 500
   - type: Anchorable
   - type: InteractionOutline
-  - type: Dumpable
+  - type: Dumpable #DeltaV
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood

--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -8,6 +8,7 @@
     price: 500
   - type: Anchorable
   - type: InteractionOutline
+  - type: Dumpable
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Wood


### PR DESCRIPTION
## About the PR
Adds the ability to ore box to dump out ores. (alt click default)

## Why / Balance
No more pickng up ores from full box for a minute. Not sure why we didnt have it honestly.

## Technical details
1 line yaml ops once again

## Media
<img width="470" height="442" alt="image" src="https://github.com/user-attachments/assets/6b45b7d3-fdad-47b8-a65d-b6198166c12f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- add: Ore Box can now dump out ores!

