### PR TITLE
kill speedboots

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/misc.yml
@@ -191,10 +191,10 @@
     price: 75
   - type: Tag
     tags: [ ]
-  - type: ReverseEngineering # DeltaV: upgrade moonboots T1 to speedboots T3
-    difficulty: 5
-    recipes:
-    - ClothingShoesBootsSpeed
+  # - type: ReverseEngineering # DeltaV: upgrade moonboots T1 to speedboots T3
+  #   difficulty: 5
+  #   recipes:
+  #   - ClothingShoesBootsSpeed
 
 - type: entity
   parent: ClothingShoesBase

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -219,6 +219,7 @@
 
 # Tier 3
 
+# DeltaV - Kill Speedboots
 # - type: technology
 #   id: QuantumFiberWeaving
 #   name: research-technology-quantum-fiber-weaving

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -219,17 +219,17 @@
 
 # Tier 3
 
-- type: technology
-  id: QuantumFiberWeaving
-  name: research-technology-quantum-fiber-weaving
-  icon:
-    sprite: Clothing/Shoes/Boots/speedboots.rsi
-    state: icon
-  discipline: CivilianServices
-  tier: 3
-  cost: 10000
-  recipeUnlocks:
-  - ClothingShoesBootsSpeed
+# - type: technology
+#   id: QuantumFiberWeaving
+#   name: research-technology-quantum-fiber-weaving
+#   icon:
+#     sprite: Clothing/Shoes/Boots/speedboots.rsi
+#     state: icon
+#   discipline: CivilianServices
+#   tier: 3
+#   cost: 10000
+#   recipeUnlocks:
+#   - ClothingShoesBootsSpeed
 
 - type: technology
   id: BluespaceChemistry


### PR DESCRIPTION
## About the PR
speedboots are no longer researchable

## Why / Balance
Speed is without a doubt the most important stat in the game. Speedboots are the eternal problem child in that regard. They both give the best stat in the game, in high amounts, and occupy a slot that is very uncontested. 
Speedboots ensure that every epistemics antag, in addition to having access to all the toys epistemics has, also has legal access to the best combat item in the game. Speedboots ensure that cultists get to give their newly converted member a pair of speedboots and culterzine and they can kill every single secoff without breaking a sweat. Speedboots are legal for epi to wear, Speedboots force every secoff to wear speedboots or be hopelessly outmatched.
An overabundance of speedboots on station sucks ass. Only a single antag having speedboots sucks ass. 

There have been many attempts to try and get speedboots into a fun item, both for the one having and the one facing it. All of these have failed. The cost of an item does not matter as long as a single antag can wear them and wipe all of sec. 
The best avenue of making speedboots into a less toxic item is the proposition of making them an item that makes you very fast for a very short amount of time. This has already been implemented. They are called jump boots.


## Technical details
commented out the research thingy


## Requirements
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.

:cl:
- remove: Removed Speedboots

