### PR TITLE
Maintaining

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Small fixes/refactors are exempt. -->
 - [ ] I have added media to this PR or it does not require an in-game showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
 
-### Optional
+## Licensing
 <!-- This is for the benefit of other forks wishing to port features from DeltaV
 Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
 This just saves them the trouble -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,9 +19,6 @@ Small fixes/refactors are exempt. -->
 - [ ] I have added media to this PR or it does not require an ingame showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
 
-## Breaking changes
-<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
-
 **Changelog**
 <!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
 Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,19 +10,28 @@
 <!-- Summary of code changes for easier review. -->
 
 ## Media
-<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
+<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
 Small fixes/refactors are exempt. -->
 
 ## Requirements
-<!-- Confirm the following by placing an X in the brackets: [X] -->
+<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
 - [ ] I have tested all added content and changes.
-- [ ] I have added media to this PR or it does not require an ingame showcase.
+- [ ] I have added media to this PR or it does not require an in-game showcase.
 <!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
+
+### Optional
+<!-- This is for the benefit of other forks wishing to port features from DeltaV
+Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
+This just saves them the trouble -->
+- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
+  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
+  - [ ] MIT (https://choosealicense.com/licenses/mit/)
+    <!-- Feel free to add more licenses as you see fit -->
 
 **Changelog**
 <!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
 Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
-Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
+Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
 <!--
 :cl:
 - add: Added fun!

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ master ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -2,7 +2,7 @@ name: Build & Test Debug
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ master ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/labeler-needsreview.yml
+++ b/.github/workflows/labeler-needsreview.yml
@@ -2,19 +2,11 @@
 
 on:
   pull_request_target:
-    types: [review_requested]
-  pull_request_review:
-    types: [submitted]
-
-permissions:
-  pull-requests: write
-  issues: write
-  contents: write
+    types: [review_requested, opened]
 
 jobs:
   add_label:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_target'
     steps:
     - uses: actions-ecosystem/action-add-labels@v1
       with:
@@ -22,24 +14,3 @@ jobs:
     - uses: actions-ecosystem/action-remove-labels@v1
       with:
         labels: "S: Awaiting Changes"
-
-  # Doesn't work on prs from foreign repos currently
-  #handle_review:
-  #  runs-on: ubuntu-latest
-  #  if: github.event_name == 'pull_request_review'
-  #  steps:
-  #  - uses: actions-ecosystem/action-add-labels@v1
-  #    if: |
-  #      github.event.review.state == 'changes_requested' &&
-  #      (github.event.review.author_association == 'OWNER' ||
-  #       github.event.review.author_association == 'MEMBER')
-  #    with:
-  #      labels: "S: Awaiting Changes"
-  #
-  #  - uses: actions-ecosystem/action-remove-labels@v1
-  #    if: |
-  #      github.event.review.state == 'changes_requested' &&
-  #      (github.event.review.author_association == 'OWNER' ||
-  #       github.event.review.author_association == 'MEMBER')
-  #    with:
-  #      labels: "S: Needs Review"

--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -1,23 +1,24 @@
-name: "Labels: Approved"
-on:
-  pull_request_review:
-    types: [submitted]
-jobs:
-  add_label:
-    # Change the repository name after you've made sure the team name is correct for your fork!
-    if: ${{ (github.repository == 'DeltaV-Station/Delta-v') && (github.event.review.state == 'APPROVED') }}
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-    - uses: tspascoal/get-user-teams-membership@v3
-      id: checkUserMember
-      with:
-        username: ${{ github.actor }}
-        team: "maintainers"
-        GITHUB_TOKEN: ${{ secrets.LABELER_PAT }}
-    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        labels: "S: Approved"
+# The PAT does not have the correct permissions to make this work; Eventually we'll want to replace this workflow with a proper bot
+# name: "Labels: Approved"
+# on:
+#   pull_request_review:
+#     types: [submitted]
+# jobs:
+#   add_label:
+#     # Change the repository name after you've made sure the team name is correct for your fork!
+#     if: ${{ (github.repository == 'DeltaV-Station/Delta-v') && (github.event.review.state == 'APPROVED') }}
+#     permissions:
+#       contents: read
+#       pull-requests: write
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: tspascoal/get-user-teams-membership@v3
+#       id: checkUserMember
+#       with:
+#         username: ${{ github.actor }}
+#         team: "maintainers"
+#         GITHUB_TOKEN: ${{ secrets.LABELER_PAT }}
+#     - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
+#       uses: actions-ecosystem/action-add-labels@v1
+#       with:
+#         labels: "S: Approved"

--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         username: ${{ github.actor }}
         team: "maintainers"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # I don't know if this token has the permissions for this but it *should* in dV's case
+        GITHUB_TOKEN: ${{ secrets.LABELER_PAT }}
     - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
       uses: actions-ecosystem/action-add-labels@v1
       with:

--- a/.github/workflows/labeler-review.yml
+++ b/.github/workflows/labeler-review.yml
@@ -1,0 +1,23 @@
+name: "Labels: Approved"
+on:
+  pull_request_review:
+    types: [submitted]
+jobs:
+  add_label:
+    # Change the repository name after you've made sure the team name is correct for your fork!
+    if: ${{ (github.repository == 'DeltaV-Station/Delta-v') && (github.event.review.state == 'APPROVED') }}
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: tspascoal/get-user-teams-membership@v3
+      id: checkUserMember
+      with:
+        username: ${{ github.actor }}
+        team: "maintainers"
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # I don't know if this token has the permissions for this but it *should* in dV's case
+    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: "S: Approved"

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -2,7 +2,7 @@
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ master ]
     paths:
       - '**.cs'
       - '**.csproj'

--- a/.github/workflows/update-credits.yml
+++ b/.github/workflows/update-credits.yml
@@ -34,21 +34,22 @@ jobs:
       # Uncomment this and comment the other line if you do this.
       # https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches
 
-      #- name: Commit new credit files
-      #  uses: stefanzweifel/git-auto-commit-action@v4
-      #  with:
-      #    commit_message: Update Credits
-      #    commit_author: PJBot <pieterjan.briers+bot@gmail.com>
+      - name: Commit new credit files
+       uses: stefanzweifel/git-auto-commit-action@v7
+       with:
+         commit_message: Update Credits
+         commit_author: DeltaV-Bot <github@deltav.gay>
+         token: ${{ secrets.GITHUB_TOKEN }}
 
       # This will make a PR
-      - name: Set current date as env variable
-        run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
+      # - name: Set current date as env variable
+      #   run: echo "NOW=$(date +'%Y-%m-%dT%H-%M-%S')" >> $GITHUB_ENV
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
-        with:
-          commit-message: Update Credits
-          title: Update Credits
-          body: This is an automated Pull Request. This PR updates the github contributors in the credits section.
-          author: DeltaV-Bot <github@deltav.gay>
-          branch: automated/credits-${{env.NOW}}
+      # - name: Create Pull Request
+      #   uses: peter-evans/create-pull-request@v5
+      #   with:
+      #     commit-message: Update Credits
+      #     title: Update Credits
+      #     body: This is an automated Pull Request. This PR updates the github contributors in the credits section.
+      #     author: DeltaV-Bot <github@deltav.gay>
+      #     branch: automated/credits-${{env.NOW}}

--- a/.github/workflows/validate-rgas.yml
+++ b/.github/workflows/validate-rgas.yml
@@ -1,7 +1,7 @@
 name: RGA schema validator
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ master ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/validate-rsis.yml
+++ b/.github/workflows/validate-rsis.yml
@@ -2,7 +2,7 @@ name: RSI Validator
 
 on:
   push:
-    branches: [ staging, trying ]
+    branches: [ master ]
   merge_group:
   pull_request:
     paths:

--- a/.github/workflows/validate_mapfiles.yml
+++ b/.github/workflows/validate_mapfiles.yml
@@ -1,7 +1,7 @@
 name: Map file schema validator
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ master ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -2,7 +2,7 @@ name: YAML Linter
 
 on:
   push:
-    branches: [ master, staging, trying ]
+    branches: [ master ]
   merge_group:
   pull_request:
     types: [ opened, reopened, synchronize, ready_for_review ]

--- a/Resources/Locale/en-US/job/role-whitelist.ftl
+++ b/Resources/Locale/en-US/job/role-whitelist.ftl
@@ -1,2 +1,2 @@
 ﻿# role-not-whitelisted = You are not whitelisted to play this role. # DeltaV - add further details to whitelist blurb
-role-not-whitelisted = To play this role, apply for a whitelist on our Discord or email trianglevee@aol.com
+role-not-whitelisted = To play this role, apply for a whitelist on our Discord under https://discord.gg/9pCVgMt9pg


### PR DESCRIPTION
## About the PR
Made various meta things a bit nicer, hopefully.

## Why / Balance
Was about time

## Technical details
Update GitHub workflows to be more in line with upstream's versions, or more tailored to dV, as appropriate.
- Credits PR should now go into master directly instead of being a PR That only repo owners can merge
- Validate-RSIs runs on master now
- Added labeler-review which should automatically add the `S: Approved` label to PRs on maint approval

Remove mention of the old trianglevee email from the whitelist tooltip and replace with a fresh invite

Improve the PR template
- Remove Breaking Changes section since I don't think anyone has ever filled those out
- Fix some typos
- Add a section that allows quickly opting in to relicense, as well as confirming that you have ownership and permission to do so

## Media
None

## Requirements
YOLO can't test workflows here goes hoping :blunt:
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Rest in piss, forever miss :pensive::fist_raised: 

**Changelog**
no CL