### PR TITLE
IPC fibers

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -109,6 +109,8 @@
   - type: EmitBuzzWhileDamaged
   - type: CanHostGuardian
   - type: WeldingHealable
+  - type: Fiber # DeltaV - IPCs leave fibers instead of prints
+    fiberMaterial: fibers-steel
   - type: CombatMode # DeltaV - let IPCs disarm
     canDisarm: true
   - type: SnoutHelmet # DeltaV - IPC Snouts


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
ipcs leave behind steel fibers

## Why / Balance
fix [#4912](https://github.com/DeltaV-Station/Delta-v/issues/4912) because they said so 

## Technical details
add fiber to ipc

## Media
<img width="669" height="482" alt="Content Client_PMJKQyHNcZ" src="https://github.com/user-attachments/assets/845d2967-52d4-4b29-b355-b8d3a099e6e6" />
 yeah

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
probably not

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: IPCs now leave behind steel fibers when touching stuff.
