### PR TITLE
Buff and fixes for energy shotgun

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -910,11 +910,11 @@
     heldPrefix: energy
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Battery
-    maxCharge: 480
-    startingCharge: 480
+    maxCharge: 720 # Delta V - Was 480
+    startingCharge: 720
   - type: BatterySelfRecharger #Delta V - Self recharging not removed
     autoRecharge: true
-    autoRechargeRate: 10
+    autoRechargeRate: 72 # Delta V - Was 10
     autoRechargePauseTime: 30
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1311,7 +1311,7 @@
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 13
+        Heat: 10 # Delta V was 13
 
 - type: entity
   name: wide laser barrage

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -1303,15 +1303,15 @@
         hard: false
         mask:
         - Opaque
-        - Impassable
-        #- BulletImpassable # DeltaV - Still shoot through windows
+      # - Impassable DeltaV allows pierces windows
+      # - BulletImpassable
       fly-by: *flybyfixture
   - type: Ammo
   - type: Projectile
     impactEffect: BulletImpactEffectOrangeDisabler
     damage:
       types:
-        Heat: 10 # DeltaV changed from 13 to 10
+        Heat: 13
 
 - type: entity
   name: wide laser barrage


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Did you know our version of the energy shotgun is actually a nerf from upstreams version? rebalances it to match upstream and fixes energy shotgun pellets not piercing windows

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The energy shotgun is pretty lack luster all things considered youll hear people complain about its dps being poor quite often another possible solution is to increase its mag size or decrease its reload time either way i have no idea why its nerfed from upstream

Practically its dps goes from 80 to 104

Also bug fixed good c: 
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Energy shotgun lethal mag size from 6 to 9 
- fix: The energy shotgun projectiles now once again pierce windows
