### PR TITLE
Addition of Shrapnel to Frag Grenade Projectiles

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -897,7 +897,7 @@
   - type: ExplodeOnTrigger
   - type: Explosive
     explosionType: Default
-    totalIntensity: 50
+    totalIntensity: 30 # Delta-V
     intensitySlope: 1
     maxIntensity: 5
     canCreateVacuum: false
@@ -905,8 +905,9 @@
     containers:
       cluster-payload: !type:Container
   - type: ProjectileGrenade
-    fillPrototype: PelletClusterLessLethal
-    capacity: 30
+    fillPrototype: PelletClusterLethal # Delta-V
+    capacity: 15 # Delta-V
+    triggerKey: trigger # Delta-V
 
 - type: entity
   parent: BaseBulletTrigger
@@ -1283,7 +1284,7 @@
           bounds: "-0.15,-0.3,0.15,0.3"
         hard: false
         mask:
-       # - Impassable 
+       # - Impassable
        # - BulletImpassable
         - Opaque # Delta-V changed from impassable so that they can go through windows
       fly-by: *flybyfixture


### PR DESCRIPTION
## About the PR

The frag grenade, typically used in conjunction with the China Lake, has been given shrapnel.

## Why / Balance

In order to live up to it's name, I think it is fitting that a frag grenade should have fragments.
Otherwise the frag grenade is just a worse blast grenade.
With this addition, the frag grenade is still worse than the blast grenade, but now it has a significant (luck based) chance to do some piercing damage via it's fragments. 

Compared to a shrapnel grenade, the fragments are halved.
Compared to a blast grenade, the total damage you would usually recieve would be about 1/3.

## Technical details

- Intensity has been reduced to 30. (Explosion does a little less damage, and the radius is a little smaller)

- Existing fill prototype has been reduced to 15 (can be adjusted), and changed to lethal pellets.

- Added triggerkey.

## Media

https://github.com/user-attachments/assets/f5f60230-25a4-4291-84f8-441b9f14a854

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

None!

**Changelog**

:cl:
- add: Frag Grenades now have shrapnel!

