### PR TITLE
Remove possession charges stacking

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -101,7 +101,7 @@ A list of such Substances follow:
 == Controlled Armaments ==
 
 
-Controlled Armaments are grouped into categories of increasing severity. If the offender possesses several categories of armaments, only the highest severity of said items should be charged.
+Controlled Armaments are grouped into categories of increasing severity. If the offender possesses several categories of contraband, only the highest severity of said items should be charged.
 
 '''Category A:''' ''Illegal possession of Cat. A controlled armaments may incur a sentence of up to 5min brig and further legal action as the situation demands.''
 

--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -101,27 +101,27 @@ A list of such Substances follow:
 == Controlled Armaments ==
 
 
-Controlled Armaments are grouped into categories of increasing severity.
+Controlled Armaments are grouped into categories of increasing severity. If the offender possesses several categories of armaments, only the highest severity of said items should be charged.
 
-'''Category A:''' ''Illegal possession of Cat. A controlled armaments may incur a sentence of up to 5min brig for each separate and distinct item, confiscation of the offending item(s), and further legal action as the situation demands.''
+'''Category A:''' ''Illegal possession of Cat. A controlled armaments may incur a sentence of up to 5min brig and further legal action as the situation demands.''
 
 * Any object or instrument specifically designed, adapted, or used to cause physical harm in close combat
 * Any object or equipment specifically designed or adapted to protect against physical harm caused by weapons, projectiles, or other forms of direct assault
 * Any object or instrument specifically designed or adapted to incapacitate or disorient by using light or sound without causing permanent injury
 * Any object or equipment specifically designed or adapted for explicitly training purposes that would otherwise fall under another category
 
-'''Category B:''' ''Illegal possession of Cat. B controlled armaments may incur a sentence of up to 10min brig for each separate and distinct item, confiscation of the offending item(s), and further legal action as the situation demands.''
+'''Category B:''' ''Illegal possession of Cat. B controlled armaments may incur a sentence of up to 10min brig and further legal action as the situation demands.''
 
 * Any object or instrument specifically designed or adapted to cause physical harm in close combat, which employs a powered system to enhance performance
 * Any manually-operated ballistic arms that possess an internal magazine or feeding system, or lack an internal magazine or feeding system altogether
 
-'''Category C:''' ''Illegal possession of Cat. C controlled armaments may incur a sentence of up to 15min brig for each separate and distinct item, confiscation of the offending item(s), and further legal action as the situation demands.''
+'''Category C:''' ''Illegal possession of Cat. C controlled armaments may incur a sentence of up to 15min brig and further legal action as the situation demands.''
 
 * Any manually-operated ballistic arms that use an external magazine or feeding system
 * Any semi-automatic ballistic arms not easily concealable within a pocket or coat
 * Any object or instrument specifically designed or adapted for explicitly less-lethal purposes that would otherwise fall under another category
 
-'''Category D:''' ''Illegal possession of Cat. D controlled armaments may incur a sentence of up to 20min brig for each separate and distinct item, confiscation of the offending item(s), and further legal action as the situation demands.''
+'''Category D:''' ''Illegal possession of Cat. D controlled armaments may incur a sentence of up to 20min brig and further legal action as the situation demands.''
 
 * Any semi-automatic ballistic arms that are easily concealable
 * Any fully-automatic ballistic arms
@@ -129,7 +129,7 @@ Controlled Armaments are grouped into categories of increasing severity.
 * Any object or device specifically designed or adapted to cause physical harm through detonation of an explosive charge
 * Any object or equipment specifically designed or adapted to protect against both a space environment and physical harm caused by weapons, projectiles, or other forms of direct assault
 
-'''Category E:''' ''Illegal possession of Cat. E controlled armaments may incur a sentence of up to 25min brig for each separate and distinct item, confiscation of the offending item(s), and further legal action as the situation demands.''
+'''Category E:''' ''Illegal possession of Cat. E controlled armaments may incur a sentence of up to 25min brig and further legal action as the situation demands.''
 
 * Any crew-served or emplaced weapon
 * Any object or instrument specifically designed or adapted to launch large-calibre explosives or projectiles for offensive or defensive purposes


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Tweaked SOP and removed the lines of "each seperate and distinct item..." in armaments. Instead, if you have a knife, a musket and an assault rifle, you only get charged with possession category D.

I'm really not a law person, so I may accidentally written in a loophole, so double checking is needed.

## Why / Balance
>be a secoff
>30 mins in and walk into a thief breaking into CMOs room
>arrest them
>their bag had their thief loadout stuff, practically about 5 possession charges
>instantly perma them
>gg for the thief, better become valid to extract or go cryo, or wait for a hearing (good luck)

## Technical details
wiki code changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: Possession charges no longer stack. The highest offending category is now charged.

