### PR TITLE
Adjust toilet loot frequency to be less frequent

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -235,7 +235,7 @@
     - id: PowerCellHigh # DeltaV - was PowerCellMedium
     - id: DoubleEmergencyOxygenTankFilled
     - id: DoubleEmergencyNitrogenTankFilled
-    - id: Sunglasses # DeltaV
+    - id: ClothingEyesGlassesSunglasses # DeltaV
     - id: voicesensor # DeltaV
     - id: CrayonMagic # DeltaV
 

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -217,8 +217,8 @@
     - id: Wrench
     - id: Wirecutter
     - id: Welder
-    - id: ClothingMaskGas
-    - id: PowerCellSmall
+    - id: ClothingMaskWeldingGas # DeltaV
+    - id: PowerCellMedium # DeltaV - was PowerCellSmall
     - id: RadioHandheld
     - id: Syringe
     - id: CableApcStack
@@ -232,9 +232,12 @@
     - id: DrinkSpaceLube
     - id: WelderIndustrial
     - id: ClothingHeadHatWeldingMaskFlame
-    - id: PowerCellMedium
+    - id: PowerCellHigh # DeltaV - was PowerCellMedium
     - id: DoubleEmergencyOxygenTankFilled
     - id: DoubleEmergencyNitrogenTankFilled
+    - id: Sunglasses # DeltaV
+    - id: voicesensor # DeltaV
+    - id: CrayonMagic # DeltaV
 
 - type: entityTable
   id: ToiletCisternUtilityTable
@@ -244,6 +247,7 @@
     - id: Ointment
     - id: Gauze
     - id: ChemistryBottleUnstableMutagen
+    - id: PillCanisterRandom # DeltaV
 
 - type: entityTable
   id: ToiletCisternWeaponsTable
@@ -255,7 +259,7 @@
     - id: SawImprov
     - id: HydroponicsToolHatchet
     - id: ClothingHandsKnuckleDusters
-    - id: WeaponFlareGun
+    #- id: WeaponFlareGun # DeltaV - too common
 
 - type: entityTable
   id: ToiletCisternSyndicateTable
@@ -266,6 +270,7 @@
     - id: SoapSyndie
     - id: SyndicatePersonalAI
     - id: UplinkLighterBox
+    - id: ClothingHandsGlovesConducting # DeltaV - fake insuls hehe
 
 - type: entityTable
   id: ToiletCisternLoot

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -162,8 +162,13 @@
         reagents:
         - ReagentId: Water
           Quantity: 180
-        - ReagentId: GastroToxin
-          Quantity: 20
+# Delta V - Begin: Add random reagent to water
+        #- ReagentId: GastroToxin
+        #  Quantity: 20
+  - type: RandomFillSolution
+    solution: tank
+    weightedRandomId: RandomFillToiletMisc
+# Delta V - End: Add random reagent to water
 
 - type: entity
   parent: ToiletEmpty
@@ -245,5 +250,10 @@
           Quantity: 160
         - ReagentId: Gold
           Quantity: 20
-        - ReagentId: GastroToxin
-          Quantity: 20
+# Delta V - Begin: Add random reagent to water
+        #- ReagentId: GastroToxin
+        #  Quantity: 20
+  - type: RandomFillSolution
+    solution: tank
+    weightedRandomId: RandomFillToiletMisc
+# Delta V - End: Add random reagent to water

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -173,7 +173,7 @@
   - type: EntityTableContainerFill
     containers:
       stash: !type:NestedSelector
-        tableId: ToiletCisternLoot
+        tableId: ToiletCisternLootPublic     # Delta V - Make better loot more common
         prob: 0.33                           # Delta V - Decrease freaquency of loot
         #rolls: !type:RangeNumberSelector
         #  range: 0, 1
@@ -186,7 +186,7 @@
   - type: EntityTableContainerFill
     containers:
       stash: !type:NestedSelector
-        tableId: ToiletCisternLoot
+        tableId: ToiletCisternLootPublic     # Delta V - Make better loot more common
         prob: 0.33                           # Delta V - Decrease freaquency of loot
         #rolls: !type:RangeNumberSelector
         #  range: 0, 1

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -174,7 +174,7 @@
     containers:
       stash: !type:NestedSelector
         tableId: ToiletCisternLoot
-        prob: 0.2                           # Delta V - Decrease freaquency of loot
+        prob: 0.33                           # Delta V - Decrease freaquency of loot
         #rolls: !type:RangeNumberSelector
         #  range: 0, 1
 
@@ -187,7 +187,7 @@
     containers:
       stash: !type:NestedSelector
         tableId: ToiletCisternLoot
-        prob: 0.2                           # Delta V - Decrease freaquency of loot
+        prob: 0.33                           # Delta V - Decrease freaquency of loot
         #rolls: !type:RangeNumberSelector
         #  range: 0, 1
 

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -174,8 +174,9 @@
     containers:
       stash: !type:NestedSelector
         tableId: ToiletCisternLoot
-        rolls: !type:RangeNumberSelector
-          range: 0, 1
+        prob: 0.2                           # Delta V - Decrease freaquency of loot
+        #rolls: !type:RangeNumberSelector
+        #  range: 0, 1
 
 - type: entity
   parent: ToiletDirtyWater
@@ -186,8 +187,9 @@
     containers:
       stash: !type:NestedSelector
         tableId: ToiletCisternLoot
-        rolls: !type:RangeNumberSelector
-          range: 0, 1
+        prob: 0.2                           # Delta V - Decrease freaquency of loot
+        #rolls: !type:RangeNumberSelector
+        #  range: 0, 1
 
 - type: entity
   parent: BaseToilet

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
@@ -8,3 +8,24 @@
       stash: !type:NestedSelector
         tableId: ToiletCisternLoot
         prob: 0.2
+
+# For public toilets
+- type: entityTable
+  id: ToiletCisternLootPublic
+  table: !type:GroupSelector
+    children:
+    - !type:NestedSelector
+      weight: 10 # from 8
+      tableId: ToiletCisternRareToolsTable
+    - !type:NestedSelector
+      weight: 8 # from 5
+      tableId: ToiletCisternUtilityTable
+    - !type:NestedSelector
+      weight: 4 # from 25
+      tableId: ToiletCisternCommonToolsTable
+    - !type:NestedSelector
+      weight: 3 # no change
+      tableId: ToiletCisternWeaponsTable
+    - !type:NestedSelector
+      weight: 1 # no change
+      tableId: ToiletCisternSyndicateTable

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
@@ -46,7 +46,7 @@
     - Water
     - Water
     - Water
-    - water
+    - Water
     # Cleaners
     - SpaceCleaner
     - SoapReagent

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
@@ -29,3 +29,67 @@
     - !type:NestedSelector
       weight: 1 # no change
       tableId: ToiletCisternSyndicateTable
+
+# Toilet reagent fill
+- type: weightedRandomFillSolution
+  id: RandomFillToiletMisc
+  fills:
+  - quantity: 20
+    reagents:
+    # 1:5 chance of clean water
+    - Water
+    - Water
+    - Water
+    - Water
+    - Water
+    - Water
+    - Water
+    - Water
+    - Water
+    - water
+    # Cleaners
+    - SpaceCleaner
+    - SoapReagent
+    - Bleach
+    - Chlorine
+    # Funny
+    - SpaceLube
+    - Laughter
+    - Happiness
+    - Holywater
+    - WeldingFuel
+    - Mopwata
+    # Puke n stuff
+    - Toxin
+    - Vomit
+    - VentCrud
+    - UncookedAnimalProteins
+    - ToxinTrash
+    - GastroToxin
+    # Foods
+    - Mold
+    - Cornoil
+    - Hotsauce
+    - Ketchup
+    - Mayo
+    - Beer
+    - MilkSpoiled
+    - HotRamen
+    - Tequila
+    # Chems & drugs
+    - Honk
+    - Nausium
+    - LotophagoiOil
+    - Enzyme
+    - SpaceDrugs
+    - Diphenhydramine
+    - Cognizine
+    - Nocturine
+    - UnstableMutagen
+    - Romerol
+    # Blood
+    - Blood
+    - Slime
+    - ZombieBlood
+    - Ichor
+    - SynthBlood

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
@@ -1,0 +1,10 @@
+- type: entity
+  parent: ToiletDirtyWaterFilled
+  id: ToiletDirtyWaterFilledPerma
+  suffix: Perma
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      stash: !type:NestedSelector
+        tableId: ToiletCisternLoot
+        prob: 0.2


### PR DESCRIPTION
## About the PR
- Title: Drops standard toilets from 50% chance of loot -> 33%
- Increases chance of better loot for public toilets
- Adds a 20% loot chance variant for mapping in perma
- Adds random reagents to the "dirty" toilets

## Why / Balance
We map a lot of these, and every perma will have a few. 50% is just too frequent.

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl:
- tweak: Lowered the chance of toilet cisterns containing loot but improved the loot table of the loot that spawned.
- tweak: Dirty toilets may now contain something better or even perhaps worse than just water or gastrotoxin.