### PR TITLE
feat: adminoverlay command

### DIFF
--- a/Content.Client/_DV/Administration/Commands/AdminOverlayCommand.cs
+++ b/Content.Client/_DV/Administration/Commands/AdminOverlayCommand.cs
@@ -1,0 +1,32 @@
+using Content.Client.Administration.Systems;
+using Robust.Shared.Console;
+
+namespace Content.Client._DV.Administration.Commands;
+
+public sealed class AdminOverlayCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly AdminSystem _admin = default!;
+    public override string Command => "adminoverlay";
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1 || !Boolean.TryParse(args[0], out var newValue))
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        if (newValue)
+        {
+            _admin.AdminOverlayOn();
+        }
+        else
+        {
+            _admin.AdminOverlayOff();
+        }
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length == 1 ? CompletionResult.FromOptions(CompletionHelper.Booleans) : CompletionResult.Empty;
+    }
+}

--- a/Resources/Locale/en-US/_DV/commands/adminoverlay-command.ftl
+++ b/Resources/Locale/en-US/_DV/commands/adminoverlay-command.ftl
@@ -1,0 +1,2 @@
+cmd-adminoverlay-desc = Activate or deactivate the admin overlay
+cmd-adminoverlay-help = adminoverlay <true|false>

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -74,6 +74,7 @@
     - dumpentities
     - fuckrules # DeltaV: move fuckrules to DEBUG
     - showaccessreaders
+    - adminoverlay # DeltaV: add adminoverlay command
 
 - Flags: MAPPING
   Commands:

--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -74,7 +74,10 @@
     - dumpentities
     - fuckrules # DeltaV: move fuckrules to DEBUG
     - showaccessreaders
-    - adminoverlay # DeltaV: add adminoverlay command
+
+- Flags: ADMIN # DeltaV
+  Commands:
+    - adminoverlay
 
 - Flags: MAPPING
   Commands:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added a command to toggle the admin overlay so I can include it in my aghost script :blunt:

## Why / Balance
I'm lazy and scripts are convenient.

## Technical details
Added client-side command that uses AdminSystem to toggle the overlay. Added access to ADMIN perm.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: DisposableCrewmember42
DELTAVADMIN:
- add: Command to toggle the admin overlay: "adminoverlay <true|false>"