### PR TITLE
Remove nukie commander whitelist

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -48,7 +48,6 @@
   - !type:DepartmentTimeRequirement # DeltaV - Command dept time requirement
     department: Command
     time: 36000 # DeltaV - 10 hours
-  - !type:WhitelistRequirement # DeltaV - Whitelist requirement
   # should be changed to nukie playtime when thats tracked (wyci)
 
 - type: startingGear


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Title

## Why / Balance
Theres been a lot of talk about it. From what i read in a community feedback thread I've been convinced that this will benefit the server. TLDR is that our nukie commanders do the same stuff over and over again and making the role more accessible will help change that

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:

- remove: Removed the whitelist requirement from Nuclear Operative Commander
