### PR TITLE
Reinforced Tinted Windows Bug Fix

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Windows/tinted_windows.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Windows/tinted_windows.yml
@@ -48,4 +48,9 @@
     sprite: _DV/Structures/Windows/reinforced_tinted_window.rsi
   - type: IconSmooth
     base: rtwindow
+  - type: Construction
+    graph: Window
+    node: reinforcedTintedWindow
   - type: Occluder
+  - type: CosmicCorruptible
+    convertTo: WindowCosmicCult


### PR DESCRIPTION
## About the PR
Deconstructing reinforced tinted windows now properly gives plastic in addition to reinforced glass.

## Why / Balance
Conservation of matter now applies.

## Technical details
Added another type to ze entity component.

## Media
N/A

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**

:cl:

- fix: Plastic is now obtainable from deconstructing a reinforced tinted window.
