### PR TITLE
Give dummy avali and chitnid moth eye sprites

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -162,3 +162,5 @@
   components:
   - type: HumanoidAppearance
     species: Chitinid
+  - type: Inventory
+    speciesId: moth

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
@@ -1,5 +1,5 @@
 - type: entity
-  save: false 
+  save: false
   name: Urist McRaptor # DeltaV - we ain't marines here
   parent: BaseMobSpeciesOrganic # DeltaV - set proper parent
   id: BaseMobAvali # DeltaV - rename base entity
@@ -20,7 +20,7 @@
       Female: RMCFemaleAvali
   - type: Speech
     speechVerb: Parrot # Didn't come with one
-    speechSounds: MaleAvali    
+    speechSounds: MaleAvali
   - type: DamageVisuals
     damageOverlayGroups:
       Brute:
@@ -31,7 +31,7 @@
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Weapons/pierce.ogg
-    damage: # DeltaV - evens out to about 5 after damage modifier    
+    damage: # DeltaV - evens out to about 5 after damage modifier
       types:
         Slash: 6
     animation: WeaponArcClaw
@@ -117,3 +117,8 @@
   parent: BaseSpeciesDummy
   id: MobAvaliDummy
   categories: [ HideSpawnMenu ]
+  # Begin DeltaV additions - Gives them moth eye sprites in the character menu
+  components:
+  - type: Inventory
+    speciesId: moth
+  # End DeltaV additions


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
In my last pr (#4835) I forgot to give the chitnid dummy `speciesId: moth`. This does that. We also gave it to avali.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes it where whenever the dummy is used for these species (in the character creator menu and probably other places) they will also have moth sprites for eyewear. Consistently. 
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
