### PR TITLE
fix: Check if RootContainer is null before referencing its members.

### DIFF
--- a/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
+++ b/Content.Shared/Body/Systems/SharedBodySystem.Body.cs
@@ -258,9 +258,8 @@ public partial class SharedBodySystem
     {
         if (id is null
             || !Resolve(id.Value, ref body, logMissing: false)
+            || body.RootContainer is null // Delta-V - Fix this shitmed change
             || body.RootContainer.ContainedEntity is null
-            || body is null // Shitmed Change
-            || body.RootContainer == default // Shitmed Change
             || !Resolve(body.RootContainer.ContainedEntity.Value, ref rootPart))
         {
             yield break;


### PR DESCRIPTION
## About the PR
We are currently experiencing a lot of broken replays that appear to be caused by broken entities during the initialization of the replay. Broken entities are caused by any unhandled exception being thrown during the application of entity state. This particular method is throwing a lot of NullReferenceExceptions because, for some unknown reason, `RootContainer` is sometimes null.

Note: I don't think this will fix replays retroactively, but I don't know enough to say for sure.

## Why / Balance
Bugfix

## Technical details
This will stop the method from throwing NullReferenceExceptions, but it is not the root cause of the replay bug. RCA is still in progress, as we need to discover the reason why our replays are suddenly experiencing this flood of broken entities during loading.

## Media
Live: 
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/511e12d8-238f-49a6-a238-ffa8ce320ebe" />

Local with Fix Included: 
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/9e2cff32-b355-4019-a11e-c0e8ab088414" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
unbreaking change, actually. 😏 

**Changelog**
:cl:
- fix: Fix for one error possibly causing replays to fail to load. Continue to report any broken replays after this fix!
