### PR TITLE
Xenoarch Research Mult Balance

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -86,7 +86,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     {
         float normalizedGlimmer = _glimmerSystem.Glimmer / 1000f;
         //DeltaV - Prevents extreme glimmer multipliers
-        return 1 + Math.Clamp((8f / 3f) * MathF.Pow(normalizedGlimmer, 3f) - 2f * MathF.Pow(normalizedGlimmer, 2f) + (4f / 3f) * (normalizedGlimmer), 0f, 2f);
+        return (float)(.5f + Math.Clamp(Math.Pow(normalizedGlimmer,.5) + 1.5f * Math.Pow(normalizedGlimmer, 10f), 0f, 2f));
 
     }
 }

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -86,7 +86,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     {
 
         //DeltaV - Prevents extreme glimmer multipliers
-        return 1 + Math.Clamp((MathF.Pow(_glimmerSystem.Glimmer / 1000f, 2f) * comp.PointGlimmerMultiplier), 0, 2);
+        return Math.Clamp(4f * MathF.Pow(_glimmerSystem.Glimmer / 1000f, 2f) - 3f * (_glimmerSystem.Glimmer / 1000f) + 2, 0f, 3f);
 
     }
 }

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -84,7 +84,10 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     // DeltaV
     private float GetGlimmerMultiplier(ArtifactAnalyzerComponent comp)
     {
-        return 1 + (MathF.Pow(_glimmerSystem.Glimmer / 1000f, 2f) * comp.PointGlimmerMultiplier);
+
+        //DeltaV - Prevents extreme glimmer multipliers
+        return 1 + Math.Clamp((MathF.Pow(_glimmerSystem.Glimmer / 1000f, 2f) * comp.PointGlimmerMultiplier), 0, 2);
+
     }
 }
 

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -84,9 +84,9 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     // DeltaV
     private float GetGlimmerMultiplier(ArtifactAnalyzerComponent comp)
     {
-
+        float normalizedGlimmer = _glimmerSystem.Glimmer / 1000f;
         //DeltaV - Prevents extreme glimmer multipliers
-        return Math.Clamp(4f * MathF.Pow(_glimmerSystem.Glimmer / 1000f, 2f) - 3f * (_glimmerSystem.Glimmer / 1000f) + 2, 0f, 3f);
+        return 1 + Math.Clamp((8f / 3f) * MathF.Pow(normalizedGlimmer, 3f) - 2f * MathF.Pow(normalizedGlimmer, 2f) + (4f / 3f) * (normalizedGlimmer), 0f, 2f);
 
     }
 }

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -86,7 +86,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     {
         float normalizedGlimmer = Math.Clamp(_glimmerSystem.Glimmer / 1000f, 0, 1);
         //DeltaV - Prevents extreme glimmer multipliers
-        return (float)(.5f + Math.Clamp(Math.Pow(normalizedGlimmer,.5) + 1.5f * Math.Pow(normalizedGlimmer, 10f), 0f, 2.5f));
+        return (float)(.5f + Math.Clamp(Math.Pow(normalizedGlimmer, 0.5f) + 1.5f * Math.Pow(normalizedGlimmer, 10f), 0f, 2.5f));
 
     }
 }

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -84,7 +84,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     // DeltaV
     private float GetGlimmerMultiplier(ArtifactAnalyzerComponent comp)
     {
-        float normalizedGlimmer = _glimmerSystem.Glimmer / 1000f;
+        float normalizedGlimmer = Math.Clamp(_glimmerSystem.Glimmer / 1000f, 0, 1);
         //DeltaV - Prevents extreme glimmer multipliers
         return (float)(.5f + Math.Clamp(Math.Pow(normalizedGlimmer,.5) + 1.5f * Math.Pow(normalizedGlimmer, 10f), 0f, 2.5f));
 

--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -86,7 +86,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     {
         float normalizedGlimmer = _glimmerSystem.Glimmer / 1000f;
         //DeltaV - Prevents extreme glimmer multipliers
-        return (float)(.5f + Math.Clamp(Math.Pow(normalizedGlimmer,.5) + 1.5f * Math.Pow(normalizedGlimmer, 10f), 0f, 2f));
+        return (float)(.5f + Math.Clamp(Math.Pow(normalizedGlimmer,.5) + 1.5f * Math.Pow(normalizedGlimmer, 10f), 0f, 2.5f));
 
     }
 }

--- a/Content.Shared/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/Components/ArtifactAnalyzerComponent.cs
@@ -19,13 +19,8 @@ public sealed partial class ArtifactAnalyzerComponent : Component
     /// <summary>
     /// DeltaV - The ratio of research points per one glimmer.
     /// </summary>
-    public int ExtractRatio = 750;
+    public int ExtractRatio = 1250;
 
-    /// <summary>
-    /// DeltaV - The maximum added multiplier, reached at max glimmer.
-    /// </summary>
-    [DataField]
-    public float PointGlimmerMultiplier = 8f;
     /// <summary>
     /// The current artifact placed on this analyzer.
     /// Can be null if none are present.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I created a new formula for the glimmer/research points multiplier for the new xenoarch system as the formula from the old system breaks the balance. This new formula will now scale glimmer multiplier to 1.5x, 2x and 3x at the glimmer values of 500, 750, and 1000 respectively and will clamp at the max of 3x.  Where as the previous version had the multiplier at 3x for 500 and no cap. I also increased the extract ratio from 750 to 1250, this will decrease the amount of glimmer added to the world per point of research to slow progress even more.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is to address concerns about my previous glimmer changes to xenoarch which brought over research values of nodes that were higher than the old system causing an issue with how the old system handled the glimmer multiplier, and how it can be abused to get research absurdly quick. This can be further adjusted based on feedback and admin logging of the new proposed system in #4994. 

These changes will make it so that it will get exceedingly dangerous to push research to the max while still rewarding and interacting with our unique glimmer system. Perhaps more changes could be made to make high glimmer values even more dangerous in later PRs.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the PointGlimmerMultiplier variable from Artifact Analyzer component as it was obsolete in the new formula. And changed Extract ratio from 750 to 1250

Created the new formula in ArtifactAnalyzerSystem as follows 

multiplier = 1 + (8/3) * (glimmer value/1000)^3 - 2 * (glimmer value/1000)^2 + (4/3) * (glimmer value/1000)

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ X] I have tested all added content and changes.
- [ X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
New Curve (Note this is before a +1)
<img width="1493" height="562" alt="Screenshot 2025-12-17 040245" src="https://github.com/user-attachments/assets/cd49d312-6f82-4df8-96db-aa2b82b8f139" />

Old Curve
<img width="673" height="920" alt="image" src="https://github.com/user-attachments/assets/f964af95-4b26-477f-8bed-16d3ef08fcd3" />


## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Nanotrasen has found scientists inflating their research evaluations. These scientists have been reprimanded by the company and re-educated on the proper way to fill out the research logs
