### PR TITLE
Adds nightvision to rat kings and xenos 

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -131,8 +131,8 @@
       gender: male
   - type: Sharp
   - type: PotentialPsionic # Nyano
-  - type: NightVision #Delta-v - Added nightvision to rat king
-    drawOverlay: false
+  - type: NightVision #Delta-v - Added nightvision
+    color: "#808080"
 
 - type: entity
   id: MobRatKingBuff

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -131,6 +131,8 @@
       gender: male
   - type: Sharp
   - type: PotentialPsionic # Nyano
+  - type: NightVision #Delta-v - Added nightvision to rat king
+    drawOverlay: false
 
 - type: entity
   id: MobRatKingBuff

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -126,6 +126,8 @@
     chance: -2
   - type: Psionic #Nyano - Summary: makes psionic by default.
     removable: false
+  - type: NightVision # Delta-v - Added nightvision to xenos
+    drawOverlay: false
 
 - type: entity
   name: praetorian

--- a/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/xeno.yml
@@ -126,8 +126,8 @@
     chance: -2
   - type: Psionic #Nyano - Summary: makes psionic by default.
     removable: false
-  - type: NightVision # Delta-v - Added nightvision to xenos
-    drawOverlay: false
+  - type: NightVision #Delta-v - Added nightvision
+    color: "#808080"
 
 - type: entity
   name: praetorian


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Feels like they should have it
Rat kings can't break lights either way because they are not insulated
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- add: Rat kings and xenos now see in the dark

