### PR TITLE
cybernetic eyes are OFF the menu

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/cybernetic.yml
@@ -4,6 +4,8 @@
   id: BaseCyberneticEyes
   components:
   - type: Cybernetics
+  - type: Food # DeltaV - can't eat it no more
+    requiresSpecialDigestion: true 
   - type: Sprite
     sprite: _Shitmed/Mobs/Species/IPC/organs.rsi
     state: "eyes"


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
cant eat cybernetic eyes

## Why / Balance
fix [#4420](https://github.com/DeltaV-Station/Delta-v/issues/4420) 

## Technical details
added food component and requireSpecialDigestion to BaseCyberneticEyes

## Media
<img width="423" height="214" alt="Content Client_cJixUA1WHI" src="https://github.com/user-attachments/assets/c8133f5f-5bb1-45e7-8067-05c16c1d4589" />
not edible! anymore

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
i hope not

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Cybernetic eyes are no longer edible.

