### PR TITLE
Fix debug assert in OnUpdateAlert of Cosmic Cult System

### DIFF
--- a/Content.Client/_DV/CosmicCult/CosmicCultSystem.cs
+++ b/Content.Client/_DV/CosmicCult/CosmicCultSystem.cs
@@ -76,9 +76,8 @@ public sealed partial class CosmicCultSystem : SharedCosmicCultSystem
         if (args.Alert.ID != ent.Comp.EntropyAlert)
             return;
         var entropy = Math.Clamp(ent.Comp.EntropyStored, 0, 14);
-        var sprite = args.SpriteViewEnt.Comp;
-        _sprite.LayerSetRsiState((ent, sprite), AlertVisualLayers.Base, $"base{entropy}");
-        _sprite.LayerSetRsiState((ent, sprite), CultAlertVisualLayers.Counter, $"num{entropy}");
+        _sprite.LayerSetRsiState(args.SpriteViewEnt.AsNullable(), AlertVisualLayers.Base, $"base{entropy}");
+        _sprite.LayerSetRsiState(args.SpriteViewEnt.AsNullable(), CultAlertVisualLayers.Counter, $"num{entropy}");
     }
     #endregion
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Fix a debug assert that occurs when making someone a cosmic cultist in debug configuration.

## Technical details
<!-- Summary of code changes for easier review. -->
Whenever I antag verbed myself into a cosmic cultist the client crashed. I tracked this down to `Content.Client/_DV/CosmicCult/CosmicCultSystem.cs` line 80 and commit `3019d8201c640585ba7e15ebcf8076e8c83243a4` introduced it.

The assertion is `Unhandled exception. Robust.Shared.Utility.DebugAssertException: Entity 11 is not the owner of the component. Component: SpriteComponent`.

To fix, instead of using the cosmic cult entity, I switched to using the actual sprite entity. I think this is the intended API usage.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

None because this is developer facing? (only happens with debug assertions enabled)