### PR TITLE
fix: rev can haunt again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -76,6 +76,7 @@
   - type: ActionGrant
     actions:
     - ActionRevenantShop
+    - ActionRevenantHaunt # Imp - Haunt ability
   - type: Store
     categories:
     - RevenantAbilities


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The Rev can now use its Haunt ability again

## Why / Balance
was accidentally removed at some point, presumably by 24e061b

## Technical details
Added via ActionGrant comp

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: DisposableCrewmember42
- fix: The revenant can use its Haunt ability again
