### PR TITLE
Borgs must amogus.

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -165,9 +165,10 @@
     speechVerb: Robotic
     speechSounds: Borg
   - type: Vocal
+    wilhelm: "/Audio/_EE/Voice/IPC/wilhelm.ogg" # DeltaV
     sounds:
       Unsexed: UnisexSilicon
-    wilhelmProbability: 0
+    wilhelmProbability: 0.001 # DeltaV
   - type: DamagedSiliconAccent
   - type: UnblockableSpeech
   - type: FootstepModifier
@@ -519,9 +520,10 @@
     allowedEmotes:
     - Laugh
   - type: Vocal
+    wilhelm: "/Audio/_EE/Voice/IPC/wilhelm.ogg" # DeltaV
     sounds:
       Unsexed: UnisexSiliconXenoborg
-    wilhelmProbability: 0
+    wilhelmProbability: 0.001 # DeltaV
   - type: DamagedSiliconAccent
   - type: UnblockableSpeech
   - type: FootstepModifier


### PR DESCRIPTION
## About the PR
Borgs/Xenoborgs can now wilhelm at same chance as IPC's.

## Why / Balance
I have no mouth but i must amogus.

## Technical details
Yaml ops.

## Media
Video has wilhelm 100%, not the actual 0.1%.
https://github.com/user-attachments/assets/f4ce513d-bd08-4dad-858e-6a3fd664a73b

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Cyborgs and Xenoborgs can now do a rare scream.
