### PR TITLE
psychokinetic scream LogPowerUsed

### DIFF
--- a/Content.Server/_DV/Abilities/Psionics/PsychokineticScreamPowerSystem.cs
+++ b/Content.Server/_DV/Abilities/Psionics/PsychokineticScreamPowerSystem.cs
@@ -11,6 +11,7 @@ public sealed partial class PsychokineticScreamPowerSystem : EntitySystem
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly ShatterLightsAbilitySystem _shatterLights = default!;
+    [Dependency] private readonly SharedPsionicAbilitiesSystem _psionics = default!;
 
     public override void Initialize()
     {
@@ -53,6 +54,8 @@ public sealed partial class PsychokineticScreamPowerSystem : EntitySystem
         _shatterLights.ShatterLightsAround(entity.Owner, entity.Comp.Radius, entity.Comp.LineOfSight);
 
         SpawnAttachedTo(entity.Comp.Effect, entity.Owner.ToCoordinates());
+
+        _psionics.LogPowerUsed(entity.Owner, "psychokinetic scream", 3, 6);
 
         args.Handled = true;
     }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Psychokinetic scream fixes:
- now adds glimmer like all the other powers do
- now mantis sees a popup when used nearby, like all other powers
- now works with xenoarch "psionic disturbance" artifact trigger

Skia ability was left untouched - I tested that it still worked.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Not having these elements was an oversight, I think. I briefly looked over the skia PR's; doesn't seem like this was intentional.

## Technical details
<!-- Summary of code changes for easier review. -->

LogPowerUsed is what all the power systems call -- does an admin log, increases glimmer, and does the "power used" event for metapsionics and artifacts

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

<img width="634" height="307" alt="image" src="https://github.com/user-attachments/assets/847cbdaa-7c42-44dd-8ee1-bc39e722cc7c" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: psychokinetic scream now works with "psionic disturbance" arti trigger

