### PR TITLE
Fix cut-off replays

### DIFF
--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -101,3 +101,7 @@ storage_limit = 2
 
 [nf14.respawn]
 time = 600
+
+[replay]
+max_compressed_size = 1048576 # 1024 x 1024 (in kb), double the default, approx. 1gb
+max_uncompressed_size = 2097152 # 1024 x 2048 (in kb), double the default, approx. 2gb


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Replay maximum compressed/uncompressed size has been doubled. Hopefully, this will fix replays getting cut off.
Fixes https://github.com/DeltaV-Station/Delta-v/issues/4926, hopefully

## Why / Balance
Priority one issue, admins not being able to reliably use replays is Bad. Sucks for normal players, too.

## Technical details
Changes two cvars on the default deltav preset.

I can't test this beyond confirming that adding the cvar to the debug preset doesn't immediately crash the server. Even if I went through the effort to reconfigure my own dedicated server to test this config, the replay wouldn't reach the limit anyways (and hetzner would kill me). Not sure if CI will test it or not. Couldn't find any other servers that override this. Somebody sanity-check this please 🥺 

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Replays should no longer get cut off early.