### PR TITLE
Xenovent event changes

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -51,38 +51,47 @@
   parent: [MobXeno, BaseMobXenoPlayer]
   id: MobXenoPlayer
   name: Burrower
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
   parent: [MobXenoPraetorianNPC, BaseMobXenoPlayer]
   id: MobXenoPraetorian
   name: Praetorian
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
   parent: [MobXenoDroneNPC, BaseMobXenoPlayer]
   id: MobXenoDrone
   name: Drone
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
   parent: [MobXenoQueenNPC, BaseMobXenoPlayer]
   id: MobXenoQueen
   name: Queen
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
   parent: [MobXenoRavagerNPC, BaseMobXenoPlayer]
   id: MobXenoRavager
   name: Ravager
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
   parent: [MobXenoRunnerNPC, BaseMobXenoPlayer]
   id: MobXenoRunner
   name: Runner
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
   parent: [MobXenoRounyNPC, BaseMobXenoPlayer]
   id: MobXenoRouny
   name: Rouny
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
   parent: [MobXenoSpitterNPC, BaseMobXenoPlayer]
   id: MobXenoSpitter
   name: Spitter
+  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
+  

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/NPCs/xeno.yml
@@ -48,50 +48,42 @@
   - type: GhostTakeoverAvailable
 
 - type: entity
-  parent: [MobXeno, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXeno] #Delta-v - reverse order so suffix works
   id: MobXenoPlayer
   name: Burrower
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
-  parent: [MobXenoPraetorianNPC, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXenoPraetorianNPC] #Delta-v - reverse order so suffix works
   id: MobXenoPraetorian
   name: Praetorian
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
-  parent: [MobXenoDroneNPC, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXenoDroneNPC] #Delta-v - reverse order so suffix works
   id: MobXenoDrone
   name: Drone
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
-  parent: [MobXenoQueenNPC, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXenoQueenNPC] #Delta-v - reverse order so suffix works
   id: MobXenoQueen
   name: Queen
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
-  parent: [MobXenoRavagerNPC, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXenoRavagerNPC] #Delta-v - reverse order so suffix works
   id: MobXenoRavager
   name: Ravager
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
-  parent: [MobXenoRunnerNPC, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXenoRunnerNPC] #Delta-v - reverse order so suffix works
   id: MobXenoRunner
   name: Runner
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
-  parent: [MobXenoRounyNPC, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXenoRounyNPC] #Delta-v - reverse order so suffix works
   id: MobXenoRouny
   name: Rouny
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
 
 - type: entity
-  parent: [MobXenoSpitterNPC, BaseMobXenoPlayer]
+  parent: [BaseMobXenoPlayer, MobXenoSpitterNPC] #Delta-v - reverse order so suffix works
   id: MobXenoSpitter
   name: Spitter
-  suffix: Ghostrole # Delta-v - xenovents change. Parented suffix doesn't work
   

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -54,22 +54,22 @@
   - type: VentCrittersRule
     table: !type:GroupSelector
       children:
-      - id: MobXeno
-        weight: 0.55
+      - id: MobXenoPlayer
+        weight: 0.20
       - id: MobXenoRouny
         weight: 0.01
       - id: MobXenoDrone
-        weight: 0.25
+        weight: 0.35
       - id: MobXenoSpitter
-        weight: 0.05
+        weight: 0.14
       - id: MobXenoRunner
-        weight: 0.08
+        weight: 0.14
       - id: MobXenoPraetorian
-        weight: 0.03
+        weight: 0.08
       - id: MobXenoRavager
-        weight: 0.02
+        weight: 0.05
       - id: MobXenoQueen
-        weight: 0.01
+        weight: 0.03
 # Mothroaches
 - type: entity
   parent: BaseGameRule


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Changed around Xenovents xeno chances
Also made the ghostrole Xenos have [Ghostrole] in the name since parented suffix didn't work
Also made it spawn MobXenoPlayer instead of MobXeno because burrower wasn't a ghostrole previously

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We made xenos scary which was completely useless because 80% of spawns were either drones or burrowers, 13% were runners and spitters and 6% were either ravagers, praetorians or queens (and 1% were rounies)
Now it's 55% of drones and burrowers, 28% of runners or spitters, and 16% are either praetorians, ravagers or queens
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Before 
<img width="348" height="221" alt="Screenshot 2025-12-21 035350" src="https://github.com/user-attachments/assets/787fbb04-7bb0-43c5-97cb-d79bb740d5b6" />

After
<img width="352" height="191" alt="image" src="https://github.com/user-attachments/assets/12af2845-7b38-456b-8be5-98fb6521bd40" />

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- tweak: Vent xenonids are now more likely to be of higher tiers
