### PR TITLE
Added double-tapping stand-up bind to push yourself up.

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -231,7 +231,14 @@ public abstract partial class SharedStunSystem
         if (playerSession.AttachedEntity is not { Valid: true } playerEnt || !Exists(playerEnt))
             return;
 
-        ToggleKnockdown(playerEnt);
+        // DeltaV - Double-tap Standup bind forces standup (unless hands full)
+        if (_standingState.IsDown(playerEnt)
+            && TryComp<KnockedDownComponent>(playerEnt, out var knockedDown)
+            && knockedDown.DoAfterId != null)
+            ForceStandUp(playerEnt);
+        else
+            ToggleKnockdown(playerEnt);
+        // END DeltaV
     }
 
     /// <summary>

--- a/Resources/Locale/en-US/stunnable/components/stunnable-component.ftl
+++ b/Resources/Locale/en-US/stunnable/components/stunnable-component.ftl
@@ -1,6 +1,7 @@
 stunnable-component-disarm-success-others = {CAPITALIZE(THE($source))} pushes {THE($target)}!
 stunnable-component-disarm-success = You push {THE($target)}!
 knockdown-component-pushup-failure = You're too exhausted to push yourself up!
-knockdown-component-pushup-success = With a burst of energy you push yourself up!
+# DeltaV - Added a bit about needing a free hand.
+knockdown-component-pushup-success = With a burst of energy, you push yourself up with one of your free hands!
 knockdown-component-stand-no-room = You try to push yourself to stand up but there's not enough room!
 worm-component-stand-attempt = You try to stand up but you cannot!


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
If you are trying to get up from crawling or being knocked down, if you have a free hand and press your stand-up again, it will get you up quicker at the cost of stamina.

This is not a new mechanic. You can already double-click the Downed icon on the side, or shove yourself while down to do this, but this makes it a bit more accessible to push yourself up at the cost of stamina.

Supersedes part of https://github.com/DeltaV-Station/Delta-v/pull/4746
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just an extra bind for this feature. Feels more fluid imo.

## Technical details
<!-- Summary of code changes for easier review. -->
None really. I just check if we're down, and already in the middle of trying to stand up, and if we are, do a call to `ForceStand`.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/13ce5dfc-7e13-4358-a41b-b67fdc373bd6

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: While trying to stand-up, you can now press your Toggle Crawling keybind to get up faster at the cost of stamina. Of course, you still still need a free hand to do this.

