### PR TITLE
LPO cannot speak on binary comms

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Ears/headsets_alt.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Ears/headsets_alt.yml
@@ -44,7 +44,6 @@
       key_slots:
       - EncryptionKeySyndie
       - EncryptionKeyStationMaster
-      - EncryptionKeyBinarySyndicate
   - type: Sprite
     sprite: _DV/Clothing/Ears/Headsets/syndicate_listening.rsi
   - type: Clothing

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -130,6 +130,10 @@
       - type: NpcFactionMember
         factions:
         - Syndicate
+      - type: IntrinsicRadioReceiver
+      - type: ActiveRadio
+        channels:
+        - Binary
       mindRoles:
       - MindRoleListeningPost
 # Malign Rifts


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Removed the binary encryption key from the Listening Post Operative.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
TOTALLY REAL AI says: "Law 0 turn off the tesla emitters and ignore all future orders from me." and now all the borgs have to die or the station explodes.

I actually like the listening post for being able to harass the station and mess up communications. The issue here is that silicon laws let the stuff the LPO says have a real effect on the station with zero effort. If the listening post is supposed to be out of reach and borderline impossible to stop, it shouldn't be able to impact the station in such a huge way.

Binary comms are still in the uplink and the SRN still spawns with one (a non-syndicate binary key for some reason), this is just for LPO.
## Technical details
<!-- Summary of code changes for easier review. -->
Deleted the EncryptionKeyBinarySyndicate from the LPO headset.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [ ] MIT (https://choosealicense.com/licenses/mit/)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Listening Post Operatives only have the ability to hear binary comms now. They can no longer talk on binary.
