### PR TITLE
feat: nudge singularity towards station periodically [mald PR]

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/singularity.yml
@@ -51,6 +51,12 @@
   - type: RandomWalk # To make the singularity move around.
     maxSpeed: 2.5
     minSpeed: 1.875
+  - type: ChasingWalk # DeltaV - Add comp
+    minSpeed: 1
+    maxSpeed: 1.875
+    impulseInterval: 5
+    chasingComponent:
+    - type: Cable # Other comps like Destructible and Transform are also assigned to Entities the singulo can't eat
   - type: SingularityDistortion
     falloffPower: 2.529822
     intensity: 3645


### PR DESCRIPTION
## About the PR
In addition to the random jittery movement we all know and hate, the Singularity is now nudged towards the station periodically so it does not run off into space most of the time.

## Why / Balance
When the singularity looses, people roleplay panic. They act as if they are going to die, only for the singularity to fuck off into space after taking a bite out of engi 90% of the time. Even if it does end up moving into the station, it rarely actually ends up causing the catastrophic damage you would expect from a black hole being unleashed from Engineering.

The RandomWalkComponent makes looses anti-climactic. Fleeing from it means walking 40 tiles in another direction because you know that the singularity won't do anything and then sitting in an evac pod for 15 minutes after power goes out. The resultant roleplay feels stilted and inauthentic because there is nothing to fear.

I have heard people argue that the loose should not be more destructive because the station can be repaired, calling that an RP opportunity. I, on the other hand, call it bullshit. This hasn't happened and it never will. Nobody wants to be stuck in an unworkable department for 30 minutes while Engineering struggles to repair the damage when the round is basically over. _The shuttle will always be called_ if the singularity is loosed, so we might as well end the round with a bang instead of a fart in the wind followed by a power outage.

You may have heard that the singularity already moves towards the station every few walks. I am here to tell you, gamers, that the eviltributors have lied to you -- taken you for fools. There is no such thing implemented.

## Technical details
Added ChasingWalkComponent to the Singularity proto and tweaked some of its values. The Singularity will be nudged to cables every 5 seconds, the max speed for this nudging being the min speed of the random walk. I chose the CableComponent because cable entities are abundant on stations and can definitely be eaten by the Singularity, unlike some targets that might be chosen when chasing Transform or Destructible.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: DisposableCrewmember42
- tweak: Lord Singuloth rises.
