### PR TITLE
Prefixes DV-specific surgical cap names with their color

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/hats.yml
@@ -84,7 +84,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatSurgcapBlack
-  name: surgical cap
+  name: black surgical cap
   description: A black cap surgeons wear during operations. Keeps their hair from tickling your internal organs.
   components:
   - type: Sprite
@@ -95,7 +95,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatSurgcapCyan
-  name: surgical cap
+  name: cyan surgical cap
   description: A cyan cap surgeons wear during operations. Keeps their hair from tickling your internal organs.
   components:
   - type: Sprite
@@ -106,7 +106,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatSurgcapCybersun
-  name: surgical cap
+  name: cybersun surgical cap
   description: A surgical cap worn by members of Cybersun's Biotechnology division.
   components:
   - type: Sprite
@@ -117,7 +117,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatSurgcapPink
-  name: surgical cap
+  name: pink surgical cap
   description: A pink cap surgeons wear during operations. Keeps their hair from tickling your internal organs.
   components:
   - type: Sprite
@@ -128,7 +128,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatSurgcapRainbow
-  name: surgical cap
+  name: rainbow surgical cap
   description: A rainbow cap surgeons wear during operations. Keeps their hair from tickling your internal organs.
   components:
   - type: Sprite
@@ -139,7 +139,7 @@
 - type: entity
   parent: ClothingHeadBase
   id: ClothingHeadHatSurgcapWhite
-  name: surgical cap
+  name: white surgical cap
   description: A black cap surgeons wear during operations. Keeps their hair from tickling your internal organs.
   components:
   - type: Sprite


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
I already did this for upstream surgical caps in https://github.com/space-wizards/space-station-14/pull/41681
I have no clue if I should be cherrypicking

The scrubs are named by color (plus Cybersun), but for some reason the surgical caps aren't.

## Media
The top surgical caps I already fixed upstream

<img width="490" height="568" alt="image" src="https://github.com/user-attachments/assets/88f6abd6-208b-442d-abef-35716ef542e2" />

(scrubs unaltered but shown regardless to make a point)
<img width="495" height="580" alt="image" src="https://github.com/user-attachments/assets/9763133e-5bbf-4d6f-84a7-35e4dbb21d43" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

I don't think this needs a changelog
