### PR TITLE
Remove BorgMaterial Tag

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/parts.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/parts.yml
@@ -74,10 +74,6 @@
   - type: GuideHelp
     guides:
     - ExpandingRepairingStation
-  - type: Tag # DeltaV
-    tags:
-    # no RodMetal 1 because ???
-    - BorgMaterial
 
 - type: entity
   parent: PartRodMetal

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -52,9 +52,6 @@
   id: BorgSecurityArmour
 
 - type: Tag
-  id: BorgMaterial # for materials that can be used in a borg construction module
-
-- type: Tag
   id: BorgStockPart
 
 - type: Tag


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removed a Tag for Borgs.

## Why / Balance
Idk Toby asked me to do this.
Apparently lets borgs grab rods?

## Technical details
7 removed line yaml ops

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
No idea

**Changelog**

:cl:
- fix: Borgs can pick up metal rods!

