### PR TITLE
Corpsman injectors

### DIFF
--- a/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
@@ -129,6 +129,7 @@ loadout-group-brig-medic-back = Corpsman backpack
 loadout-group-brig-medic-neck = Corpsman neck
 loadout-group-brig-medic-outerclothing = Corpsman outer clothing
 loadout-group-corpsman-eyewear = Corpsman eyewear
+loadout-group-corpsman-injectors = Corpsman Injectors
 
 loadout-group-prison-guard-head = Prison Guard head
 loadout-group-prison-guard-jumpsuit = Prison Guard jumpsuit

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -143,7 +143,6 @@
     - id: HandheldGPSBasic # Delta V - added it for tracking the implant tracker pop up.
     - id: BoxBodyBag
     - id: EmergencyRollerBedSpawnFolded
-    - id: MedkitCombatFilled
     - id: Portafib
     # End DeltaV additions
     - id: MedkitFilled

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/brigmedic.yml
@@ -58,3 +58,70 @@
   id: PrescriptionCorpsmanGlasses
   equipment:
     eyes: ClothingEyesPrescriptionCorpsmanGlasses
+
+# Injectors
+- type: loadout
+  id: brute auto-injector1
+  storage:
+    back:
+    - BruteAutoInjector
+
+- type: loadout
+  id: brute auto-injector2
+  storage:
+    back:
+    - BruteAutoInjector
+
+- type: loadout
+  id: burn auto-injector1
+  storage:
+    back:
+    - BurnAutoInjector
+
+- type: loadout
+  id: burn auto-injector2
+  storage:
+    back:
+    - BurnAutoInjector
+
+- type: loadout
+  id: puncturase auto-injector1
+  storage:
+    back:
+    - PunctAutoInjector
+
+- type: loadout
+  id: puncturase auto-injector2
+  storage:
+    back:
+    - PunctAutoInjector
+
+- type: loadout
+  id: pyrazine auto-injector1
+  storage:
+    back:
+    - PyraAutoInjector
+
+- type: loadout
+  id: pyrazine auto-injector2
+  storage:
+    back:
+    - PyraAutoInjector
+
+- type: loadout
+  id: airloss auto-injector
+  storage:
+    back:
+    - AirlossAutoInjector
+
+- type: loadout
+  id: poison auto-injector
+  storage:
+    back:
+    - AntiPoisonMedipen
+
+- type: loadout
+  id: rad auto-injector
+  storage:
+    back:
+    - RadAutoInjector

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/brigmedic.yml
@@ -61,67 +61,67 @@
 
 # Injectors
 - type: loadout
-  id: brute auto-injector1
+  id: AutoInjectorBrute1
   storage:
     back:
     - BruteAutoInjector
 
 - type: loadout
-  id: brute auto-injector2
+  id: AutoInjectorBrute2
   storage:
     back:
     - BruteAutoInjector
 
 - type: loadout
-  id: burn auto-injector1
+  id: AutoInjectorBurn1
   storage:
     back:
     - BurnAutoInjector
 
 - type: loadout
-  id: burn auto-injector2
+  id: AutoInjectorBurn2
   storage:
     back:
     - BurnAutoInjector
 
 - type: loadout
-  id: puncturase auto-injector1
+  id: AutoInjectorPuncturase1
   storage:
     back:
     - PunctAutoInjector
 
 - type: loadout
-  id: puncturase auto-injector2
+  id: AutoInjectorPuncturase2
   storage:
     back:
     - PunctAutoInjector
 
 - type: loadout
-  id: pyrazine auto-injector1
+  id: AutoInjectorPyrazine1
   storage:
     back:
     - PyraAutoInjector
 
 - type: loadout
-  id: pyrazine auto-injector2
+  id: AutoInjectorPyrazine2
   storage:
     back:
     - PyraAutoInjector
 
 - type: loadout
-  id: airloss auto-injector
+  id: AutoInjectorAirloss
   storage:
     back:
     - AirlossAutoInjector
 
 - type: loadout
-  id: poison auto-injector
+  id: AutoInjectorPoison
   storage:
     back:
     - AntiPoisonMedipen
 
 - type: loadout
-  id: rad auto-injector
+  id: AutoInjectorRadiation
   storage:
     back:
     - RadAutoInjector

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -335,17 +335,17 @@
   minLimit: 0
   maxLimit: 4
   loadouts:
-  - brute auto-injector1
-  - brute auto-injector2
-  - burn auto-injector1
-  - burn auto-injector2
-  - puncturase auto-injector1
-  - puncturase auto-injector2
-  - pyrazine auto-injector1
-  - pyrazine auto-injector2
-  - airloss auto-injector
-  - poison auto-injector
-  - rad auto-injector
+  - AutoInjectorBrute1
+  - AutoInjectorBrute2
+  - AutoInjectorBurn1
+  - AutoInjectorBurn2
+  - AutoInjectorPuncturase1
+  - AutoInjectorPuncturase2
+  - AutoInjectorPyrazine1
+  - AutoInjectorPyrazine2
+  - AutoInjectorAirloss
+  - AutoInjectorPoison
+  - AutoInjectorRadiation
 
 
 ## Security Cadet

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -329,6 +329,25 @@
   loadouts:
   - LoadoutSpeciesBreathToolCorpsman
 
+- type: loadoutGroup
+  id: CorpsmanInjectors
+  name: loadout-group-corpsman-injectors
+  minLimit: 0
+  maxLimit: 4
+  loadouts:
+  - brute auto-injector1
+  - brute auto-injector2
+  - burn auto-injector1
+  - burn auto-injector2
+  - puncturase auto-injector1
+  - puncturase auto-injector2
+  - pyrazine auto-injector1
+  - pyrazine auto-injector2
+  - airloss auto-injector
+  - poison auto-injector
+  - rad auto-injector
+
+
 ## Security Cadet
 - type: loadoutGroup
   id: SecurityCadetHead

--- a/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_DV/Loadouts/role_loadouts.yml
@@ -46,6 +46,7 @@
   - GroupSpeciesBreathToolCorpsman
   - SecurityFirearm
   - SecurityFirearmAmmo
+  - CorpsmanInjectors
 
 # Medical
 - type: roleLoadout


### PR DESCRIPTION
## About the PR
Add round start injectors to corpsman in a loadout

## Why / Balance
corpsman use to get 2 brute and 2 burn auto injectors that made a huge difference in combat whether or not a teammate survived or you as corps survived this was replaced with a round start combat kit but that sometimes just does not spawn i believe and that still removes 2 injectors and not having them can make a huge difference 

## Technical details
Adds a injector loadout option that includes the following 
note you can only pick 4 injectors 

2 brute injectors
2 burn injectors
2 puncturase injectors
2 pyrazine injectors
1 airloss injector
1 poison injector
1 rad injector

## Media

<img width="998" height="994" alt="Screenshot 2026-01-08 174327" src="https://github.com/user-attachments/assets/fda8a4fa-81d1-4409-8964-759c90adef75" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**

:cl:
- add: Added a corpsman injector loadout
-->
