### PR TITLE
early merge: freezers/heaters/mail teleporters start off

### DIFF
--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -42,12 +42,15 @@ namespace Content.Server.Power.Components
         /// <summary>
         ///     When true, causes this to never appear powered.
         /// </summary>
-        [DataField("powerDisabled")]
+        [ViewVariables]
         public override bool PowerDisabled
         {
             get => !NetworkLoad.Enabled;
             set => NetworkLoad.Enabled = !value;
         }
+
+        [DataField("powerDisabled"), ViewVariables(VVAccess.ReadOnly)]
+        public bool StartingPowerDisabled = false;
 
         [ViewVariables]
         public PowerState.Load NetworkLoad { get; } = new PowerState.Load

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -49,7 +49,7 @@ namespace Content.Server.Power.Components
             set => NetworkLoad.Enabled = !value;
         }
 
-        [DataField("powerDisabled"), ViewVariables(VVAccess.ReadOnly)]
+        [DataField("powerDisabled"), ViewVariables(VVAccess.ReadOnly)] // Early merge of #42260
         public bool StartingPowerDisabled = false;
 
         [ViewVariables]

--- a/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
+++ b/Content.Server/Power/Components/ApcPowerReceiverComponent.cs
@@ -42,7 +42,7 @@ namespace Content.Server.Power.Components
         /// <summary>
         ///     When true, causes this to never appear powered.
         /// </summary>
-        [ViewVariables]
+        [ViewVariables] // Early merge of #42260
         public override bool PowerDisabled
         {
             get => !NetworkLoad.Enabled;

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -21,6 +21,7 @@ namespace Content.Server.Power.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
+            SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentStartup>(OnReceiverStartup);
             SubscribeLocalEvent<ApcPowerReceiverComponent, ExaminedEvent>(OnExamined);
 
             SubscribeLocalEvent<ApcPowerReceiverComponent, ExtensionCableSystem.ProviderConnectedEvent>(OnProviderConnected);
@@ -37,6 +38,11 @@ namespace Content.Server.Power.EntitySystems
 
             _recQuery = GetEntityQuery<ApcPowerReceiverComponent>();
             _provQuery = GetEntityQuery<ApcPowerProviderComponent>();
+        }
+
+        private void OnReceiverStartup(Entity<ApcPowerReceiverComponent> ent, ref ComponentStartup args)
+        {
+            ent.Comp.PowerDisabled = ent.Comp.StartingPowerDisabled;
         }
 
         private void OnExamined(Entity<ApcPowerReceiverComponent> ent, ref ExaminedEvent args)

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -40,7 +40,7 @@ namespace Content.Server.Power.EntitySystems
             _provQuery = GetEntityQuery<ApcPowerProviderComponent>();
         }
 
-        private void OnReceiverStartup(Entity<ApcPowerReceiverComponent> ent, ref ComponentStartup args)
+        private void OnReceiverStartup(Entity<ApcPowerReceiverComponent> ent, ref ComponentStartup args) // Early merge of #42260
         {
             ent.Comp.PowerDisabled = ent.Comp.StartingPowerDisabled;
         }

--- a/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
+++ b/Content.Server/Power/EntitySystems/PowerReceiverSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Server.Power.EntitySystems
         public override void Initialize()
         {
             base.Initialize();
-            SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentStartup>(OnReceiverStartup);
+            SubscribeLocalEvent<ApcPowerReceiverComponent, ComponentStartup>(OnReceiverStartup); // Early merge of #42260
             SubscribeLocalEvent<ApcPowerReceiverComponent, ExaminedEvent>(OnExamined);
 
             SubscribeLocalEvent<ApcPowerReceiverComponent, ExtensionCableSystem.ProviderConnectedEvent>(OnProviderConnected);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Early cherry pick of upstream https://github.com/space-wizards/space-station-14/pull/42260

Freezers, heaters, space heaters, **and mail teleporters** (DeltaV-specific) now start with their power turned off, unless mappers have specifically selected the variation with `suffix: Enabled` from the Entity Spawn Menu.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Alternative to https://github.com/DeltaV-Station/Delta-v/pull/5141 . It's a fix in anticipation of the fact that we will eventually be merging upstream's changes to APCs that cause them to be tripped off when too much power is going through them -- this will make sure mappers can have atmos machines start the shift powered off, if their atmos areas contain too many machines for a single APC to power.

## Technical details
<!-- Summary of code changes for easier review. -->

See the cherry pick, I have some notes in the Technical details section there.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

See the cherry pick. Though I have tested this in my local DeltaV instance too, not just my local upstream instance.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

<!--

:cl:
- tweak: Designs for more cost-effective APCs are nearly complete. In anticipation of this, freezers, heaters, and mail teleporters will now be automatically turned off between shifts to prevent dangerous start-of-shift power spikes.

-->