### PR TITLE
Remove Harbinger Bundle job restriction

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Uplink/weaponry.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/weaponry.yml
@@ -69,9 +69,4 @@
   cost:
     Telecrystal: 12
   categories:
-  - UplinkJob
-  conditions:
-  - !type:BuyerJobCondition
-    whitelist:
-    - Chaplain
-    - Botanist
+  - UplinkWeaponry


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The Harbinger Bundle/Accursed Scythe can now be purchased by all traitors.

## Why / Balance
Stats-wise, this is easily the best melee weapon in the game for combat.
- Deals 30 damage a swing
- Attack rate of 1.5 (esword is 1.0), effective 1.5x DPS of the esword
- 2/3 of it's damage is armor piercing and difficult to heal (shadow, combat hardsuit has 15% resist but that's pretty inconsequential)
- The remaining 1/3 is slash, which causes bleed, and isn't cauterized immediately (unlike esword)

Additionally, the fact that it gives you a ninja blink makes it one of the most useful traitor utility items in the game. This plus an emag means you can teleport into T3 armory (or vault, cap room, ai upload, what have you) on many maps, take 30 seconds to steal things and be evil, and then teleport right out. I'd spend 12 TC for that alone.

Having this item with insane overall utility be available only to chaplains and botanists feels a bit unfair.

## Technical details
yamlops

## Media
semi-unrelated but did you know blink stacks with avali zoom? fun!

https://github.com/user-attachments/assets/92639aca-01af-479c-8d00-575e228baee2

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The Harbinger Bundle is now available to all traitors.
