### PR TITLE
100% Ion resistance on Ninja Suit and Visor NVG.

### DIFF
--- a/Content.Server/_DV/Silicons/SiliconEmpSystem.cs
+++ b/Content.Server/_DV/Silicons/SiliconEmpSystem.cs
@@ -19,6 +19,6 @@ public sealed class SiliconEmpSystem : EntitySystem
     {
         args.Cancel(); // Stop all the normal effects of the EMP
         if (args.Damage is not { } damage) return;
-        _damageable.TryChangeDamage(ent, damage / 2, true); // Damage is divided by 2 because the event is raised twice (once from entity itself, and another is relayed from it's power cell) and I'm too lazy for an actual fix
+        _damageable.TryChangeDamage(ent, damage / 2, false); // Damage is divided by 2 because the event is raised twice (once from entity itself, and another is relayed from it's power cell) and I'm too lazy for an actual fix
     }
 }

--- a/Content.Server/_DV/Silicons/SiliconEmpSystem.cs
+++ b/Content.Server/_DV/Silicons/SiliconEmpSystem.cs
@@ -19,6 +19,6 @@ public sealed class SiliconEmpSystem : EntitySystem
     {
         args.Cancel(); // Stop all the normal effects of the EMP
         if (args.Damage is not { } damage) return;
-        _damageable.TryChangeDamage(ent, damage / 2, false); // Damage is divided by 2 because the event is raised twice (once from entity itself, and another is relayed from it's power cell) and I'm too lazy for an actual fix
+        _damageable.TryChangeDamage(ent, damage / 2, false); // Damage is divided by 2 because the event is raised twice (once from entity itself, and another is relayed from it's power cell) and I'm too lazy for an actual fix - NoElka | Make EMP not ignore armor.
     }
 }

--- a/Resources/Locale/en-US/_DV/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/_DV/armor/armor-examine.ftl
@@ -9,3 +9,5 @@ held-armor-whitelist-fail = You are not [color=yellow]{$reason}[/color].
 held-armor-blacklist-fail = You are [color=red]{$reason}[/color].
 
 held-armor-bible-user-fail = faithful
+
+armor-damage-type-ion = Ion

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -18,3 +18,4 @@ armor-damage-type-poison = Poison
 armor-damage-type-shock = Shock
 armor-damage-type-structural = Structural
 armor-damage-type-holy = Holy
+    

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -18,3 +18,4 @@ armor-damage-type-poison = Poison
 armor-damage-type-shock = Shock
 armor-damage-type-structural = Structural
 armor-damage-type-holy = Holy
+armor-damage-type-ion = Ion

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -18,4 +18,3 @@ armor-damage-type-poison = Poison
 armor-damage-type-shock = Shock
 armor-damage-type-structural = Structural
 armor-damage-type-holy = Holy
-armor-damage-type-ion = Ion

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -18,4 +18,3 @@ armor-damage-type-poison = Poison
 armor-damage-type-shock = Shock
 armor-damage-type-structural = Structural
 armor-damage-type-holy = Holy
-    

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -257,7 +257,7 @@
   parent: [ClothingEyesBase, BaseMajorContraband]
   id: ClothingEyesVisorNinja
   name: ninja visor
-  description: An advanced visor protecting a ninja's eyes from flashing lights.
+  description: An advanced visor protecting a ninja's eyes from flashing lights while having an ability to see in the dark.
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -264,7 +264,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
-  - type: NightVision
+  - type: NightVision # DeltaV
     isEquipment: true
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -257,7 +257,7 @@
   parent: [ClothingEyesBase, BaseMajorContraband]
   id: ClothingEyesVisorNinja
   name: ninja visor
-  description: An advanced visor protecting a ninja's eyes from flashing lights while having an ability to see in the dark.
+  description: An advanced visor protecting a ninja's eyes from flashing lights while having an ability to see in the dark. # DeltaV
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -264,6 +264,8 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/ninjavisor.rsi
   - type: FlashImmunity
+  - type: NightVision
+    isEquipment: true
 
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, BaseSecurityContraband]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -166,6 +166,7 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.8
+        Ion: 0
   # phase cloak
   - type: ToggleClothing
     action: ActionTogglePhaseCloak

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -166,7 +166,7 @@
         Slash: 0.8
         Piercing: 0.8
         Heat: 0.8
-        Ion: 0
+        Ion: 0 # DeltaV - I love self gibbing as ninja IPC!!
   # phase cloak
   - type: ToggleClothing
     action: ActionTogglePhaseCloak


### PR DESCRIPTION
## About the PR
Made the ninja suit have full Ion resistance (100%) annd ninja visor have NVG.

## Why / Balance
I dont know why having an IPC ninja take Ion damage honestly.
As per NVG, others told me to add too, so why not.

## Technical details
yaml, cs and ftl ops.
Also EMP/Ion damage doesnt ignore Armor anymore.

## Media
<img width="330" height="198" alt="image" src="https://github.com/user-attachments/assets/82f734fa-5130-479b-b3e9-68f53c4186fb" />

Previously written:
<img width="383" height="127" alt="image" src="https://github.com/user-attachments/assets/86831d34-eafa-434a-a916-8d278ecd5c2e" />
Now:
<img width="392" height="151" alt="image" src="https://github.com/user-attachments/assets/c113c750-520b-4fb5-a884-17122ee1354c" />
Showcase of both:
https://github.com/user-attachments/assets/c6fb8966-733a-4fca-a127-7e1e6e27f31c



## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Surely none :clueless:

**Changelog**
:cl:
- add: Ninja visor now has Night Vision!
- tweak: Ninja Hardsuit is now fully Ion resistant!
