### PR TITLE
tweak: nanotask papers don't provide throwing pushback

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Content.Server.Stack;
 using Content.Server.Stunnable;
+using Content.Shared._DV.Item;
 using Content.Shared._NF.Standing; // Frontier
 using Content.Shared.ActionBlocker;
 using Content.Shared.Body.Part;
@@ -224,7 +225,8 @@ namespace Content.Server.Hands.Systems
             if (IsHolding((player, hands), throwEnt, out _) && !TryDrop(player, throwEnt.Value))
                 return false;
 
-            _throwingSystem.TryThrow(ev.ItemUid, ev.Direction, ev.ThrowSpeed, ev.PlayerUid, compensateFriction: !HasComp<LandAtCursorComponent>(ev.ItemUid));
+            // DeltaV - Set pushback to 0 if NoThrowingPushback, previously unset
+            _throwingSystem.TryThrow(ev.ItemUid, ev.Direction, ev.ThrowSpeed, ev.PlayerUid, pushbackRatio: HasComp<Shared._DV.Item.Components.NoThrowingPushbackComponent>(ev.ItemUid) ? 0 : ThrowingSystem.PushbackDefault, compensateFriction: !HasComp<LandAtCursorComponent>(ev.ItemUid));
 
             return true;
         }

--- a/Content.Shared/_DV/Item/Components/NoThrowingPushbackComponent.cs
+++ b/Content.Shared/_DV/Item/Components/NoThrowingPushbackComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._DV.Item.Components;
+
+[RegisterComponent]
+public sealed partial class NoThrowingPushbackComponent : Component;

--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -236,6 +236,7 @@
     contentMargin: 12.0, 0.0, 12.0, 0.0
     # This is a narrow piece of paper
     maxWritableArea: 256.0, 0.0
+  - type: NoThrowingPushback # DeltaV - Added comp
 
 - type: entity
   id: PaperCargoBountyManifest


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Stop NanoTask printouts from providing pushback to the thrower when thrown.

## Why / Balance
Being able to infinitely print paper that you can use to traverse space seems unintentional.

## Technical details
Added NoThrowingPushbackComponent, which is checked for in the HandsSystem to set the pushbackRatio to 0.

## Media

https://github.com/user-attachments/assets/68e2c6d9-8946-4414-8516-2c2c94963e17



## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: DisposableCrewmember42
- tweak: NanoTask cartridges were the target of budget cuts. Task printouts are now too lightweight to provide throwing pushback in space.
