### PR TITLE
Increase devil chance to match wizard

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -25,7 +25,7 @@
     - id: SubWizard
       prob: 0.05
     - id: Devil # Goob
-      prob: 0.05 # DeltaV
+      prob: 0.05 # DeltaV - Was 0.02
 
 - type: entity
   parent: BaseGameRule
@@ -36,7 +36,7 @@
     - id: Thief
       prob: 0.5
     - id: Devil # Goob
-      prob: 0.05 # DeltaV
+      prob: 0.05 # DeltaV - Was 0.02
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -25,7 +25,7 @@
     - id: SubWizard
       prob: 0.05
     - id: Devil # Goob
-      prob: 0.02
+      prob: 0.05 # DeltaV
 
 - type: entity
   parent: BaseGameRule
@@ -36,7 +36,7 @@
     - id: Thief
       prob: 0.5
     - id: Devil # Goob
-      prob: 0.02
+      prob: 0.05 # DeltaV
 
 - type: entity
   parent: BaseGameRule


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
devils weight of running before was .02 .05, you should see them bout as often as round start wizards. 

Taken from a wyci suggestion through the discord
## Why / Balance
Devils are super cool and I agree part of what makes em so cool is because they are rare but I think it could be a tad more common. Having something thats rare to see is neat but I dont think I've seen a naturally spawning devil in a while previously it was a 20th of the chance of thiefs rolling which sucks bc devils are such a rp heavy antag and great for round variety 

Rare antag = cool, Antag you never see = :c

## Technical details
<!-- Summary of code changes for easier review. -->
2 whole lines of yml 
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:

- tweak: Devils will now role 2.5 times more often.
