### PR TITLE
Ninja Stealth Fix?/Nerf?

### DIFF
--- a/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
+++ b/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Alert;
+using Content.Shared.FixedPoint; // DeltaV
 using Content.Shared.Ninja.Systems;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -54,4 +55,10 @@ public sealed partial class SpaceNinjaComponent : Component
     /// </summary>
     [DataField]
     public ProtoId<AlertPrototype> SuitPowerAlert = "SuitPower";
+
+    /// <summary>
+    /// DeltaV - The minimum damage to reveal the ninja on damage. Should be positive, since negative values are considered healing.
+    /// </summary>
+    [DataField]
+    public FixedPoint2 MinimumRevealDamage = 5;
 }

--- a/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
+++ b/Content.Shared/Ninja/Components/SpaceNinjaComponent.cs
@@ -58,7 +58,8 @@ public sealed partial class SpaceNinjaComponent : Component
 
     /// <summary>
     /// DeltaV - The minimum damage to reveal the ninja on damage. Should be positive, since negative values are considered healing.
+    /// Note that the ninja suit has 20% brute resist and punches deal 5 damage, so 4 should be enough to reveal.
     /// </summary>
     [DataField]
-    public FixedPoint2 MinimumRevealDamage = 5;
+    public FixedPoint2 MinimumRevealDamage = 4;
 }

--- a/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedNinjaSuitSystem.cs
@@ -114,8 +114,14 @@ public abstract class SharedNinjaSuitSystem : EntitySystem
 
         var uid = ent.Owner;
         var comp = ent.Comp;
-        if (_toggle.TryDeactivate(uid, user) || !disable)
+
+        // DeltaV
+        if (!_toggle.TryDeactivate(uid, user))
             return;
+
+        if (!disable)
+            return;
+        // End DeltaV
 
         // previously cloaked, disable abilities for a short time
         _audio.PlayPredicted(comp.RevealSound, uid, user);

--- a/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
@@ -100,23 +100,19 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
     private void OnNinjaAttacked(Entity<SpaceNinjaComponent> ent, ref DamageChangedEvent args)
     {
         // If there's no damage delta, just return
-        if (args.DamageDelta is not { })
+        if (args.DamageDelta is not { } damage)
             return;
 
-        // Don't reveal on healing
+        // Don't reveal on (most) healing
         if (!args.DamageIncreased)
             return;
 
         // If the damage doesn't have a source, we need to check the type, in case it 
         // was a grenade or explosion. We want to ignore airloss and toxin damage types.
-        if (!args.Origin.HasValue && args.DamageDelta is { } damage)
+        if (!args.Origin.HasValue)
         {
-            // If there are any negative values, its probably natual or chem healing, so don't reveal
+            // If there are any negative values, its probably natual or chem healing, so don't reveal. It might be an OD from medicine.
             if (!damage.AnyPositive())
-                return;
-
-            // Only reveal on damage greater than the minumum. This prevents tiny ticks of damage (e.g. from malign rifts pulses)
-            if (damage.GetTotal() < ent.Comp.MinimumRevealDamage)
                 return;
 
             // Check the damage types for damage types that should reveal (brute, burns)
@@ -125,6 +121,10 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
             if (!damageGroups.ContainsKey("Brute") && !damageGroups.ContainsKey("Burn")) // This feels a bit dirty, oh well.
                 return;
         }
+
+        // Only reveal on damage greater than the minumum. This prevents tiny ticks of damage (e.g. from malign rifts pulses)
+        if (damage.GetTotal() <= ent.Comp.MinimumRevealDamage)
+            return;
 
         // Yea, now reveal that son of a bitch >:3
         TryRevealNinja(ent, disable: true);

--- a/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
@@ -3,6 +3,9 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Popups;
 using System.Diagnostics.CodeAnalysis;
+using Content.Shared.Damage.Systems; // DeltaV
+using Content.Shared.Stealth.Components; // DeltaV
+using Robust.Shared.Prototypes; // DeltaV
 
 namespace Content.Shared.Ninja.Systems;
 
@@ -13,6 +16,7 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
 {
     [Dependency] protected readonly SharedNinjaSuitSystem Suit = default!;
     [Dependency] protected readonly SharedPopupSystem Popup = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!; // DeltaV
 
     public EntityQuery<SpaceNinjaComponent> NinjaQuery;
 
@@ -22,9 +26,11 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
 
         NinjaQuery = GetEntityQuery<SpaceNinjaComponent>();
 
-        SubscribeLocalEvent<SpaceNinjaComponent, AttackedEvent>(OnNinjaAttacked);
+        // SubscribeLocalEvent<SpaceNinjaComponent, AttackedEvent>(OnNinjaAttacked); // DeltaV - Handled by the DamageChangedEvent
         SubscribeLocalEvent<SpaceNinjaComponent, MeleeAttackEvent>(OnNinjaAttack);
         SubscribeLocalEvent<SpaceNinjaComponent, ShotAttemptedEvent>(OnShotAttempted);
+
+        SubscribeLocalEvent<SpaceNinjaComponent, DamageChangedEvent>(OnNinjaAttacked); // DeltaV - Reveal the ninja on damage
     }
 
     public bool IsNinja([NotNullWhen(true)] EntityUid? uid)
@@ -78,11 +84,49 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
         return false;
     }
 
+    // DeltaV - Handled by the DamageChangedEvent
     /// <summary>
     /// Handle revealing ninja if cloaked when attacked.
     /// </summary>
-    private void OnNinjaAttacked(Entity<SpaceNinjaComponent> ent, ref AttackedEvent args)
+    //private void OnNinjaAttacked(Entity<SpaceNinjaComponent> ent, ref AttackedEvent args)
+    //{
+    //    TryRevealNinja(ent, disable: true);
+    //}
+    // END DeltaV
+
+    /// <summary>
+    /// DeltaV - Handle revealing ninja if cloaked when attacked by a hitscan attack.
+    /// </summary>
+    private void OnNinjaAttacked(Entity<SpaceNinjaComponent> ent, ref DamageChangedEvent args)
     {
+        // If there's no damage delta, just return
+        if (args.DamageDelta is not { })
+            return;
+
+        // Don't reveal on healing
+        if (!args.DamageIncreased)
+            return;
+
+        // If the damage doesn't have a source, we need to check the type, in case it 
+        // was a grenade or explosion. We want to ignore airloss and toxin damage types.
+        if (!args.Origin.HasValue && args.DamageDelta is { } damage)
+        {
+            // If there are any negative values, its probably natual or chem healing, so don't reveal
+            if (!damage.AnyPositive())
+                return;
+
+            // Only reveal on damage greater than the minumum. This prevents tiny ticks of damage (e.g. from malign rifts pulses)
+            if (damage.GetTotal() < ent.Comp.MinimumRevealDamage)
+                return;
+
+            // Check the damage types for damage types that should reveal (brute, burns)
+            // Basically, we want to ignore most indirect forms of damage (airloss, toxins)
+            var damageGroups = damage.GetDamagePerGroup(_prototypeManager);
+            if (!damageGroups.ContainsKey("Brute") && !damageGroups.ContainsKey("Burn")) // This feels a bit dirty, oh well.
+                return;
+        }
+
+        // Yea, now reveal that son of a bitch >:3
         TryRevealNinja(ent, disable: true);
     }
 
@@ -97,8 +141,17 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
 
     private void TryRevealNinja(Entity<SpaceNinjaComponent> ent, bool disable)
     {
-        if (ent.Comp.Suit is {} uid && TryComp<NinjaSuitComponent>(ent.Comp.Suit, out var suit))
-            Suit.RevealNinja((uid, suit), ent, disable: disable);
+        // DeltaV - Reveal ninja on damage
+        if (ent.Comp.Suit is not {} uid)
+            return;
+
+        if (!TryComp<NinjaSuitComponent>(ent.Comp.Suit, out var suit))
+            return;
+
+        if (!HasComp<StealthComponent>(ent)) // Only attempt to reveal if stealthed
+            return;
+        // END DeltaV
+        Suit.RevealNinja((uid, suit), ent, disable: disable);
     }
 
     /// <summary>

--- a/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
+++ b/Content.Shared/Ninja/Systems/SharedSpaceNinjaSystem.cs
@@ -122,8 +122,8 @@ public abstract class SharedSpaceNinjaSystem : EntitySystem
                 return;
         }
 
-        // Only reveal on damage greater than the minumum. This prevents tiny ticks of damage (e.g. from malign rifts pulses)
-        if (damage.GetTotal() <= ent.Comp.MinimumRevealDamage)
+        // Only reveal on damage at least the minumum. This prevents tiny ticks of damage (e.g. from malign rifts pulses)
+        if (damage.GetTotal() < ent.Comp.MinimumRevealDamage)
             return;
 
         // Yea, now reveal that son of a bitch >:3


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Doing at least 5 damage to the ninja will reveal the ninja.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The `AttackedEvent` only applies to melee attack events, not to projectiles or general damage.

## Technical details
<!-- Summary of code changes for easier review. -->
Using the much more generic `DamageChangedEvent` instead of `AttackedEvent`. I tried using `ProjectileHit` and other ranged attacking events but they just weren't working so I'm guessing they were marked handled or whatever.

But this does a few checks.
* Is there a damage change? If no, return.
* Is the change in damage healing only? If yes, return.
* Does the damage have a source still? If no, it might be passive healing, airloss from space, bleed damage, etc, so let's check for those things.
  * Was there damage *and* healing? If so, return because its probably just an OD from 10u derma or whatever.
  * If the damage didn't have brute or burn types, then return.
* Does it meet the minumum damage requirement? (4 damage)? If no, return

* Then reveal the ninja (but only if its stealthed)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/26940440-7a9b-4734-8a94-97e314d98891

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [x] MIT (https://choosealicense.com/licenses/mit/)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The ninja is now revealed with hit with attacks, projectiles, explosions, and grenades that do damage.
- fix: The ninja is now revealed with hit with attacks, projectiles, explosions, and grenades that do damage.
