### PR TITLE
Fix beacon map colors

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -221,7 +221,7 @@
     defaultText: station-beacon-detective
 
 - type: entity
-  parent: DefaultStationBeaconSecurity
+  parent: DefaultStationBeaconJustice # Delta V - Courtroom uses justice colors
   id: DefaultStationBeaconCourtroom
   suffix: Courtroom
   components:
@@ -229,7 +229,7 @@
     defaultText: station-beacon-courtroom
 
 - type: entity
-  parent: DefaultStationBeaconService #Delta V - Lawer is Service until Justice Dept is a thing
+  parent: DefaultStationBeaconJustice # Delta V - Law office uses justice colors
   id: DefaultStationBeaconLawOffice
   suffix: Law Office
   components:
@@ -659,7 +659,7 @@
     defaultText: station-beacon-chapel
 
 - type: entity
-  parent: DefaultStationBeacon
+  parent: DefaultStationBeaconScience #Delta V - Library is in Epi
   id: DefaultStationBeaconLibrary
   suffix: Library
   components:
@@ -667,7 +667,7 @@
     defaultText: station-beacon-library
 
 - type: entity
-  parent: DefaultStationBeacon
+  parent: DefaultStationBeaconService # Delta V - Use Service colors
   id: DefaultStationBeaconTheater
   suffix: Theater
   components:

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/station_beacon.yml
@@ -142,11 +142,27 @@
 
 - type: entity
   parent: DefaultStationBeaconService
-  id: DefaultStationBeaconRestroom
-  suffix: Restroom
+  id: DefaultStationBeaconBoxing
+  suffix: Boxing Ring
   components:
   - type: NavMapBeacon
-    defaultText: station-beacon-restroom
+    defaultText: station-beacon-boxing-ring
+
+- type: entity
+  parent: DefaultStationBeaconService
+  id: DefaultStationBeaconBarbershop
+  suffix: Barbershop
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-barbershop
+
+- type: entity
+  parent: DefaultStationBeaconService
+  id: DefaultStationBeaconZoo
+  suffix: Zoo
+  components:
+  - type: NavMapBeacon
+    defaultText: station-beacon-zoo
 
 #Surveilance
 - type: entity
@@ -158,13 +174,6 @@
     defaultText: station-beacon-camera-servers
 
 #General
-- type: entity
-  parent: DefaultStationBeacon
-  id: DefaultStationBeaconBoxing
-  suffix: Boxing Ring
-  components:
-  - type: NavMapBeacon
-    defaultText: station-beacon-boxing-ring
 
 - type: entity
   parent: DefaultStationBeacon
@@ -200,14 +209,6 @@
 
 - type: entity
   parent: DefaultStationBeacon
-  id: DefaultStationBeaconBarbershop
-  suffix: Barbershop
-  components:
-  - type: NavMapBeacon
-    defaultText: station-beacon-barbershop
-
-- type: entity
-  parent: DefaultStationBeacon
   id: DefaultStationBeaconArcade
   suffix: Arcade
   components:
@@ -216,11 +217,11 @@
 
 - type: entity
   parent: DefaultStationBeacon
-  id: DefaultStationBeaconZoo
-  suffix: Zoo
+  id: DefaultStationBeaconRestroom
+  suffix: Restroom
   components:
   - type: NavMapBeacon
-    defaultText: station-beacon-zoo
+    defaultText: station-beacon-restroom
 
 #Security
 - type: entity


### PR DESCRIPTION
## About the PR
- Courtroom and Law office use Justice colors
- Library uses Epistemics colors
- Theater, Boxing Ring, Barber Shop, Zoo use Service colors
- Restroom uses General colors

## Why / Balance
Consistency

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
