### PR TITLE
Rat lungs don't scale by quantity of miasma

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -259,7 +259,7 @@
         - !type:ReagentThreshold
           reagent: Ammonia
           min: 1
-        scaleByQuantity: true
+        scaleByQuantity: false # DeltaV - Nerf rat lungs, upstream doesn't have shitmed
         ignoreResistances: true
         damage:
           groups:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Changed scaleByQuantity to false to nerf rat lungs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Upstream doesn't have shitmed, and implanting rat lungs and having a tank of Miasma makes you invincible.

## Technical details
<!-- Summary of code changes for easier review. -->
one-line

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Healing from breathing miasma with rat lungs no longer scales by quantity of the gas in the air.