### PR TITLE
Give Engineering Department Helmets Welding Protection

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -81,6 +81,7 @@
     coolingCoefficient: 0.005
   - type: FireProtection
     reduction: 0.2
+  - type: EyeProtection
   - type: Tag
     tags:
     - CorgiWearable
@@ -161,6 +162,7 @@
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000
+  - type: EyeProtection
   - type: Tag
     tags:
     - CorgiWearable
@@ -524,6 +526,7 @@
     lowPressureMultiplier: 1000
   - type: FireProtection
     reduction: 0.2
+  - type: EyeProtection
   - type: Tag
     tags:
     - CorgiWearable

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -309,6 +309,7 @@
     highPressureMultiplier: 0.25
     lowPressureMultiplier: 1000
   - type: IdentityBlocker
+  - type: EyeProtection
   - type: Tag
     tags:
     - WhitelistChameleon


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->
## About the PR
<!-- What did you change? -->
Does as title says, gives all engineering department helmets welding protection (flash protection not included).
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The specialized for engineering hardsuits should have something to make them actually feel specialized for engineering besides high explosion resistance and like one billion percent slows. As for the Atmos fire helm... it felt bad leaving it out.
## Technical details
<!-- Summary of code changes for easier review. -->
tiny bit of YML changes
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/0220cb58-307f-4081-961f-617a0c58e366


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: Engineering department helmets now have welding protection built in!

