### PR TITLE
fix senior job icons / names

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -266,6 +266,9 @@
     - sprite: *icon-rsi
       offset: *icon-offset
       state: SeniorEngineer
+  - type: IdCard # DeltaV
+    jobTitle: job-name-senior-engineer
+    jobIcon: JobIconSeniorEngineer
 
 #Medical
 
@@ -374,6 +377,9 @@
     - sprite: *icon-rsi
       offset: *icon-offset
       state: SeniorPhysician
+  - type: IdCard # DeltaV
+    jobTitle: job-name-senior-physician
+    jobIcon: JobIconSeniorPhysician
 
 #Science
 
@@ -428,6 +434,9 @@
     - sprite: *icon-rsi
       offset: *icon-offset
       state: SeniorResearcher
+  - type: IdCard # DeltaV
+    jobTitle: job-name-senior-researcher
+    jobIcon: JobIconSeniorResearcher
 
 #Security
 
@@ -534,6 +543,9 @@
     - sprite: *icon-rsi-dv # DeltaV - Sec Icon Resprite
       offset: *icon-offset
       state: SeniorOfficer
+  - type: IdCard # DeltaV
+    jobTitle: job-name-senior-officer
+    jobIcon: JobIconSeniorOfficer
 
 #Service
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
fixes the senior roles to actually change your job name and icon now instead of not doing it
right now it just gives you the PDA and ID card sprite but without changing the job
must've broke during the upstream merge

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Picking senior PDAs in the loadout will now change your job name accordingly once again.
