### PR TITLE
Reduce stealth hardsuit armor

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -19,9 +19,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7 # DeltaV - was 0.65
-        Slash: 0.7 # DeltaV - was 0.65
-        Piercing: 0.6 
+        Blunt: 0.8 # DeltaV - was 0.65
+        Slash: 0.8 # DeltaV - was 0.65
+        Piercing: 0.8 # DeltaV - Was 0.6
         Heat: 0.8 # DeltaV - was 0.6
         Radiation: 0.8 # DeltaV - was 0.55
         #Caustic: 0.7 # DeltaV


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Stealth suit res changed to 20% across the board

## Why / Balance
based on community feedback, You can have either armor or invis but not both. Overall this should make these less viable but still a fun thing to bring.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**

:cl:
- tweak: Stealth suit resistances have been reduced.

