### PR TITLE
harpy gasp when pollutant gases are present

### DIFF
--- a/Resources/Locale/en-US/_DV/metabolism/metabolizer_types.ftl
+++ b/Resources/Locale/en-US/_DV/metabolism/metabolizer_types.ftl
@@ -1,2 +1,3 @@
 metabolizer-type-feroxi = Feroxi
 metabolizer-type-feroxi-dehydrated = Dehydrated Feroxi
+metabolizer-type-harpy = Harpy

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -493,6 +493,11 @@
         ratios: # DeltaV no duplicating O2 >:3
           CarbonDioxide: 0.5
           WaterVapor: -1.0
+      - !type:Oxygenate # DeltaV - Harpy sensitive to air quality
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Harpy ]
+        factor: -1
       # DeltaV - End changes
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -271,6 +271,11 @@
         - !type:MetabolizerTypeCondition
           type: [ Vox ]
         factor: -4
+      - !type:Oxygenate # DeltaV - Harpy sensitive to air quality
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Harpy ]
+        factor: -4
 
 
 - type: reagent

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -13,7 +13,7 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Human, Animal, Rat, Plant ]
+          type: [ Human, Animal, Rat, Plant, Feroxi, Harpy ] # DeltaV
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:
@@ -44,7 +44,7 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Human, Animal, Rat, Plant, Feroxi ] # DeltaV
+          type: [ Human, Animal, Rat, Plant, Feroxi, Harpy ] # DeltaV
       # Convert Oxygen into CO2.
       - !type:ModifyLungGas
         conditions:
@@ -108,6 +108,11 @@
         minScale: 3
         clear: True
         time: 5
+      - !type:Oxygenate # DeltaV - Harpy sensitive to air quality
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Harpy ]
+        factor: -8
   reactiveEffects:
     Flammable:
       methods: [ Touch ]
@@ -153,6 +158,11 @@
         minScale: 3
         clear: True
         time: 5
+      - !type:Oxygenate # DeltaV - Harpy sensitive to air quality
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Harpy ]
+        factor: -8
 
 - type: reagent
   id: CarbonDioxide
@@ -181,9 +191,14 @@
       - !type:Oxygenate
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Plant ]
+          type: [ Plant, Harpy ] # DeltaV - Harpy moved below
           inverted: true
         factor: -4
+      - !type:Oxygenate # DeltaV - Harpy more sensitive to air quality
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Harpy ]
+        factor: -12
     Gas:
       effects:
       - !type:Oxygenate
@@ -206,12 +221,17 @@
       - !type:Oxygenate # carbon dioxide displaces oxygen from the bloodstream, causing asphyxiation
         conditions:
         - !type:MetabolizerTypeCondition
-          type: [ Plant ]
+          type: [ Plant, Harpy ] # DeltaV - Harpy moved below
           inverted: true
         factor: -4
       # We need a metabolism effect on reagent removal
       #- !type:AdjustAlert
       #  alertType: CarbonDioxide
+      - !type:Oxygenate # DeltaV - Harpy more sensitive to air quality
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Harpy ]
+        factor: -12
 
 - type: reagent
   id: Nitrogen
@@ -405,3 +425,8 @@
         messages: [ "frezon-euphoric" ]
         probability: 0.1
         minScale: 2
+      - !type:Oxygenate # DeltaV - Harpy sensitive to air quality
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [ Harpy ]
+        factor: -4

--- a/Resources/Prototypes/_DV/Body/Organs/harpy.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/harpy.yml
@@ -12,14 +12,13 @@
   - type: Organ
     slotId: lungs
   - type: Metabolizer
-    updateInterval: 2.0
     removeEmpty: true
     solutionOnBody: false
     solution: "Lung"
-    metabolizerTypes: [ Human ]
+    metabolizerTypes: [ Harpy ]
     groups:
     - id: Gas
-      rateModifier: 200.0
+      rateModifier: 100.0
   - type: SolutionContainerManager
     solutions:
       organ:

--- a/Resources/Prototypes/_DV/Chemistry/metabolizer_types.yml
+++ b/Resources/Prototypes/_DV/Chemistry/metabolizer_types.yml
@@ -8,3 +8,7 @@
 - type: metabolizerType
   id: FeroxiDehydrated
   name: metabolizer-type-feroxi-dehydrated
+
+- type: metabolizerType
+  id: Harpy
+  name: metabolizer-type-harpy

--- a/Resources/ServerInfo/Guidebook/Mobs/_DV/Harpy.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/_DV/Harpy.xml
@@ -29,12 +29,12 @@
   - Comes with the Ultraviolet Vision trait by default. This can be disabled via accessibility options.
   - Cannot wear Jumpsuits, and will automatically start with a Jumpskirt instead.
   - While singing, musical notes appear floating around their head.
-  - Gases breathed in metabolize twice as fast.
 
   ## Drawbacks
 
   - They take [color=#ffa500]15% more Blunt, Slash, and Piercing damage.[/color]
   - Their low bone density makes them very light, weighing half as much as a Human and less than even Felinids.
+  - Harpies are much more sensitive to pollutant gases in the air, such as Carbon Dioxide and Miasma.
   <!-- Delta V: Changed drawbacks to remove the 2 factually incorrect details, which were air tanks lasting half as long and air quality -->
 
 </Document>


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Harpies now gasp when certain thresholds of "bad" gases are present in the room:

| Gas | Harpies Now Gasp At | Other Species (not changed) |
| --- | --- | --- |
| CO2 | 0.4%+ | gasp at 1.1%+ |
| Plasma, Trit | 0.6% | do not gasp |
| Frezon, Miasma | 1.1% | do not gasp |
| Water Vapor | 4% | do not gasp |
| Nitrous Oxide | do not gasp | do not gasp |

The community is already aware of a "harpies are sensitive to air quality" feature. This PR just implements it in a proper/consistent/predictable/intuitive way, instead of it being based on a finicky, misunderstood bug that we should remove in https://github.com/DeltaV-Station/Delta-v/pull/5157

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

I think most harpy players are happy with the existing air quality limitation; it makes for a good RP challenge. 

Harpies have a breathing mask and emergency o2 tank in their survival box that provide protection from pollutants in a pinch. They can also ask atmos players to install extra air scrubbers in rooms that they spend a lot of time in if gases become a problem (e.g. medbay, the kitchen, etc.)

## Technical details
<!-- Summary of code changes for easier review. -->

Made the gases cause anti-respiration just like CO2 already does.

The rate of asphyxiation damage caused by these gases is proportional to the values set in the code, and the thresholds in the table above which I found through testing.

So, e.g. harpies will take ~3x the asphyxiation damage that a human would at poisonous CO2 levels (e.g. 1.5%).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Harpies are now reliably more sensitive to pollutant gases than other species. For example, 0.4% of CO2 will make harpies start gasping, while humans are okay up to 1.1% CO2
