### PR TITLE
Revert "Remove crate Melting"

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -203,8 +203,8 @@
     sprite: _DV/Structures/Storage/Crates/sec_gear.rsi # DeltaV - resprite security crates
   - type: AccessReader
     access: [["Security"]]
-#  - type: AntiTamper # DeltaV - port impstation's anti-tamper
-#    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+  - type: AntiTamper # DeltaV - port impstation's anti-tamper
+    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: CrateBaseSecure
@@ -309,8 +309,8 @@
     sprite: Structures/Storage/Crates/weapon.rsi
   - type: AccessReader
     access: [["Armory"]]
-#  - type: AntiTamper # DeltaV - port impstation's anti-tamper
-#    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+  - type: AntiTamper # DeltaV - port impstation's anti-tamper
+    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: [ CrateBaseSecure, BaseSecurityContraband ]


### PR DESCRIPTION
Reverts DeltaV-Station/Delta-v#5050

Test merge basically failed because people would buy weapons just to buy weapons in multiple instances.

:cl:
- tweak: Secure crates from Logistics once again have a 75% chance of acidifying the contents inside.  