### PR TITLE
Trait typofixes

### DIFF
--- a/Resources/Locale/en-US/_DV/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DV/traits/traits.ftl
@@ -8,7 +8,7 @@ trait-spanish-accent-name = Spanish accent
 trait-spanish-accent-desc = Your Espanish traditions shine through, get those espesos!
 
 trait-mobster-accent-name = Mobster accent
-trait-mobster-accent-desc = Fugeddaboutit! Yous talk numhallly, capiche?
+trait-mobster-accent-desc = Fugeddaboutit! Yous talk numhally, capiche?
 
 trait-irish-accent-name = Irish accent
 trait-irish-accent-desc = Ya sap! Seems you got a pet hate fer rubbish!

--- a/Resources/Locale/en-US/_DV/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DV/traits/traits.ftl
@@ -1,11 +1,11 @@
-trait-scottish-accent-name = Scottish Accent
+trait-scottish-accent-name = Scottish accent
 trait-scottish-accent-desc = Fer tha folk who come frae Hielan clan.
 
 trait-french-accent-name = French accent
-trait-french-accent-desc = 'Ze winds are changing, and you 'ave a strong desire for wine and baguettes
+trait-french-accent-desc = 'Ze winds are changing, and you 'ave a strong desire for wine and baguettes.
 
 trait-spanish-accent-name = Spanish accent
-trait-spanish-accent-desc = Your Epanish traditions shine through, get those espesos!
+trait-spanish-accent-desc = Your Espanish traditions shine through, get those espesos!
 
 trait-mobster-accent-name = Mobster accent
 trait-mobster-accent-desc = Fugeddaboutit! Yous talk numhallly, capiche?
@@ -13,7 +13,7 @@ trait-mobster-accent-desc = Fugeddaboutit! Yous talk numhallly, capiche?
 trait-irish-accent-name = Irish accent
 trait-irish-accent-desc = Ya sap! Seems you got a pet hate fer rubbish!
 
-trait-ultravision-name = Ultraviolet Vision
+trait-ultravision-name = Ultraviolet vision
 trait-ultravision-desc = Whether through custom bionic eyes, random mutation,
                          or being a Harpy, you perceive the world with ultraviolet light.
 
@@ -25,7 +25,7 @@ trait-hushed-name = Hushed
 trait-hushed-desc = You are unable to speak louder than a whisper.
 
 trait-uncloneable-name = Uncloneable
-trait-uncloneable-desc = Cannot be cloned
+trait-uncloneable-desc = You cannot be cloned.
 
 trait-inpain-name = Chronic pain
 trait-inpain-desc = You’re constantly in discomfort. You need painkillers to function.
@@ -33,7 +33,7 @@ trait-inpain-desc = You’re constantly in discomfort. You need painkillers to f
 trait-addicted-name = Addicted
 trait-addicted-desc = You crave the substance, and your thoughts keep drifting back to it. Without it, you feel incomplete, anxious, and on edge.
 
-trait-unborgable-name = Machine Incompatible
+trait-unborgable-name = Machine incompatible
 trait-unborgable-desc = Your brain cannot be put into a man-machine interface.
 
 trait-depression-name = Depression


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
1. For names: Lowercases the start of every word but the first one. Upstream consistency in naming (except for the one Impaired Mobility trait thats upstream... that one is Capitalized Like This, but it's the only one upstream that does it so whatever)
2. Changes "Epanish" to "Espanish" because that didn't look right
3. Removes apparent extra L from "numhallly" in the Mobster accent. I have no clue if this is correct but I don't know any words that have three Ls
4. Adds a period at the end of the French accent+Uncloneable description
5. Rephrases the uncloneable trait for consistency

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->