### PR TITLE
Update potted plants with slightly larger interaction zone

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/potted_plants.yml
@@ -15,8 +15,8 @@
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeCircle
-          radius: 0.1
+          !type:PhysShapeAabb # Delta V - Switch to square for more accuracy and enlarge for easier interactions
+          bounds: "-0.20,-0.25,0.20,0.20"
         density: 190
         mask:
         - HighImpassable


### PR DESCRIPTION
## About the PR
Changes the fixture bounds to make them easier to interact with. 

## Why / Balance
It is frustratingly difficult to grab them 

## Technical details
n/a

## Media
<img width="119" height="103" alt="image" src="https://github.com/user-attachments/assets/b4cfff74-92fb-4859-a4b4-236ffc603f13" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- fix: Fixed potted plants not being easy to grab
