### PR TITLE
The DREADED Advanced Plate Carrier Buffs

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
@@ -59,18 +59,18 @@
     sprite: _DV/Clothing/OuterClothing/Vests/advcarrier.rsi
   - type: Clothing
     sprite: _DV/Clothing/OuterClothing/Vests/advcarrier.rsi
-  - type: Armor # intended as Head of Security's and Warden's armour only, hence high values; resists at 30% flat with 50% pierce and 20% shock.
+  - type: Armor # intended as Head of Security's and Warden's armour only, hence high values; resists at 40% flat with 60% pierce and 30% shock.
     modifiers:
       coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.5
-        Shock: 0.8
-        Heat: 0.7
+        Blunt: 0.6
+        Slash: 0.6
+        Piercing: 0.4
+        Shock: 0.7
+        Heat: 0.6
   - type: StaminaResistance
     damageCoefficient: 0.6
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 0.85
   - type: ExplosionResistance
-    damageCoefficient: 0.7
+    damageCoefficient: 0.6


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Increased the armor values on the APC by roughly 10% in each respective category to make it more, you know, advanced.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In most rounds I struggle to ever see the HoS or warden literally ever wear this thing, it's a 15% slow for armor that's worse than the HoS hardsuit and only ever so slightly better than the normal plate carrier. The only real upside it has right now is that it has an internal 2x3 storage.
## Technical details
<!-- Summary of code changes for easier review. -->
changed like 6 numbers in YML, pretty advanced I know.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="356" height="236" alt="image" src="https://github.com/user-attachments/assets/dda29d03-36af-4cf6-a476-824046e7b62b" />

Post Buff APC Values

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: Adjusted the armor values on the Advanced Plate Carrier to make it all around stronger.
