### PR TITLE
Fix Duplicate Kill Heads Objectives and Add TargetObjectiveImmune

### DIFF
--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -1,11 +1,7 @@
-using Content.Server._DV.Objectives.Components;
+using Content.Server._DV.Objectives.Components; // DeltaV
 using Content.Server.Objectives.Components;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
-using Content.Shared.Roles; // DeltaV
-using Content.Server.GameTicking.Rules;
-using Robust.Shared.Prototypes; // DeltaV
-using Robust.Shared.Random;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -96,3 +92,4 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
         _target.SetTarget(ent, picked, target);
     }
 }
+

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -28,14 +28,6 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
 
     private void OnSpecificPersonAssigned(Entity<PickSpecificPersonComponent> ent, ref ObjectiveAssignedEvent args)
     {
-        // DeltaV - TargetObjectiveImmune
-        if (HasComp<TargetObjectiveImmuneComponent>(ent.Owner))
-        {
-            args.Cancelled = true;
-            return;
-        }
-        // END DeltaV
-
         // invalid objective prototype
         if (!TryComp<TargetObjectiveComponent>(ent.Owner, out var target))
         {
@@ -53,6 +45,14 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
             return;
         }
 
+        // DeltaV - TargetObjectiveImmune
+        if (HasComp<TargetObjectiveImmuneComponent>(target.Target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+        // END DeltaV
+
         var user = args.Mind.OwnedEntity.Value;
         if (!TryComp<TargetOverrideComponent>(user, out var targetComp) || targetComp.Target == null)
         {
@@ -65,14 +65,6 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
 
     private void OnRandomPersonAssigned(Entity<PickRandomPersonComponent> ent, ref ObjectiveAssignedEvent args)
     {
-        // DeltaV - TargetObjectiveImmune
-        if (HasComp<TargetObjectiveImmuneComponent>(ent.Owner))
-        {
-            args.Cancelled = true;
-            return;
-        }
-        // END DeltaV
-
         // invalid objective prototype
         if (!TryComp<TargetObjectiveComponent>(ent, out var target))
         {
@@ -90,6 +82,16 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
             args.Cancelled = true;
             return;
         }
+
+        // DeltaV - TargetObjectiveImmune
+        // Pretty much just a back-up check. Ideally, we should have filtered out all the minds
+        // with this comp with the mind filter TargetObjectiveMindFilter.
+        if (HasComp<TargetObjectiveImmuneComponent>(picked))
+        {
+            args.Cancelled = true;
+            return;
+        }
+        // END DeltaV
 
         _target.SetTarget(ent, picked, target);
     }

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -1,13 +1,11 @@
+using Content.Server._DV.Objectives.Components;
 using Content.Server.Objectives.Components;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Roles; // DeltaV
-using Content.Shared.Roles.Jobs; // DeltaV
 using Content.Server.GameTicking.Rules;
-using Content.Server.Revolutionary.Components;
 using Robust.Shared.Prototypes; // DeltaV
 using Robust.Shared.Random;
-using System.Linq;
 
 namespace Content.Server.Objectives.Systems;
 
@@ -19,10 +17,6 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
 {
     [Dependency] private readonly TargetObjectiveSystem _target = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
-    [Dependency] private readonly SharedRoleSystem _role = default!; // DeltaV
-    [Dependency] private readonly IPrototypeManager _proto = default!; // DeltaV
-    [Dependency] private readonly IRobustRandom _random = default!;
-    [Dependency] private readonly TraitorRuleSystem _traitorRule = default!;
 
     public override void Initialize()
     {
@@ -34,6 +28,14 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
 
     private void OnSpecificPersonAssigned(Entity<PickSpecificPersonComponent> ent, ref ObjectiveAssignedEvent args)
     {
+        // DeltaV - TargetObjectiveImmune
+        if (HasComp<TargetObjectiveImmuneComponent>(ent.Owner))
+        {
+            args.Cancelled = true;
+            return;
+        }
+        // END DeltaV
+
         // invalid objective prototype
         if (!TryComp<TargetObjectiveComponent>(ent.Owner, out var target))
         {
@@ -63,6 +65,14 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
 
     private void OnRandomPersonAssigned(Entity<PickRandomPersonComponent> ent, ref ObjectiveAssignedEvent args)
     {
+        // DeltaV - TargetObjectiveImmune
+        if (HasComp<TargetObjectiveImmuneComponent>(ent.Owner))
+        {
+            args.Cancelled = true;
+            return;
+        }
+        // END DeltaV
+
         // invalid objective prototype
         if (!TryComp<TargetObjectiveComponent>(ent, out var target))
         {

--- a/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
+++ b/Content.Server/Objectives/Systems/PickObjectiveTargetSystem.cs
@@ -41,20 +41,20 @@ public sealed class PickObjectiveTargetSystem : EntitySystem
             return;
         }
 
-        // DeltaV - TargetObjectiveImmune
-        if (HasComp<TargetObjectiveImmuneComponent>(target.Target))
-        {
-            args.Cancelled = true;
-            return;
-        }
-        // END DeltaV
-
         var user = args.Mind.OwnedEntity.Value;
         if (!TryComp<TargetOverrideComponent>(user, out var targetComp) || targetComp.Target == null)
         {
             args.Cancelled = true;
             return;
         }
+
+        // DeltaV - TargetObjectiveImmune
+        if (HasComp<TargetObjectiveImmuneComponent>(targetComp.Target))
+        {
+            args.Cancelled = true;
+            return;
+        }
+        // END DeltaV
 
         _target.SetTarget(ent.Owner, targetComp.Target.Value);
     }

--- a/Content.Server/_DV/Objectives/Components/TargetObjectiveImmuneComponent.cs
+++ b/Content.Server/_DV/Objectives/Components/TargetObjectiveImmuneComponent.cs
@@ -1,9 +1,8 @@
-namespace Content.Server.Objectives.Components;
+
+namespace Content.Server._DV.Objectives.Components;
 
 /// <summary>
 /// Use this to mark a player as immune to any target objectives, useful for ghost roles or events.
 /// </summary>
 [RegisterComponent]
-public sealed partial class TargetObjectiveImmuneComponent : Component
-{
-}
+public sealed partial class TargetObjectiveImmuneComponent : Component;

--- a/Resources/Prototypes/Objectives/traitor.yml
+++ b/Resources/Prototypes/Objectives/traitor.yml
@@ -101,6 +101,7 @@
       blacklist:
         components:
         - KillPersonCondition
+        - TargetObjectiveImmune # DeltaV
   - type: KillPersonCondition
     requireMaroon: true
 
@@ -127,6 +128,7 @@
       blacklist:
         components:
         - KillPersonCondition
+        - TargetObjectiveImmune # DeltaV
   - type: KillPersonCondition
     # don't count missing evac as killing as heads are higher profile, so you really need to do the dirty work
     # if ce flies a shittle to centcom you better find a way onto it
@@ -156,6 +158,7 @@
         components:
         - HelpProgressCondition
         - KeepAliveCondition
+        - TargetObjectiveImmune # DeltaV
 
 - type: entity
   parent: [BaseTraitorSocialObjective, BaseHelpProgressObjective]
@@ -185,6 +188,7 @@
         components:
         - HelpProgressCondition
         - KeepAliveCondition
+        - TargetObjectiveImmune # DeltaV
 
 # steal
 

--- a/Resources/Prototypes/_DV/Objectives/asakim.yml
+++ b/Resources/Prototypes/_DV/Objectives/asakim.yml
@@ -40,6 +40,7 @@
       blacklist:
         components:
         - KillPersonCondition
+        - TargetObjectiveImmune
   - type: RerollAfterCompletion
     rerollObjectivePrototype: AsakimKillObjective
     rerollObjectiveMessage: objective-condition-asakim-terminate-reroll-message

--- a/Resources/Prototypes/_DV/Objectives/menaceskeleton.yml
+++ b/Resources/Prototypes/_DV/Objectives/menaceskeleton.yml
@@ -42,6 +42,7 @@
       blacklist:
         components:
         - KillPersonCondition
+        - TargetObjectiveImmune
 
 - type: entity
   parent: SkeletonBaseObjective

--- a/Resources/Prototypes/_DV/Objectives/ninja.yml
+++ b/Resources/Prototypes/_DV/Objectives/ninja.yml
@@ -24,6 +24,10 @@
       whitelist:
         components:
         - CommandStaff
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - TargetObjectiveImmune
 
 - type: entity
   parent: BaseNinjaTeachLessonObjective
@@ -48,6 +52,10 @@
       whitelist:
         components:
         - CommandStaff
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - TargetObjectiveImmune
 
   - type: KillPersonCondition
     requireDead: true

--- a/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
+++ b/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
@@ -50,6 +50,10 @@
       whitelist:
         components:
         - CommandStaff
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - TargetObjectiveImmune
   - type: KillPersonCondition
     requireDead: true
 

--- a/Resources/Prototypes/_DV/Objectives/skia.yml
+++ b/Resources/Prototypes/_DV/Objectives/skia.yml
@@ -25,6 +25,7 @@
       blacklist:
         components:
         - KillPersonCondition
+        - TargetObjectiveImmune
   - type: RerollAfterCompletion
     rerollObjectivePrototype: SkiaReapObjective
     rerollObjectiveMessage: objective-condition-reap-soul-reroll-message

--- a/Resources/Prototypes/_DV/Objectives/traitor.yml
+++ b/Resources/Prototypes/_DV/Objectives/traitor.yml
@@ -101,15 +101,12 @@
     title: objective-condition-teach-person-title
   - type: PickRandomPerson
     filters:
-    - !type:BodyMindFilter
-      whitelist:
-        components:
-        - CommandStaff
     # Can't have multiple objectives to kill the same person.
     - !type:TargetObjectiveMindFilter
       blacklist:
         components:
         - KillPersonCondition
+        - TargetObjectiveImmune
 
 # Kill fellow traitor objective
 - type: entity

--- a/Resources/Prototypes/_DV/Objectives/wizard.yml
+++ b/Resources/Prototypes/_DV/Objectives/wizard.yml
@@ -94,6 +94,10 @@
         components:
         - CommandStaff
         - KillPersonCondition # Should also choose those who have targets on their heads by other antags :3
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - TargetObjectiveImmune
 
 - type: entity
   parent: [BaseWizardObjective, BaseKillObjective]

--- a/Resources/Prototypes/_DV/Objectives/wizard.yml
+++ b/Resources/Prototypes/_DV/Objectives/wizard.yml
@@ -113,6 +113,7 @@
       blacklist:
         components:
         - KillPersonCondition
+        - TargetObjectiveImmune
   - type: KillPersonCondition
     requireDead: true
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixed TargetObjectiveImmune.

Also, traitors will get more variety of teach a lesson objectives (since before it was just choosing heads)

Dedicated to @PureBreadBagel 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!

-->
:cl:
- fix: Fixed teach a lesson objectives from only choosing heads of staff.
