### PR TITLE
[Mapping] Add new command for showing network links

### DIFF
--- a/Content.Client/_DV/NetworkConfigurator/MappingNetworkConfiguratorLinkOverlay.cs
+++ b/Content.Client/_DV/NetworkConfigurator/MappingNetworkConfiguratorLinkOverlay.cs
@@ -1,0 +1,77 @@
+using Content.Client.NetworkConfigurator.Systems;
+using Content.Shared.DeviceNetwork.Components;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Map;
+using Robust.Shared.Random;
+
+namespace Content.Client._DV.NetworkConfigurator;
+
+/// <summary>
+/// Mapping version of <see cref="NetworkConfiguratorLinkOverlay"> that shows the linkages
+/// as we move around the map, rather than using component markers.
+/// Using markers means it only applies to objects the user is currently in PVS range, but this
+/// version continually searches for device networks to draw.
+/// </summary>
+public sealed class MappingNetworkConfiguratorLinkOverlay : Overlay
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    private readonly DeviceListSystem _deviceListSystem;
+    private readonly SharedTransformSystem _transformSystem;
+
+    public Dictionary<EntityUid, Color> Colors = [];
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    public MappingNetworkConfiguratorLinkOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _deviceListSystem = _entityManager.System<DeviceListSystem>();
+        _transformSystem = _entityManager.System<SharedTransformSystem>();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var query = _entityManager.EntityQueryEnumerator<DeviceNetworkComponent>();
+        while (query.MoveNext(out var uid, out _))
+        {
+            if (_entityManager.Deleted(uid) || !_entityManager.TryGetComponent(uid, out DeviceListComponent? deviceList))
+                continue; // Deleted or doesn't have any device linkages
+
+            var sourceTransform = _entityManager.GetComponent<TransformComponent>(uid);
+            if (sourceTransform.MapID == MapId.Nullspace)
+            {
+                // Can happen if the item is outside the client's view. In that case,
+                // we don't have a sensible transform to draw, so we need to skip it.
+                continue;
+            }
+
+            if (!Colors.TryGetValue(uid, out var color))
+            {
+                color = new Color(
+                    _random.NextByte(0, 255),
+                    _random.NextByte(0, 255),
+                    _random.NextByte(0, 255));
+                Colors.Add(uid, color);
+            }
+
+            foreach (var device in _deviceListSystem.GetAllDevices(uid, deviceList))
+            {
+                if (_entityManager.Deleted(device))
+                {
+                    continue;
+                }
+
+                var linkTransform = _entityManager.GetComponent<TransformComponent>(device);
+                if (linkTransform.MapID == MapId.Nullspace)
+                {
+                    continue;
+                }
+
+                args.WorldHandle.DrawLine(_transformSystem.GetWorldPosition(sourceTransform), _transformSystem.GetWorldPosition(linkTransform), color);
+            }
+        }
+    }
+}

--- a/Content.Client/_DV/NetworkConfigurator/MappingNetworkConfiguratorLinkOverlay.cs
+++ b/Content.Client/_DV/NetworkConfigurator/MappingNetworkConfiguratorLinkOverlay.cs
@@ -34,7 +34,7 @@ public sealed class MappingNetworkConfiguratorLinkOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        var query = _entityManager.EntityQueryEnumerator<DeviceNetworkComponent>();
+        var query = _entityManager.AllEntityQueryEnumerator<DeviceNetworkComponent>();
         while (query.MoveNext(out var uid, out _))
         {
             if (_entityManager.Deleted(uid) || !_entityManager.TryGetComponent(uid, out DeviceListComponent? deviceList))

--- a/Content.Client/_DV/NetworkConfigurator/ShowNetworkLinksCommand.cs
+++ b/Content.Client/_DV/NetworkConfigurator/ShowNetworkLinksCommand.cs
@@ -1,0 +1,20 @@
+using Robust.Client.Graphics;
+using Robust.Shared.Console;
+
+namespace Content.Client._DV.NetworkConfigurator;
+
+public sealed class ToggleNetworkLinksCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+
+    public override string Command => "togglenetworklinks";
+    public override string Description => "Toggles seeing network configurator links.";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (_overlay.RemoveOverlay<MappingNetworkConfiguratorLinkOverlay>())
+            return;
+
+        _overlay.AddOverlay(new MappingNetworkConfiguratorLinkOverlay());
+    }
+}

--- a/Content.Client/_DV/NetworkConfigurator/ShowNetworkLinksCommand.cs
+++ b/Content.Client/_DV/NetworkConfigurator/ShowNetworkLinksCommand.cs
@@ -8,7 +8,7 @@ public sealed class ToggleNetworkLinksCommand : LocalizedEntityCommands
     [Dependency] private readonly IOverlayManager _overlay = default!;
 
     public override string Command => "togglenetworklinks";
-    public override string Description => "Toggles seeing network configurator links.";
+    public override string Description => Loc.GetString("cmd-togglenetworklinks-desc");
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {

--- a/Resources/Locale/en-US/_DV/commands/togglenetworklinks-command.ftl
+++ b/Resources/Locale/en-US/_DV/commands/togglenetworklinks-command.ftl
@@ -1,0 +1,1 @@
+cmd-togglenetworklinks-desc = Toggles seeing network configurator links


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds a new client side command `togglenetworklinks` to show all device network linkages, as though you had clicked "show" via a network configurator on all of them.

## Why / Balance
Pharaz offered their soul to me for this.

## Technical details
Using the regular mapping overlay, which works via marker components, only worked in PVS range so users would have to set the command on constantly in order to see all the networks involved. With a new overlay that just works over all device networks, via enumerator, we can just have the user move around and constantly update the visible networks.

## Media
<img width="1508" height="1174" alt="image" src="https://github.com/user-attachments/assets/67be772e-842f-4967-af0b-b732682f8732" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Added new mapping command 'togglenetworklinks'

