### PR TITLE
Clean up perma chefvend and add dull bread knife

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedchefvend.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedchefvend.yml
@@ -16,8 +16,8 @@
     FoodMeat: 6
     FoodMeatChicken: 4
     FoodMeatDuck: 2
-    ReagentContainerSalt: 1
-    ReagentContainerPepper: 1
+    ReagentContainerSalt: 2
+    ReagentContainerPepper: 2
     FoodCondimentPacketAstrotame: 5
     FoodCondimentPacketBbq: 5
     FoodCondimentPacketColdsauce: 5

--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedchefvend.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/unlockedchefvend.yml
@@ -25,18 +25,15 @@
     FoodCondimentPacketHotsauce: 5
     FoodCondimentPacketKetchup: 5
     FoodCondimentPacketMustard: 5
-    FoodCondimentPacketPepper: 5
-    FoodCondimentPacketSalt: 5
     FoodCondimentPacketSoy: 5
-    FoodCondimentPacketSugar: 5
-    FoodCondimentPacketCornoil: 5
-    ForkPlastic: 10
-    SpoonPlastic: 10
-    KnifePlastic: 10
-    FoodPlatePlastic: 10
+    ForkPlastic: 6
+    SpoonPlastic: 6
+    KnifePlastic: 6
+    FoodPlatePlastic: 6
     FoodPlateSmallPlastic: 10
+    PrisonKnife: 2
   contrabandInventory:
-    FoodShakerSalt: 1
-    FoodShakerPepper: 1
-    FoodCondimentBottleKetchup: 1
-    ReagentContainerMayo: 1
+    VariantCubeBox: 1
+    ReagentContainerCornmeal: 1
+    FoodCannabisButter: 1
+    FoodKebabSkewer: 4

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/knife.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: KitchenKnife
   id: PrisonKnife
-  name: prisoner's knife
+  name: dull bread knife
   description: A slightly dulled bread knife
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
- Tidies up the unlocked chefvend inventory, removes redundancies and adds more interesting contraband
- Adds 2 "prisoner knifes" renamed "dull bread knife" to the unlocked chefvend inventory

## Why / Balance
- Discussed in direction content review

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
n/a

**Changelog**
:cl: Velcroboy
- tweak: Prisoners can find dull bread knives in the ChefVend.  
