### PR TITLE
New glimmer events! Foxfire & Restyle

### DIFF
--- a/Content.Server/_DV/StationEvents/Components/GlimmerFoxfireSpawnRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/GlimmerFoxfireSpawnRuleComponent.cs
@@ -39,5 +39,5 @@ public sealed partial class GlimmerFoxfireSpawnRuleComponent : Component
     /// Available colors for the foxfire's light.
     /// </summary>
     [DataField]
-    public List<Color> RandomColorList = new();
+    public List<Color>? RandomColorList = new();
 }

--- a/Content.Server/_DV/StationEvents/Components/GlimmerFoxfireSpawnRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/GlimmerFoxfireSpawnRuleComponent.cs
@@ -1,0 +1,43 @@
+using Content.Server._DV.StationEvents.Events;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.StationEvents.Components;
+
+/// <summary>
+/// Spawns a small amount of randomly-colored foxfires,
+/// centered around either the Oracle or Sophic Grammateus.
+/// </summary>
+[RegisterComponent, Access(typeof(GlimmerFoxfireSpawnRule))]
+public sealed partial class GlimmerFoxfireSpawnRuleComponent : Component
+{
+    /// <summary>
+    /// Minimum+ amounts of foxfires to spawn.
+    /// </summary>
+    [DataField]
+    public int MinimumSpawned = 1;
+
+    /// <summary>
+    /// Maximum amounts of foxfires to spawn.
+    /// </summary>
+    [DataField]
+    public int MaximumSpawned = 5;
+
+    /// <summary>
+    /// Maximum distance from the Oracle or Sophic Grammateus in which the
+    /// foxfire will be spawned.
+    /// </summary>
+    [DataField]
+    public int SpawnRange = 10;
+
+    /// <summary>
+    /// Prototype to be spawned.
+    /// </summary>
+    [DataField]
+    public EntProtoId FoxfirePrototype = "Foxfire";
+
+    /// <summary>
+    /// Available colors for the foxfire's light.
+    /// </summary>
+    [DataField]
+    public List<Color> RandomColorList = new();
+}

--- a/Content.Server/_DV/StationEvents/Components/GlimmerFoxfireSpawnRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/GlimmerFoxfireSpawnRuleComponent.cs
@@ -14,13 +14,13 @@ public sealed partial class GlimmerFoxfireSpawnRuleComponent : Component
     /// Minimum+ amounts of foxfires to spawn.
     /// </summary>
     [DataField]
-    public int MinimumSpawned = 1;
+    public int MinimumSpawned = 10;
 
     /// <summary>
     /// Maximum amounts of foxfires to spawn.
     /// </summary>
     [DataField]
-    public int MaximumSpawned = 5;
+    public int MaximumSpawned = 20;
 
     /// <summary>
     /// Maximum distance from the Oracle or Sophic Grammateus in which the

--- a/Content.Server/_DV/StationEvents/Components/GlimmerRestyleRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/GlimmerRestyleRuleComponent.cs
@@ -1,0 +1,35 @@
+using Content.Server._DV.StationEvents.Events;
+
+namespace Content.Server._DV.StationEvents.Components;
+
+/// <summary>
+/// Attempts to change the hair and facial hair markings, plus their color
+/// of a small amount of people.
+/// </summary>
+[RegisterComponent, Access(typeof(GlimmerRestyleRule))]
+public sealed partial class GlimmerRestyleRuleComponent : Component
+{
+    /// <summary>
+    /// Minimum number of valid targets that will get restyled.
+    /// </summary>
+    [DataField]
+    public int MinimumTargets = 1;
+
+    /// <summary>
+    /// Maximum number of valid targets that will get restyled.
+    /// </summary>
+    [DataField]
+    public int MaximumTargets = 5;
+
+    /// <summary>
+    /// Chance of completely removing all hair markings instead of selecting a random one.
+    /// </summary>
+    [DataField]
+    public float BaldChance = 0.2f;
+
+    /// <summary>
+    /// Chance of completely removing all facial hair markings instead of selecting a random one.
+    /// </summary>
+    [DataField]
+    public float CleanShavenChance = 0.5f;
+}

--- a/Content.Server/_DV/StationEvents/Events/GlimmerFoxfireSpawnRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerFoxfireSpawnRule.cs
@@ -1,0 +1,55 @@
+using System.Numerics;
+using Content.Server._DV.StationEvents.Components;
+using Content.Server.Nyanotrasen.Research.SophicScribe;
+using Content.Server.Research.Oracle;
+using Content.Server.StationEvents.Events;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Server._DV.StationEvents.Events;
+
+public sealed class GlimmerFoxfireSpawnRule : StationEventSystem<GlimmerFoxfireSpawnRuleComponent>
+{
+    [Dependency] private readonly SharedPointLightSystem _light = default!;
+
+    protected override void Started(EntityUid uid,
+        GlimmerFoxfireSpawnRuleComponent comp,
+        GameRuleComponent gameRule,
+        GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        var locations = new List<EntityCoordinates>();
+        var queryScribe = EntityQueryEnumerator<SophicScribeComponent, TransformComponent>();
+        var queryOracle = EntityQueryEnumerator<OracleComponent, TransformComponent>();
+
+        while (queryScribe.MoveNext(out _, out var transform))
+        {
+            locations.Add(transform.Coordinates);
+        }
+
+        while (queryOracle.MoveNext(out _, out var transform))
+        {
+            locations.Add(transform.Coordinates);
+        }
+
+        if (locations.Count == 0)
+            return;
+
+        var selectedLocation = RobustRandom.Pick(locations);
+
+        var amountToSpawn = RobustRandom.Next(comp.MinimumSpawned, comp.MaximumSpawned);
+        for (var i = 0; i < amountToSpawn; i++)
+        {
+            var spawnLocation = selectedLocation.Offset(new Vector2(
+                RobustRandom.Next(-comp.SpawnRange, comp.SpawnRange),
+                RobustRandom.Next(-comp.SpawnRange, comp.SpawnRange)
+            ));
+
+
+            var fireEnt = Spawn(comp.FoxfirePrototype, spawnLocation);
+            _light.SetColor(fireEnt, RobustRandom.Pick(comp.RandomColorList));
+        }
+    }
+}

--- a/Content.Server/_DV/StationEvents/Events/GlimmerFoxfireSpawnRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerFoxfireSpawnRule.cs
@@ -50,7 +50,7 @@ public sealed class GlimmerFoxfireSpawnRule : StationEventSystem<GlimmerFoxfireS
 
             var color = Color.GhostWhite;
             if (comp.RandomColorList != null && comp.RandomColorList.Count != 0)
-                color = RobustRandom.Pick(comp.RandomColorList)
+                color = RobustRandom.Pick(comp.RandomColorList);
 
             var fireEnt = Spawn(comp.FoxfirePrototype, spawnLocation);
             _light.SetColor(fireEnt, color);

--- a/Content.Server/_DV/StationEvents/Events/GlimmerFoxfireSpawnRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerFoxfireSpawnRule.cs
@@ -48,8 +48,12 @@ public sealed class GlimmerFoxfireSpawnRule : StationEventSystem<GlimmerFoxfireS
             ));
 
 
+            var color = Color.GhostWhite;
+            if (comp.RandomColorList != null && comp.RandomColorList.Count != 0)
+                color = RobustRandom.Pick(comp.RandomColorList)
+
             var fireEnt = Spawn(comp.FoxfirePrototype, spawnLocation);
-            _light.SetColor(fireEnt, RobustRandom.Pick(comp.RandomColorList));
+            _light.SetColor(fireEnt, color);
         }
     }
 }

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server._DV.StationEvents.Components;
+using Content.Server.Psionics;
 using Content.Server.StationEvents.Events;
 using Content.Shared.Abilities.Psionics;
 using Content.Shared.GameTicking.Components;
@@ -29,7 +30,7 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
 
         while (query.MoveNext(out var entity, out var humanoid, out var mobState))
         {
-            if (!_mob.IsAlive(entity, mobState) || HasComp<PsionicInsulationComponent>(entity))
+            if (!_mob.IsAlive(entity, mobState) || HasComp<PsionicInsulationComponent>(entity) || !HasComp<PotentialPsionicComponent>(entity))
                 continue;
             potentialTargets.Add((entity, humanoid));
         }
@@ -49,7 +50,7 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
             var changedFacialHair = TryApplyRestyle((entity, humanoid), MarkingCategories.FacialHair, comp.CleanShavenChance);
             if (changedHair || changedFacialHair)
                 _popup.PopupEntity(Loc.GetString("glimmer-restyle-event"), entity, entity, PopupType.Medium);
-                Dirty(entity, humanoid);
+            Dirty(entity, humanoid);
         }
     }
 

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using Content.Server._DV.StationEvents.Components;
+using Content.Server.StationEvents.Events;
+using Content.Shared.Abilities.Psionics;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Markings;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Popups;
+using Robust.Shared.Random;
+
+namespace Content.Server._DV.StationEvents.Events;
+
+public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleComponent>
+{
+    [Dependency] private readonly MobStateSystem _mob = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly MarkingManager _markingManager = default!;
+
+    protected override void Started(EntityUid uid, GlimmerRestyleRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, comp, gameRule, args);
+
+        var query = EntityQueryEnumerator<HumanoidAppearanceComponent, MobStateComponent>();
+        List<(EntityUid, HumanoidAppearanceComponent)> potentialTargets = new();
+
+        while (query.MoveNext(out var entity, out var humanoid, out var mobState))
+        {
+            if (!_mob.IsAlive(entity, mobState) || HasComp<PsionicInsulationComponent>(entity))
+                continue;
+            potentialTargets.Add((entity, humanoid));
+        }
+
+        _random.Shuffle(potentialTargets);
+        var targetsToRestyle = _random.Next(comp.MinimumTargets, comp.MaximumTargets);
+
+        foreach (var (entity, humanoid) in potentialTargets)
+        {
+            if (targetsToRestyle-- <= 0)
+                break;
+
+            var changedHair = ApplyRestyle(humanoid, MarkingCategories.Hair, comp.BaldChance);
+            var changedFacialHair = ApplyRestyle(humanoid, MarkingCategories.FacialHair, comp.CleanShavenChance);
+            if (changedHair || changedFacialHair)
+            {
+                _popup.PopupEntity(Loc.GetString("glimmer-restyle-event"), entity, entity, PopupType.Medium);
+                Dirty(entity, humanoid);
+            }
+        }
+    }
+
+    private bool ApplyRestyle(HumanoidAppearanceComponent humanoid, MarkingCategories category, float baldChance)
+    {
+        var newHairColor = new Color(_random.NextFloat(), _random.NextFloat(), _random.NextFloat());
+        var hairStyles = _markingManager.MarkingsByCategoryAndSpecies(category, humanoid.Species);
+        if (hairStyles.Count == 0)
+            return false;
+
+        humanoid.MarkingSet.RemoveCategory(category);
+        if (_random.Prob(baldChance))
+            return true;
+
+        var newHair = _random.Pick(hairStyles.Values.ToList()).AsMarking();
+        newHair.SetColor(newHairColor);
+
+        humanoid.MarkingSet.AddCategory(category);
+        humanoid.MarkingSet.AddFront(category, newHair);
+        return true;
+    }
+}

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -41,7 +41,7 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
         {
             if(HasComp<SSDIndicatorComponent>(entity))
                 continue;
-        
+
             if (targetsToRestyle-- <= 0)
                 break;
 

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -61,9 +61,10 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
         if (hairStyles.Count == 0)
             return false;
 
+        var hadCategoryBefore = ent.Comp.MarkingSet.TryGetCategory(category, out _);
         ent.Comp.MarkingSet.RemoveCategory(category);
         if (_random.Prob(noMarkingsChance))
-            return true;
+            return hadCategoryBefore; //Do not show the popup if you go from no markings to no markings.
 
         var newMarking = _random.Pick(hairStyles.Values.ToList()).AsMarking();
         newMarking.SetColor(newMarkingColor);

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -38,6 +38,9 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
 
         foreach (var (entity, humanoid) in potentialTargets)
         {
+            if(HasComp<SSDIndicatorComponent>(entity))
+                continue;
+        
             if (targetsToRestyle-- <= 0)
                 break;
 

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -57,8 +57,8 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
     private bool TryApplyRestyle(Entity<HumanoidAppearanceComponent> ent, MarkingCategories category, float noMarkingsChance)
     {
         var newMarkingColor = new Color(_random.NextFloat(), _random.NextFloat(), _random.NextFloat());
-        var hairStyles = _markingManager.MarkingsByCategoryAndSpecies(category, ent.Comp.Species);
-        if (hairStyles.Count == 0)
+        var availableMarkings = _markingManager.MarkingsByCategoryAndSpecies(category, ent.Comp.Species);
+        if (availableMarkings.Count == 0)
             return false;
 
         var hadCategoryBefore = ent.Comp.MarkingSet.TryGetCategory(category, out _);
@@ -66,7 +66,7 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
         if (_random.Prob(noMarkingsChance))
             return hadCategoryBefore; //Do not show the popup if you go from no markings to no markings.
 
-        var newMarking = _random.Pick(hairStyles.Values.ToList()).AsMarking();
+        var newMarking = _random.Pick(availableMarkings.Values.ToList()).AsMarking();
         newMarking.SetColor(newMarkingColor);
 
         ent.Comp.MarkingSet.AddCategory(category);

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -45,32 +45,30 @@ public sealed class GlimmerRestyleRule : StationEventSystem<GlimmerRestyleRuleCo
             if (targetsToRestyle-- <= 0)
                 break;
 
-            var changedHair = ApplyRestyle(humanoid, MarkingCategories.Hair, comp.BaldChance);
-            var changedFacialHair = ApplyRestyle(humanoid, MarkingCategories.FacialHair, comp.CleanShavenChance);
+            var changedHair = TryApplyRestyle((entity, humanoid), MarkingCategories.Hair, comp.BaldChance);
+            var changedFacialHair = TryApplyRestyle((entity, humanoid), MarkingCategories.FacialHair, comp.CleanShavenChance);
             if (changedHair || changedFacialHair)
-            {
                 _popup.PopupEntity(Loc.GetString("glimmer-restyle-event"), entity, entity, PopupType.Medium);
                 Dirty(entity, humanoid);
-            }
         }
     }
 
-    private bool ApplyRestyle(HumanoidAppearanceComponent humanoid, MarkingCategories category, float baldChance)
+    private bool TryApplyRestyle(Entity<HumanoidAppearanceComponent> ent, MarkingCategories category, float noMarkingsChance)
     {
-        var newHairColor = new Color(_random.NextFloat(), _random.NextFloat(), _random.NextFloat());
-        var hairStyles = _markingManager.MarkingsByCategoryAndSpecies(category, humanoid.Species);
+        var newMarkingColor = new Color(_random.NextFloat(), _random.NextFloat(), _random.NextFloat());
+        var hairStyles = _markingManager.MarkingsByCategoryAndSpecies(category, ent.Comp.Species);
         if (hairStyles.Count == 0)
             return false;
 
-        humanoid.MarkingSet.RemoveCategory(category);
-        if (_random.Prob(baldChance))
+        ent.Comp.MarkingSet.RemoveCategory(category);
+        if (_random.Prob(noMarkingsChance))
             return true;
 
-        var newHair = _random.Pick(hairStyles.Values.ToList()).AsMarking();
-        newHair.SetColor(newHairColor);
+        var newMarking = _random.Pick(hairStyles.Values.ToList()).AsMarking();
+        newMarking.SetColor(newMarkingColor);
 
-        humanoid.MarkingSet.AddCategory(category);
-        humanoid.MarkingSet.AddFront(category, newHair);
+        ent.Comp.MarkingSet.AddCategory(category);
+        ent.Comp.MarkingSet.AddFront(category, newMarking);
         return true;
     }
 }

--- a/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/GlimmerRestyleRule.cs
@@ -6,6 +6,7 @@ using Content.Shared.GameTicking.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Mobs.Components;
+using Content.Shared.SSDIndicator;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Robust.Shared.Random;

--- a/Content.Shared/Humanoid/Markings/MarkingManager.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingManager.cs
@@ -65,6 +65,11 @@ namespace Content.Shared.Humanoid.Markings
             var markingPoints = _prototypeManager.Index(speciesProto.MarkingPoints);
             var res = new Dictionary<string, MarkingPrototype>();
 
+            // Begin DeltaV addition - prevents errors when category is missing
+            if (!markingPoints.Points.ContainsKey(category))
+                return res;
+            // End DeltaV addition
+
             foreach (var (key, marking) in MarkingsByCategory(category))
             {
                 if ((markingPoints.OnlyWhitelisted || markingPoints.Points[category].OnlyWhitelisted) && marking.SpeciesRestrictions == null)

--- a/Resources/Locale/en-US/_DV/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/_DV/abilities/psionic.ftl
@@ -93,4 +93,4 @@ fractured-form-sleepy = You feel very sleepy... You should find somewhere to res
 fractured-form-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } in a deep sleep. { CAPITALIZE(POSS-ADJ($ent)) } eyes seem to be darting around as if dreaming.
 fractured-form-examine-self = You feel a strange connection to { OBJECT($ent) }.
 
-glimmer-restyle-event = You feel your hair suddenly change!
+glimmer-restyle-event = You feel like something changed about your looks...

--- a/Resources/Locale/en-US/_DV/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/_DV/abilities/psionic.ftl
@@ -92,3 +92,5 @@ fractured-form-nobodies = You have no alternate forms to switch to!
 fractured-form-sleepy = You feel very sleepy... You should find somewhere to rest.
 fractured-form-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } in a deep sleep. { CAPITALIZE(POSS-ADJ($ent)) } eyes seem to be darting around as if dreaming.
 fractured-form-examine-self = You feel a strange connection to { OBJECT($ent) }.
+
+glimmer-restyle-event = You feel your hair stare suddenly change!

--- a/Resources/Locale/en-US/_DV/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/_DV/abilities/psionic.ftl
@@ -93,4 +93,4 @@ fractured-form-sleepy = You feel very sleepy... You should find somewhere to res
 fractured-form-ssd = { CAPITALIZE(SUBJECT($ent)) } { CONJUGATE-BE($ent) } in a deep sleep. { CAPITALIZE(POSS-ADJ($ent)) } eyes seem to be darting around as if dreaming.
 fractured-form-examine-self = You feel a strange connection to { OBJECT($ent) }.
 
-glimmer-restyle-event = You feel your hair stare suddenly change!
+glimmer-restyle-event = You feel your hair suddenly change!

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -230,6 +230,6 @@
   parent: BaseGlimmerSignaturesEvent
   components:
   - type: GlimmerEvent
-    minimumGlimmer: 500
-    maximumGlimmer: 900
+    minimumGlimmer: 300
+    maximumGlimmer: 700
   - type: GlimmerRestyleRule

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -17,6 +17,8 @@
     #- id: LockProbers
     - id: PsionicNosebleedEvent
     - id: MinorMassMindSwap # Delta V
+    - id: GlimmerFoxfireSpawn
+    - id: GlimmerRestyle
 
 - type: entity
   parent: BaseGameRule
@@ -197,3 +199,37 @@
   - type: GlimmerEvent
     minimumGlimmer: 350
   - type: PsionicNosebleedRule
+
+- type: entity
+  parent: BaseGlimmerEvent
+  id: GlimmerFoxfireSpawn
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 100
+    maximumGlimmer: 500
+  - type: GlimmerFoxfireSpawnRule
+    randomColorList:
+    - aqua
+    - betterviolet
+    - blue
+    - chartreuse
+    - cyan
+    - deeppink
+    - fuchsia
+    - green
+    - indigo
+    - lime
+    - pink
+    - red
+    - silver
+    - yellow
+
+
+- type: entity
+  id: GlimmerRestyle
+  parent: BaseGlimmerSignaturesEvent
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 500
+    maximumGlimmer: 900
+  - type: GlimmerRestyleRule


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added two new low-impact glimmer events!

**Glimmer Foxfire**: happening at lower glimmer levels (from 100 to 500), this event simply causes a few randomly colored Foxfires (the same kind that Kitsunes spawn) to appear in a small range around the Oracle or Sophic Grammateus. It's harmless and just provides a little bit of Spooky Ambience around them.
**Glimmer Restyle**: happening at medium glimmer levels (from 300 to 700), it randomizes the hair and facial hair (colors included!) of a few random people, including to bald. Again, harmless, outside of your own wounded pride.

## Why / Balance
The topic of adding more Weird Noospheric Bullshit has come up often enough in the Discord, and these two are some proposal I thought were interesting and easy to add.

## Technical details
Two new game rules and their respective events.
Biggest thing we've ever wrote in C#, we tried to follow what we've seen in other files but not sure if it's correct or a mess.

Additionally, made one small change in MarkinManager to prevent it erroring out with species that lack a marking category completely (fixes a test fail and also some issues with barber scissors).

## Media
A lot of foxfires!
<img width="1130" height="868" alt="foxfire" src="https://github.com/user-attachments/assets/1fa97e36-4d71-4055-994d-19479b43e552" />

Three formerly-bald Urists.
<img width="616" height="376" alt="restyle" src="https://github.com/user-attachments/assets/60a97b1e-4420-4b86-ba4d-e1ea4614b4be" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: New Glimmer event: the Oracle and Sophic Grammateus will now occasionally attract foxfire!
- add: New Glimmer event: the Noosphere is coming for your hair, and its fashion sense is... random.
- fix: Using barber scissors on kobolds no longer causes massive errors.


