### PR TITLE
xenoarch: early merge radiation trigger fix

### DIFF
--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -51,9 +51,9 @@ public sealed partial class RadiationSystem : EntitySystem
         _accumulator = 0f;
     }
 
-    public void IrradiateEntity(EntityUid uid, float radsPerSecond, float time)
+    public void IrradiateEntity(EntityUid uid, float radsPerSecond, float time, EntityUid? origin = null)
     {
-        var msg = new OnIrradiatedEvent(time, radsPerSecond, uid);
+        var msg = new OnIrradiatedEvent(time, radsPerSecond, origin);
         RaiseLocalEvent(uid, msg);
     }
 

--- a/Content.Shared/Radiation/Events/OnIrradiatedEvent.cs
+++ b/Content.Shared/Radiation/Events/OnIrradiatedEvent.cs
@@ -4,13 +4,13 @@ namespace Content.Shared.Radiation.Events;
 ///     Raised on entity when it was irradiated
 ///     by some radiation source.
 /// </summary>
-public readonly record struct OnIrradiatedEvent(float FrameTime, float RadsPerSecond, EntityUid Origin)
+public readonly record struct OnIrradiatedEvent(float FrameTime, float RadsPerSecond, EntityUid? Origin)
 {
     public readonly float FrameTime = FrameTime;
 
     public readonly float RadsPerSecond = RadsPerSecond;
 
-    public readonly EntityUid Origin = Origin;
+    public readonly EntityUid? Origin = Origin;
 
     public float TotalRads => RadsPerSecond * FrameTime;
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Proposing that we early-merge this upstream PR (instead of waiting for the October merge).

This PR allows artifacts with the "Radiation" trigger to be triggered by ambient radiation sources, such as the singulo, a breached RTG, another irradiated artifact, an experimental anomaly vessel or any other source.

https://github.com/space-wizards/space-station-14/pull/41065 "Fix radiation damage being misattributed to radiation receiver (caused artifacts to not be triggered by ambient rads)"

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

People have been unhappy with new xenoarch system lately; I think improving some of these weird triggers and effects would help. Better sooner than later, since people have been asking to revert the whole system: https://github.com/DeltaV-Station/Delta-v/pull/4640

Currently the only way to do the "Radiation" trigger is stabbing the arti with a uranium spear, which is kinda lame.

## Technical details
<!-- Summary of code changes for easier review. -->

cherry picked commit `dd9a1de77ffc68e26d097e4671aa269d4d56e724`

It removes the "attacker" entity value of ambient radiation damage (it doesn't make sense to attribute the damage to a single source entity, because the damage is an aggregate of all sources on the map). Previously it was attributing all the damage to the radiation *victim* (self-damage...), which was the cause of the arti trigger bug.

Did some searching of the related classes/methods; I don't see any additional DeltaV-specific stuff we need to change.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

Radiation can take a moment to accumulate (depending on the `rads` count):

https://github.com/user-attachments/assets/74903295-1943-4a9c-b89d-27266ea6972b


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: TheGrimbeeper
- fix: Artifacts can now be triggered by ambient radiation, not just uranium spears

