### PR TITLE
Command Turret Notification Alert

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
@@ -184,6 +184,7 @@
   components:
   - type: AccessReader
     access: [["StationAi"], ["Command"]]
+  - type: StationAiTurret #DeltaV
   - type: TurretTargetSettings
     exemptAccessLevels:
     - Command


### PR DESCRIPTION
## About the PR
Fix notifications not being on the command turrets

## Why / Balance
Because most maps use the command turrets so the ai can choose who they dont shoot right away but that does not give the notification of the turrets defending the ai core

Note: i wanted to make one for sec turrets but i would need to change so many files to make its own alert so the ai knows its not there core that's under attack 

## Technical details


## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**

:cl:
- fix: Now normal command turrets alert the AI to an intruder