### PR TITLE
Atmos Ops: dP Guidebook Entry 

### DIFF
--- a/Content.Server/Atmos/Components/DeltaPressureComponent.cs
+++ b/Content.Server/Atmos/Components/DeltaPressureComponent.cs
@@ -1,6 +1,7 @@
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Damage;
 using Content.Shared.FixedPoint;
+using Content.Shared.Guidebook;
 
 namespace Content.Server.Atmos.Components;
 
@@ -82,6 +83,7 @@ public sealed partial class DeltaPressureComponent : Component
     /// The minimum difference in pressure between any side required for the entity to start taking damage.
     /// </summary>
     [DataField]
+    [GuidebookData]
     public float MinPressureDelta = 7500;
 
     /// <summary>

--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -37,6 +37,7 @@ guide-entry-gasminingandstorage = Gas Mining and Storage
 guide-entry-atmosphericupsets = Atmospheric Upsets
 guide-entry-fires = Fires
 guide-entry-spacing = Spacing
+guide-entry-deltapressure = Delta Pressure
 guide-entry-atmostools = Atmos Tools
 guide-entry-gasses = Gasses
 guide-entry-botany = Botany

--- a/Resources/Prototypes/Guidebook/engineering.yml
+++ b/Resources/Prototypes/Guidebook/engineering.yml
@@ -231,6 +231,7 @@
   children:
   - Fires
   - Spacing
+  - DeltaPressure
 
 - type: guideEntry
   id: Fires
@@ -241,6 +242,11 @@
   id: Spacing
   name: guide-entry-spacing
   text: "/ServerInfo/Guidebook/Engineering/Spacing.xml"
+
+- type: guideEntry
+  id: DeltaPressure
+  name: guide-entry-deltapressure
+  text: "/ServerInfo/Guidebook/Engineering/DeltaPressure.xml"
 
 - type: guideEntry
   id: AtmosTools

--- a/Resources/ServerInfo/Guidebook/Engineering/DeltaPressure.xml
+++ b/Resources/ServerInfo/Guidebook/Engineering/DeltaPressure.xml
@@ -1,0 +1,69 @@
+<Document>
+  # Delta Pressure
+  Delta Pressure, or ΔP, is the difference in pressure between two areas.
+  This difference in pressure can exert a force on objects between the two areas, dealing [bold]pressure damage[/bold] to some objects in its way.
+
+  Various objects made out of glass, such as Windows, Windoors, and Shutters can experience pressure damage if the ΔP between the two sides is high enough.
+  This damage can cause these objects to shatter, allowing gas to flow freely between the two areas.
+
+  Different types of objects have different thresholds for how much ΔP they can withstand before shattering.
+  Generally, the stronger the glass, the higher the threshold. Objects that are thin will also have lower thresholds.
+
+  Objects like walls, airlocks, and firelocks are not affected by ΔP.
+
+  ## Standard Glass and Objects
+  <Box>
+    <GuideEntityEmbed Entity="Window" Caption=""/>
+    <GuideEntityEmbed Entity="WindowDirectional" Caption=""/>
+    <GuideEntityEmbed Entity="Windoor" Caption=""/>
+    <GuideEntityEmbed Entity="ShuttersWindow" Caption=""/>
+    <GuideEntityEmbed Entity="InflatableWall" Caption=""/>
+  </Box>
+
+  Standard full-size glass and other weak objects can withstand a ΔP of up to [color=orange][protodata="Window" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+  Quarter-size glass, such as directional windows, can withstand a ΔP of up to [color=orange][protodata="WindowDirectional" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+  ## Reinforced Glass and Objects
+  <Box>
+    <GuideEntityEmbed Entity="ReinforcedWindow" Caption=""/>
+    <GuideEntityEmbed Entity="WindowReinforcedDirectional" Caption=""/>
+    <GuideEntityEmbed Entity="WindoorSecure" Caption=""/>
+    <GuideEntityEmbed Entity="ShuttleWindow" Caption=""/>
+  </Box>
+
+  Reinforced full-size glass can withstand a ΔP of up to [color=orange][protodata="ReinforcedWindow" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+  Reinforced quarter-size glass can withstand a ΔP of up to [color=orange][protodata="WindowReinforcedDirectional" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+  ## Plasma/Uranium Glass
+  <Box>
+    <GuideEntityEmbed Entity="PlasmaWindow" Caption=""/>
+    <GuideEntityEmbed Entity="PlasmaWindowDirectional" Caption=""/>
+    <GuideEntityEmbed Entity="WindoorPlasma" Caption=""/>
+    <GuideEntityEmbed Entity="UraniumWindow" Caption=""/>
+    <GuideEntityEmbed Entity="UraniumWindowDirectional" Caption=""/>
+    <GuideEntityEmbed Entity="WindoorUranium" Caption=""/>
+  </Box>
+
+  Plasma glass and uranium glass can withstand a ΔP of up to [color=orange][protodata="PlasmaWindow" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+  Plasma and uranium quarter-size glass can withstand a ΔP of up to [color=orange][protodata="PlasmaWindowDirectional" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+  ## Reinforced Plasma/Uranium Glass
+
+  <Box>
+    <GuideEntityEmbed Entity="ReinforcedPlasmaWindow" Caption=""/>
+    <GuideEntityEmbed Entity="PlasmaReinforcedWindowDirectional" Caption=""/>
+    <GuideEntityEmbed Entity="WindoorSecurePlasma" Caption=""/>
+    <GuideEntityEmbed Entity="ReinforcedUraniumWindow" Caption=""/>
+    <GuideEntityEmbed Entity="UraniumReinforcedWindowDirectional" Caption=""/>
+    <GuideEntityEmbed Entity="WindoorSecureUranium" Caption=""/>
+
+  </Box>
+
+  Reinforced plasma glass and uranium glass can withstand a ΔP of up to [color=orange][protodata="ReinforcedPlasmaWindow" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+  Reinforced plasma and uranium quarter-size glass can withstand a ΔP of up to [color=orange][protodata="PlasmaReinforcedWindowDirectional" comp="DeltaPressure" member="MinPressureDelta"/] kPa[/color] before starting to crack.
+
+</Document>


### PR DESCRIPTION
## About the PR
 - This PR adds a guidebook entry regarding Atmospherics Delta-pressure events, cherry picked from Wizden #40194

## Why / Balance
Delta-P is a significant change to atmos gameplay, and the maximum rated pressures for various windows are not visible elsewhere in game. 

## Technical details
Mostly YAML and XML, one line addition to DeltaPressureComponent.cs

## Media
![ss13-ss14](https://github.com/user-attachments/assets/e15ac765-61e4-4ed3-afc3-ada29874bdac)

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
n/a

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: zelezniciar, ArtisticRoomba
 - add: Atmospherics Delta-Pressure now has a short guidebook entry. You can find it in Jobs > Engineering > Atmospherics > Atmospheric Upsets > Delta Pressure.

