### PR TITLE
Give Medical Borgs Crew Monitors

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -898,6 +898,7 @@
     hands:
     - item: HandheldHealthAnalyzerUnpowered
     - item: DefibrillatorOneHandedUnpowered
+    - item: HandheldCrewMonitorUnpowered # DeltaV
     - item: BorgFireExtinguisher
     - item: BorgHandheldGPSBasic
     - item: HandLabeler

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -1,0 +1,8 @@
+- type: entity
+  id: HandheldCrewMonitorUnpowered
+  parent: HandheldCrewMonitor
+  suffix: Unpowered
+  components:
+  - type: ItemSlots
+  - type: PowerCellDraw
+    useRate: 0

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -6,3 +6,5 @@
   - type: ItemSlots
   - type: PowerCellDraw
     useRate: 0
+  - type: CrewMonitoringConsole
+    alertsEnabled: false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Title sums it up!
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Saw borg players wanting it and seems fitting for the rescue module.
## Technical details
<!-- Summary of code changes for easier review. -->
1 line YAML + new _DV file for `HandheldCrewMonitorUnpowered` similar to other borg equipments.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Medical borgs now have access to a crew monitor as part of the rescue cyborg module!