### PR TITLE
Cardboard Box Weightless Fix (#40260)

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -55,6 +55,7 @@
       node: basebigbox
       containers:
         - entity_storage
+    - type: GravityAffected
 
 - type: entity
   id: StealthBox


### PR DESCRIPTION
## About the PR
Box is no longer space faring
Cherry-pick of https://github.com/space-wizards/space-station-14/pull/40260
Fixes https://github.com/DeltaV-Station/Delta-v/issues/4791

## Why / Balance
Bugfix

## Technical details
Adds GravityAffected to cardboard box parent

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Has anyone ever filled this on dV?

**Changelog**
:cl:
- fix: Cardboard boxes are now affected by gravity