### PR TITLE
xenoarch: fix "node scanner target deleted" console error

### DIFF
--- a/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
@@ -34,12 +34,13 @@ public sealed class NodeScannerSystem : EntitySystem
             connected.NextUpdate = _timing.CurTime + connected.LinkUpdateInterval;
 
             var attachedArtifact = connected.AttachedTo;
-            var artifactCoordinates = Transform(attachedArtifact).Coordinates;
-            if (!_transform.InRange(artifactCoordinates, transform.Coordinates, scanner.MaxLinkedRange))
+            // DeltaV - begin of deleted artifact bugfix
+            if (Deleted(attachedArtifact) || !_transform.InRange(Transform(attachedArtifact).Coordinates, transform.Coordinates, scanner.MaxLinkedRange))
             {
                 //scanner is too far, disconnect
                 RemCompDeferred(uid, connected);
             }
+            // DeltaV - end of deleted artifact bugfix
         }
     }
 


### PR DESCRIPTION

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Fixed an annoying exception being thrown if you connect the *handheld* node scanner to an artifact, and then Erase Mode the artifact.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This error was spamming the console, annoying while testing xenoarch features.

## Technical details
<!-- Summary of code changes for easier review. -->

Just check whether the artifact has been deleted -- this is what the GasAnalyzerSystem does for the targeted pipes.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
