### PR TITLE
Fix sharp katana being unable to fit into katana sheathe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -132,6 +132,8 @@
     - Back
     - Belt
   - type: DisarmMalus
+  - tags: # DeltaV so it can fit in katana sheath
+    - Katana
 
 - type: entity
   name: energy katana

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -132,7 +132,8 @@
     - Back
     - Belt
   - type: DisarmMalus
-  - tags: # DeltaV so it can fit in katana sheath
+  - type: Tag
+    tags:
     - Katana
 
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
title

## Why / Balance
only dull katana in katana sheathe?

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**

:cl:
- fix: Fixed sharp katana's being unable to fit into katana sheaths.
