### PR TITLE
Global Mid/Highpop Detective Increases

### DIFF
--- a/Resources/Maps/terra.yml
+++ b/Resources/Maps/terra.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 11/28/2025 22:56:24
-  entityCount: 28493
+  time: 11/24/2025 23:01:07
+  entityCount: 28491
 maps:
 - 1
 grids:
@@ -83883,13 +83883,6 @@ entities:
     - type: Transform
       pos: -54.866085,-10.217259
       parent: 2
-- proto: ForensicScanner
-  entities:
-  - uid: 28492
-    components:
-    - type: Transform
-      pos: -61.472694,-16.653166
-      parent: 2
 - proto: ForkPlastic
   entities:
   - uid: 12914
@@ -127180,13 +127173,6 @@ entities:
     components:
     - type: Transform
       pos: -11.67022,-62.76212
-      parent: 2
-- proto: LogProbeCartridge
-  entities:
-  - uid: 28493
-    components:
-    - type: Transform
-      pos: -61.369255,-14.887237
       parent: 2
 - proto: LootSpawnerMaterials
   entities:

--- a/Resources/Maps/terra.yml
+++ b/Resources/Maps/terra.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 11/24/2025 23:01:07
-  entityCount: 28491
+  time: 11/28/2025 22:56:24
+  entityCount: 28493
 maps:
 - 1
 grids:
@@ -83883,6 +83883,13 @@ entities:
     - type: Transform
       pos: -54.866085,-10.217259
       parent: 2
+- proto: ForensicScanner
+  entities:
+  - uid: 28492
+    components:
+    - type: Transform
+      pos: -61.472694,-16.653166
+      parent: 2
 - proto: ForkPlastic
   entities:
   - uid: 12914
@@ -127173,6 +127180,13 @@ entities:
     components:
     - type: Transform
       pos: -11.67022,-62.76212
+      parent: 2
+- proto: LogProbeCartridge
+  entities:
+  - uid: 28493
+    components:
+    - type: Transform
+      pos: -61.369255,-14.887237
       parent: 2
 - proto: LootSpawnerMaterials
   entities:

--- a/Resources/Prototypes/Maps/academy.yml
+++ b/Resources/Prototypes/Maps/academy.yml
@@ -43,7 +43,7 @@
           Surgeon: [ 1, 2 ]
           #security
           Brigmedic: [ 1, 1 ]
-          Detective: [ 1, 1 ]
+          Detective: [ 2, 2 ]
           HeadOfSecurity: [ 1, 1 ]
           Prisoner: [ 2, 2 ]
           PrisonGuard: [ 1, 1 ]

--- a/Resources/Prototypes/Maps/elegance.yml
+++ b/Resources/Prototypes/Maps/elegance.yml
@@ -48,7 +48,7 @@
             Surgeon: [ 1, 1]
           #security
             Brigmedic: [ 1, 1 ]
-            Detective: [ 1, 1 ]
+            Detective: [ 2, 2 ]
             Prisoner: [ 3, 4 ]
             PrisonGuard: [ 1, 2 ]
             SecurityOfficer: [ 4, 6 ]

--- a/Resources/Prototypes/Maps/hammurabi.yml
+++ b/Resources/Prototypes/Maps/hammurabi.yml
@@ -41,7 +41,7 @@
             Psychologist: [ 1, 1 ]
           #security
             Brigmedic: [ 1, 1 ]
-            Detective: [ 1, 1 ]
+            Detective: [ 2, 2 ]
             HeadOfSecurity: [ 1, 1 ]
             Prisoner: [ 4, 6 ] # move back to 10, 12 when ready
             PrisonGuard: [ 4, 6 ] # someday a 2:1 ratio of prisoner:guard is preferred

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -38,7 +38,7 @@
             Surgeon: [ 1, 2 ]
           #security
             Brigmedic: [ 2, 2 ]
-            Detective: [ 2, 2 ]
+            Detective: [ 3, 2 ]
             HeadOfSecurity: [ 1, 1 ]
             Prisoner: [ 2, 4 ]
             PrisonGuard: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -38,7 +38,7 @@
             Surgeon: [ 1, 2 ]
           #security
             Brigmedic: [ 2, 2 ]
-            Detective: [ 3, 3 ]
+            Detective: [ 3, 2 ]
             HeadOfSecurity: [ 1, 1 ]
             Prisoner: [ 2, 4 ]
             PrisonGuard: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/submarine.yml
+++ b/Resources/Prototypes/Maps/submarine.yml
@@ -38,7 +38,7 @@
             Surgeon: [ 1, 2 ]
           #security
             Brigmedic: [ 2, 2 ]
-            Detective: [ 3, 2 ]
+            Detective: [ 3, 3 ]
             HeadOfSecurity: [ 1, 1 ]
             Prisoner: [ 2, 4 ]
             PrisonGuard: [ 1, 2 ]

--- a/Resources/Prototypes/Maps/terra.yml
+++ b/Resources/Prototypes/Maps/terra.yml
@@ -43,7 +43,7 @@
             Surgeon: [ 1, 1 ]
           #security
             Brigmedic: [ 1, 1 ]
-            Detective: [ 1, 1 ]
+            Detective: [ 2, 2 ]
             Gladiator: [ 2, 2 ]
             HeadOfSecurity: [ 1, 1 ]
             Prisoner: [ 2, 3 ]

--- a/Resources/Prototypes/Maps/tortuga.yml
+++ b/Resources/Prototypes/Maps/tortuga.yml
@@ -44,7 +44,7 @@
             Surgeon: [ 1, 2 ]
           #security
             Brigmedic: [ 1, 1 ]
-            Detective: [ 1, 1 ]
+            Detective: [ 2, 2 ]
             HeadOfSecurity: [ 1, 1 ]
             Prisoner: [ 2, 3 ]
             PrisonGuard: [ 1, 1 ]


### PR DESCRIPTION
## About the PR
Increases Detective slots to:
Academy: 2
Elegance: 2
Hammu: 2
Terra: 2
Tortuga: 2
Submarine: 3

Places a Scanner / Seperate locker depending on sizes for each map, details below

## This comes Pre-approved from direction
## Why / Balance
playing on 60+ pop with one detective is horrid. Although sometimes they dont have enough to do, traitor rounds are abhorent with one Det. QOL changes mostly. This balances because this accelerates how fast dets can do things, since theres two of them

## Map details
Mapping changes have been removed from the PR.

## Media
None 

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Increased Detective slots on Mid/High pop maps to 2+

