### PR TITLE
Fix the wings in salvage's suits

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -151,6 +151,7 @@
     - CorgiWearable
     - Hardsuit
     - WhitelistChameleon
+    - HidesHarpyWings # DeltaV - Harpy specific sprite
 
 #Goliath Hardsuit
 - type: entity
@@ -196,6 +197,7 @@
     - CorgiWearable
     - Hardsuit
     - WhitelistChameleon
+    - HidesHarpyWings # DeltaV - Harpy specific sprite
 
 #Maxim Hardsuit
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Mining, Rhino and Goliath hardsuits didn't cover up the wings for harpies anymore.  Now they do again.

## Why / Balance
the fluffie. the feathers. they must be protected.

## Technical details
Just added the relevant tag.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed the exposed harpy wings in salvage's hardsuits.

