### PR TITLE
Add Space Cleaner Regen to Janiborg's Adv. Internal Spray Jet

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -119,6 +119,13 @@
         reagents:
         - ReagentId: SpaceCleaner
           Quantity: 200
+  - type: SolutionRegeneration # Delta-V - Refill borg's spray 1 full use per 10 seconds
+    solution: spray
+    generated:
+      reagents:
+      - ReagentId: SpaceCleaner
+        Quantity: 10
+    duration: 10
 
 - type: entity
   parent: MegaSprayBottle
@@ -134,6 +141,13 @@
         reagents:
         - ReagentId: SpaceCleaner
           Quantity: 500
+  - type: SolutionRegeneration # Delta-V - Refill borg's mega spray 1 full use per 5 seconds
+    solution: spray
+    generated:
+      reagents:
+      - ReagentId: SpaceCleaner
+        Quantity: 10
+    duration: 5
 
 # Vapor
 - type: entity
@@ -166,7 +180,7 @@
         hard: false
         mask:
         - FullTileMask
-        - Opaque
+        - Opaque 
         layer:
         - ItemMask
   - type: Appearance

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -119,13 +119,6 @@
         reagents:
         - ReagentId: SpaceCleaner
           Quantity: 200
-  - type: SolutionRegeneration # Delta-V - Refill borg's spray 1 full use per 10 seconds
-    solution: spray
-    generated:
-      reagents:
-      - ReagentId: SpaceCleaner
-        Quantity: 10
-    duration: 10
 
 - type: entity
   parent: MegaSprayBottle

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -180,7 +180,7 @@
         hard: false
         mask:
         - FullTileMask
-        - Opaque 
+        - Opaque
         layer:
         - ItemMask
   - type: Appearance

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/wall_dispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/wall_dispensers.yml
@@ -67,13 +67,6 @@
         reagents:
         - ReagentId: SpaceCleaner
           Quantity: 5000
-  - type: SolutionRegeneration # Delta-v - refill wall dispenser 1 full bottle per minute.
-    solution: tank
-    generated:
-      reagents:
-      - ReagentId: SpaceCleaner
-        Quantity: 100
-    duration: 60
 
 - type: entity
   parent: BaseDispenser

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/wall_dispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Storage/wall_dispensers.yml
@@ -67,6 +67,13 @@
         reagents:
         - ReagentId: SpaceCleaner
           Quantity: 5000
+  - type: SolutionRegeneration # Delta-v - refill wall dispenser 1 full bottle per minute.
+    solution: tank
+    generated:
+      reagents:
+      - ReagentId: SpaceCleaner
+        Quantity: 100
+    duration: 60
 
 - type: entity
   parent: BaseDispenser


### PR DESCRIPTION
## About the PR

Adds the solution regeneration component to Space Cleaner Dispensers and JaniBorgs Internal Spray Jets and Adv. Internal Spray Jets.

## Why / Balance

This change was requested on discord as an alternative to waiting on, or being ignored by, chemists (who may or may not have time to make ammonia for a janitor that wants to make NT proud and actually clean the caked-on dirt).

Also, Engineering Cyborgs have the experimental RCD that regenerates charges, so it seemed precedented to give Janitor Cyborgs regenerating space cleaner. Janitor Cyborgs may also, as usual, refill their bottles from the wall dispenser.

- ~~Wall Dispensers will generate 100u (One full bottle, 10 uses) every 1 minute. This equates to approximately 1.66u per second.~~ (Removed after Dir. review)
- ~~Internal Spray Jet will regenerate 10u (One use) every 10 seconds. This equates to 1u per second.~~ (Removed after Dir. review)
- Adv. Internal Spray Jet will regenerate 10u (One use) every 5 seconds. This equates to 2u per second.

## Technical details
100% free range discord requests mechanically processed into YAML Ops. (YAML only change)

## Media
<img width="1617" height="823" alt="image" src="https://github.com/user-attachments/assets/389fa140-169a-480c-a2be-3dd2b88030d2" />
<img width="1497" height="836" alt="image" src="https://github.com/user-attachments/assets/91af6a90-327b-4992-927e-f1824502d45d" />

## Requirements
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
No breaking changes.

**Changelog**
:cl:
- add: Adv. Cleaning Cyborg Module now regenerates Space Cleaner.
