### PR TITLE
Buff/fix forensic pads

### DIFF
--- a/Content.Server/Forensics/Systems/ForensicPadSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicPadSystem.cs
@@ -82,7 +82,12 @@ namespace Content.Server.Forensics
 
             // Begin DeltaV changes - add Fiberprint to display
             if (TryComp<FiberComponent>(args.Target, out var fiber))
-                StartScan(uid, args.User, args.Target.Value, component, string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-pad-fibers", ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint ?? string.Empty)) : Loc.GetString("forensic-pad-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint ?? string.Empty)));
+            {
+                var text = Loc.GetString("forensic-pad-fibers", ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint ?? string.Empty));
+                if (!string.IsNullOrEmpty(fiber.FiberColor)) // If there are colored fibers, use that locale instead
+                    text = Loc.GetString("forensic-pad-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint ?? string.Empty));
+                StartScan(uid, args.User, args.Target.Value, component, text);
+            }
             // End DeltaV changes
         }
 

--- a/Content.Server/Forensics/Systems/ForensicPadSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicPadSystem.cs
@@ -81,8 +81,8 @@ namespace Content.Server.Forensics
             }
 
             // Begin DeltaV changes - add Fiberprint to display
-            if (TryComp<FiberComponent>(args.Target, out var fiber) && fiber.Fiberprint != null)
-                StartScan(uid, args.User, args.Target.Value, component, string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-pad-fibers", ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint)) : Loc.GetString("forensic-pad-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint)));
+            if (TryComp<FiberComponent>(args.Target, out var fiber))
+                StartScan(uid, args.User, args.Target.Value, component, string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-pad-fibers", ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint ?? string.Empty)) : Loc.GetString("forensic-pad-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint ?? string.Empty)));
             // End DeltaV changes
         }
 

--- a/Content.Server/Forensics/Systems/ForensicPadSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicPadSystem.cs
@@ -81,7 +81,7 @@ namespace Content.Server.Forensics
             }
 
             if (TryComp<FiberComponent>(args.Target, out var fiber))
-                StartScan(uid, args.User, args.Target.Value, component, string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial)) : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial)));
+                StartScan(uid, args.User, args.Target.Value, component, string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial)) + " ; " + fiber.Fiberprint : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial)) + " ; " + fiber.Fiberprint); // DeltaV - add fiberprint to display.
         }
 
         private void StartScan(EntityUid used, EntityUid user, EntityUid target, ForensicPadComponent pad, string sample)

--- a/Content.Server/Forensics/Systems/ForensicPadSystem.cs
+++ b/Content.Server/Forensics/Systems/ForensicPadSystem.cs
@@ -80,8 +80,10 @@ namespace Content.Server.Forensics
                 return;
             }
 
-            if (TryComp<FiberComponent>(args.Target, out var fiber))
-                StartScan(uid, args.User, args.Target.Value, component, string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-fibers", ("material", fiber.FiberMaterial)) + " ; " + fiber.Fiberprint : Loc.GetString("forensic-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial)) + " ; " + fiber.Fiberprint); // DeltaV - add fiberprint to display.
+            // Begin DeltaV changes - add Fiberprint to display
+            if (TryComp<FiberComponent>(args.Target, out var fiber) && fiber.Fiberprint != null)
+                StartScan(uid, args.User, args.Target.Value, component, string.IsNullOrEmpty(fiber.FiberColor) ? Loc.GetString("forensic-pad-fibers", ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint)) : Loc.GetString("forensic-pad-fibers-colored", ("color", fiber.FiberColor), ("material", fiber.FiberMaterial), ("fiberprint", fiber.Fiberprint)));
+            // End DeltaV changes
         }
 
         private void StartScan(EntityUid used, EntityUid user, EntityUid target, ForensicPadComponent pad, string sample)

--- a/Resources/Locale/en-US/_DV/forensics/fibers.ftl
+++ b/Resources/Locale/en-US/_DV/forensics/fibers.ftl
@@ -5,3 +5,6 @@ fibers-plasteel = plasteel
 fibers-degraded-plasteel = degraded plasteel
 fibers-replicated-plasteel = replicated plasteel
 fibers-nanomachine = nanomachine
+# Forensic pads should show the fiber prints
+forensic-pad-fibers = {LOC($material)} fibers ; {LOC($fiberprint)}
+forensic-pad-fibers-colored = {LOC($color)} {LOC($material)} fibers ; {LOC($fiberprint)}

--- a/Resources/Locale/en-US/_DV/forensics/fibers.ftl
+++ b/Resources/Locale/en-US/_DV/forensics/fibers.ftl
@@ -6,5 +6,5 @@ fibers-degraded-plasteel = degraded plasteel
 fibers-replicated-plasteel = replicated plasteel
 fibers-nanomachine = nanomachine
 # Forensic pads should show the fiber prints
-forensic-pad-fibers = {LOC($material)} fibers ; {LOC($fiberprint)}
-forensic-pad-fibers-colored = {LOC($color)} {LOC($material)} fibers ; {LOC($fiberprint)}
+forensic-pad-fibers = {LOC($material)} fibers ; {$fiberprint}
+forensic-pad-fibers-colored = {LOC($color)} {LOC($material)} fibers ; {$fiberprint}


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Forensic pads, when used to scan gloves, now also display their fiber ID on top of their type.

## Why / Balance
Forensic pads at the moment are a bit useless. Grabbing somebody's fingerprints in person is rarely useful when you have them all in the sec records, and for gloves they only show you the type of fiber which is only helpful when you're still learning detective.
Scanning gloves for their fibers is also unintuitive as hell, as you can't scan them directly in any way and must do some work around (like taking them, touching something and scanning that).
On top of that, and why I call this "fix": the Forensic Scanner has a feature where you can tap it with a pad and it automatically tells you if the prints on the pad match any of those in the current scan. There's code already there to make it work with glove fibers too, but without pads actually taking the fiber ID it's just broken.

## Technical details
One line. Matching the format the forensic scanner wants.

## Media
<img width="392" height="213" alt="pad1" src="https://github.com/user-attachments/assets/4d854917-6fc0-4289-8b9b-92a8e3efe8da" />
<img width="206" height="137" alt="pad2" src="https://github.com/user-attachments/assets/6865f749-f125-4395-be8c-62b9168ddb93" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: forensic pads used to scan gloves now also show the fiber's ID.
