### PR TITLE
less stupid stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,11 +20,16 @@ jobs:
     - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        exempt-issue-labels: 'Priority: 1-Urgent,ignore-stale'
+
         days-before-stale: 90
-        stale-issue-message: 'This issue will close in 2 days due to inactivity'
-        days-before-close: 2
-        stale-pr-message: 'This Pull Request will close in 2 days due to inactivity'
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
         remove-stale-when-updated: true
+
+        stale-issue-message: 'This issue has not been triaged for 90 days'
+        only-issue-labels: 'S: Untriaged'
+        stale-issue-label: 'Stale'
+        days-before-issue-close: -1
+
+        stale-pr-message: 'This Pull Request has not seen activity in 90 days, and will be closed in 2 days without activity'
+        exempt-pr-labels: 'Ignore Stale'
+        stale-pr-label: 'Stale'
+        days-before-pr-close: 2


### PR DESCRIPTION
## About the PR
Improve the half-forgotten stale issues workflow

## Why / Balance
Issues should not be closed due to inactivity

## Technical details
***Untriaged*** Issues (that is, issues with the `S: Untriaged` label) get labeled `Stale` after 90 days without activity.
PRs get labelled stale after 90 days without activity unless they have the "Ignore Stale" label, and closed after 2 further days without activity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
- [ ] ~~I have tested all added content and changes.~~ can't test this, sorgy
- [X] I have added media to this PR or it does not require an ingame showcase.