### PR TITLE
Removed direction from Texture directory changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,6 @@
 # Server config files
 /Resources/ConfigPresets/ @Toby222
 
-# Sprites - Direction in lack of art director
-/Resources/Textures/ @DeltaV-Station/direction
-
 # Lobby art and music - automatically direction issues since its immediately visible to players
 /Resources/Audio/Lobby/ @DeltaV-Station/direction
 /Resources/Textures/LobbyScreens/ @DeltaV-Station/direction


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Removed direction from texture changes. @Toby222 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Needless requirement to have direction team (on github) manually approve anything that happens in the Texture directory. What ends up happening is I usually have to nag @Proxysseia or @Cepelinas1 to approve it, or @Toby222 just ignores those required approvals and merges it.

Internal direction discussions already go over the art style of new textures, and commenting on getting direction approval is given with that in mind. 

There have been a lot of PRs lately that just get held up since we're waiting on one of two people to actually approve it. Just remove this blocker.

## Technical details
<!-- Summary of code changes for easier review. -->
Defaults to maintainers since Resources is specified earlier.
