### PR TITLE
Add missing tag to GasPipeHalf to make flintlock craftable

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -114,6 +114,10 @@
     guides:
     - Pipes
     - PipeNetworks
+  - type: Tag
+    tags:
+    - Pipe
+    - GasPipeHalf
 
 - type: entity
   parent: GasPipeBase


### PR DESCRIPTION
## About the PR
Add missing tag to GasPipeHalf to make flintlock craftable
Fixes https://github.com/DeltaV-Station/Delta-v/issues/4756

## Why / Balance
to make flintlock craftable

## Technical details
Add missing tag to GasPipeHalf

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
n/A

**Changelog**
:cl:
- fix: Flintlock is now craftable as intended