### PR TITLE
Circular Saws and Mining Drills revert/fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -359,10 +359,10 @@
     attackRate: 4
     # End DeltaV additions
     damage:
-      groups:
-        Brute: 3 # DeltaV: 15 Brute changed to 3 Brute
       types:
-        Structural: 7.5 # DeltaV - Add structural damage; Half as much as a regular drill
+        Slash: 1.5 # DeltaV: 15 brute changed to 1.5 slash
+        Piercing: 1.5 # DeltaV: 15 brute changed to 1.5 piercing
+        Structural: 7.5 # DeltaV: Added structural damage; Exactly half as much as a regular drill
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool
@@ -387,10 +387,10 @@
     heldPrefix: advanced
   - type: MeleeWeapon
     damage:
-      groups:
-        Brute: 6 # DeltaV: 15 Brute changed to 6 brute
       types:
-        Structural: 15 # DeltaV - Add structural damage; Half as much as a diamond drill
+        Slash: 3 # DeltaV: 15 brute changed to 3 slash
+        Piercing: 3 # DeltaV: 15 brute changed 3 piercing
+        Structural: 20 # DeltaV: Added 20 structural damage
   - type: Tool
     speedModifier: 2.0
   - type: BoneSaw # Shitmed

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -360,9 +360,9 @@
     # End DeltaV additions
     damage:
       types:
-        Slash: 1.5 # DeltaV: 15 brute changed to 1.5 slash
-        Piercing: 1.5 # DeltaV: 15 brute changed to 1.5 piercing
-        Structural: 7.5 # DeltaV: Added structural damage; Exactly half as much as a regular drill
+        Slash: 2 # DeltaV: 15 brute changed to 2 slash
+        Piercing: 2 # DeltaV: 15 brute changed to 2 piercing
+        Structural: 10 # DeltaV: Added 10 structural damage
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool
@@ -388,8 +388,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Slash: 3 # DeltaV: 15 brute changed to 3 slash
-        Piercing: 3 # DeltaV: 15 brute changed 3 piercing
+        Slash: 4 # DeltaV: 15 brute changed to 4 slash
+        Piercing: 4 # DeltaV: 15 brute changed 4 piercing
         Structural: 20 # DeltaV: Added 20 structural damage
   - type: Tool
     speedModifier: 2.0

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -359,9 +359,12 @@
     attackRate: 4
     # End DeltaV additions
     damage:
+      groups:
+        Brute: 3 # DeltaV: 15 Brute changed to 3 Brute
+      # Start DeltaV additions
       types:
-        Slash: 3 # DeltaV: 15 Brute changed to 3 Slash
-        Structural: 10 # DeltaV: Added a small amount of structural
+        Structural: 7.5 # Half as much as a regular drill
+      # End DeltaV additions
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool
@@ -385,12 +388,13 @@
     storedRotation: 90
     heldPrefix: advanced
   - type: MeleeWeapon
-    # Start DeltaV additions
     damage:
+      groups:
+        Brute: 6 # DeltaV: 15 Brute changed to 6 brute
+      # Start DeltaV additions
       types:
-        Slash: 6
-        Structural: 20
-    # End DeltaV additions
+        Structural: 15 # Half as much as a diamond drill
+      # End DeltaV additions
   - type: Tool
     speedModifier: 2.0
   - type: BoneSaw # Shitmed

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -361,10 +361,8 @@
     damage:
       groups:
         Brute: 3 # DeltaV: 15 Brute changed to 3 Brute
-      # Start DeltaV additions
       types:
-        Structural: 7.5 # Half as much as a regular drill
-      # End DeltaV additions
+        Structural: 7.5 # DeltaV - Add structural damage; Half as much as a regular drill
     soundHit:
       path: /Audio/Items/drill_hit.ogg
   - type: Tool
@@ -391,10 +389,8 @@
     damage:
       groups:
         Brute: 6 # DeltaV: 15 Brute changed to 6 brute
-      # Start DeltaV additions
       types:
-        Structural: 15 # Half as much as a diamond drill
-      # End DeltaV additions
+        Structural: 15 # DeltaV - Add structural damage; Half as much as a diamond drill
   - type: Tool
     speedModifier: 2.0
   - type: BoneSaw # Shitmed

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -62,9 +62,9 @@
       path: "/Audio/Items/drill_hit.ogg"
     attackRate: 4
     damage:
-      groups:
-        Brute: 3
       types:
+        Piercing: 1.5 # DeltaV: 3 brute changed to 1.5 piercing
+        Slash: 1.5 # DeltaV: 3 brute changed to 1.5 slash
         Structural: 15
   - type: ReverseEngineering # DeltaV
     difficulty: 2
@@ -88,11 +88,10 @@
       path: "/Audio/Items/drill_hit.ogg"
     attackRate: 4
     damage:
-      groups:
-        Brute: 6
       types:
+        Piercing: 3 # DeltaV: 6 brute changed to 3 piercing
+        Slash: 3 # DeltaV: 6 brute changed to 3 slash
         Structural: 30
-
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -62,8 +62,9 @@
       path: "/Audio/Items/drill_hit.ogg"
     attackRate: 4
     damage:
+      groups:
+        Brute: 3
       types:
-        Piercing: 3 # DeltaV: Blunt changed to Piercing
         Structural: 15
   - type: ReverseEngineering # DeltaV
     difficulty: 2
@@ -87,8 +88,9 @@
       path: "/Audio/Items/drill_hit.ogg"
     attackRate: 4
     damage:
+      groups:
+        Brute: 6
       types:
-        Piercing: 6 # DeltaV: Brute changed to Piercing
         Structural: 30
 
 


### PR DESCRIPTION
## About the PR

- Circular saws and mining drills deal a combined slash & piercing damage, instead of just one or the other.
- Circular saws deal a little more entity damage

(prior to direction review: )
- ~~Circular saws, and Mining Drills now deal brute damage instead of slash/piercing again.~~
- ~~Circular saws now deal half the structural damage of their mining drill counterparts.~~

## Why / Balance

I realized that having only 1 damage type is a bit of a nerf to weapons that are already mediocre.
I also realized that while a scalpel makes a clean slash, saws and drills are much messier, and should do messier damage.

~~On another note, circular saws did a little too well at destroying structures, compared to their drill counterparts which are designed for that purpose solely in mind. Therefore, the advanced circular saw is now as good as a regular mining drill, instead of being better, and the regular circular saw is now half as good as a regular mining drill.~~

## Technical details

Simple value changes in mining.yml and surgery.yml
Some comments have been adjusted and fixed

## Media

N/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

None

**Changelog**

:cl:
- tweak: Saws are now a little more lethal
