### PR TITLE
EntropicDegen Fix

### DIFF
--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs
@@ -62,6 +62,7 @@ public sealed class CosmicRiftSystem : EntitySystem
 
             var pos = Transform(uid).Coordinates;
             Spawn(comp.PulseVFX, pos);
+            _mobs.Clear();
             _lookup.GetEntitiesInRange<MobStateComponent>(pos, comp.PulseRange, _mobs);
             _mobs.RemoveWhere(target => _chaplainsQuery.HasComp(target) || _cultistsQuery.HasComp(target) || _colossiQuery.HasComp(target));
             foreach(var mob in _mobs)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
This might fix #4929. In theory, it does. But the code needs to be re-worked at some point.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hotfix.

## Technical details
<!-- Summary of code changes for easier review. -->
GetEntitiesInRange only ever adds to the hashset. It won't clear the entries. These entries will persist between rounds and cause server errors. It will also reapply the debuff even if they aren't near for EACH rift that is currently pulsing, giving them an infinite debuff as long as there's at least one rift alive anywhere. lmao.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Entropic Degen should no longer last forever.
