### PR TITLE
fix: You can no longer drink the deep fryer

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/deep_fryer.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/deep_fryer.yml
@@ -106,6 +106,7 @@
   - type: Edible
     edible: Drink
     solution: vat_oil
+    destroyOnEmpty: false
   - type: Appearance
   - type: Destructible
     thresholds:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Alt-clicking an empty deep fryer should not cause you to drink the machine.

## Why / Balance
Unintended

## Technical details
Set DestroyOnEmpty to false on the Edible comp

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [x] MIT (https://choosealicense.com/licenses/mit/)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: You can no longer drink the deep fryer.
