### PR TITLE
remove prison knife

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -78,9 +78,7 @@
       - id: GroundCannabis
         amount: !type:RangeNumberSelector
           range: 1, 6
-    # Begin DeltaV modifications
-    - id: ClothingHeadsetPrison # Added prisoner headsets
-    # End DeltaV modifications
+    - id: ClothingHeadsetPrison # DeltaV - Added prisoner headsets
 
 #- type: entity
 #  id: WardrobePajamaFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/wardrobe_job.yml
@@ -80,7 +80,6 @@
           range: 1, 6
     # Begin DeltaV modifications
     - id: ClothingHeadsetPrison # Added prisoner headsets
-    - id: PrisonKnife # Bread cutting knife, does 4 damage total.
     # End DeltaV modifications
 
 #- type: entity

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedchefvend.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedchefvend.yml
@@ -18,3 +18,25 @@
     FoodMeatDuck: 2
     ReagentContainerSalt: 1
     ReagentContainerPepper: 1
+    FoodCondimentPacketAstrotame: 5
+    FoodCondimentPacketBbq: 5
+    FoodCondimentPacketColdsauce: 5
+    FoodCondimentPacketHorseradish: 5
+    FoodCondimentPacketHotsauce: 5
+    FoodCondimentPacketKetchup: 5
+    FoodCondimentPacketMustard: 5
+    FoodCondimentPacketPepper: 5
+    FoodCondimentPacketSalt: 5
+    FoodCondimentPacketSoy: 5
+    FoodCondimentPacketSugar: 5
+    FoodCondimentPacketCornoil: 5
+    ForkPlastic: 10
+    SpoonPlastic: 10
+    KnifePlastic: 10
+    FoodPlatePlastic: 10
+    FoodPlateSmallPlastic: 10
+  contrabandInventory:
+    FoodShakerSalt: 1
+    FoodShakerPepper: 1
+    FoodCondimentBottleKetchup: 1
+    ReagentContainerMayo: 1


### PR DESCRIPTION

## About the PR
redoes #4923 partially reverts #2304, removes prison knife spawns from prison locker

## Why / Balance
noone likes prison knives, they dont get used to cut bread in perma, permas still make shivs anyways, and guards still dont care about shivs anyways because why would they.
all prison knives to in their current form is serve as self antag bait for the tempbrig and clutter for the permabrig.


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- remove: Prison Knives no longer spawn in Prison Lockers


