### PR TITLE
More players required for nukies

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -118,8 +118,8 @@
   id: Nukeops
   components:
   - type: GameRule
-    minPlayers: 10 # DeltaV - was 20
-    minTotalPlayers: 35 # DeltaV
+    minPlayers: 20
+    minTotalPlayers: 40 # DeltaV
   - type: LoadMapRule
     mapPath: /Maps/Nonstations/nukieplanet.yml
   - type: NukieOperation # DeltaV - Nukie operations!


### PR DESCRIPTION
## About the PR
changed requirements for nukies to spawn, 20 readied (from 10) and 40 total (from 35)

## Why / Balance
idunno what you call the opposite of a mald pr but that basically
got yelled at for doing nukie stuff in lowpop and felt bad xd

## Technical details
like tiny stuff in yaml

## Media
nothin really to show here

## Requirements
- [] I have tested all added content and changes. - i have absolutely zero clue how to test this sorry about that lmk how to and will do!
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
goodness i hope not

**Changelog**
:cl:
- tweak: Increased minimum player count for nukies to 20 ready and 40 total players.
