### PR TITLE
Syndiborg fixes

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -173,7 +173,7 @@
           map: ["light"]
           visible: false
     - type: BorgChassis
-      maxModules: 6 # Delta V - Given additional modules
+      maxModules: 7 # Delta V - Given additional modules, +1 for SRN's Engi module
       moduleWhitelist:
         tags:
           - BorgModuleGeneric

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -591,6 +591,8 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+  - type: RandomMetadata # Delta V - Gives syndiborgs cool names!
+    nameSegments: [NamesDeathCommando]
 
 - type: entity
   id: PlayerBorgSyndicateAssaultGhostRole
@@ -630,6 +632,8 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+  - type: RandomMetadata # Delta V - Gives syndiborgs cool names!
+    nameSegments: [NamesDeathCommando]
 
 - type: entity
   id: PlayerBorgSyndicateSaboteurGhostRole

--- a/Resources/Prototypes/_DV/Catalog/roboneuroticist_sets.yml
+++ b/Resources/Prototypes/_DV/Catalog/roboneuroticist_sets.yml
@@ -42,7 +42,6 @@
   - PlayerBorgSyndicateSaboteurGhostRole
   - BorgModuleEsword
   - BorgModuleRCD
-  - RCDRecharging
   - BorgModuleChameleonProjector
 
 - type: thiefBackpackSet

--- a/Resources/Prototypes/_DV/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Player/silicon.yml
@@ -57,6 +57,8 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
+  - type: RandomMetadata # Delta V - Gives syndiborgs cool names!
+    nameSegments: [NamesDeathCommando]
 
 - type: entity
   parent: BorgChassisSyndicateMedicalBattery

--- a/Resources/Prototypes/_DV/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Player/silicon.yml
@@ -57,7 +57,7 @@
       cell_slot:
         name: power-cell-slot-component-slot-name-default
         startingItem: PowerCellHyper
-  - type: RandomMetadata # Delta V - Gives syndiborgs cool names!
+  - type: RandomMetadata
     nameSegments: [NamesDeathCommando]
 
 - type: entity


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Increased MaxModules on Syndicate Saboteur from 6 to 7 so that the Engineering module that comes with SRN kit can fit.
The other modules that come with the kit are meant to be used on other borgs.
Syndicate assault, medical, and saboteur borgs now get the reinforcement random name gen (Requested by javadocs).
Removed Extra Recharging RCD as Engineering module already has one.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #4257

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- add: Syndicate Assault, Medical, and Saboteur borgs now get names.
- fix: Fixed SRN Saboteur borg not being able to fit Engineering module

