### PR TITLE
CMO Hardsuit Buff

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -435,12 +435,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Caustic: 0.3 #DeltaV (was 0.1)
         Blunt: 0.70 #DeltaV
         Slash: 0.70 #DeltaV
         Piercing: 0.85 #DeltaV
         Heat: 0.80 #DeltaV
         Radiation: 0.80 #DeltaV
+        Caustic: 0.3 #DeltaV (was 0.1)
   - type: ExplosionResistance #DeltaV
     damageCoefficient: 0.80 #deltaV
   - type: ZombificationResistance

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -435,9 +435,16 @@
   - type: Armor
     modifiers:
       coefficients:
-        Caustic: 0.1
+        Caustic: 0.3 #DeltaV (was 0.1)
+        Blunt: 0.70 #DeltaV
+        Slash: 0.70 #DeltaV
+        Piercing: 0.85 #DeltaV
+        Heat: 0.80 #DeltaV
+        Radiation: 0.80 #DeltaV
+  - type: ExplosionResistance #DeltaV
+    damageCoefficient: 0.80 #deltaV
   - type: ZombificationResistance
-    zombificationResistanceCoefficient: 0.4
+    zombificationResistanceCoefficient: 0.2 #DeltaV (was 0.4)
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95


### PR DESCRIPTION
## About the PR
Fix cmo suit so its not the worst suit in the game

## Why / Balance
Cmo suit only protected from caustic and infection that being only one good thing the infection (no one uses caustic damige) but even then the infection is only 60% for a suit that should be more 

## Technical details
caustic is 70% (lowered from 90%)
blunt 30% (why medbay fights with unruly patients)
slash 30% (why medbay fights with unruly patients)
piercing 15% 
heat 20% (dont know if i should increase more since caustic and heat are under the same damage type) 
rads 20% (should be fine maybe)
explosion 20% (almost all suits have this and so cmo is not intsa gibbed by any bomb)
infection resistance 80% (cmo should have more then only 60% for a bio suit)

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- tweak: Made cmo hardsuit better
