### PR TITLE
Change how Minor Mass Mind Swap Cooldown starts/Fix Telegnosis

### DIFF
--- a/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
+++ b/Content.Server/Nyanotrasen/Abilities/Psionics/Abilities/MindSwapPowerSystem.cs
@@ -168,7 +168,7 @@ namespace Content.Server.Abilities.Psionics
                 psionic.PsionicAbility = component.MindSwapReturnActionEntity;
         }
 
-        public void Swap(EntityUid performer, EntityUid target, bool end = false)
+        public void Swap(EntityUid performer, EntityUid target, bool end = false, int ReturnSwapCooldown = 0)
         {
             if (end && (!HasComp<MindSwappedComponent>(performer) || !HasComp<MindSwappedComponent>(target)))
                 return;
@@ -209,6 +209,15 @@ namespace Content.Server.Abilities.Psionics
 
             var perfComp = EnsureComp<MindSwappedComponent>(performer);
             var targetComp = EnsureComp<MindSwappedComponent>(target);
+
+            // Delta V - Cooldown for Returning back
+            if (ReturnSwapCooldown > 0)
+            {
+                var cooldown = TimeSpan.FromSeconds(ReturnSwapCooldown);
+                _actions.SetCooldown(perfComp.MindSwapReturnActionEntity, cooldown);
+                _actions.SetCooldown(targetComp.MindSwapReturnActionEntity, cooldown);
+            }
+            // Delta V
 
             perfComp.OriginalEntity = target;
             targetComp.OriginalEntity = performer;

--- a/Content.Server/_DV/StationEvents/Components/MinorMassMindSwapRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/MinorMassMindSwapRuleComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class MinorMassMindSwapRuleComponent : Component
     public TimeSpan Delay = TimeSpan.FromSeconds(60);
 
     [DataField]
-    public TimeSpan ReturnSwapCooldown = TimeSpan.FromSeconds(120);
+    public int ReturnSwapCooldown = 120;
 
     [DataField]
     public SoundSpecifier AnnouncementSound = new SoundPathSpecifier("/Audio/Misc/notice1.ogg");

--- a/Content.Server/_DV/StationEvents/Components/MinorMassMindSwapRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/MinorMassMindSwapRuleComponent.cs
@@ -17,6 +17,9 @@ public sealed partial class MinorMassMindSwapRuleComponent : Component
     public TimeSpan Delay = TimeSpan.FromSeconds(60);
 
     [DataField]
+    public TimeSpan ReturnSwapCooldown = TimeSpan.FromSeconds(120);
+
+    [DataField]
     public SoundSpecifier AnnouncementSound = new SoundPathSpecifier("/Audio/Misc/notice1.ogg");
 
     [DataField]

--- a/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
@@ -11,6 +11,8 @@ using Robust.Server.Audio;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
+using Content.Shared.Actions;
+using Content.Shared._DV.Abilities.Psionics;
 
 namespace Content.Server._DV.StationEvents.Events;
 
@@ -22,6 +24,7 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly MindSwapPowerSystem _mindSwap = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly SharedActionsSystem _action = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MobStateSystem _mobstateSystem = default!;
 
@@ -73,6 +76,14 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
         }
     }
 
+    private void StartSwapMindsCooldown(EntityUid target)
+    {
+        // Cooldown Solution just for this.
+        var targetMindPowerComp = Comp<MindSwappedComponent>(target);
+
+        _action.SetCooldown(targetMindPowerComp.MindSwapReturnActionEntity, TimeSpan.FromSeconds(120));
+    }
+
     private void SwapMinds(MinorMassMindSwapRuleComponent component)
     {
         List<EntityUid> psionicActors = new();
@@ -96,6 +107,9 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
             var target02 = _random.PickAndTake(psionicActors);
 
             _mindSwap.Swap(target01, target02);
+
+            StartSwapMindsCooldown(target01);
+            StartSwapMindsCooldown(target02);
 
             if (!component.IsTemporary)
             {

--- a/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
@@ -76,12 +76,12 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
         }
     }
 
-    private void StartSwapMindsCooldown(EntityUid target)
+    private void StartSwapMindsCooldown(MinorMassMindSwapRuleComponent component, EntityUid target)
     {
         // Cooldown Solution just for this.
         var targetMindPowerComp = Comp<MindSwappedComponent>(target);
 
-        _action.SetCooldown(targetMindPowerComp.MindSwapReturnActionEntity, TimeSpan.FromSeconds(120));
+        _action.SetCooldown(targetMindPowerComp.MindSwapReturnActionEntity, component.ReturnSwapCooldown);
     }
 
     private void SwapMinds(MinorMassMindSwapRuleComponent component)
@@ -108,8 +108,8 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
 
             _mindSwap.Swap(target01, target02);
 
-            StartSwapMindsCooldown(target01);
-            StartSwapMindsCooldown(target02);
+            StartSwapMindsCooldown(component, target01);
+            StartSwapMindsCooldown(component, target02);
 
             if (!component.IsTemporary)
             {

--- a/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
@@ -76,14 +76,6 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
         }
     }
 
-    private void StartSwapMindsCooldown(MinorMassMindSwapRuleComponent component, EntityUid target)
-    {
-        // Cooldown Solution just for this.
-        var targetMindPowerComp = Comp<MindSwappedComponent>(target);
-
-        _action.SetCooldown(targetMindPowerComp.MindSwapReturnActionEntity, component.ReturnSwapCooldown);
-    }
-
     private void SwapMinds(MinorMassMindSwapRuleComponent component)
     {
         List<EntityUid> psionicActors = new();
@@ -106,10 +98,7 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
             var target01 = _random.PickAndTake(psionicActors);
             var target02 = _random.PickAndTake(psionicActors);
 
-            _mindSwap.Swap(target01, target02);
-
-            StartSwapMindsCooldown(component, target01);
-            StartSwapMindsCooldown(component, target02);
+            _mindSwap.Swap(target01, target02, false, component.ReturnSwapCooldown);
 
             if (!component.IsTemporary)
             {

--- a/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs
@@ -11,8 +11,6 @@ using Robust.Server.Audio;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
-using Content.Shared.Actions;
-using Content.Shared._DV.Abilities.Psionics;
 
 namespace Content.Server._DV.StationEvents.Events;
 
@@ -24,7 +22,6 @@ internal sealed class MinorMassMindSwapRule : StationEventSystem<MinorMassMindSw
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly MindSwapPowerSystem _mindSwap = default!;
     [Dependency] private readonly ChatSystem _chat = default!;
-    [Dependency] private readonly SharedActionsSystem _action = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MobStateSystem _mobstateSystem = default!;
 

--- a/Resources/Prototypes/_DV/Actions/psionic.yml
+++ b/Resources/Prototypes/_DV/Actions/psionic.yml
@@ -68,8 +68,7 @@
     icon:
       sprite: _DV/Interface/Actions/actions_psionics.rsi
       state: mind_swap_return
-    startDelay: true # Delta V - Start Delay after Mind Swap
-    useDelay: 120 # Delta V - 20 => 120
+    useDelay: 20 
     checkCanInteract: false
   - type: InstantAction
     event: !type:MindSwapPowerReturnActionEvent

--- a/Resources/Prototypes/_DV/Actions/psionic.yml
+++ b/Resources/Prototypes/_DV/Actions/psionic.yml
@@ -68,7 +68,7 @@
     icon:
       sprite: _DV/Interface/Actions/actions_psionics.rsi
       state: mind_swap_return
-    useDelay: 20 
+    useDelay: 20
     checkCanInteract: false
   - type: InstantAction
     event: !type:MindSwapPowerReturnActionEvent


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Changed where the cooldown started... cause I'm somewhat baffled that until this time nobody complained about Telegnosis being borked.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Two minutes of being a ghost in Telegnosis is hardcore.

## Technical details
<!-- Summary of code changes for easier review. -->

Remove the Cooldown start of delay and changes in the psionic.yml and move them as a manual start within the same method where as we do the swap.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Remove Telegnosis having a two minute cooldown to return
