### PR TITLE
Engi Void Suit printable

### DIFF
--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/engineering.yml
@@ -37,3 +37,4 @@
   - ClothingOuterHardsuitAtmos
   - ClothingOuterSuitAtmosFire
   - ClothingHeadHelmetAtmosFire
+  - ClothingOuterVoidsuitEngineering

--- a/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/clothing.yml
@@ -449,6 +449,19 @@
     Plastic: 400
     Plasma: 600
 
+- type: latheRecipe
+  parent: BaseHardsuitRecipe
+  id: ClothingOuterVoidsuitEngineering
+  result: ClothingOuterVoidsuitEngineering
+  materials:
+    Plasteel: 500
+    Durathread: 500
+    Steel: 400
+    Glass: 500
+    Plastic: 400
+    Plasma: 600
+    Gold: 400
+
 ## Security
 - type: latheRecipe
   parent: BaseHardsuitArmoredRecipe

--- a/Resources/Prototypes/_DV/Research/industrial.yml
+++ b/Resources/Prototypes/_DV/Research/industrial.yml
@@ -26,6 +26,7 @@
   cost: 7500
   recipeUnlocks:
   - ClothingOuterHardsuitEngineering
+  - ClothingOuterVoidsuitEngineering
 
 # Tier 3
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds a lathe recipe to the Engineering Void Suit from #4944. Unlocked in the same T2 recipe as the main Engineering suit.

## Why / Balance
Added it a while ago, Engi still slow as hell, leaving it unobtainable unless somebody maps it feels like a waste.
Recipe is based on the Atmos hardsuit but takes less steel and more gold.

(also unrelatedly I'm willing to make it as weak as Direction wants if we can get the speed penalty to 15% lmao)

## Technical details
YAML ops.

## Media
<img width="381" height="193" alt="void1" src="https://github.com/user-attachments/assets/58a769af-ad2f-4e6e-9f85-3f17deb75f8d" />
<img width="595" height="257" alt="void2" src="https://github.com/user-attachments/assets/4918f8b9-c50b-47e5-9be3-f5c396e8e1e5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Made the Engineering Void Suit printable!
