### PR TITLE
Pebble is not small station anymore!

### DIFF
--- a/Resources/Maps/pebble.yml
+++ b/Resources/Maps/pebble.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/02/2025 04:25:01
+  time: 12/03/2025 10:58:30
   entityCount: 27775
 maps:
 - 1
@@ -137129,6 +137129,11 @@ entities:
     - type: Transform
       pos: -40.5,-26.5
       parent: 2
+  - uid: 27594
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 2
   - uid: 27644
     components:
     - type: Transform
@@ -163134,13 +163139,6 @@ entities:
     components:
     - type: Transform
       pos: 22.5,-30.5
-      parent: 2
-- proto: VendingMachineMedicaPublic
-  entities:
-  - uid: 27594
-    components:
-    - type: Transform
-      pos: -4.5,16.5
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:

--- a/Resources/Prototypes/Maps/pebble.yml
+++ b/Resources/Prototypes/Maps/pebble.yml
@@ -2,8 +2,8 @@
   id: Pebble
   mapName: 'Pebble'
   mapPath: /Maps/pebble.yml
-  minPlayers: 0
-  maxPlayers: 35
+  minPlayers: 5
+  maxPlayers: 55
   stations:
     PebbleStation:
       stationProto: StandardNanotrasenStation


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Pebble is not a small station any longer.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Stated above.

## Technical details
<!-- Summary of code changes for easier review. -->
- Bumped max pop to 55 from 35.
- Bumped min pop to 5 from 0.
- Replaced public nanomed with a potted plant spawner.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: FieldCommand
MAPS:
- tweak: Pebble: Increased min and max soft cap from 0 - 35 to 5 - 55
