### PR TITLE
Small to Medium Battery for Handheld Crew Monitor

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -35,6 +35,11 @@
     - HighRiskItem
   - type: StealTarget
     stealGroup: HandheldCrewMonitor
+  - type: ItemSlots # Delta V - Bigger Battery
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default 
+        startingItem: PowerCellMedium
 
 - type: entity
   id: HandheldCrewMonitorEmpty


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I simply changed the cell size of the starting handheld crew monitor from small to medium

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The only thing this would change is a 1-2 minute excursion stealing a cell from a fire helmet.
Simply makes a bit more sense to have a bigger battery for such a well-used item.

## Technical details
<!-- Summary of code changes for easier review. -->
- Edited the handheld crew monitor yml to add the medium cell.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Crew Monitor cell size is now Medium
