### PR TITLE
Hard hats tweaked to be protective

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -15,7 +15,7 @@
   - type: Armor #Delta V - Personal protective equipment is now protective!
     modifiers:
       coefficients:
-        Blunt: 0.85
+        Blunt: 0.90
         Slash: 0.95
   - type: PointLight
     enabled: false

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -12,6 +12,11 @@
       map: [ "light" ]
   - type: Clothing
     equippedPrefix: off
+  - type: Armor #Delta V - Personal protective equipment is now protective!
+    modifiers:
+      coefficients:
+        Blunt: 0.85
+        Slash: 0.95
   - type: PointLight
     enabled: false
     mask: /Textures/Effects/LightMasks/cone.png


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
On the all hard hats: Blunt damage reduced by 15%, Slash damage reduced by 5%.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It makes less sense for them to have no protection than to have any. At the moment hard hats are just headlamps.

## Technical details
<!-- Summary of code changes for easier review. -->
Added armor component to hardhat base,

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
[
<img width="416" height="170" alt="Screenshot 2026-01-11 013845" src="https://github.com/user-attachments/assets/8cc08780-4786-40ef-bbb1-3897efe77c07" />
](url)

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- tweak: Hard hats are now protective!
