### PR TITLE
Make pride clothing be able to chameleon into similar pieces of pride clothing

### DIFF
--- a/Content.Client/Clothing/UI/ChameleonBoundUserInterface.cs
+++ b/Content.Client/Clothing/UI/ChameleonBoundUserInterface.cs
@@ -58,6 +58,13 @@ public sealed class ChameleonBoundUserInterface : BoundUserInterface
         {
             _menu?.UpdateState(targets, st.SelectedId);
         }
+
+    // Begin Delta-V: Override for the name of the chameleon stuff, so you can have items use the chameleon system without being illegal.
+    if (_menu is { } menu && EntMan.TryGetComponent<ChameleonClothingComponent>(Owner, out var chameleon) && chameleon.WindowTitleOverride is { } titleOverride)
+        {
+            _menu.Title = Loc.GetString(titleOverride);
+        }
+    // End Delta-V
     }
 
     private void OnIdSelected(string selectedId)

--- a/Content.Shared/Clothing/Components/ChameleonClothingComponent.cs
+++ b/Content.Shared/Clothing/Components/ChameleonClothingComponent.cs
@@ -65,6 +65,18 @@ public sealed partial class ChameleonClothingComponent : Component
     /// </summary>
     [AutoPausedField, DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
     public TimeSpan NextEmpChange = TimeSpan.Zero;
+
+    /// <summary>
+    ///     Delta-V: Override for the name of the chameleon stuff, so you can have items use the chameleon system without being illegal.
+    /// </summary>
+    [DataField]
+    public LocId? WindowTitleOverride;
+
+    /// <summary>
+    ///     Delta-V: Override for the name of the chameleon stuff, so you can have items use the chameleon system without being illegal.
+    /// </summary>
+    [DataField]
+    public LocId? VerbNameOverride;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/SharedChameleonClothingSystem.cs
@@ -132,7 +132,7 @@ public abstract class SharedChameleonClothingSystem : EntitySystem
 
         args.Verbs.Add(new InteractionVerb()
         {
-            Text = Loc.GetString("chameleon-component-verb-text"),
+            Text = Loc.GetString(ent.Comp.VerbNameOverride ?? "chameleon-component-verb-text"), // Delta-V: Override for the name of the Chameleon Verb
             Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/settings.svg.192dpi.png")),
             Act = () => UI.TryToggleUi(ent.Owner, ChameleonUiKey.Key, user)
         });

--- a/Resources/Locale/en-US/_DV/clothing/chameleon-clothing.ftl
+++ b/Resources/Locale/en-US/_DV/clothing/chameleon-clothing.ftl
@@ -1,0 +1,3 @@
+change-pin-face = Change Pin Face
+change-scarf-pattern = Change Scarf Pattern
+change-cloak-pattern = Change Cloak Pattern

--- a/Resources/Locale/en-US/_DV/clothing/chameleon-pin.ftl
+++ b/Resources/Locale/en-US/_DV/clothing/chameleon-pin.ftl
@@ -1,1 +1,0 @@
-change-pin-face = Change pin face

--- a/Resources/Locale/en-US/_DV/clothing/chameleon-pin.ftl
+++ b/Resources/Locale/en-US/_DV/clothing/chameleon-pin.ftl
@@ -1,0 +1,1 @@
+change-pin-face = Change pin face

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -211,7 +211,7 @@
     proto: alien
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakAce
   name: pilot's cloak
   description: Cloak awarded to Nanotrasen's finest space aces.
@@ -222,7 +222,7 @@
     default: ClothingNeckCloakAce # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakAro
   name: werewolf cloak
   description: This cloak lets others know you're a lone wolf.
@@ -233,7 +233,7 @@
     default: ClothingNeckCloakAro # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakAroace
   name: aeropilot's cloak # thank you happyman442 this was the best name idea ever
   description: Cloak awarded to Nanotrasen's finest pilots on planets with inhabitable atmospheres.
@@ -244,7 +244,7 @@
     default: ClothingNeckCloakAroace # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakBi
   name: poison cloak
   description: The purple color is a clear indicator you are poisonous.
@@ -255,7 +255,7 @@
     default: ClothingNeckCloakBi # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakIntersex
   name: cyclops cloak
   description: The circle on this cloak represents a cyclops' eye.
@@ -266,7 +266,7 @@
     default: ClothingNeckCloakIntersex # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakLesbian
   name: poet cloak
   description: This cloak belonged to an ancient poet, you forgot which one.
@@ -277,7 +277,7 @@
     default: ClothingNeckCloakLesbian # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakGay
   name: multi-level marketing cloak
   description: This cloak is highly sought after in the Nanotrasen Marketing Offices.
@@ -288,7 +288,7 @@
     default: ClothingNeckCloakGay # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakEnby
   name: treasure hunter cloak
   description: This cloak belonged to a greedy treasure hunter.
@@ -299,7 +299,7 @@
     default: ClothingNeckCloakEnby # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingGenderCloakBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakPan
   name: chef's cloak
   description: Meant to be worn alongside a frying pan.

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -136,13 +136,15 @@
     sprite: Clothing/Neck/Cloaks/miner.rsi
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckCloakTrans
   name: vampire cloak
   description: Worn by high ranking vampires of the transylvanian society of vampires.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/trans.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakTrans # DeltaV - Chameleon pride clothing
 
 - type: entity
   parent: ClothingNeckBase
@@ -209,83 +211,101 @@
     proto: alien
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakAce
   name: pilot's cloak
   description: Cloak awarded to Nanotrasen's finest space aces.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/ace.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakAce # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakAro
   name: werewolf cloak
   description: This cloak lets others know you're a lone wolf.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/aro.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakAro # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakAroace
   name: aeropilot's cloak # thank you happyman442 this was the best name idea ever
   description: Cloak awarded to Nanotrasen's finest pilots on planets with inhabitable atmospheres.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/aroace.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakAroace # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakBi
   name: poison cloak
   description: The purple color is a clear indicator you are poisonous.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/bi.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakBi # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakIntersex
   name: cyclops cloak
   description: The circle on this cloak represents a cyclops' eye.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/intersex.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakIntersex # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakLesbian
   name: poet cloak
   description: This cloak belonged to an ancient poet, you forgot which one.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/les.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakLesbian # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakGay
   name: multi-level marketing cloak
   description: This cloak is highly sought after in the Nanotrasen Marketing Offices.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/gay.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakGay # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakEnby
   name: treasure hunter cloak
   description: This cloak belonged to a greedy treasure hunter.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/enby.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakEnby # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingNeckBase
+  parent: ClothingGenderCloakBase
   id: ClothingNeckCloakPan
   name: chef's cloak
   description: Meant to be worn alongside a frying pan.
   components:
   - type: Sprite
     sprite: Clothing/Neck/Cloaks/pan.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckCloakPan # DeltaV - Chameleon pride clothing
 

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -21,6 +21,7 @@
     slot: Neck
 #    default: ClothingNeckLGBTPin
     requireTag: GenderPin
+    affectedByEmp: false
   - type: UserInterface
     interfaces:
       enum.ChameleonUiKey.Key:

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -14,6 +14,25 @@
 
 - type: entity
   parent: ClothingNeckPinBase
+  id: ClothingGenderPinBase
+  abstract: true
+  components:
+  - type: ChameleonClothing
+    slot: Neck
+#    default: ClothingNeckLGBTPin
+    requireTag: GenderPin
+  - type: UserInterface
+    interfaces:
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
+  - type: Tag
+    tags:
+    - ClothMade #idk man its on the parent
+    - WhitelistChameleon
+    - GenderPin
+
+- type: entity
+  parent: ClothingGenderPinBase
   id: ClothingNeckLGBTPin
   name: LGBT pin
   description: Be gay do crime.
@@ -22,9 +41,11 @@
     state: lgbt
   - type: Clothing
     equippedPrefix: lgbt
+  - type: ChameleonClothing
+    default: ClothingNeckLGBTPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckAllyPin
   name: straight ally pin
   description: Be ally do crime.
@@ -33,9 +54,11 @@
     state: ally
   - type: Clothing
     equippedPrefix: ally
+  - type: ChameleonClothing
+    default: ClothingNeckAllyPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckAromanticPin
   name: aromantic pin
   description: Be aro do crime.
@@ -44,9 +67,11 @@
     state: aro
   - type: Clothing
     equippedPrefix: aro
+  - type: ChameleonClothing
+    default: ClothingNeckAromanticPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckAroacePin
   name: aroace pin
   description: Be aroace do crime.
@@ -55,9 +80,11 @@
     state: aroace
   - type: Clothing
     equippedPrefix: aroace
+  - type: ChameleonClothing
+    default: ClothingNeckAroacePin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckAsexualPin
   name: asexual pin
   description: Be ace do crime.
@@ -66,9 +93,11 @@
     state: asex
   - type: Clothing
     equippedPrefix: asex
+  - type: ChameleonClothing
+    default: ClothingNeckAsexualPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckBisexualPin
   name: bisexual pin
   description: Be bi do crime.
@@ -77,9 +106,11 @@
     state: bi
   - type: Clothing
     equippedPrefix: bi
+  - type: ChameleonClothing
+    default: ClothingNeckBisexualPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckGayPin
   name: gay pin
   description: Be gay~ do crime.
@@ -88,9 +119,11 @@
     state: gay
   - type: Clothing
     equippedPrefix: gay
+  - type: ChameleonClothing
+    default: ClothingNeckGayPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckIntersexPin
   name: intersex pin
   description: Be intersex do crime.
@@ -99,9 +132,11 @@
     state: inter
   - type: Clothing
     equippedPrefix: inter
+  - type: ChameleonClothing
+    default: ClothingNeckIntersexPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckLesbianPin
   name: lesbian pin
   description: Be lesbian do crime.
@@ -110,9 +145,11 @@
     state: les
   - type: Clothing
     equippedPrefix: les
+  - type: ChameleonClothing
+    default: ClothingNeckLesbianPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckNonBinaryPin
   name: non-binary pin
   description: "01100010 01100101 00100000 01100101 01101110 01100010 01111001 00100000 01100100 01101111 00100000 01100011 01110010 01101001 01101101 01100101"
@@ -121,9 +158,11 @@
     state: non
   - type: Clothing
     equippedPrefix: non
+  - type: ChameleonClothing
+    default: ClothingNeckNonBinaryPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckPansexualPin
   name: pansexual pin
   description: Be pan do crime.
@@ -132,9 +171,11 @@
     state: pan
   - type: Clothing
     equippedPrefix: pan
+  - type: ChameleonClothing
+    default: ClothingNeckPansexualPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckPluralPin
   name: plural pin
   description: Be plural, do crimes.
@@ -143,9 +184,11 @@
     state: plural
   - type: Clothing
     equippedPrefix: plural
+  - type: ChameleonClothing
+    default: ClothingNeckPluralPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckOmnisexualPin
   name: omnisexual pin
   description: Be omni do crime.
@@ -154,9 +197,11 @@
     state: omni
   - type: Clothing
     equippedPrefix: omni
+  - type: ChameleonClothing
+    default: ClothingNeckOmnisexualPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckGenderqueerPin
   name: genderqueer pin
   description: be crime, do gender
@@ -165,9 +210,11 @@
     state: gender
   - type: Clothing
     equippedPrefix: gender
+  - type: ChameleonClothing
+    default: ClothingNeckGenderqueerPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckGenderfluidPin
   name: genderfluid pin
   description: be gender, be fluid
@@ -176,9 +223,11 @@
     state: fluid
   - type: Clothing
     equippedPrefix: fluid
+  - type: ChameleonClothing
+    default: ClothingNeckGenderfluidPin
 
 - type: entity
-  parent: ClothingNeckPinBase
+  parent: ClothingGenderPinBase
   id: ClothingNeckTransPin
   name: transgender pin
   description: Be trans do crime.
@@ -187,6 +236,8 @@
     state: trans
   - type: Clothing
     equippedPrefix: trans
+  - type: ChameleonClothing
+    default: ClothingNeckTransPin
 
 - type: entity
   parent: ClothingNeckPinBase

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -22,6 +22,8 @@
 #    default: ClothingNeckLGBTPin
     requireTag: GenderPin
     affectedByEmp: false
+    windowTitleOverride: change-pin-face # DeltaV - Rename the chameleon stuff so it's not illegal
+    verbNameOverride: change-pin-face # DeltaV - Rename the chameleon stuf so it's not illegal
   - type: UserInterface
     interfaces:
       enum.ChameleonUiKey.Key:

--- a/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/scarfs.yml
@@ -136,7 +136,7 @@
 
 # Pride Scarves
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedAce
   name: striped asexual scarf
   description: A stylish striped asexual scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -145,9 +145,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/ace.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/ace.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedAce # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedAro
   name: striped aromantic scarf
   description: A stylish striped aromantic scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -156,9 +158,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aro.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aro.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedAro # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedAroace
   name: striped aroace scarf
   description: A stylish striped aroace scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -167,9 +171,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aroace.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/aroace.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedAroace # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedBiSexual
   name: striped bisexual scarf
   description: A stylish striped bisexual scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -178,9 +184,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/bi.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/bi.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedBiSexual # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedGay
   name: striped gay scarf
   description: A stylish striped gay scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -189,9 +197,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/gay.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/gay.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedGay # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedInter
   name: striped intersex scarf
   description: A stylish striped intersex scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -200,9 +210,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/inter.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/inter.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedInter # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedLesbian
   name: striped lesbian scarf
   description: A stylish striped lesbian scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -211,9 +223,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedLesbian # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedPan
   name: striped pan scarf
   description: A stylish striped pan scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -222,9 +236,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/pan.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/pan.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedPan # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedNonBinary
   name: striped non-binary scarf
   description: A stylish striped non-binary scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -233,9 +249,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/non.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/non.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedNonBinary # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedRainbow
   name: rainbow scarf
   description: A stylish rainbow scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -244,9 +262,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/rainbow.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/rainbow.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedRainbow # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedTrans
   name: striped trans scarf
   description: A stylish striped trans scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks.
@@ -255,9 +275,11 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/trans.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/trans.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedTrans # DeltaV - Chameleon pride clothing
 
 - type: entity
-  parent: ClothingScarfBase
+  parent: ClothingGenderScarfBase # DeltaV - Chameleon pride clothing
   id: ClothingNeckScarfStripedLesbianLong
   name: long bacon
   description: Long bacon! Perfect for sharing with your girlfriend!
@@ -266,3 +288,5 @@
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian-long.rsi
   - type: Clothing
     sprite: Clothing/Neck/Scarfs/PrideScarfs/lesbian-long.rsi
+  - type: ChameleonClothing # DeltaV - Chameleon pride clothing
+    default: ClothingNeckScarfStripedLesbianLong # DeltaV - Chameleon pride clothing

--- a/Resources/Prototypes/_DV/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Neck/cloaks.yml
@@ -55,3 +55,22 @@
     sprite: _DV/Clothing/Neck/Cloaks/witchcloak.rsi
   - type: Clothing
     sprite: _DV/Clothing/Neck/Cloaks/witchcloak.rsi
+
+- type: entity
+  parent: ClothingNeckBase
+  id: ClothingGenderCloakBase
+  abstract: true
+  components:
+  - type: ChameleonClothing
+    slot: Neck
+    requireTag: GenderCloak
+    affectedByEmp: false
+  - type: UserInterface
+    interfaces:
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
+  - type: Tag
+    tags:
+    - ClothMade # for whatever reason, these tags aren't being inhereted from the parent
+    - WhitelistChameleon
+    - GenderCloak

--- a/Resources/Prototypes/_DV/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Neck/cloaks.yml
@@ -65,6 +65,8 @@
     slot: Neck
     requireTag: GenderCloak
     affectedByEmp: false
+    windowTitleOverride: change-cloak-pattern
+    verbNameOverride: change-cloak-pattern
   - type: UserInterface
     interfaces:
       enum.ChameleonUiKey.Key:

--- a/Resources/Prototypes/_DV/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Neck/scarfs.yml
@@ -1,0 +1,20 @@
+- type: entity
+  parent: ClothingScarfBase
+  id: ClothingGenderScarfBase
+  abstract: true
+  components:
+  - type: ChameleonClothing
+    slot: Neck
+    requireTag: GenderScarf
+    affectedByEmp: false
+  - type: UserInterface
+    interfaces:
+      enum.ChameleonUiKey.Key:
+        type: ChameleonBoundUserInterface
+  - type: Tag
+    tags:
+    - ClothMade # for whatever reason, these tags aren't being inhereted from the parent
+    - WhitelistChameleon
+    - GenderScarf
+
+

--- a/Resources/Prototypes/_DV/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Neck/scarfs.yml
@@ -7,6 +7,8 @@
     slot: Neck
     requireTag: GenderScarf
     affectedByEmp: false
+    windowTitleOverride: change-scarf-pattern
+    verbNameOverride: change-scarf-pattern
   - type: UserInterface
     interfaces:
       enum.ChameleonUiKey.Key:

--- a/Resources/Prototypes/_DV/Entities/Clothing/Neck/scarfs.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Neck/scarfs.yml
@@ -16,5 +16,3 @@
     - ClothMade # for whatever reason, these tags aren't being inhereted from the parent
     - WhitelistChameleon
     - GenderScarf
-
-

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -221,3 +221,9 @@
 
 - type: Tag # Ovinia, allows them to use specified emotes
   id: OviniaEmotes
+
+- type: Tag
+  id: GenderScarf
+
+- type: Tag
+  id: GenderCloak

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -634,6 +634,9 @@
   id: GhostOnlyWarp
 
 - type: Tag
+  id: GenderPin
+
+- type: Tag
   id: GlassAirlock
 
 - type: Tag


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Early merge of space-wizards/space-station-14/pull/36894 and space-wizards/space-station-14/pull/40425. 
I also made pride scarves and pride cloaks able to transform into their respective types, using the same method. The chameleon verb and window were renamed, so that the items aren't illegal either! 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's mostly QOL. This allows people to get the clothing that they'd prefer with less hassle. This was also requested in [#wyci-suggeststions](https://discord.com/channels/968983104247185448/1442264026368311316). 

## Technical details
<!-- Summary of code changes for easier review. -->
It ~~is~~ was just a bunch of yaml. Each piece of pride clothing inherits from an abstract entity that has the chameleon components and whatnot. 
(also first time doing a cherry pick, please tell me if I did this wrong)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1197" height="743" alt="Screenshot 2025-12-06 160420" src="https://github.com/user-attachments/assets/678f572d-0fe4-43d2-8b99-0a75c11c48ee" />



## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
no

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Eternally-Confused and Toby222
- tweak: Pride pins, scarves, and cloaks are now able to change into similar pieces of pride clothing! 