### PR TITLE
Smooth combat mode rotation (Make Flashlights Awesome)

### DIFF
--- a/Content.Shared/MouseRotator/MouseRotatorComponent.cs
+++ b/Content.Shared/MouseRotator/MouseRotatorComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class MouseRotatorComponent : Component
     ///     How much the desired angle needs to change before a predictive event is sent
     /// </summary>
     [DataField, AutoNetworkedField]
-    public Angle AngleTolerance = Angle.FromDegrees(20.0);
+    public Angle AngleTolerance = Angle.FromDegrees(5.0); // DeltaV - smooth flashlights, was 20
 
     /// <summary>
     ///     The angle that will be lerped to
@@ -37,7 +37,7 @@ public sealed partial class MouseRotatorComponent : Component
     ///     like turrets or ship guns, which have finer range of movement.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool Simple4DirMode = true;
+    public bool Simple4DirMode; // DeltaV - smooth flashlights, was true
 }
 
 /// <summary>


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Player rotation is now set constantly instead of being locked to four directions when in combat mode. This, effectively, makes flashlights follow your cursor and lets you spin around in bar chairs better. Mono has this, it's awesome.

## Why / Balance
hrp flashlight ops are real

## Technical details
"""port""" of https://github.com/Monolith-Station/Monolith/pull/2673 (itself a goob port) but it's just two component values changed

## Media

https://github.com/user-attachments/assets/0a1bd113-632a-4dba-9362-b647c7590c32



## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Flashlights will now always point towards your cursor in combat mode.
