### PR TITLE
Turrets Fix/Buff and QOL

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1215,7 +1215,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 28
+        Heat: 32 #DeltaV was 28
 
 - type: entity
   name : disabler bolt
@@ -1231,12 +1231,13 @@
     - state: mediumstun # imp
       shader: unshaded
   - type: StaminaDamageOnCollide
-    damage: 30
+    damage: 40 #DeltaV
   - type: Projectile
     impactEffect: BulletImpactEffectDisabler
     damage:
       types:
         Heat: 0
+        Ion: 20 # DeltaV
     soundHit:
       collection: WeakHit
     forceSound: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
@@ -87,8 +87,8 @@
     - proto: BulletEnergyTurretLaser
       fireCost: 100
   - type: DeployableTurret
-    retractedDamageModifierSetId: Retracted #DeltaV
-    deployedDamageModifierSetId: Deployed #DeltaV
+    retractedDamageModifierSetId: RetractedAITurret #DeltaV
+    deployedDamageModifierSetId: DeployedAITurret #DeltaV
   - type: Damageable
     damageModifierSet: Metallic
   - type: Repairable

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_energy.yml
@@ -87,8 +87,8 @@
     - proto: BulletEnergyTurretLaser
       fireCost: 100
   - type: DeployableTurret
-    retractedDamageModifierSetId: Metallic
-    deployedDamageModifierSetId: FlimsyMetallic
+    retractedDamageModifierSetId: Retracted #DeltaV
+    deployedDamageModifierSetId: Deployed #DeltaV
   - type: Damageable
     damageModifierSet: Metallic
   - type: Repairable
@@ -158,6 +158,8 @@
   - type: DeviceNetwork
     receiveFrequencyId: TurretControlAI
     transmitFrequencyId: TurretAI
+  - type: StationAiVision #DeltaV
+    range: 0
 
 - type: entity
   parent: WeaponEnergyTurretStationBase
@@ -195,3 +197,5 @@
   - type: DeviceNetwork
     receiveFrequencyId: TurretControl
     transmitFrequencyId: Turret
+  - type: StationAiVision #DeltaV
+    range: 0

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -222,7 +222,7 @@
     containers:
       board:
       - WeaponEnergyTurretCommandControlPanelElectronics
-  - type: StationAiVision
+  - type: StationAiVision # DeltaV
     range: 0
   - type: TurretTargetSettings
     exemptAccessLevels:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -181,7 +181,7 @@
   - type: DeviceNetwork
     receiveFrequencyId: TurretAI
     transmitFrequencyId: TurretControlAI
-  - type: StationAiVision
+  - type: StationAiVision # DeltaV
     range: 0
   - type: TurretTargetSettings
     exemptAccessLevels:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -181,6 +181,8 @@
   - type: DeviceNetwork
     receiveFrequencyId: TurretAI
     transmitFrequencyId: TurretControlAI
+  - type: StationAiVision
+    range: 0
   - type: TurretTargetSettings
     exemptAccessLevels:
     - BasicSilicon
@@ -220,6 +222,8 @@
     containers:
       board:
       - WeaponEnergyTurretCommandControlPanelElectronics
+  - type: StationAiVision
+    range: 0
   - type: TurretTargetSettings
     exemptAccessLevels:
     - Command

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -10,6 +10,9 @@
     cultistText: cosmic-examine-text-cultentity
     othersText: cosmic-examine-text-entities
   - type: AntagImmune
+  - type: NpcFactionMember
+    factions:
+    - SimpleHostile
   - type: StaminaResistance
     damageCoefficient: 0 # No more stunning colossi
     worn: false

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/hostiles.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/hostiles.yml
@@ -19,6 +19,7 @@
   - type: NpcFactionMember
     factions:
     - CosmicCult
+    - SimpleHostile
   - type: Tag
     tags:
     - DoorBumpOpener

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -185,7 +185,7 @@
     Heat: 100
 
 - type: damageModifierSet
-  id: Deployed
+  id: DeployedAITurret
   coefficients:
     Blunt: 0.7
     Slash: 0.6

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -168,3 +168,30 @@
     Slash: 40
     Piercing: 15
     Heat: 10
+
+- type: damageModifierSet
+  id: Retracted
+  coefficients:
+    Blunt: 0.7
+    Slash: 0.7
+    Piercing: 0.7
+    Heat: 1.0 # does not work
+    Shock: 1.2
+    Structural: 0.7
+  flatReductions:
+    Blunt: 10
+    Slash: 10
+    Piercing: 5
+    Heat: 100
+
+- type: damageModifierSet
+  id: Deployed
+  coefficients:
+    Blunt: 0.7
+    Slash: 0.6
+    Piercing: 0.7
+    Heat: 1.0 # does not work
+    Shock: 1.2
+    Structural: 0.3
+  flatReductions:
+    Heat: 100

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -175,7 +175,7 @@
     Blunt: 0.3
     Slash: 0.3
     Piercing: 0.3
-    Heat: 0
+    Heat: 0.7
     Shock: 0
     Structural: 0.3
   flatReductions:
@@ -189,5 +189,5 @@
     Blunt: 0.3
     Slash: 0.3
     Piercing: 0.3
-    Heat: 0
+    Heat: 0.7
     Shock: 0

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -175,7 +175,7 @@
     Blunt: 0.3
     Slash: 0.3
     Piercing: 0.3
-    Heat: 0 
+    Heat: 0
     Shock: 0
     Structural: 0.3
   flatReductions:

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -170,7 +170,7 @@
     Heat: 10
 
 - type: damageModifierSet
-  id: Retracted
+  id: RetractedAITurret
   coefficients:
     Blunt: 0.7
     Slash: 0.7

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -172,26 +172,22 @@
 - type: damageModifierSet
   id: RetractedAITurret
   coefficients:
-    Blunt: 0.7
-    Slash: 0.7
-    Piercing: 0.7
-    Heat: 1.0 # does not work
-    Shock: 1.2
-    Structural: 0.7
+    Blunt: 0.3
+    Slash: 0.3
+    Piercing: 0.3
+    Heat: 0 
+    Shock: 0
+    Structural: 0.3
   flatReductions:
-    Blunt: 10
-    Slash: 10
+    Blunt: 5
+    Slash: 5
     Piercing: 5
-    Heat: 100
 
 - type: damageModifierSet
   id: DeployedAITurret
   coefficients:
-    Blunt: 0.7
-    Slash: 0.6
-    Piercing: 0.7
-    Heat: 1.0 # does not work
-    Shock: 1.2
-    Structural: 0.3
-  flatReductions:
-    Heat: 100
+    Blunt: 0.3
+    Slash: 0.3
+    Piercing: 0.3
+    Heat: 0
+    Shock: 0


### PR DESCRIPTION
## About the PR
This pr will fix some things that where not working and buff the turrets by a tiny bit
I wanted to add the security panel to the wirepanel but it was ether not possible with how it's set up or way to hard

## Why / Balance
Right now some things the turrets should have had was broken or not working.
The buff is because the turrets can be taken out or messed with too easily when they should not be also the target lock rate is random ether being over 10 seconds or 1 second so i believe they should be buffed in a way that fixes that 


## Technical details
Fix: turret can now shoot the colossus
Fix: damage was at 28 for the laser cannon that is used in making it deltav laser cannon does 32 damage so it should do 32
Fix: turret now does ion damage with the disabler mode
Buff: turret now does 40 stamina (since its a turret and not a disabler it has more power) and 20 ion damage
QOL: turrets now have ai vision only being the tile the turret is on so even with cams gone the ai can defend its self (only being ai and command turrets not security turrets also not sure if i should make it like holopads vision)
QOL: turret control panels now have ai vision only being the tile its on

Buff: buffed the following resistance
Fix: Fixed the heat resistance 

Please note this is a fix for the original pr

Retracted: (under the floor)
blunt 70% (was 30%)
slash 70% (was 50%)
piercing 70% (was 30%)
heat 100% (was 0)
shock 100% (was -20%)
structural 70% (was 50%)
Flat Reduction:
blunt 10 (was 5)
slash 10 (was 0)
piercing 5 (guns can not even hit it was 0)

Deployed: (can shoot)
blunt 70% (was 30%)
slash 70% ( was 50%)
piercing 70% (was 30%)
heat 100% (was 0)
shock 100% (was -20%)


## Media

<img width="393" height="387" alt="Screenshot 2026-01-04 202453" src="https://github.com/user-attachments/assets/e379fc43-8480-4a8a-9d41-9fc7336a4006" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
:cl:
- add: AI can now see there turrets and turret control panel without cameras
- tweak: Turrets now have more resistance where they should
- tweak: Turrets now do 40 stamina damage instead of 30
- fix: Turrets can now target the colossus and there minions
- fix: Turrets now do ion damage that being 20
- fix: Turrets resistance was fixed now doing the intended amount
- fix: Turrets now do the intended damage of 32 instead of 28
-->
