### PR TITLE
Fixed agent visor not able to see silicon and kitsune health bars

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -262,6 +262,12 @@
     sprite: Clothing/Eyes/Hud/syndagent.rsi
   - type: ShowSyndicateIcons
   - type: ShowHealthBars
+    damageContainers:
+    - Biological
+    - BiologicalMetaphysical # DeltaV - Kitsune
+    - Inorganic # DeltaV
+    - Silicon # DeltaV - Borgs
+    - HumanoidSilicon # DeltaV - IPCs
   - type: Tag
     tags:
     - PetWearable

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -140,7 +140,7 @@
       hasMindState: synd_medical_e
       noMindState: synd_medical
     - type: ShowHealthBars
-      damageContainers:
+      damageContainers: # DeltaV
       - Biological
       - BiologicalMetaphysical # Kitsune
     - type: InteractionPopup

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -140,6 +140,9 @@
       hasMindState: synd_medical_e
       noMindState: synd_medical
     - type: ShowHealthBars
+      damageContainers:
+      - Biological
+      - BiologicalMetaphysical # Kitsune
     - type: InteractionPopup
       interactSuccessString: petting-success-syndicate-cyborg
       interactFailureString: petting-failure-syndicate-cyborg

--- a/Resources/Prototypes/_White/Entities/Clothing/Eyes/goggles.yml
+++ b/Resources/Prototypes/_White/Entities/Clothing/Eyes/goggles.yml
@@ -39,6 +39,7 @@
   - type: ShowHealthBars
     damageContainers:
     - Biological
+    - BiologicalMetaphysical # DeltaV - Kitsune
 
 - type: entity
   parent: ClothingEyesNightVisionGogglesSyndie


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixes #4485 and Kitsune health bars not showing up. We just forgot to update the nukie visor lol.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fix.

## Technical details
<!-- Summary of code changes for easier review. -->
Why do we have so many damage containers?


## Media
<img width="647" height="258" alt="image" src="https://github.com/user-attachments/assets/b3d8e818-40e1-47e7-8a50-6372cb2cf416" />

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!

-->

:cl:
- fix: The nukie agent's visor can finally see silicon health.
