### PR TITLE
Flesh anomalite doesn't get damaged by meat kudzu

### DIFF
--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1801,7 +1801,7 @@
   footstepSounds:
     collection: FootstepBlood
   itemDrop: FloorTileItemFlesh
-  # friction: 0.25 #slippy + Delta-v - Flesh tiles no longer slippery
+  friction: 0.25 #slippy
   heatCapacity: 10000
 
 - type: tile

--- a/Resources/Prototypes/Tiles/floors.yml
+++ b/Resources/Prototypes/Tiles/floors.yml
@@ -1801,7 +1801,7 @@
   footstepSounds:
     collection: FootstepBlood
   itemDrop: FloorTileItemFlesh
-  friction: 0.25 #slippy
+  # friction: 0.25 #slippy + Delta-v - Flesh tiles no longer slippery
   heatCapacity: 10000
 
 - type: tile

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Anomalites/anomalites.yml
@@ -367,6 +367,12 @@
   - type: InnerBodyAnomaly
     injectionProto: AnomalyInjectionFlesh
     skipStun: true
+  - type: Tag # Delta-v - add flesh to flesh anomalite so it isn't damaged by meat anomaly kudzu
+    tags:
+    - VimPilot
+    - DoorBumpOpener
+    - AnomalyHost # this is potentially really funny. if not, or if it causes problems, we can remove it.
+    - Flesh
 
 # Rock
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Removes slippery from meat tiles
Adds Flesh Tag to flesh anomalite
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Who made them slippery and WHY
## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
**Changelog**

:cl:
- fix: Flesh anomalite no longer get damaged by meat kudzu