### PR TITLE
Readding the slim version of T1 vest to sec

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -109,6 +109,7 @@
       prob: 0.3
     - id: ClothingOuterArmorPlateCarrier # DeltaV - ClothingOuterArmorBasic replaced in favour of plate carrier and stabproof vest
     - id: ClothingOuterArmorDuraVest # DeltaV
+    - id: ClothingOuterArmorBasicSlim # DeltaV - Only armor from ClothingOuterArmorBasic we are keeping
 
 - type: entity
   id: LockerBrigmedicFilled

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -286,6 +286,7 @@
   - StasecWinterCoatCorpsman
   - PlateCarrier
   - DuraVest
+  - ArmorVestSlim
 
 - type: loadoutGroup
   id: CorpsmanEyewear
@@ -454,6 +455,7 @@
   - DuraVest
   - StasecSweater
   - StasecWinterCoat
+  - ArmorVestSlim
 
 ## Warden
 - type: loadoutGroup
@@ -463,6 +465,7 @@
   - PlateCarrier
   - DuraVest
   - StasecWinterCoatWarden
+  - ArmorVestSlim
 
 ## Head of Security
 - type: loadoutGroup
@@ -473,6 +476,7 @@
   - DuraVest
   - StasecWinterCoatHoS
   - HeadOfSecurityTrenchcoat
+  - ArmorVestSlim
 
 ## Detective
 - type: loadoutGroup
@@ -496,6 +500,7 @@
   - PlateCarrier
   - DuraVest
   - DetPlatedCoat
+  - ArmorVestSlim
 
 # Medical
 ## Psychologist


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Literally just the title, puts the armored vest that is already mapped on a ton of stations into the sec loadout

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Unsure exactly why they were removed they are pretty similar to sec coats but without the pockets or cold protection, the normal armored vest looks pretty awful but the slim one looks fine imo

(they are also mapped in a buncha places so like this doesnt really change much)

## Technical details
<!-- Summary of code changes for easier review. -->
6 lines of yml hopefully in the right spot

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="2550" height="1058" alt="image" src="https://github.com/user-attachments/assets/388339e1-7c15-40ee-aba0-937e428c8c55" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: The T1 armored vest (slim) can now once again be picked in security loadouts.
