### PR TITLE
Makes the crash cart obtainable via ordering

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Cargo/cargo_medical.yml
@@ -38,3 +38,13 @@
   cost: 10000
   category: Medical
   group: market
+
+- type: cargoProduct
+  id: CrashCartCrate
+  icon:
+    sprite: _Funkystation/Objects/Specific/Medical/crashcart.rsi
+    state: cart
+  product: CrateCrashCart
+  cost: 1000
+  category: Medical
+  group: market

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/medical.yml
@@ -42,3 +42,13 @@
     - id: ClothingMaskSterile
       amount: 2
     - id: PaperViralCarePackageManual
+
+- type: entity
+  id: CrateCrashCart
+  parent: CrateMedical
+  name: crash cart crate
+  description: Contains one empty crash cart.
+  components:
+  - type: StorageFill
+    contents:
+    - id: CrashCart


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR makes the unobtainable and completely unused crash cart accessible by a means other than a mapper potentially choosing to add it to a map in the future

It comes loose in a crate (which isn't exactly in line with other large things—they're usually flatpacked—but whatever)

Crash carts would be awesome to have for medical and ~~might actually cause medics to do something differently for a round~~ it's a shame to see it apparently unobtainable here and on Funkystation

## Why / Balance
I have no idea how to balance things. The price is 1000 spesos for a completely empty cart and I genuinely have no frame of reference for if that's good or bad. I'm leaning towards "that's too cheap"

Things to consider when correcting my likely-awful price:
- The crash cart has a defibrillator slot
- The crash cart has a tank slot (can hold air tanks, oxygen tanks, nitrogen tanks, nitrous tanks, plasma tanks...)
- The crash cart has 48 slots total (if I'm counting this correctly). 2\*6 or 12 slots per "shelf". For context, crates can hold 30 glass shards. See images for 30 glass shards in a crash cart
- The crash cart in the crate is completely empty
- Crash carts have a StaticPrice of 500 spesos
- Crash carts apparently have no restrictions on what types of items can be put in them. Below is me picking up random junk and putting it in one
- From a quick check, dragging it seems to be about the same as dragging a crate (but more slippery because it's got wheels)
- The crash cart be anchored (this is less of a balance consideration and more something I wanted to add to the list because I like it)

## Technical details
Hooks, for some reason, completely stopped working so I bypassed them. I have no idea what this may have done but I also do not really care for debugging exactly why it can't find a program on my computer

## Media
Crash carts (filled and nonfilled) and the crash cart crate (using the default medical crate)
<img width="211" height="103" alt="image" src="https://github.com/user-attachments/assets/bd995111-c917-4c85-b377-c4c492154562" />

<img width="383" height="136" alt="image" src="https://github.com/user-attachments/assets/010b026e-60b8-40f4-bb4a-3dae362c5355" />

<img width="584" height="449" alt="image" src="https://github.com/user-attachments/assets/6045eddc-7fd5-49df-964f-e341531628a6" />

Showing how it has no item type restrictions. ~~Bonus points if you know the path I took picking up this junk~~
<img width="307" height="595" alt="image" src="https://github.com/user-attachments/assets/d3def6f7-f0e5-43e0-9c03-dcd39748495d" />

Crates can hold 30 glass shards (I chose them because they are the smallest item I thought of). This is 30 glass shards in a crash cart
<img width="316" height="579" alt="image" src="https://github.com/user-attachments/assets/50088036-d758-4c59-91f7-84bb7f51955f" />

---

**END OF ACTUALLY-PR-RELATED IMAGES.** I'm just showing off the crash cart at this point because I think it's cool

I arranged some stuff and quite like it
- Defibrillator (in item slot)
- Nitrous canister (in item slot)
- 6 jugs
- 3 rollerbeds
- 3 bodybags
- Inflatable walls and doors (for cordoning off areas)
- Wrench (for anchoring the crash cart)
<img width="290" height="727" alt="image" src="https://github.com/user-attachments/assets/530f0681-a132-4360-86cb-a03a332bbe40" />

Significantly less thought put into this loadout. Engineering-focused one
<img width="261" height="785" alt="image" src="https://github.com/user-attachments/assets/2db1cde1-37c2-421c-a228-d1af5b7e8f37" />

A little scene I put together using the medical loadout shown above. A field hospital
<img width="654" height="471" alt="image" src="https://github.com/user-attachments/assets/3d29f561-6deb-49bd-ae3a-29a7d505c38b" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: Minerva
- add: Crash carts can now be ordered from Logistics under the Medical category.