### PR TITLE
Make the cane loadout group include the librarian cane

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/trinkets.yml
@@ -288,19 +288,18 @@
     - OffsetCaneNT
   groupBy: "canes"
 
-# DeltaV - Cane already available to everyone in loadout - Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
-#- type: loadout
-#  id: Cane
-#  effects:
+- type: loadout
+  id: Cane
+#  effects: #DeltaV - Make this cane availible to everyone
 #  - !type:JobRequirementLoadoutEffect
 #    requirement:
 #      !type:RoleTimeRequirement
 #      role: JobLibrarian
 #      time: 3600 # 1hr same as Jamjar.
-#  storage:
-#    back:
-#    - Cane
-#  groupBy: "canes"
+  storage:
+    back:
+    - Cane
+  groupBy: "canes"
 
 # Towels
 - type: loadout

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -66,7 +66,6 @@
   - AACTablet
   - GoldRing
   - SilverRing
-  - Cane
   - WhiteCane
   - CDDogtags # taken from Cosmatic Drift
   - TapeRecorder

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
@@ -17,12 +17,6 @@
     - SilverRing
 
 - type: loadout
-  id: Cane
-  storage:
-    back:
-    - Cane
-
-- type: loadout
   id: WhiteCane
   storage:
     back:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
The brown librarian cane wasn't included in the cane loadout group, so I fixed it.  I also removed the duplicate entry of that cane in the loadout menu. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
bugfix

## Technical details
<!-- Summary of code changes for easier review. -->
Just a bunch of yaml. I removed the duplicate loadout entry from deltaV's namespace,  and uncommented the original one

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="785" height="622" alt="Screenshot 2025-12-07 151415" src="https://github.com/user-attachments/assets/90065351-361c-4bef-bd09-392817959975" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!--## Breaking changes -->
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Shouldn't be necessary