### PR TITLE
mobs no longer gasp when in the presence of many types of gases

### DIFF
--- a/Content.Server/Body/Components/MetabolizerComponent.cs
+++ b/Content.Server/Body/Components/MetabolizerComponent.cs
@@ -72,8 +72,11 @@ namespace Content.Server.Body.Components
         ///     Used to nerf 'stacked poisons' where having 5+ different poisons in a syringe, even at low
         ///     quantity, would be muuuuch better than just one poison acting.
         /// </summary>
+        /// <remarks>
+        /// DeltaV - changed from an `int` to an `int?` to support lungs not having a limit
+        /// </remarks>
         [DataField("maxReagents")]
-        public int MaxReagentsProcessable = 3;
+        public int? MaxReagentsProcessable = 3;
 
         /// <summary>
         ///     A list of metabolism groups that this metabolizer will act on, in order of precedence.

--- a/Content.Server/Body/Systems/MetabolizerSystem.cs
+++ b/Content.Server/Body/Systems/MetabolizerSystem.cs
@@ -157,8 +157,13 @@ public sealed class MetabolizerSystem : SharedMetabolizerSystem
             }
 
             // we're done here entirely if this is true
-            if (reagents >= ent.Comp1.MaxReagentsProcessable)
+            // DeltaV - start of null limit allowed
+            if (
+                ent.Comp1.MaxReagentsProcessable is { } maxReagentsProcessable 
+                && reagents >= maxReagentsProcessable
+            )
                 return;
+            // DeltaV - end of null limit allowed
 
 
             // loop over all our groups and see which ones apply

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -51,6 +51,10 @@
     groups:
     - id: Gas
       rateModifier: 100.0
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: SolutionContainerManager
     solutions:
       Lung:

--- a/Resources/Prototypes/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/slimes.yml
@@ -53,6 +53,10 @@
       groups:
       - id: Gas
         rateModifier: 100.0
+      # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+      # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+      # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+      maxReagents: null
     - type: SolutionContainerManager
       solutions:
         organ:

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -75,6 +75,10 @@
     groups:
     - id: Gas
       rateModifier: 100.0
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/Prototypes/Body/Organs/diona.yml
+++ b/Resources/Prototypes/Body/Organs/diona.yml
@@ -132,6 +132,10 @@
     groups:
     - id: Gas
       rateModifier: 100.0
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/Prototypes/Body/Organs/human.yml
+++ b/Resources/Prototypes/Body/Organs/human.yml
@@ -149,6 +149,10 @@
     groups:
     - id: Gas
       rateModifier: 100.0
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/Prototypes/Body/Organs/rat.yml
+++ b/Resources/Prototypes/Body/Organs/rat.yml
@@ -5,6 +5,10 @@
   components:
   - type: Metabolizer
     metabolizerTypes: [ Rat ]
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
 
 - type: entity
   id: OrganRatStomach

--- a/Resources/Prototypes/Body/Organs/slime.yml
+++ b/Resources/Prototypes/Body/Organs/slime.yml
@@ -62,6 +62,10 @@
     groups:
     - id: Gas
       rateModifier: 100.0
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -9,6 +9,10 @@
     sprite: Mobs/Species/Vox/organs.rsi
   - type: Metabolizer
     metabolizerTypes: [ Vox ]
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: Lung
     alert: LowNitrogen
   - type: Item

--- a/Resources/Prototypes/_DV/Body/Organs/feroxi.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/feroxi.yml
@@ -47,6 +47,10 @@
     groups:
     - id: Gas
       rateModifier: 100.0
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/Prototypes/_DV/Body/Organs/feroxi.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/feroxi.yml
@@ -48,7 +48,7 @@
     - id: Gas
       rateModifier: 100.0
     # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
-    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug:
     # Oxygen is occasionally randomly excluded from being processed when many gas types are present
     maxReagents: null
   - type: SolutionContainerManager

--- a/Resources/Prototypes/_DV/Body/Organs/harpy.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/harpy.yml
@@ -21,7 +21,7 @@
     - id: Gas
       rateModifier: 200.0
     # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
-    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug:
     # Oxygen is occasionally randomly excluded from being processed when many gas types are present
     maxReagents: null
   - type: SolutionContainerManager

--- a/Resources/Prototypes/_DV/Body/Organs/harpy.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/harpy.yml
@@ -20,6 +20,10 @@
     groups:
     - id: Gas
       rateModifier: 200.0
+    # DeltaV - All lungs should process all gas types on every update. Players are not likely to abuse poison stacking with gases.
+    # On the other hand, limiting the reagent count causes the Metabolic Roll Asphyxiation bug: 
+    # Oxygen is occasionally randomly excluded from being processed when many gas types are present
+    maxReagents: null
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/ServerInfo/Guidebook/Mobs/_DV/Harpy.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/_DV/Harpy.xml
@@ -29,7 +29,6 @@
   - Comes with the Ultraviolet Vision trait by default. This can be disabled via accessibility options.
   - Cannot wear Jumpsuits, and will automatically start with a Jumpskirt instead.
   - While singing, musical notes appear floating around their head.
-  - Gases breathed in metabolize twice as fast.
 
   ## Drawbacks
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Fixed a bug where all mobs were asphyxiating when 4 or more gas types are present, even if these gases were at entirely safe levels (e.g. 0.1% CO2 is very safe alone, but caused gasping when more gas types were added)

This was also the source of the fabled harpy gasping "air quality" myths: https://github.com/DeltaV-Station/Delta-v/issues/4671 . Due to arcane interactions with obscure harpy metabolizer settings, harpies were made *more* vulnerable to this bug. However, *all* species were vulnerable to this bug when there are enough different gas types in the air, not just harpies.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

It makes no sense for the *number of gas types* in the air to cause asphyxiation; the *amounts (mols/%)* of bad gas is what should matter. Currently, this bug would still suffocate all species even if the amounts were absolutely miniscule.

Mobs were asphyxiating because lungs (just like all organs) only process up to 3 different reagents at a time, to prevent poison stacking abuse. This was causing Oxygen to occasionally be excluded from the processing due to random chance (3 reagents are randomly selected), even though plenty of Oxygen is present in the air.

This PR simply removes this limit for lungs -- lungs will now process up to all 9 gas types simultaneously; all gases present in a room.

"Poison stacking" is the fact that, because reagents are metabolized in parallel, multiple poisons in a syringe causes damage more quickly than a single poison in a syringe. To prevent players from abusing this, all organs are limited to only processing 3 reagent types a time. IMO poison stacking is irrelevant for lungs. Reason 1: nobody is using gases to poison people as an antag; it's impractical. Reason 2: there are only 9 gases in the game (three of which are inert oxygen/nitrogen/water vapor), so the potential for crazy abuse of poison stacking is not really there for gases like it is with the vast number of liquid reagents.

Finally, for those who want to keep the "harpy's are more sensitive to air quality" around, I agree with you! I have a followup PR planned to implement that feature properly, instead of keeping around a bug that nobody really understands very well: https://github.com/DeltaV-Station/Delta-v/pull/5158

## Technical details
<!-- Summary of code changes for easier review. -->

See this issue for a more detailed explanation of the bug: https://github.com/DeltaV-Station/Delta-v/issues/4671

The fix code itself should be pretty self explanatory though; let me know if it's not.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

### Before this PR:

All species gasp in rooms that have 4+ gas types present, regardless of the actual amounts (%/mols) of those gases. Harpies happen to gasp more frequently in this situation due to strange code interactions.

For context: 1% is the CO2 threshold for most species to start gasping (when in a room with only oxygen, nitrogen, and CO2 alone). So the fact that 0.1% CO2 here is causing gasping in humans is pretty weird. The other gases are not related to respiration; they do not cause gasping (when added alone). This is all happening due to the bug.

![metabolic_roll_asphyx_demo](https://github.com/user-attachments/assets/a4804b22-2bb1-4cd5-8891-7b4013220fc2)


### After this PR:

Species do not gasp in rooms with lots of trace pollutant gases. The gases are safe as long as they are in very small amounts.

![metabolic_roll_asphyx_removed](https://github.com/user-attachments/assets/01f9cefa-34ab-47af-b807-972fc5e3b8b3)


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed a bug where all species (not just harpies) were gasping in the presence of *extremely* trace amounts of pollutant gases (0.01%).

