### PR TITLE
Adv Truncheon Stamina Damage Tweak. Jug Suit Melee Stamina Damage Resistance.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -782,6 +782,7 @@
     damageCoefficient: 0.3
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.1
+    meleeResistance: true
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/advanced_truncheon.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/advanced_truncheon.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: Truncheon
   id: AdvancedTruncheon
-  name: Advanced Truncheon
+  name: advanced truncheon
   description: A longer, rigid, steel-studded baton, meant to harm more!
   components:
   - type: Sprite
@@ -12,7 +12,7 @@
     damage:
       types:
         Blunt: 22.5
-    bluntStaminaDamageFactor: 1.60 # 36 stamina damage
+    bluntStaminaDamageFactor: 1.2 # Before resists, 27 stamina damage, 36 while wielded, 48.6 when wielded by an Oni
 #  - type: MeleeStaminaCost
 #    swing: 10
 #    wieldCoefficient: 0.35 #if wielded you will only consume 3.5 stam its a weapon after all
@@ -20,7 +20,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 7.5
+        Blunt: 7.5 # 30 when wielded, 40.5 when wielded by an Oni
   - type: Clothing
     sprite: _DV/Objects/Weapons/Melee/advanced_truncheon.rsi
     quickEquip: false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
* Reduced blunt stamina damage of advanced from 1.6x to 1.2x.
* Allowed juggernaut suit to actually live up to its name by being very melee stamina damage resistant.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Currently, the advanced truncheon does 36 stamina damage normally, 48 while wielded, and if you're an Oni, it does a whopping 64.8 stamina damage per hit.

With the new modifier, it would do 27 stamina damage per hit, 36 while wielded, and if you're an Oni, it would do 48.6 when wielded by an Oni.

Also, just gave the Jugg suit insane melee damage resistance because the literal definition of juggernaut is "someone or something overwhelmingly powerful, dominant, and **unstoppable**", so melee stamina damage shouldn't affect them very much, if at all.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: The advanced truncheon's stamina damage modified has been reduced from 1.6x to 1.2x.
- tweak: The juggernaut suit now lives up to its name and actually laughs in the face of melee stamina damage.
