### PR TITLE
xenoarch: artifacts no longer irradiate themselves (much)

### DIFF
--- a/Content.Server/Radiation/Components/RadiationReceiverComponent.cs
+++ b/Content.Server/Radiation/Components/RadiationReceiverComponent.cs
@@ -16,5 +16,11 @@ public sealed partial class RadiationReceiverComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
     public float CurrentRadiation;
+
+    /// <summary>
+    /// DeltaV - multiplier on the rads received if the RadiationSource is the same entity as this RadiationReceiver
+    /// </summary>
+    [DataField]
+    public float SelfSourceMultiplier = 1.0f;
 }
 

--- a/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
@@ -79,7 +79,8 @@ public partial class RadiationSystem
 
                 // add rads to total rad exposure
                 if (ray.ReachedDestination)
-                    rads += ray.Rads;
+                    // DeltaV - apply a modifier if you are irradiating yourself
+                    rads += ray.Rads * (source.Entity.Owner == destUid ? (source.Entity.Comp1.SelfReceiverMultiplier * dest.SelfSourceMultiplier) : 1f);
 
                 if (!debug)
                     continue;

--- a/Content.Shared/Radiation/Components/RadiationSourceComponent.cs
+++ b/Content.Shared/Radiation/Components/RadiationSourceComponent.cs
@@ -26,4 +26,10 @@ public sealed partial class RadiationSourceComponent : Component
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool Enabled = true;
+
+    /// <summary>
+    /// DeltaV - multiplier on the rads delivered if the RadiationReceiver is the same entity as this RadiationSource
+    /// </summary>
+    [DataField]
+    public float SelfReceiverMultiplier = 1.0f;
 }

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/xenoartifacts.yml
@@ -45,6 +45,7 @@
   - type: Psionic # DeltaV - sentient artifacts are psionic
   # These components are needed for certain triggers to work.
   - type: RadiationReceiver
+    selfSourceMultiplier: 0.1 # DeltaV - a radiation effect triggering a radiation trigger on the same artifact is often annoying
   - type: Reactive
     groups:
       Flammable: [Touch]


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Artifacts take 90% less radiation from themselves.

i.e.
Your artifact has two nodes. Node 1 has an *effect* of "become radioactive". Node 2 has a *trigger* of "radiation". If you activate node 1, then, from then on Node 2 will trigger over and over, due to the artifact's radiation irradiating itself.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Right now an artifact in this situation will trigger the radiation trigger about every 10 seconds. That really inhibits your ability to unlock non-radiation nodes since the radiation trigger will trigger and conflict very often.

I considered removing the self irradiation entirely but I think it could be fun/useful to keep in. Just need it to be infrequent enough so that scientists can work around it. (with this PR it will trigger about every 2 minutes; or you can still use an outside radiation source like a uranium spear to make it faster)

## Technical details
<!-- Summary of code changes for easier review. -->

This was an unintended side-effect of https://github.com/DeltaV-Station/Delta-v/pull/4817 -- radiation is aggregated each frame before applying, so it can't be attributed to a single source, so the more general "you can't damage yourself" system wasn't able to take effect.

Tested that this PR works by putting two artifacts with "radiation" triggers next to eachother. Turned one of them into a radiation source -- it triggered way slower than the other one, as intended.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
