### PR TITLE
AI HUD and Comms Update

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -19,6 +19,7 @@
     # Begin DeltaV additions
     - Justice
     - Prison
+    - Traffic
     # End DeltaV additions
   - type: ActiveRadio
     channels:
@@ -34,6 +35,7 @@
     # Begin DeltaV additions
     - Justice
     - Prison
+    - Traffic
     # End DeltaV additions
   - type: IgnoreUIRange
   - type: StationAiHeld
@@ -322,6 +324,14 @@
       state: ai_female
   - type: NameIdentifier
     group: StationAi
+  # Begin DeltaV additions
+  - type: ShowMindShieldIcons
+  - type: ShowHealthBars
+    damageContainers:
+    - Inorganic
+    - Silicon
+    - HumanoidSilicon
+  # End DeltaV additions
 
 # Hologram projection that the AI's eye tracks.
 - type: entity

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -325,7 +325,6 @@
   - type: NameIdentifier
     group: StationAi
   # Begin DeltaV additions
-  - type: ShowMindShieldIcons
   - type: ShowHealthBars
     damageContainers:
     - Inorganic


### PR DESCRIPTION
## About the PR
This will give the ai access to traffic coms now witch was never added after it was added and diagnostic hud\mind shield hud

## Why / Balance
To give the ai access to trafic coms without them needing to use the intercom all the time and since cap\lo have it why should the station ai not have access to it

diagnostic hud is for the ai to see there borgs health and make sure there all ok under there watch 

mind shield hud is to let the ai see who is and is not mindshield so they can better go about there work 

## Technical details
added trafic coms to the ai coms list
added the diagnostic component and mind shield component to the list of the player ai component

## Media


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes


**Changelog**

:cl:
- add: Station AI can now use traffic comms. Your secrets are no longer safe.
- add: Station AI can now see silicon health, just like diagnostic HUDs. 
