### PR TITLE
Fix grinder items not being reduced

### DIFF
--- a/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
+++ b/Content.Server/Kitchen/EntitySystems/ReagentGrinderSystem.cs
@@ -121,7 +121,7 @@ namespace Content.Server.Kitchen.EntitySystems
                         solution = scaledSolution;
 
                         // _stackSystem.ReduceCount((item, stack), fitsCount); // Setting to 0 will QueueDel // Imp
-                        toSet.Add((item, stack.Count - fitsCount)); // Imp
+                        toSet.Add((item, fitsCount)); // Imp
 
                     }
                     else


### PR DESCRIPTION
## About the PR
Properly reduce item count instead of set

## Why / Balance
Fixes #5073

## Technical details
Missed change from upstream

## Media
/

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: The grinder no longer produces infinite resources
