### PR TITLE
Fixes Ovinia mimes not getting a survival box

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -97,6 +97,7 @@
     - Thaven
     - Kitsune
     - Avali
+    - Ovinia
     # End DeltaV additions
 
 - type: loadoutEffectGroup


### PR DESCRIPTION
## About the PR
Fixes Ovinia mimes not getting a survival box. They didn't before

## Media
<img width="317" height="585" alt="image" src="https://github.com/user-attachments/assets/70b6ad3a-9e59-4788-95fa-1142ad90e39f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

:cl: 
- fix: Ovinia now start with a emergency survival box.
