### PR TITLE
fix emergency JOL not using battery

### DIFF
--- a/Content.Server/_DV/Tools/PryingRequiresPowerSystem.cs
+++ b/Content.Server/_DV/Tools/PryingRequiresPowerSystem.cs
@@ -20,13 +20,12 @@ public sealed class PryingRequiresPowerSystem : EntitySystem
 
     private void OnPried(Entity<PryingRequiresPowerComponent> ent, ref PriedEvent args)
     {
-        // Tool is a battery use its power
-        if (_battery.TryUseCharge(ent.Owner, ent.Comp.PowerCost))
+        // Entity has a PowerCellSlot, try that first
+        if (_cell.TryUseCharge(ent.Owner, ent.Comp.PowerCost))
             return;
 
-        // User has a battery
-        if (_battery.TryUseCharge(ent.Owner, ent.Comp.PowerCost))
-            return;
+        // The entity itself is a battery
+        _battery.TryUseCharge(ent.Owner, ent.Comp.PowerCost);
     }
 
     private void OnBeforePry(Entity<PryingRequiresPowerComponent> ent, ref BeforePryEvent args)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
JOL aren’t a battery, they are a battery container

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed emergency jaws of life not draining their battery when prying doors.
