### PR TITLE
Fix Cosmic Cult Server Crash

### DIFF
--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -284,7 +284,7 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
 
     private void StewardVote()
     {
-        // If there's already an entity with steward, don't hold a vote. This allows admins to add the Cosmic Cult rule a 2nd time 
+        // If there's already an entity with steward, don't hold a vote. This allows admins to add the Cosmic Cult rule a 2nd time
         // in the case that there is only one cultist and they've been chosen as the steward already.
         var stewardExists = false;
         var stewardQuery = EntityQueryEnumerator<CosmicCultLeadComponent>();

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -284,6 +284,19 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
 
     private void StewardVote()
     {
+        // If there's already an entity with steward, don't hold a vote. This allows admins to add the Cosmic Cult rule a 2nd time 
+        // in the case that there is only one cultist and they've been chosen as the steward already.
+        var stewardExists = false;
+        var stewardQuery = EntityQueryEnumerator<CosmicCultLeadComponent>();
+        while (stewardQuery.MoveNext(out var steward, out _))
+            stewardExists = true;
+
+        if (stewardExists)
+        {
+            _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"There is already a cosmic cult steward. Cancelling steward vote.");
+            return;
+        }
+
         var cultists = new List<(string, EntityUid)>();
 
         var cultQuery = EntityQueryEnumerator<CosmicCultComponent, MetaDataComponent>();

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -286,17 +286,12 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     {
         // If there's already an entity with steward, don't hold a vote. This allows admins to add the Cosmic Cult rule a 2nd time
         // in the case that there is only one cultist and they've been chosen as the steward already.
-        var stewardExists = false;
-        var stewardQuery = EntityQueryEnumerator<CosmicCultLeadComponent>();
-        while (stewardQuery.MoveNext(out var steward, out _))
-            stewardExists = true;
-
-        if (stewardExists)
+        if (EntityQuery<CosmicCultLeadComponent>().Any())
         {
-            _adminLogger.Add(LogType.Vote, LogImpact.Medium, $"There is already a cosmic cult steward. Cancelling steward vote.");
+            _adminLogger.Add(LogType.Vote, LogImpact.Medium,
+                $"Cosmic cult steward already exists. Cancelling steward vote.");
             return;
         }
-
         var cultists = new List<(string, EntityUid)>();
 
         var cultQuery = EntityQueryEnumerator<CosmicCultComponent, MetaDataComponent>();

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -321,8 +321,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         // If there are no cultists, don't hold a vote, or the server will crash.
         if (cultists.Count == 0)
         {
-            Log.Warning($"There are no cultists present for the steward vote. Voting is cancelled to prevent the server crashing.");
-            _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"There are no cultists for the steward vote. Steward vote is cancelled to prevent the server crashing.");
+            Log.Warning($"There are no cosmic cultists present for the steward vote. Voting is cancelled to prevent the server crashing.");
+            _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"There are no cosmic cultists for the steward vote. Steward vote is cancelled to prevent the server crashing.");
             return;
         }
 
@@ -335,8 +335,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         // Holding a vote with zero options crashes the server.
         if (options.Options.Count == 0)
         {
-            Log.Warning($"There are {cultists.Count} cultists but no options for the steward vote. Voting is cancelled to prevent the server crashing.");
-            _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"There are {cultists.Count} cultists but no options for the steward vote. Steward vote is cancelled to prevent the server crashing.");
+            Log.Warning($"There are {cultists.Count} cosmic cultists but no options for the steward vote. Voting is cancelled to prevent the server crashing.");
+            _adminLogger.Add(LogType.Vote, LogImpact.Extreme, $"There are {cultists.Count} cosmic cultists but no options for the steward vote. Steward vote is cancelled to prevent the server crashing.");
             return;
         }
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixed a bug where if there were zero cultists and the server tried to hold an option with zero options, the entire server would crash.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Server crashing bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Just added sanity checks and if there are zero cultists or zero options, it prevents the vote from happening. (Admins can course-correct the round if this happens.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed a server-crashing bug where the server would crash if there were zero cosmic cultists and it would try to hold a steward vote with zero options.

