### PR TITLE
Update landmine spawner

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/landmines.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/landmines.yml
@@ -2,18 +2,36 @@
   parent: MarkerBase
   id: LandmineSpawner
   name: Landmine Random Spawner
+  placement:
+    mode: PlaceFree
   components:
+  - type: Transform
+    anchored: false
   - type: Sprite
     sprite: Objects/Misc/landmine.rsi
     layers:
     - state: landmine
   - type: EntityTableSpawner
-    offset: 0
-    table: !type:GroupSelector
+    table: !type:NestedSelector
+      tableId: LandmineTable
       prob: 0.90
-      children:
-      - id: LandMineShrapnel
-        weight: 10
-      - id: LandMineHE
-        weight: 2
-      - id: LandMineExplosive
+
+- type: entity
+  parent: LandmineSpawner
+  id: LandmineSpawner33
+  suffix: 33%
+  components:
+  - type: EntityTableSpawner
+    table: !type:NestedSelector
+      tableId: LandmineTable
+      prob: 0.33
+
+- type: entityTable
+  id: LandmineTable
+  table: !type:GroupSelector
+    children:
+    #- id: LandMineShrapnel Temporary disabled until fixed
+    #  weight: 10
+    - id: LandMineHE
+      weight: 2
+    - id: LandMineExplosive


### PR DESCRIPTION
## About the PR
- Adds a 33% chance landmine spawner for more randomness/mapping flexibility
- Adjusts to be free placeable
- Temporarily removes the shrapnel mine until it is fixed

## Why / Balance
Mapping freedom and more explosions!

## Technical details
- Still unable to fix them spawning in sideways. I tried a bunch of things. I'll take any advice on that?
- Re-add shrapnel mines when fixed

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
n/a
