### PR TITLE
The Jetpack Stays On During Harmbatoning

### DIFF
--- a/Content.Shared/Movement/Components/JetpackComponent.cs
+++ b/Content.Shared/Movement/Components/JetpackComponent.cs
@@ -38,6 +38,6 @@ public sealed partial class JetpackComponent : Component
     /// The user whose jetpack is waiting to activate.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public EntityUid? WaitingUser;
+    public EntityUid? AutomaticUser;
     // DeltaV End - Jetpacks automatically toggle on.
 }

--- a/Content.Shared/Movement/Components/JetpackComponent.cs
+++ b/Content.Shared/Movement/Components/JetpackComponent.cs
@@ -25,4 +25,19 @@ public sealed partial class JetpackComponent : Component
 
     [ViewVariables(VVAccess.ReadWrite), DataField("weightlessModifier")]
     public float WeightlessModifier = 1.2f;
+
+    // DeltaV Start - Jetpacks automatically toggle on.
+    /// <summary>
+    /// When toggling the jetpack, this will turn true/false.
+    /// Upon leaving a grid, this will determine if the jetpack activates.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool AutomaticMode;
+
+    /// <summary>
+    /// The user whose jetpack is waiting to activate.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid? WaitingUser;
+    // DeltaV End - Jetpacks automatically toggle on.
 }

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._DV.Movement.Components; // DeltaV - Jetpacks automatically toggle on.
 using Content.Shared.Actions;
 using Content.Shared.Gravity;
 using Content.Shared.Interaction.Events;
@@ -11,7 +12,7 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared.Movement.Systems;
 
-public abstract class SharedJetpackSystem : EntitySystem
+public abstract partial class SharedJetpackSystem : EntitySystem // DeltaV - Made Partial
 {
     [Dependency] private readonly MovementSpeedModifierSystem _movementSpeedModifier = default!;
     [Dependency] protected readonly SharedAppearanceSystem Appearance = default!;
@@ -34,6 +35,7 @@ public abstract class SharedJetpackSystem : EntitySystem
 
         SubscribeLocalEvent<GravityChangedEvent>(OnJetpackUserGravityChanged);
         SubscribeLocalEvent<JetpackComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<WaitingJetpackUserComponent, EntParentChangedMessage>(OnWaitingJetpackEntParentChanged); // DeltaV - Jetpacks automatically toggle on.
     }
 
     private void OnJetpackUserWeightlessMovement(Entity<JetpackUserComponent> ent, ref RefreshWeightlessModifiersEvent args)
@@ -71,13 +73,17 @@ public abstract class SharedJetpackSystem : EntitySystem
 
     private void OnJetpackDropped(EntityUid uid, JetpackComponent component, DroppedEvent args)
     {
+        RemoveWaiter(component); // DeltaV - Jetpacks automatically toggle on.
         SetEnabled(uid, component, false, args.User);
     }
 
     private void OnJetpackMoved(Entity<JetpackComponent> ent, ref EntGotInsertedIntoContainerMessage args)
     {
         if (args.Container.Owner != ent.Comp.JetpackUser)
+        {
+            RemoveWaiter(ent.Comp); // DeltaV - Jetpacks automatically toggle on.
             SetEnabled(ent, ent.Comp, false, ent.Comp.JetpackUser);
+        }
     }
 
     private void OnJetpackUserCanWeightless(EntityUid uid, JetpackUserComponent component, ref CanWeightlessMoveEvent args)
@@ -125,20 +131,22 @@ public abstract class SharedJetpackSystem : EntitySystem
         _movementSpeedModifier.RefreshWeightlessModifiers(uid);
     }
 
-    private void OnJetpackToggle(EntityUid uid, JetpackComponent component, ToggleJetpackEvent args)
-    {
-        if (args.Handled)
-            return;
-
-        if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid))
-        {
-            _popup.PopupClient(Loc.GetString("jetpack-no-station"), uid, args.Performer);
-
-            return;
-        }
-
-        SetEnabled(uid, component, !IsEnabled(uid));
-    }
+    /// DeltaV Start - Replaced with DeltaV method in <see cref="SharedJetpackSystem"/>
+    // private void OnJetpackToggle(EntityUid uid, JetpackComponent component, ToggleJetpackEvent args)
+    // {
+    //     if (args.Handled)
+    //         return;
+    //
+    //     if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid))
+    //     {
+    //         _popup.PopupClient(Loc.GetString("jetpack-no-station"), uid, args.Performer);
+    //
+    //         return;
+    //     }
+    //
+    //     SetEnabled(uid, component, !IsEnabled(uid));
+    // }
+    // DeltaV End - Replaced with DeltaV method.
 
     private bool CanEnableOnGrid(EntityUid? gridUid)
     {
@@ -173,11 +181,14 @@ public abstract class SharedJetpackSystem : EntitySystem
 
         if (enabled)
         {
+            RemComp<WaitingJetpackUserComponent>(user.Value); // DeltaV - Jetpacks automatically turn on when toggled.
             SetupUser(user.Value, uid, component);
             EnsureComp<ActiveJetpackComponent>(uid);
         }
         else
         {
+            if (component.AutomaticMode) // DeltaV - Jetpacks automatically turn on when toggled.
+                EnsureComp<WaitingJetpackUserComponent>(user.Value).Jetpack = uid;
             RemoveUser(user.Value, component);
             RemComp<ActiveJetpackComponent>(uid);
         }

--- a/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJetpackSystem.cs
@@ -35,7 +35,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem // DeltaV - Mad
 
         SubscribeLocalEvent<GravityChangedEvent>(OnJetpackUserGravityChanged);
         SubscribeLocalEvent<JetpackComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<WaitingJetpackUserComponent, EntParentChangedMessage>(OnWaitingJetpackEntParentChanged); // DeltaV - Jetpacks automatically toggle on.
+        SubscribeLocalEvent<AutomaticJetpackUserComponent, EntParentChangedMessage>(OnAutomaticJetpackEntParentChanged); // DeltaV - Jetpacks automatically toggle on.
     }
 
     private void OnJetpackUserWeightlessMovement(Entity<JetpackUserComponent> ent, ref RefreshWeightlessModifiersEvent args)
@@ -73,7 +73,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem // DeltaV - Mad
 
     private void OnJetpackDropped(EntityUid uid, JetpackComponent component, DroppedEvent args)
     {
-        RemoveWaiter(component); // DeltaV - Jetpacks automatically toggle on.
+        RemoveAutomaticJetpack((uid, component)); // DeltaV - Jetpacks automatically toggle on.
         SetEnabled(uid, component, false, args.User);
     }
 
@@ -81,7 +81,7 @@ public abstract partial class SharedJetpackSystem : EntitySystem // DeltaV - Mad
     {
         if (args.Container.Owner != ent.Comp.JetpackUser)
         {
-            RemoveWaiter(ent.Comp); // DeltaV - Jetpacks automatically toggle on.
+            RemoveAutomaticJetpack(ent); // DeltaV - Jetpacks automatically toggle on.
             SetEnabled(ent, ent.Comp, false, ent.Comp.JetpackUser);
         }
     }
@@ -179,16 +179,15 @@ public abstract partial class SharedJetpackSystem : EntitySystem // DeltaV - Mad
             user = container.Owner;
         }
 
+        RefreshAutomaticJetpack((uid, component), user.Value, enabled); // DeltaV - Jetpacks automatically turn on when toggled.
+
         if (enabled)
         {
-            RemComp<WaitingJetpackUserComponent>(user.Value); // DeltaV - Jetpacks automatically turn on when toggled.
             SetupUser(user.Value, uid, component);
             EnsureComp<ActiveJetpackComponent>(uid);
         }
         else
         {
-            if (component.AutomaticMode) // DeltaV - Jetpacks automatically turn on when toggled.
-                EnsureComp<WaitingJetpackUserComponent>(user.Value).Jetpack = uid;
             RemoveUser(user.Value, component);
             RemComp<ActiveJetpackComponent>(uid);
         }

--- a/Content.Shared/_DV/Movement/Components/AutomaticJetpackUserComponent.cs
+++ b/Content.Shared/_DV/Movement/Components/AutomaticJetpackUserComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Shared._DV.Movement.Components;
 /// Added when someone holds a jetpack that is toggled active and waits to turn on.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class WaitingJetpackUserComponent : Component
+public sealed partial class AutomaticJetpackUserComponent : Component
 {
     /// <summary>
     /// The jetpack that will automatically activate.

--- a/Content.Shared/_DV/Movement/Components/WaitingJetpackUserComponent.cs
+++ b/Content.Shared/_DV/Movement/Components/WaitingJetpackUserComponent.cs
@@ -1,0 +1,16 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._DV.Movement.Components;
+
+/// <summary>
+/// Added when someone holds a jetpack that is toggled active and waits to turn on.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class WaitingJetpackUserComponent : Component
+{
+    /// <summary>
+    /// The jetpack that will automatically activate.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public EntityUid Jetpack;
+}

--- a/Content.Shared/_DV/Movement/Components/WaitingJetpackUserComponent.cs
+++ b/Content.Shared/_DV/Movement/Components/WaitingJetpackUserComponent.cs
@@ -1,4 +1,4 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._DV.Movement.Components;
 

--- a/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
@@ -58,7 +58,7 @@ public abstract partial class SharedJetpackSystem
     {
         if (jetpackEnabled)
             RemComp<AutomaticJetpackUserComponent>(user);
-        if (jetpack.Comp.AutomaticMode) // DeltaV - Jetpacks automatically turn on when toggled.
+        else if (jetpack.Comp.AutomaticMode) // DeltaV - Jetpacks automatically turn on when toggled.
             EnsureComp<AutomaticJetpackUserComponent>(user).Jetpack = jetpack;
 
     }

--- a/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
@@ -1,0 +1,54 @@
+﻿using Content.Shared._DV.Movement.Components;
+using Content.Shared.Movement.Components;
+using Content.Shared.Movement.Events;
+
+namespace Content.Shared.Movement.Systems;
+
+public abstract partial class SharedJetpackSystem
+{
+    private void OnJetpackToggle(EntityUid uid, JetpackComponent component, ToggleJetpackEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        component.AutomaticMode = !component.AutomaticMode;
+        component.WaitingUser = args.Performer;
+        Dirty(uid, component);
+
+        if (TryComp(uid, out TransformComponent? xform) && !CanEnableOnGrid(xform.GridUid))
+        {
+            if (component.AutomaticMode)
+                EnsureComp<WaitingJetpackUserComponent>(args.Performer).Jetpack = uid;
+            else
+                RemComp<WaitingJetpackUserComponent>(args.Performer);
+
+            var message = component.AutomaticMode ? "jetpack-activated-on-grid" : "jetpack-deactivated";
+            _popup.PopupClient(Loc.GetString(message), uid, args.Performer);
+            DirtyEntity(args.Performer);
+            return;
+        }
+
+        var messageOffGrid = component.AutomaticMode ? "jetpack-activated-off-grid" : "jetpack-deactivated";
+        _popup.PopupClient(Loc.GetString(messageOffGrid), uid, args.Performer);
+
+        SetEnabled(uid, component, !IsEnabled(uid));
+    }
+
+    private void OnWaitingJetpackEntParentChanged(Entity<WaitingJetpackUserComponent> jetpackUser, ref EntParentChangedMessage args)
+    {
+        if (!TryComp<JetpackComponent>(jetpackUser.Comp.Jetpack, out var jetpack)
+            || args.Transform.GridUid != null)
+            return;
+
+        SetEnabled(jetpackUser.Comp.Jetpack, jetpack, true, args.Entity);
+        _popup.PopupClient(Loc.GetString("jetpack-activates-automatically"), args.Entity, args.Entity);
+    }
+
+    private void RemoveWaiter(JetpackComponent component)
+    {
+        component.AutomaticMode = false;
+        if (component.WaitingUser.HasValue)
+            RemComp<WaitingJetpackUserComponent>(component.WaitingUser.Value);
+        component.WaitingUser = null;
+    }
+}

--- a/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared._DV.Movement.Components;
+using Content.Shared._DV.Movement.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 

--- a/Resources/Locale/en-US/_DV/movement/jetpacks.ftl
+++ b/Resources/Locale/en-US/_DV/movement/jetpacks.ftl
@@ -1,4 +1,4 @@
-﻿jetpack-activated-on-grid = The jetpack will automatically turn on when leaving the station.
+jetpack-activated-on-grid = The jetpack will automatically turn on when leaving the station.
 jetpack-activated-off-grid = The jetpack turns on.
 jetpack-activates-automatically = The jetpack automatically turns on.
 jetpack-deactivated = The jetpack will no longer turn on.

--- a/Resources/Locale/en-US/_DV/movement/jetpacks.ftl
+++ b/Resources/Locale/en-US/_DV/movement/jetpacks.ftl
@@ -1,0 +1,4 @@
+﻿jetpack-activated-on-grid = The jetpack will automatically turn on when leaving the station.
+jetpack-activated-off-grid = The jetpack turns on.
+jetpack-activates-automatically = The jetpack automatically turns on.
+jetpack-deactivated = The jetpack will no longer turn on.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I made Jetpacks automatically activate when leaving the grid, if they have been toggled active.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Is gud. QoL. And the less times you need to interact with the horrid action bar, the better.

## Technical details
<!-- Summary of code changes for easier review. -->
Made the System `SharedJetpackSystem.cs` partial and replaced a method in it.
Added a DV version of `SharedJetpackSystem.cs`.
Minor C# changes to add the logic behind the automation.
Added two variables to `JetpackComponent.cs` to allow tracking of waiting users.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/8eb40317-4f4b-46c1-b49e-d7dd81c89ef3


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Jetpacks now automatically turn on when leaving a grid, if you have toggled them on!