### PR TITLE
Advanced plate carrier nerf

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
@@ -62,11 +62,11 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.75
-        Slash: 0.75
+        Blunt: 0.7
+        Slash: 0.7
         Piercing: 0.4
         Shock: 0.8
-        Heat: 0.75
+        Heat: 0.7
   - type: StaminaResistance
     damageCoefficient: 0.6
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
@@ -59,14 +59,14 @@
     sprite: _DV/Clothing/OuterClothing/Vests/advcarrier.rsi
   - type: Clothing
     sprite: _DV/Clothing/OuterClothing/Vests/advcarrier.rsi
-  - type: Armor # intended as Head of Security's and Warden's armour only, hence high values; resists at 40% flat with 60% pierce and 30% shock.
+  - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
+        Blunt: 0.75
+        Slash: 0.75
         Piercing: 0.4
-        Shock: 0.7
-        Heat: 0.6
+        Shock: 0.8
+        Heat: 0.75
   - type: StaminaResistance
     damageCoefficient: 0.6
   - type: ClothingSpeedModifier


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Moves the APCs off values to be a bit less exessive

## Why / Balance
Right now as hos your armor choices are a coat that does 25% across the board a trench coat that does 35-40% across the board and a plate carrier that makes you 15% slower for 40% across the board and a 60% in pierce resistance which is madness that's 25% faster than the warden hardsuit for nearly the same values. Plate carriers are allowed to be strong against ballistics because they are weak to literally everything else and are slow. I dont think that 5% slowness compared to a normal plate carrier is enough of a nerf for 15% more armor across the board. If we want hos to be a counterable force they should probably be weak to their counters (A energy sword, emagged lathe's energy weapons) 

P.S.: keep in mind that this nerf will effect both warden and ERT as they both spawn with a advanced plate carrier

Hos armor options below to compare it to
## Technical details
3 lines of yml inside _DV changes removed a note bc it was both redundant and factually incorrect

## Media
<img width="586" height="363" alt="image" src="https://github.com/user-attachments/assets/c28803fb-ab5d-4a45-8150-c39b43d94efa" />
<img width="846" height="506" alt="image" src="https://github.com/user-attachments/assets/db7709aa-63b0-4476-b185-e8ab545f4a56" />
<img width="835" height="501" alt="image" src="https://github.com/user-attachments/assets/edac557f-7cd3-47e9-a235-cbae81b04c62" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Advanced plate carrier's heat, slash, and blunt resistance nerfed from 40% to 30%. Shock nerfed from 30% to 20%

