### PR TITLE
Remove warnings in Content.Server for _DV content

### DIFF
--- a/Content.Server/_DV/Abilities/Chitinid/ChitinidSystem.cs
+++ b/Content.Server/_DV/Abilities/Chitinid/ChitinidSystem.cs
@@ -11,7 +11,6 @@ namespace Content.Server._DV.Abilities.Chitinid;
 public sealed partial class ChitinidSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly ItemCougherSystem _cougher = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneFoxSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneFoxSystem.cs
@@ -19,7 +19,7 @@ public sealed class KitsuneFoxSystem : EntitySystem
 
     private void OnStunned(Entity<KitsuneFoxComponent> ent, ref StunnedEvent args)
     {
-        if (!TryComp<PolymorphedEntityComponent>(ent, out var _))
+        if (!HasComp<PolymorphedEntityComponent>(ent))
             return;
 
         _polymorph.Revert(ent.Owner);

--- a/Content.Server/_DV/Abilities/Kitsune/KitsuneFoxSystem.cs
+++ b/Content.Server/_DV/Abilities/Kitsune/KitsuneFoxSystem.cs
@@ -9,7 +9,6 @@ namespace Content.Server._DV.Abilities.Kitsune;
 public sealed class KitsuneFoxSystem : EntitySystem
 {
     [Dependency] private readonly PolymorphSystem _polymorph = default!;
-    [Dependency] private readonly SharedStaminaSystem _stamina = default!;
 
     public override void Initialize()
     {
@@ -20,7 +19,7 @@ public sealed class KitsuneFoxSystem : EntitySystem
 
     private void OnStunned(Entity<KitsuneFoxComponent> ent, ref StunnedEvent args)
     {
-        if (!TryComp<PolymorphedEntityComponent>(ent, out var polymorph))
+        if (!TryComp<PolymorphedEntityComponent>(ent, out var _))
             return;
 
         _polymorph.Revert(ent.Owner);

--- a/Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs
+++ b/Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs
@@ -27,7 +27,6 @@ public sealed class PrecognitionPowerSystem : EntitySystem
 {
     [Dependency] private readonly DoAfterSystem _doAfter = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
-    [Dependency] private readonly MindSystem _mind = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -35,7 +34,6 @@ public sealed class PrecognitionPowerSystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IComponentFactory _factory = default!;
-    [Dependency] private readonly IGameTiming _gameTiming = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly MovementModStatusSystem _movementMod = default!;

--- a/Content.Server/_DV/Addictions/AddictionSystem.cs
+++ b/Content.Server/_DV/Addictions/AddictionSystem.cs
@@ -25,6 +25,7 @@ public sealed class AddictionSystem : SharedAddictionSystem
     private const int SuppressionDuration = 10;
 
     private EntityQuery<AddictedComponent> _addicted;
+    private readonly string _datasetId = "AddictionEffects";
 
     public override void Initialize()
     {
@@ -86,7 +87,7 @@ public sealed class AddictionSystem : SharedAddictionSystem
 
     private string GetRandomPopup()
     {
-        return Loc.GetString(_random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>("AddictionEffects").Values));
+        return Loc.GetString(_random.Pick(_prototypeManager.Index<LocalizedDatasetPrototype>(_datasetId).Values));
     }
 
     private void DoAddictionEffect(EntityUid uid)

--- a/Content.Server/_DV/Addictions/AddictionSystem.cs
+++ b/Content.Server/_DV/Addictions/AddictionSystem.cs
@@ -25,7 +25,7 @@ public sealed class AddictionSystem : SharedAddictionSystem
     private const int SuppressionDuration = 10;
 
     private EntityQuery<AddictedComponent> _addicted;
-    private readonly string _datasetId = "AddictionEffects";
+    private readonly ProtoId<LocalizedDatasetPrototype> _datasetId = "AddictionEffects";
 
     public override void Initialize()
     {

--- a/Content.Server/_DV/Administration/Commands/SpawnPlayer.cs
+++ b/Content.Server/_DV/Administration/Commands/SpawnPlayer.cs
@@ -24,8 +24,6 @@ public sealed class SpawnPlayer : LocalizedEntityCommands
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IServerPreferencesManager _prefs = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
-    [Dependency] private readonly TraitSystem _trait = default!;
-    [Dependency] private readonly PlayTimeTrackingManager _playTimeTracking = default!;
 
     public override string Command => "spawnplayer";
 

--- a/Content.Server/_DV/Cargo/Systems/CargoSystem.ATS.cs
+++ b/Content.Server/_DV/Cargo/Systems/CargoSystem.ATS.cs
@@ -89,7 +89,7 @@ public sealed partial class CargoSystem
         {
             Components =
             [
-                Factory.GetComponentName(typeof(CargoShuttleComponent))
+                Factory.GetComponentName<CargoShuttleComponent>()
             ]
         };
 

--- a/Content.Server/_DV/Cargo/Systems/PricingSystem.Modifier.cs
+++ b/Content.Server/_DV/Cargo/Systems/PricingSystem.Modifier.cs
@@ -13,7 +13,7 @@ public sealed partial class PricingSystem
     /// <returns>The modified price.</returns>
     private double ApplyPrototypePriceModifier(EntityPrototype prototype, double basePrice)
     {
-        if (prototype.Components.TryGetValue(Factory.GetComponentName(typeof(PriceModifierComponent)),
+        if (prototype.Components.TryGetValue(Factory.GetComponentName<PriceModifierComponent>(),
                 out var modProto))
         {
             var priceModifier = (PriceModifierComponent)modProto.Component;

--- a/Content.Server/_DV/Cargo/Systems/StockMarketSystem.cs
+++ b/Content.Server/_DV/Cargo/Systems/StockMarketSystem.cs
@@ -109,7 +109,7 @@ public sealed class StockMarketSystem : EntitySystem
                     break;
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new InvalidOperationException($"Unknown UiAction type [{message.Action}]");
             }
 
             // Play confirmation sound if the transaction was successful

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicConversionSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicConversionSystem.cs
@@ -18,7 +18,6 @@ public sealed class CosmicConversionSystem : EntitySystem
     [Dependency] private readonly CosmicCultRuleSystem _cultRule = default!;
     [Dependency] private readonly CosmicGlyphSystem _cosmicGlyph = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly SharedCosmicCultSystem _cosmicCult = default!;

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -74,7 +74,6 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
     [Dependency] private readonly AntagSelectionSystem _antag = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
     [Dependency] private readonly ChatSystem _chatSystem = default!;
-    [Dependency] private readonly DamageableSystem _damage = default!;
     [Dependency] private readonly EmergencyShuttleSystem _emergency = default!;
     [Dependency] private readonly EuiManager _euiMan = default!;
     [Dependency] private readonly GhostSystem _ghost = default!;

--- a/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
+++ b/Content.Server/_DV/CosmicCult/DeconversionSystem.cs
@@ -27,15 +27,12 @@ namespace Content.Server._DV.CosmicCult;
 public sealed class DeconversionSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damageable = default!;
-    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly MobStateSystem _mobState = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedJitteringSystem _jittering = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedToolSystem _tools = default!;
-    [Dependency] private readonly UseDelaySystem _delay = default!;
     [Dependency] private readonly SharedStunSystem _stun = default!;
     [Dependency] private readonly SharedMindSystem _mind = default!;
     [Dependency] private readonly IPlayerManager _playerMan = default!;

--- a/Content.Server/_DV/CosmicCult/EntitySystems/CosmicEntropyDegenSystem.cs
+++ b/Content.Server/_DV/CosmicCult/EntitySystems/CosmicEntropyDegenSystem.cs
@@ -12,7 +12,6 @@ namespace Content.Server._DV.CosmicCult.EntitySystems;
 public sealed partial class CosmicEntropyDegenSystem : EntitySystem
 {
     [Dependency] private readonly IGameTiming _timing = default!;
-    [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
 
     public override void Initialize()

--- a/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
+++ b/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
@@ -523,8 +523,7 @@ public sealed partial class CwoinkSystem : SharedCwoinkSystem
                 GameRunLevel.PreRoundLobby => "\n\n:arrow_forward: _**Pre-round lobby started**_\n",
                 GameRunLevel.InRound => "\n\n:arrow_forward: _**Round started**_\n",
                 GameRunLevel.PostRound => "\n\n:stop_button: _**Post-round started**_\n",
-                _ => throw new ArgumentOutOfRangeException(nameof(_gameTicker.RunLevel),
-                    $"{_gameTicker.RunLevel} was not matched."),
+                _ => throw new InvalidOperationException( $"{_gameTicker.RunLevel} was not matched."),
             };
 
             existingEmbed.LastRunLevel = _gameTicker.RunLevel;
@@ -615,8 +614,7 @@ public sealed partial class CwoinkSystem : SharedCwoinkSystem
                 : $"pre-round lobby for round {_gameTicker.RoundId + 1}",
             GameRunLevel.InRound => $"round {_gameTicker.RoundId}",
             GameRunLevel.PostRound => $"post-round {_gameTicker.RoundId}",
-            _ => throw new ArgumentOutOfRangeException(nameof(_gameTicker.RunLevel),
-                $"{_gameTicker.RunLevel} was not matched."),
+            _ => throw new InvalidOperationException( $"{_gameTicker.RunLevel} was not matched."),
         };
 
         return new WebhookPayload

--- a/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
+++ b/Content.Server/_DV/Curation/Systems/CwoinkSystem.cs
@@ -54,7 +54,7 @@ public sealed partial class CwoinkSystem : SharedCwoinkSystem
     private static partial Regex DiscordRegex();
 
     private string _webhookUrl = string.Empty;
-    private WebhookData? _webhookData;
+    private WebhookData? _webhookData = null;
 
     private readonly HttpClient _httpClient = new();
 

--- a/Content.Server/_DV/Execution/ExecutionSystem.cs
+++ b/Content.Server/_DV/Execution/ExecutionSystem.cs
@@ -261,7 +261,7 @@ public sealed class ExecutionSystem : EntitySystem
                 break;
 
             default:
-                throw new ArgumentOutOfRangeException();
+                throw new InvalidOperationException($"Unknown shootable type [{ev.Ammo[0].Shootable}]");
         }
 
         // Clumsy people have a chance to shoot themselves (not in the head)

--- a/Content.Server/_DV/Execution/ExecutionSystem.cs
+++ b/Content.Server/_DV/Execution/ExecutionSystem.cs
@@ -40,7 +40,6 @@ public sealed class ExecutionSystem : EntitySystem
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
-    [Dependency] private readonly InteractionSystem _interactionSystem = default!;
     [Dependency] private readonly ActionBlockerSystem _actionBlockerSystem = default!;
     [Dependency] private readonly DamageableSystem _damageableSystem = default!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;

--- a/Content.Server/_DV/Grappling/EntitySystems/GrapplingSystem.cs
+++ b/Content.Server/_DV/Grappling/EntitySystems/GrapplingSystem.cs
@@ -44,7 +44,6 @@ public sealed partial class GrapplingSystem : SharedGrapplingSystem
     [Dependency] private readonly PopupSystem _popup = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly StandingStateSystem _standingState = default!;
-    [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly SharedVirtualItemSystem _virtual = default!;
 
     private ProtoId<TagPrototype> _grappleTargetId = "GrappleTarget";

--- a/Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs
+++ b/Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs
@@ -6,21 +6,21 @@ namespace Content.Server.Roboisseur.Roboisseur
     public sealed partial class RoboisseurComponent : Component
     {
         [ViewVariables]
-        [DataField("accumulator")]
+        [DataField]
         public float Accumulator = 0f;
 
         [ViewVariables(VVAccess.ReadOnly)]
-        [DataField("impatient")]
+        [DataField]
         public Boolean Impatient { get; set; } = false;
 
         [ViewVariables]
-        [DataField("resetTime")]
+        [DataField]
         public TimeSpan ResetTime = TimeSpan.FromMinutes(10);
 
-        [DataField("barkAccumulator")]
+        [DataField]
         public float BarkAccumulator = 0f;
 
-        [DataField("barkTime")]
+        [DataField]
         public TimeSpan BarkTime = TimeSpan.FromMinutes(1);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Content.Server.Roboisseur.Roboisseur
         /// </summary>
         public TimeSpan StateTime = default!;
 
-        [DataField("stateCD")]
+        [DataField]
         public TimeSpan StateCD = TimeSpan.FromSeconds(5);
 
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Content.Server/_DV/NPC/Roboisseur/RoboisseurSystem.cs
+++ b/Content.Server/_DV/NPC/Roboisseur/RoboisseurSystem.cs
@@ -21,7 +21,6 @@ namespace Content.Server.Roboisseur.Roboisseur
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly ChatSystem _chat = default!;
         [Dependency] private readonly MaterialStorageSystem _material = default!;
-        [Dependency] private readonly AppearanceSystem _appearance = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IAdminLogManager _adminLog = default!;
 

--- a/Content.Server/_DV/Objectives/Components/NotJobsRequirementComponent.cs
+++ b/Content.Server/_DV/Objectives/Components/NotJobsRequirementComponent.cs
@@ -1,6 +1,8 @@
-using Content.Server.Objectives.Systems;
+using Content.Server._DV.Objectives.Systems;
 using Content.Shared.Roles;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.List;
+
+namespace Content.Server._DV.Objectives.Components;
 
 /// <summary>
 /// Requires that the player not have a certain job to have this objective.

--- a/Content.Server/_DV/Objectives/Systems/NotJobsRequirementSystem.cs
+++ b/Content.Server/_DV/Objectives/Systems/NotJobsRequirementSystem.cs
@@ -1,8 +1,8 @@
-using Content.Server.Objectives.Components;
+using Content.Server._DV.Objectives.Components;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Roles.Components;
 
-namespace Content.Server.Objectives.Systems;
+namespace Content.Server._DV.Objectives.Systems;
 
 /// <summary>
 /// Handles checking the job blacklist for this objective.

--- a/Content.Server/_DV/Station/Systems/AutomaticSpareIdSystem.cs
+++ b/Content.Server/_DV/Station/Systems/AutomaticSpareIdSystem.cs
@@ -77,7 +77,7 @@ public sealed class AutomaticSpareIdSystem : EntitySystem
             MoveToAlerted(ent);
     }
 
-    private void RoundStartCaptain(Entity<AutomaticSpareIdComponent> ent)
+    private static void RoundStartCaptain(Entity<AutomaticSpareIdComponent> ent)
     {
         ent.Comp.State = AutomaticSpareIdState.CaptainPresent;
         ent.Comp.Timeout = null;

--- a/Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs
@@ -16,46 +16,46 @@ public sealed partial class MeteorSwarmRuleComponent : Component
     [DataField("waves")]
     public int? WaveCounter = null;
 
-    [DataField("minimumWaves")]
+    [DataField]
     public int MinimumWaves = 3;
 
-    [DataField("maximumWaves")]
+    [DataField]
     public int MaximumWaves = 8;
 
-    [DataField("minimumCooldown")]
+    [DataField]
     public float MinimumCooldown = 10f;
 
-    [DataField("maximumCooldown")]
+    [DataField]
     public float MaximumCooldown = 60f;
 
-    [DataField("meteorsPerWave")]
+    [DataField]
     public int MeteorsPerWave = 5;
 
-    [DataField("meteorVelocity")]
+    [DataField]
     public float MeteorVelocity = 10f;
 
-    [DataField("maxAngularVelocity")]
+    [DataField]
     public float MaxAngularVelocity = 2f;
 
-    [DataField("minAngularVelocity")]
+    [DataField]
     public float MinAngularVelocity = -2f;
 
     /// <summary>
     /// Stagger the spawns a bit, but not too much so they still come in waves
     /// </summary>
-    [DataField("spawnDistanceVariation")]
+    [DataField]
     public float SpawnDistanceVariation = 50f;
 
     /// <summary>
     /// Percentage of the station area to target. Allow for some near-miss fly-by meteors to jump-scare crew on EVAs.
     /// Stations aren't perfect rectangles like the targeting area, so even 1.0 will still have some near-misses.
     /// </summary>
-    [DataField("targetingSpread")]
+    [DataField]
     public float TargetingSpread = 1.05f;
 
     /// <summary>
     /// How long before a meteor despawns (in case it missed everything).
     /// </summary>
-    [DataField("meteorLifetime")]
+    [DataField]
     public float MeteorLifetime = 300f;
 }

--- a/Content.Server/_DV/StationEvents/Components/MinorMassMindSwapRuleComponent.cs
+++ b/Content.Server/_DV/StationEvents/Components/MinorMassMindSwapRuleComponent.cs
@@ -10,7 +10,7 @@ public sealed partial class MinorMassMindSwapRuleComponent : Component
     /// <summary>
     /// The mind swap is only temporary if true.
     /// </summary>
-    [DataField("isTemporary")]
+    [DataField]
     public bool IsTemporary = false;
 
     [DataField]

--- a/Content.Server/_DV/StationEvents/Events/FugitiveRule.cs
+++ b/Content.Server/_DV/StationEvents/Events/FugitiveRule.cs
@@ -108,35 +108,35 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
     private FormattedMessage GenerateReport(EntityUid uid, FugitiveRuleComponent rule)
     {
         var report = new FormattedMessage();
-        report.PushMarkup(Loc.GetString("fugitive-report-title"));
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-title"));
         report.PushNewline();
-        report.PushMarkup(Loc.GetString("fugitive-report-first-line"));
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-first-line"));
         report.PushNewline();
 
         if (!TryComp<HumanoidAppearanceComponent>(uid, out var humanoid))
         {
-            report.AddMarkup(Loc.GetString("fugitive-report-inhuman", ("name", uid)));
+            report.AddMarkupOrThrow(Loc.GetString("fugitive-report-inhuman", ("name", uid)));
             return report;
         }
 
         var species = PrototypeManager.Index(humanoid.Species);
 
-        report.PushMarkup(Loc.GetString("fugitive-report-morphotype", ("species", Loc.GetString(species.Name))));
-        report.PushMarkup(Loc.GetString("fugitive-report-age", ("age", humanoid.Age)));
-        report.PushMarkup(Loc.GetString("fugitive-report-sex", ("sex", humanoid.Sex.ToString())));
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-morphotype", ("species", Loc.GetString(species.Name))));
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-age", ("age", humanoid.Age)));
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-sex", ("sex", humanoid.Sex.ToString())));
 
         if (TryComp<PhysicsComponent>(uid, out var physics))
-            report.PushMarkup(Loc.GetString("fugitive-report-weight", ("weight", Math.Round(physics.FixturesMass))));
+            report.AddMarkupOrThrow(Loc.GetString("fugitive-report-weight", ("weight", Math.Round(physics.FixturesMass))));
 
         // add a random identifying quality that officers can use to track them down
-        report.PushMarkup(RobustRandom.Next(0, 2) switch
+        report.AddMarkupOrThrow(RobustRandom.Next(0, 2) switch
         {
             0 => Loc.GetString("fugitive-report-detail-dna", ("dna", GetDNA(uid))),
             _ => Loc.GetString("fugitive-report-detail-prints", ("prints", GetPrints(uid)))
         });
 
         report.PushNewline();
-        report.PushMarkup(Loc.GetString("fugitive-report-crimes-header"));
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crimes-header"));
 
         // generate some random crimes to avoid this situation
         // "officer what are my charges?"
@@ -144,7 +144,7 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         AddCharges(report, rule);
 
         report.PushNewline();
-        report.AddMarkup(Loc.GetString("fugitive-report-last-line"));
+        report.AddMarkupOrThrow(Loc.GetString("fugitive-report-last-line"));
 
         return report;
     }
@@ -172,7 +172,7 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         foreach (var crime in crimes)
         {
             var count = RobustRandom.Next(rule.MinCounts, rule.MaxCounts + 1);
-            report.PushMarkup(Loc.GetString("fugitive-report-crime", ("crime", Loc.GetString(crime)), ("count", count)));
+            report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crime", ("crime", Loc.GetString(crime)), ("count", count)));
         }
     }
 }

--- a/Content.Server/_DV/Weapons/Ranged/Components/EnergyGunComponent.cs
+++ b/Content.Server/_DV/Weapons/Ranged/Components/EnergyGunComponent.cs
@@ -16,14 +16,14 @@ public sealed partial class EnergyGunComponent : Component
     /// <summary>
     /// A list of the different firing modes the energy gun can switch between
     /// </summary>
-    [DataField("fireModes", required: true)]
+    [DataField(required: true)]
     [AutoNetworkedField]
     public List<EnergyWeaponFireMode> FireModes = new();
 
     /// <summary>
     /// The currently selected firing mode
     /// </summary>
-    [DataField("currentFireMode")]
+    [DataField]
     [AutoNetworkedField]
     public EnergyWeaponFireMode? CurrentFireMode = default!;
 }
@@ -40,18 +40,18 @@ public sealed partial class EnergyWeaponFireMode
     /// <summary>
     /// The battery cost to fire the projectile associated with this firing mode
     /// </summary>
-    [DataField("fireCost")]
+    [DataField]
     public float FireCost = 100;
 
     /// <summary>
     /// The name of the selected firemode
     /// </summary>
-    [DataField("name")]
+    [DataField]
     public string Name = string.Empty;
 
     /// <summary>
     /// What RsiState we use for that firemode if it needs to change.
     /// </summary>
-    [DataField("state")]
+    [DataField]
     public string State = string.Empty;
 }

--- a/Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Effects/Systems/PsionicProducingArtifactSystem.cs
+++ b/Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Effects/Systems/PsionicProducingArtifactSystem.cs
@@ -32,8 +32,6 @@ public sealed class PsionicProducingArtifactSystem : EntitySystem
 
         // Pick first active node
         var node = _artifact.GetActiveNodes(artifactEntity).FirstOrDefault();
-        if (node == null)
-            return;
 
         // Track psionic usage using ConsumedResearchValue
         var currentAmount = _artifact.GetResearchValue(node);

--- a/Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Effects/Systems/PsionicProducingArtifactSystem.cs
+++ b/Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Effects/Systems/PsionicProducingArtifactSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.Psionics;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
 
+namespace Content.Server._DV.Xenoarchaeology.XenoArtifacts.Effects.Systems;
 public sealed class PsionicProducingArtifactSystem : EntitySystem
 {
     [Dependency] private readonly SharedXenoArtifactSystem _artifact = default!;

--- a/Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMetapsionicTriggerSystem.cs
+++ b/Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMetapsionicTriggerSystem.cs
@@ -9,8 +9,6 @@ namespace Content.Server.Xenoarchaeology.XenoArtifacts.Triggers.Systems;
 
 public sealed class ArtifactMetapsionicTriggerSystem : BaseXATSystem<ArtifactMetapsionicTriggerComponent>
 {
-    [Dependency] private readonly XenoArtifactSystem _artifact = default!;
-
     private EntityQuery<XenoArtifactComponent> _xenoArtifactQuery;
 
     public override void Initialize()


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixing up warnings in Content.Server for anything under _DV.
Down to 17 at time of writing.

## Why / Balance
I must be a janitor somewhere and here sounds good.

## Technical details
I've listed the error code in the commit to try and make it a bit easier to understand why.

```
[CS8073] The result of the expression is always the same since a value of this type is never equal to 'null' [https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS8073)]
        Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Effects/Systems/PsionicProducingArtifactSystem.cs:34 - The result of the expression is always 'false' since a value of type 'Entity<XenoArtifactNodeComponent>' is never equal to 'null' of type 'Entity<XenoArtifactNodeComponent>?'
[CS0612] Type or member is obsolete [https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0612)]
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:111 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:113 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:124 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:125 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:126 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:129 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:132 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:139 - 'FormattedMessage.PushMarkup(string)' is obsolete
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:175 - 'FormattedMessage.PushMarkup(string)' is obsolete
[CS0649] Field is never assigned to, and will always have its default value [https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0649)]
        Content.Server/_DV/Curation/Systems/CwoinkSystem.cs:57 - Field 'CwoinkSystem._webhookData' is never assigned to, and will always have its default value 
[CS0414] Field is assigned but its value is never used [https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0414)]
        Content.Server/_DV/CosmicCult/DeconversionSystem.cs:34 - The field 'DeconversionSystem._doAfter' is assigned but its value is never used
        Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs:30 - The field 'PrecognitionPowerSystem._mind' is assigned but its value is never used
        Content.Server/_DV/Administration/Commands/SpawnPlayer.cs:28 - The field 'SpawnPlayer._playTimeTracking' is assigned but its value is never used
        Content.Server/_DV/Execution/ExecutionSystem.cs:43 - The field 'ExecutionSystem._interactionSystem' is assigned but its value is never used
        Content.Server/_DV/CosmicCult/DeconversionSystem.cs:38 - The field 'DeconversionSystem._delay' is assigned but its value is never used
        Content.Server/_DV/Xenoarchaeology/XenoArtifacts/Triggers/Systems/ArtifactMetapsionicTriggerSystem.cs:12 - The field 'ArtifactMetapsionicTriggerSystem._artifact' is assigned but its value is never used
        Content.Server/_DV/Grappling/EntitySystems/GrapplingSystem.cs:47 - The field 'GrapplingSystem._tag' is assigned but its value is never used
        Content.Server/_DV/NPC/Roboisseur/RoboisseurSystem.cs:24 - The field 'RoboisseurSystem._appearance' is assigned but its value is never used
        Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs:38 - The field 'PrecognitionPowerSystem._gameTiming' is assigned but its value is never used
        Content.Server/_DV/Abilities/Kitsune/KitsuneFoxSystem.cs:12 - The field 'KitsuneFoxSystem._stamina' is assigned but its value is never used
        Content.Server/_DV/CosmicCult/Abilities/CosmicConversionSystem.cs:21 - The field 'CosmicConversionSystem._timing' is assigned but its value is never used
        Content.Server/_DV/CosmicCult/DeconversionSystem.cs:30 - The field 'DeconversionSystem._entityManager' is assigned but its value is never used
        Content.Server/_DV/Abilities/Chitinid/ChitinidSystem.cs:14 - The field 'ChitinidSystem._proto' is assigned but its value is never used
        Content.Server/_DV/CosmicCult/EntitySystems/CosmicEntropyDegenSystem.cs:15 - The field 'CosmicEntropyDegenSystem._random' is assigned but its value is never used
        Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs:77 - The field 'CosmicCultRuleSystem._damage' is assigned but its value is never used
        Content.Server/_DV/Administration/Commands/SpawnPlayer.cs:27 - The field 'SpawnPlayer._trait' is assigned but its value is never used
[RA0033] Parameter forbids literal values
        Content.Server/_DV/Addictions/AddictionSystem.cs:89 - The id parameter of Index forbids literal values
[RA0027] Data field has redundant tag specified
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:22 - Data field MaximumWaves in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:25 - Data field MinimumCooldown in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:28 - Data field MaximumCooldown in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:31 - Data field MeteorsPerWave in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:34 - Data field MeteorVelocity in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:37 - Data field MaxAngularVelocity in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:40 - Data field MinAngularVelocity in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:46 - Data field SpawnDistanceVariation in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:53 - Data field TargetingSpread in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:59 - Data field MeteorLifetime in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MeteorSwarmRuleComponent.cs:19 - Data field MinimumWaves in data definition MeteorSwarmRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/Weapons/Ranged/Components/EnergyGunComponent.cs:26 - Data field CurrentFireMode in data definition EnergyGunComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/Weapons/Ranged/Components/EnergyGunComponent.cs:19 - Data field FireModes in data definition EnergyGunComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/Weapons/Ranged/Components/EnergyGunComponent.cs:43 - Data field FireCost in data definition EnergyWeaponFireMode has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/Weapons/Ranged/Components/EnergyGunComponent.cs:49 - Data field Name in data definition EnergyWeaponFireMode has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/Weapons/Ranged/Components/EnergyGunComponent.cs:55 - Data field State in data definition EnergyWeaponFireMode has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/StationEvents/Components/MinorMassMindSwapRuleComponent.cs:13 - Data field IsTemporary in data definition MinorMassMindSwapRuleComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs:20 - Data field BarkAccumulator in data definition RoboisseurComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs:31 - Data field StateCD in data definition RoboisseurComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs:23 - Data field BarkTime in data definition RoboisseurComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs:9 - Data field Accumulator in data definition RoboisseurComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs:17 - Data field ResetTime in data definition RoboisseurComponent has an explicitly set tag that matches autogenerated tag
        Content.Server/_DV/NPC/Roboisseur/RoboisseurComponent.cs:13 - Data field Impatient in data definition RoboisseurComponent has an explicitly set tag that matches autogenerated tag
```

Leaving these for another PR since they are a tad more involved and require a bit more testing:

```
[CS0618] Type or member is obsolete [https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0618)]
        Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs:31 - 'StatusEffectsSystem' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/CosmicCult/CosmicCultSystem.cs:63 - 'StatusEffectsSystem' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs:25 - 'StatusEffectsSystem' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs:35 - 'StatusEffectsSystem' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/CartridgeLoader/Cartridges/LogProbeCartridgeSystem.NanoChat.cs:71 - 'AudioHelpers.WithVariation(float, IRobustRandom?)' is obsolete: 'Use AudioParams.Variation data-field'
        Content.Server/_DV/NPC/Roboisseur/RoboisseurSystem.cs:64 - 'Component.Owner' is obsolete: 'Update your API to allow accessing Owner through other means'
        Content.Server/_DV/NPC/Roboisseur/RoboisseurSystem.cs:106 - 'Component.Owner' is obsolete: 'Update your API to allow accessing Owner through other means'
        Content.Server/_DV/StationEvents/Events/MinorMassMindSwapRule.cs:29 - 'ResolvedSoundSpecifier.implicit operator ResolvedSoundSpecifier(string)' is obsolete: 'String literals for sounds are deprecated, use a SoundSpecifier or ResolvedSoundSpecifier as appropriate instead'
        Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs:88 - 'StatusEffectsSystem.TryAddStatusEffect<T>(EntityUid, string, TimeSpan, bool, StatusEffectsComponent?)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs:116 - 'StatusEffectsSystem.TryRemoveStatusEffect(EntityUid, string, StatusEffectsComponent?, bool)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/Abilities/Psionics/PrecognitionPowerSystem.cs:117 - 'StatusEffectsSystem.TryRemoveStatusEffect(EntityUid, string, StatusEffectsComponent?, bool)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/Silicons/StationAiShopSystem.cs:70 - 'MapGridComponent.TryGetTileRef(EntityCoordinates, out TileRef)' is obsolete: 'Use the MapSystem method'
        Content.Server/_DV/Silicons/StationAiShopSystem.cs:79 - 'MapGridComponent.MapToGrid(MapCoordinates)' is obsolete: 'Use the MapSystem method'
        Content.Server/_DV/Biscuit/BiscuitSystem.cs:44 - 'ResolvedSoundSpecifier.implicit operator ResolvedSoundSpecifier(string)' is obsolete: 'String literals for sounds are deprecated, use a SoundSpecifier or ResolvedSoundSpecifier as appropriate instead'
        Content.Server/_DV/CosmicCult/EntitySystems/CosmicRiftSystem.cs:74 - 'StatusEffectsSystem.TryAddStatusEffect<T>(EntityUid, string, TimeSpan, bool, StatusEffectsComponent?)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/StationEvents/Events/DebrisSpawnerRule.cs:45 - 'TransformComponent.WorldMatrix' is obsolete: 'Use the system method instead'
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:118 - 'FormattedMessage.AddMarkup(string)' is obsolete: 'Use AddMarkupOrThrow or TryAddMarkup'
        Content.Server/_DV/StationEvents/Events/FugitiveRule.cs:147 - 'FormattedMessage.AddMarkup(string)' is obsolete: 'Use AddMarkupOrThrow or TryAddMarkup'
        Content.Server/_DV/CosmicCult/CosmicCultSystem.cs:179 - 'StatusEffectsSystem.TryAddStatusEffect<T>(EntityUid, string, TimeSpan, bool, StatusEffectsComponent?)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/CosmicCult/CosmicCultSystem.cs:187 - 'StatusEffectsSystem.TryRemoveStatusEffect(EntityUid, string, StatusEffectsComponent?, bool)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/CosmicCult/CosmicCultSystem.cs:193 - 'StatusEffectsSystem.TryAddStatusEffect<T>(EntityUid, string, TimeSpan, bool, StatusEffectsComponent?)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/CosmicCult/CosmicCultSystem.cs:202 - 'StatusEffectsSystem.TryRemoveStatusEffect(EntityUid, string, StatusEffectsComponent?, bool)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
        Content.Server/_DV/CosmicCult/Abilities/CosmicSiphonSystem.cs:103 - 'StatusEffectsSystem.TryAddStatusEffect<T>(EntityUid, string, TimeSpan, bool, StatusEffectsComponent?)' is obsolete: 'Migration to Content.Shared.StatusEffectNew.StatusEffectsSystem is required'
```

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
