### PR TITLE
admin logs for research, glimmer, artifacts

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -97,7 +97,10 @@ public sealed partial class AnomalySystem
         if (!this.IsPowered(uid, EntityManager) || component.Anomaly is not {} anomaly)
             return;
 
-        args.Points += (int) (GetAnomalyPointValue(anomaly) * component.PointMultiplier);
+        args.Sources.Add(new ResearchServerPointsPerSecondSource(
+            Source: uid,
+            PointsPerSecond: (int) (GetAnomalyPointValue(anomaly) * component.PointMultiplier)
+        ));
     }
 
     private void OnVesselAnomalyShutdown(ref AnomalyShutdownEvent args)

--- a/Content.Server/Anomaly/AnomalySystem.Vessel.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Vessel.cs
@@ -97,10 +97,12 @@ public sealed partial class AnomalySystem
         if (!this.IsPowered(uid, EntityManager) || component.Anomaly is not {} anomaly)
             return;
 
+        // DeltaV - start of research statistics admin logs
         args.Sources.Add(new ResearchServerPointsPerSecondSource(
             Source: uid,
             PointsPerSecond: (int) (GetAnomalyPointValue(anomaly) * component.PointMultiplier)
         ));
+        // DeltaV - end of research statistics admin logs
     }
 
     private void OnVesselAnomalyShutdown(ref AnomalyShutdownEvent args)

--- a/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/PsionicAbilitiesSystem.cs
@@ -1,5 +1,7 @@
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.Actions;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
 using Content.Shared.Psionics.Glimmer;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
@@ -23,6 +25,7 @@ namespace Content.Server.Abilities.Psionics
         [Dependency] private readonly SharedJitteringSystem _jittering = default!;
         [Dependency] private readonly GlimmerSystem _glimmerSystem = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
         public override void Initialize()
         {
@@ -123,7 +126,13 @@ namespace Content.Server.Abilities.Psionics
                 }
             }
 
-            _glimmerSystem.Glimmer -= _random.Next(50, 70);
+            var glimmerBurned = _random.Next(50, 70);
+            _glimmerSystem.Glimmer -= glimmerBurned;
+            _adminLogger.Add(
+                LogType.Glimmer,
+                LogImpact.Low,
+                $"{ToPrettyString(uid)} drained {glimmerBurned} glimmer through mindbreaking"
+            );
 
             _statusEffectsSystem.TryAddStatusEffect(uid, "Stutter", TimeSpan.FromMinutes(1), false, "StutteringAccent");
             _statusEffectsSystem.TryAddStatusEffect(uid, "KnockedDown", TimeSpan.FromSeconds(3), false, "KnockedDown");

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/Structures/GlimmerStructuresSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/Structures/GlimmerStructuresSystem.cs
@@ -1,7 +1,9 @@
 using Content.Server.Anomaly.Components;
 using Content.Server.Power.Components;
 using Content.Server.Power.EntitySystems;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Anomaly.Components;
+using Content.Shared.Database;
 using Content.Shared.Power;
 using Content.Shared.Psionics.Glimmer;
 
@@ -14,6 +16,7 @@ namespace Content.Server.Psionics.Glimmer
     {
         [Dependency] private readonly PowerReceiverSystem _powerReceiverSystem = default!;
         [Dependency] private readonly GlimmerSystem _glimmerSystem = default!;
+        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
         public override void Initialize()
         {
@@ -78,6 +81,11 @@ namespace Content.Server.Psionics.Glimmer
                     {
                         _glimmerSystem.Glimmer--;
                     }
+                    _adminLogger.Add(
+                        LogType.Glimmer,
+                        LogImpact.Low,
+                        $"{ToPrettyString(source.Owner)} {(source.AddToGlimmer ? "produced" : "drained")} 1 glimmer passively"
+                    );
                 }
             }
         }

--- a/Content.Server/Research/Systems/ResearchSystem.PointSource.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.PointSource.cs
@@ -14,7 +14,7 @@ public sealed partial class ResearchSystem
     private void OnGetPointsPerSecond(Entity<ResearchPointSourceComponent> source, ref ResearchServerGetPointsPerSecondEvent args)
     {
         if (CanProduce(source))
-            args.Points += source.Comp.PointsPerSecond;
+            args.Sources.Add(new ResearchServerPointsPerSecondSource(source, source.Comp.PointsPerSecond));
     }
 
     public bool CanProduce(Entity<ResearchPointSourceComponent> source)

--- a/Content.Server/Research/Systems/ResearchSystem.PointSource.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.PointSource.cs
@@ -14,7 +14,7 @@ public sealed partial class ResearchSystem
     private void OnGetPointsPerSecond(Entity<ResearchPointSourceComponent> source, ref ResearchServerGetPointsPerSecondEvent args)
     {
         if (CanProduce(source))
-            args.Sources.Add(new ResearchServerPointsPerSecondSource(source, source.Comp.PointsPerSecond));
+            args.Sources.Add(new ResearchServerPointsPerSecondSource(source, source.Comp.PointsPerSecond)); // DeltaV - research statistics admin logs
     }
 
     public bool CanProduce(Entity<ResearchPointSourceComponent> source)

--- a/Content.Server/Research/Systems/ResearchSystem.Server.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Server.cs
@@ -72,7 +72,7 @@ public sealed partial class ResearchSystem
                 _adminLogger.Add(
                     LogType.Research,
                     LogImpact.Low,
-                    $"{uid} collected {points} points from {sources.Count} sources over {time} seconds: {pointsStr}"
+                    $"{ToPrettyString(uid)} collected {points} points from {sources.Count} sources over {time} seconds: {pointsStr}"
                 );
             }
         }

--- a/Content.Server/Research/Systems/ResearchSystem.Server.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.Server.cs
@@ -1,7 +1,7 @@
 using System.Linq;
-using System.Text;
+using System.Text; // DeltaV
 using Content.Server.Power.EntitySystems;
-using Content.Shared.Database;
+using Content.Shared.Database; // DeltaV
 using Content.Shared.Research.Components;
 
 namespace Content.Server.Research.Systems;
@@ -52,6 +52,7 @@ public sealed partial class ResearchSystem
         if (!CanRun(uid))
             return;
         
+        // DeltaV - start of research statistics admin logs
         int points = 0;
         var sources = GetPointsPerSecond(uid, component);
         if (sources.Count > 0)
@@ -77,6 +78,7 @@ public sealed partial class ResearchSystem
         }
         
         ModifyServerPoints(uid, points, component);
+        // DeltaV - end of research statistics admin logs
     }
 
     /// <summary>
@@ -157,22 +159,25 @@ public sealed partial class ResearchSystem
     /// <param name="uid"></param>
     /// <param name="component"></param>
     /// <returns></returns>
+    /// <remarks>
+    /// DeltaV - changed return type as part of research statistics admin logs
+    /// </remarks>
     public List<ResearchServerPointsPerSecondSource> GetPointsPerSecond(EntityUid uid, ResearchServerComponent? component = null)
     {
-        var sources = new List<ResearchServerPointsPerSecondSource>();
+        var sources = new List<ResearchServerPointsPerSecondSource>(); // DeltaV - research statistics admin logs
 
         if (!Resolve(uid, ref component))
-            return sources;
+            return sources; // DeltaV - rename
 
         if (!CanRun(uid))
-            return sources;
+            return sources; // DeltaV - rename
 
-        var ev = new ResearchServerGetPointsPerSecondEvent(uid, sources);
+        var ev = new ResearchServerGetPointsPerSecondEvent(uid, sources); // DeltaV - rename
         foreach (var client in component.Clients)
         {
             RaiseLocalEvent(client, ref ev);
         }
-        return ev.Sources;
+        return ev.Sources; // DeltaV - rename
     }
 
     /// <summary>

--- a/Content.Server/Research/Systems/ResearchSystem.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.cs
@@ -4,8 +4,8 @@ using Content.Server.Administration.Logs;
 using Content.Server.Radio.EntitySystems;
 using Content.Shared._DV.Shuttles.Components; // DeltaV
 using Content.Shared.Access.Systems;
-using Content.Shared.Administration.Logs;
-using Content.Shared.Database;
+using Content.Shared.Administration.Logs; // DeltaV
+using Content.Shared.Database; // DeltaV
 using Content.Shared.Popups;
 using Content.Shared.Research.Components;
 using Content.Shared.Research.Systems;
@@ -25,7 +25,7 @@ namespace Content.Server.Research.Systems
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
-        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!; // DeltaV - research statistics admin logs
 
         private static readonly HashSet<Entity<ResearchServerComponent>> ClientLookup = new();
 
@@ -128,6 +128,7 @@ namespace Content.Server.Research.Systems
             var query = EntityQueryEnumerator<ResearchServerComponent>();
             while (query.MoveNext(out var uid, out var server))
             {
+                // DeltaV - inverted the if-continue pattern to make room for research statistics admin logs
                 if (server.NextUpdateTime <= _timing.CurTime)
                 {
                     server.NextUpdateTime = _timing.CurTime + server.ResearchConsoleUpdateTime;
@@ -135,6 +136,7 @@ namespace Content.Server.Research.Systems
                     UpdateServer(uid, (int) server.ResearchConsoleUpdateTime.TotalSeconds, server);
                 }
                 
+                // DeltaV - start of research statistics admin logs
                 if (server.NextAdminLogTime <= _timing.CurTime)
                 {
                     server.NextAdminLogTime = _timing.CurTime + server.ResearchServerAdminLogTime;
@@ -145,6 +147,7 @@ namespace Content.Server.Research.Systems
                         $"current points in {ToPrettyString(uid)}: {server.Points}"
                     );
                 }
+                // DeltaV - end of research statistics admin logs
             }
         }
     }

--- a/Content.Server/Research/Systems/ResearchSystem.cs
+++ b/Content.Server/Research/Systems/ResearchSystem.cs
@@ -4,6 +4,8 @@ using Content.Server.Administration.Logs;
 using Content.Server.Radio.EntitySystems;
 using Content.Shared._DV.Shuttles.Components; // DeltaV
 using Content.Shared.Access.Systems;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
 using Content.Shared.Popups;
 using Content.Shared.Research.Components;
 using Content.Shared.Research.Systems;
@@ -23,6 +25,7 @@ namespace Content.Server.Research.Systems
         [Dependency] private readonly UserInterfaceSystem _uiSystem = default!;
         [Dependency] private readonly SharedPopupSystem _popup = default!;
         [Dependency] private readonly RadioSystem _radio = default!;
+        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
         private static readonly HashSet<Entity<ResearchServerComponent>> ClientLookup = new();
 
@@ -125,11 +128,23 @@ namespace Content.Server.Research.Systems
             var query = EntityQueryEnumerator<ResearchServerComponent>();
             while (query.MoveNext(out var uid, out var server))
             {
-                if (server.NextUpdateTime > _timing.CurTime)
-                    continue;
-                server.NextUpdateTime = _timing.CurTime + server.ResearchConsoleUpdateTime;
+                if (server.NextUpdateTime <= _timing.CurTime)
+                {
+                    server.NextUpdateTime = _timing.CurTime + server.ResearchConsoleUpdateTime;
 
-                UpdateServer(uid, (int) server.ResearchConsoleUpdateTime.TotalSeconds, server);
+                    UpdateServer(uid, (int) server.ResearchConsoleUpdateTime.TotalSeconds, server);
+                }
+                
+                if (server.NextAdminLogTime <= _timing.CurTime)
+                {
+                    server.NextAdminLogTime = _timing.CurTime + server.ResearchServerAdminLogTime;
+
+                    _adminLogger.Add(
+                        LogType.Research,
+                        LogImpact.Low,
+                        $"current points in {ToPrettyString(uid)}: {server.Points}"
+                    );
+                }
             }
         }
     }

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
@@ -1,7 +1,7 @@
-using System.Text;
-using Content.Shared.Administration.Logs;
+using System.Text; // DeltaV
+using Content.Shared.Administration.Logs; // DeltaV
 using Content.Shared.Cargo;
-using Content.Shared.Database;
+using Content.Shared.Database; // DeltaV
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 
@@ -10,7 +10,7 @@ namespace Content.Server.Xenoarchaeology.Artifact;
 /// <inheritdoc cref="SharedXenoArtifactSystem"/>
 public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
 {
-    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!; // DeltaV - research statistics admin logs
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -26,6 +26,7 @@ public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
         if (ent.Comp.IsGenerationRequired)
             GenerateArtifactStructure(ent);
 
+        // DeltaV - start of research statistics admin logs
         foreach (var node in GetAllNodes(ent))
         {
             var effectStatusString = node.Comp.LockedEffectTipHidden ? "Hidden" : node.Comp.LockedEffectTipVague ? "Vague" : "Specific";
@@ -48,6 +49,7 @@ public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
                 $"{ToPrettyString(ent.Owner)} spawned with node {ToPrettyString(node)} with depth {node.Comp.Depth}; effect status {effectStatusString}; {triggerStr.ToString()}"
             );
         }
+        // DeltaV - end of research statistics admin logs
     }
 
     private void OnCalculatePrice(Entity<XenoArtifactComponent> ent, ref PriceCalculationEvent args)

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
@@ -1,4 +1,7 @@
+using System.Text;
+using Content.Shared.Administration.Logs;
 using Content.Shared.Cargo;
+using Content.Shared.Database;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 
@@ -7,6 +10,8 @@ namespace Content.Server.Xenoarchaeology.Artifact;
 /// <inheritdoc cref="SharedXenoArtifactSystem"/>
 public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
 {
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+
     /// <inheritdoc/>
     public override void Initialize()
     {
@@ -20,6 +25,29 @@ public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
     {
         if (ent.Comp.IsGenerationRequired)
             GenerateArtifactStructure(ent);
+
+        foreach (var node in GetAllNodes(ent))
+        {
+            var effectStatusString = node.Comp.LockedEffectTipHidden ? "Hidden" : node.Comp.LockedEffectTipVague ? "Vague" : "Specific";
+
+            var triggerStr = new StringBuilder();
+            var predecessors = GetPredecessorNodes((ent, ent), node);
+            triggerStr.Append(predecessors.Count);
+            triggerStr.Append(" triggers: ");
+            triggerStr.Append(node.Comp.TriggerTip ?? "Unknown");
+            foreach (var predecessor in predecessors)
+            {
+                triggerStr.Append(",");
+                triggerStr.Append(predecessor.Comp.TriggerTip ?? "Unknown");
+            }
+
+            _adminLogger.Add(
+                LogType.ArtifactNode,
+                LogImpact.Low,
+                // note: effect type is already logged by ToPrettyString(node)
+                $"{ToPrettyString(ent.Owner)} spawned with node {ToPrettyString(node)} with depth {node.Comp.Depth}; effect status {effectStatusString}; {triggerStr.ToString()}"
+            );
+        }
     }
 
     private void OnCalculatePrice(Entity<XenoArtifactComponent> ent, ref PriceCalculationEvent args)

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
@@ -43,7 +43,7 @@ public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
             }
 
             _adminLogger.Add(
-                LogType.ArtifactNode,
+                LogType.ArtifactDetails,
                 LogImpact.Low,
                 // note: effect type is already logged by ToPrettyString(node)
                 $"{ToPrettyString(ent.Owner)} spawned with node {ToPrettyString(node)} with depth {node.Comp.Depth}; effect status {effectStatusString}; {triggerStr.ToString()}"

--- a/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/XenoArtifactSystem.cs
@@ -33,7 +33,7 @@ public sealed partial class XenoArtifactSystem : SharedXenoArtifactSystem
 
             var triggerStr = new StringBuilder();
             var predecessors = GetPredecessorNodes((ent, ent), node);
-            triggerStr.Append(predecessors.Count);
+            triggerStr.Append(predecessors.Count + 1);
             triggerStr.Append(" triggers: ");
             triggerStr.Append(node.Comp.TriggerTip ?? "Unknown");
             foreach (var predecessor in predecessors)

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -65,7 +65,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
                 // Log all the variables that affect research value (see UpdateNodeResearchValue).
                 var predecessors = _xenoArtifact.GetPredecessorNodes((artifact.Value, artifact.Value), node);
                 _adminLogger.Add(
-                    LogType.ArtifactNode,
+                    LogType.ArtifactDetails,
                     LogImpact.Low,
                     $"{ToPrettyString(ent.Owner)} extracted {research} points and {glimmer} glimmer from node {ToPrettyString(node)}. Details: base {node.Comp.BasePointValue}; predecessors {predecessors.Count}; durability {node.Comp.Durability}/{node.Comp.MaxDurability}; subtotal {subtotalResearch}; glimmerMultiplier {glimmerMultiplier}"
                 );

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -55,7 +55,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
             var research = _xenoArtifact.GetResearchValue(node);
             _xenoArtifact.SetConsumedResearchValue(node, node.Comp.ConsumedResearchValue + research);
 
-            // Begin DeltaV - Artifacts glimmer interaction
+            // Begin DeltaV - glimmer interaction & research statistics admin logs
             var subtotalResearch = research;
             research = (int)(subtotalResearch * glimmerMultiplier);
             var glimmer = (int)(subtotalResearch / (float)analyzer.Value.Comp.ExtractRatio);
@@ -80,7 +80,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
             }
 
             sumGlimmer += glimmer;
-            // End DeltaV
+            // End DeltaV - glimmer interaction & research statistics admin logs
             sumResearch += research;
         }
         UpdateClientUI(ent, analyzer!.Value); // DeltaV

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -1,8 +1,8 @@
 using System; // DeltaV
 using Content.Server.Research.Systems;
 using Content.Server.Xenoarchaeology.Artifact;
-using Content.Shared.Administration.Logs;
-using Content.Shared.Database;
+using Content.Shared.Administration.Logs; // DeltaV
+using Content.Shared.Database; // DeltaV
 using Content.Shared.Popups;
 using Content.Shared.Psionics.Glimmer;// DeltaV
 using Content.Shared._DV.Xenoarchaeology.BUI;// DeltaV
@@ -24,7 +24,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     [Dependency] private readonly XenoArtifactSystem _xenoArtifact = default!;
     [Dependency] private readonly GlimmerSystem _glimmerSystem = default!; // DeltaV
     [Dependency] private readonly ArtifactAnalyzerSystem _analyzerSystem = default!; //DeltaV
-    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!; // DeltaV
 
     /// <inheritdoc/>
     public override void Initialize()

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -1,6 +1,8 @@
 using System; // DeltaV
 using Content.Server.Research.Systems;
 using Content.Server.Xenoarchaeology.Artifact;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
 using Content.Shared.Popups;
 using Content.Shared.Psionics.Glimmer;// DeltaV
 using Content.Shared._DV.Xenoarchaeology.BUI;// DeltaV
@@ -22,6 +24,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     [Dependency] private readonly XenoArtifactSystem _xenoArtifact = default!;
     [Dependency] private readonly GlimmerSystem _glimmerSystem = default!; // DeltaV
     [Dependency] private readonly ArtifactAnalyzerSystem _analyzerSystem = default!; //DeltaV
+    [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -44,6 +47,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
         var sumGlimmer = 0;
         if (!_analyzerSystem.TryGetAnalyzer(ent, out var analyzer))
             return;
+        var glimmerMultiplier = GetGlimmerMultiplier(analyzer.Value.Comp);
         // End DeltaV
 
         foreach (var node in _xenoArtifact.GetAllNodes(artifact.Value))
@@ -51,12 +55,31 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
             var research = _xenoArtifact.GetResearchValue(node);
             _xenoArtifact.SetConsumedResearchValue(node, node.Comp.ConsumedResearchValue + research);
 
-            // Begin DeltaV - Only run if we have an artifact ready for extraction
-            if (analyzer != null)
+            // Begin DeltaV - Artifacts glimmer interaction
+            var subtotalResearch = research;
+            research = (int)(subtotalResearch * glimmerMultiplier);
+            var glimmer = (int)(subtotalResearch / (float)analyzer.Value.Comp.ExtractRatio);
+            
+            if (research > 0 || glimmer > 0)
             {
-                sumGlimmer += (int)(research / (float)analyzer.Value.Comp.ExtractRatio);
-                research = (int)(research * GetGlimmerMultiplier(analyzer.Value.Comp));
+                // Log all the variables that affect research value (see UpdateNodeResearchValue).
+                var predecessors = _xenoArtifact.GetPredecessorNodes((artifact.Value, artifact.Value), node);
+                _adminLogger.Add(
+                    LogType.ArtifactNode,
+                    LogImpact.Low,
+                    $"{ToPrettyString(ent.Owner)} extracted {research} points and {glimmer} glimmer from node {ToPrettyString(node)}. Details: base {node.Comp.BasePointValue}; predecessors {predecessors.Count}; durability {node.Comp.Durability}/{node.Comp.MaxDurability}; subtotal {subtotalResearch}; glimmerMultiplier {glimmerMultiplier}"
+                );
             }
+            if (glimmer > 0)
+            {
+                _adminLogger.Add(
+                    LogType.Glimmer,
+                    LogImpact.Low,
+                    $"{ToPrettyString(ent.Owner)} produced {glimmer} glimmer from extracting node {ToPrettyString(node)}"
+                );
+            }
+
+            sumGlimmer += glimmer;
             // End DeltaV
             sumResearch += research;
         }

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -396,6 +396,7 @@ public enum LogType
     ObjectiveSummary = 422, // DeltaV
     Glimmer = 423, // DeltaV
     Research = 424, // DeltaV
+    ArtifactDetails = 425, // DeltaV
 
     /// <summary>
     /// A client has sent too many chat messages recently and is temporarily blocked from sending more.

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -394,6 +394,8 @@ public enum LogType
     BagOfHolding = 420, //Nyano - Summary: adds bag of holding.
     Psionics = 421, //Nyano - Summary: ads psionic as a log type.
     ObjectiveSummary = 422, // DeltaV
+    Glimmer = 423, // DeltaV
+    Research = 424, // DeltaV
 
     /// <summary>
     /// A client has sent too many chat messages recently and is temporarily blocked from sending more.

--- a/Content.Shared/Research/Components/ResearchServerComponent.cs
+++ b/Content.Shared/Research/Components/ResearchServerComponent.cs
@@ -42,6 +42,10 @@ public sealed partial class ResearchServerComponent : Component
 
     [DataField("researchConsoleUpdateTime"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan ResearchConsoleUpdateTime = TimeSpan.FromSeconds(1);
+
+    public TimeSpan NextAdminLogTime = TimeSpan.Zero;
+
+    public TimeSpan ResearchServerAdminLogTime = TimeSpan.FromSeconds(60);
 }
 
 /// <summary>
@@ -59,5 +63,6 @@ public readonly record struct ResearchServerPointsChangedEvent(EntityUid Server,
 /// <param name="Server"></param>
 /// <param name="Points"></param>
 [ByRefEvent]
-public record struct ResearchServerGetPointsPerSecondEvent(EntityUid Server, int Points);
+public record struct ResearchServerGetPointsPerSecondEvent(EntityUid Server, List<ResearchServerPointsPerSecondSource> Sources);
 
+public record struct ResearchServerPointsPerSecondSource(EntityUid Source, int PointsPerSecond);

--- a/Content.Shared/Research/Components/ResearchServerComponent.cs
+++ b/Content.Shared/Research/Components/ResearchServerComponent.cs
@@ -43,8 +43,10 @@ public sealed partial class ResearchServerComponent : Component
     [DataField("researchConsoleUpdateTime"), ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan ResearchConsoleUpdateTime = TimeSpan.FromSeconds(1);
 
+    /// DeltaV - timing for research statistics admin logs
     public TimeSpan NextAdminLogTime = TimeSpan.Zero;
 
+    /// DeltaV - timing for research statistics admin logs
     public TimeSpan ResearchServerAdminLogTime = TimeSpan.FromSeconds(60);
 }
 
@@ -62,7 +64,11 @@ public readonly record struct ResearchServerPointsChangedEvent(EntityUid Server,
 /// </summary>
 /// <param name="Server"></param>
 /// <param name="Points"></param>
+/// <remarks>
+/// DeltaV - changed from `int Points` to list of sources for research statistics admin logs
+/// </remarks>
 [ByRefEvent]
 public record struct ResearchServerGetPointsPerSecondEvent(EntityUid Server, List<ResearchServerPointsPerSecondSource> Sources);
 
+/// DeltaV - for research statistics admin logs
 public record struct ResearchServerPointsPerSecondSource(EntityUid Source, int PointsPerSecond);

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Content.Shared.Database;
+using Content.Shared.Database; // DeltaV
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -75,14 +75,17 @@ public abstract partial class SharedXenoArtifactSystem
         SoundSpecifier? soundEffect;
         if (TryGetNodeFromUnlockState(ent, out var node))
         {
+            // DeltaV - start of research statistics admin logs
             _adminLogger.Add(
                 LogType.ArtifactNode,
                 LogImpact.Low,
                 $"{ToPrettyString(ent.Owner)} node {ToPrettyString(node.Value)} unlocked"
             );
+            // DeltaV - end of research statistics admin logs
 
             SetNodeUnlocked((ent, artifactComponent), node.Value);
 
+            // DeltaV - start of research statistics admin logs
             foreach (var logNode in GetAllNodes((ent, ent)))
             {
                 if (!logNode.Comp.Locked)
@@ -98,6 +101,7 @@ public abstract partial class SharedXenoArtifactSystem
                     );
                 }
             }
+            // DeltaV - end of research statistics admin logs
 
             ActivateNode((ent, ent), (node.Value, node.Value), null, null, Transform(ent).Coordinates, false);
             unlockAttemptResultMsg = "artifact-unlock-state-end-success";

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -77,7 +77,7 @@ public abstract partial class SharedXenoArtifactSystem
         {
             // DeltaV - start of research statistics admin logs
             _adminLogger.Add(
-                LogType.ArtifactNode,
+                LogType.ArtifactDetails,
                 LogImpact.Low,
                 $"{ToPrettyString(ent.Owner)} node {ToPrettyString(node.Value)} unlocked"
             );
@@ -95,7 +95,7 @@ public abstract partial class SharedXenoArtifactSystem
                 if (logNodePredecessors.Contains(node.Value) && logNodePredecessors.All(p => !p.Comp.Locked))
                 {
                     _adminLogger.Add(
-                        LogType.ArtifactNode,
+                        LogType.ArtifactDetails,
                         LogImpact.Low,
                         $"{ToPrettyString(ent.Owner)} node {ToPrettyString(logNode)} revealed"
                     );


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Added new epistemics admin logs. I intend to use them to analyze generally how players are generating research points, and how players are interacting with glimmer, anomalies, and xenoarch.

We should start collecting data ASAP. Grafana visualizations or one-off analyses based on these logs will come later.

To be clear: these are logs that appear in the \`adminlogs\` menu, or the `admin_log` database table. They are "LogSeverity.Low", so they do *not* spam/appear in the chat window. Most admins won't know they're there

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Xenoarch is busted. The recent [glimmer scaling PR](https://github.com/DeltaV-Station/Delta-v/pull/4486) has combined poorly with other scalings, and [discord users are reporting](https://discord.com/channels/968983104247185448/968983104662409244/1450391143916376115) that xenoarcheologists are finishing the research tree very early in the shift, due to nodes producing insane amounts of research points.

It'd be awesome if we start collecting data *now*, so that we will have solid before & after statistics on whatever balance changes we make in the near future.

## Technical details
<!-- Summary of code changes for easier review. -->

There are 11 new types of log messages being generated. In total, I estimate ~20,000 more logs per round to be generated. The current average ([as discussed on discord](https://discord.com/channels/968983104247185448/1449276473650450432)) is probably about ~150,000 per round, so this is a fairly significant increase! 

However, I think these are okay to add for now, and we can look at slimming down our logs over the next couple months. A month or two of 15% more logs shouldn't break the bank on server disk storage. (we're currently storing the past year of rounds)

Examples of the 11 new logs:

### New `Research` category
1. **Points report:** (1 log every 60s, ~120 logs per round)
> current points in R&D server (10255/n10255, ResearchAndDevelopmentServer): 4592
2. **Passive research point generation:** (1 log every 1s, ~7200 logs per round)
> R&D server (10255/n10255, ResearchAndDevelopmentServer) collected 236 points from 3 sources over 1 seconds: 179 points from glimmer prober (7922/n7922, GlimmerProber), 30 points from anomaly vessel (8732/n8732, MachineAnomalyVessel), 27 points from anomaly vessel (8733/n8733, MachineAnomalyVessel), 

### New `ArtifactDetails` category

(originally had these in the existing `ArtifactNode` but I'd like to keep them separate in case we want to revert this PR & purge these logs)

3. **Each node's details logged when artifact spawns:** (~100 logs per round)
> artifact (74112/n74112, ComplexXenoArtifact) spawned with node effect (XAN-801) (74118/n74118, XenoArtifactFloraSpawn) with depth 1; effect status Hidden; 3 triggers: xenoarch-trigger-tip-examine,xenoarch-trigger-tip-wrenching,xenoarch-trigger-tip-heat
4. **Depth 1+ node revealed - all predecessors unlocked:** (~80 logs per round)
> artifact (74112/n74112, ComplexXenoArtifact) node effect (XAN-801) (74118/n74118, XenoArtifactFloraSpawn) revealed
5. **Node unlocked:** (~50 logs per round)
> artifact (74112/n74112, ComplexXenoArtifact) node effect (XAN-801) (74118/n74118, XenoArtifactFloraSpawn) unlocked
6. **Node extracted:** (~50 logs per round)
> analysis console (4615/n4615, ComputerAnalysisConsole) extracted 40383 points and 20 glimmer from node effect (XAN-801) (74118/n74118, XenoArtifactFloraSpawn). Details: base 4000; predecessors 2; durability 4/4; subtotal 15038; glimmerMultiplier 2.685448

### New `Glimmer` category

(a lot of things change glimmer. I just picked out some of the most "important" ones; we can group the rest into an "Other" category on Grafana, for now.)

7. **Node extracted:** (again. ~50 logs per round)
> analysis console (4615/n4615, ComputerAnalysisConsole) produced 20 glimmer from extracting node effect (XAN-801) (74118/n74118, XenoArtifactFloraSpawn)
8. **Person mindbroken:** (~5 logs per round)
> Urist McHands (142431/n142431, MobHuman, localhost@JoeGenero) drained 52 glimmer through mindbreaking
9. **Passive drain:** (1 log per 12 seconds, ~120 logs per round)
> system drained 1 glimmer passively
10. **Points report:** (1 log per 60 seconds, ~120 logs per round)
> current glimmer: 446
11. **Passive generators/drains:**
  - the glimmer prober is 1 log per 1-10 seconds, depending on the current glimmer level. ~4000 logs per round
  - all other sources are 1 log per 10 seconds. ~720 logs per source per round.
  - in total, I'd expect ~8000 logs per round.
> anomaly (137686/n137686, AnomalyFlora) produced 1 glimmer passively

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
