### PR TITLE
Remove laika's unbalanced knockdown

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/pets.yml
@@ -56,12 +56,7 @@
   - type: Temperature
     heatDamageThreshold: 315 # 10 lower than base
     coldDamageThreshold: 240 # 20 lower than base
-  - type: Grappler
-    handDisabling: SingleActive
-    grapplingPart: grapple-part-jaws
-    proneOnGrapple: true # Make sure Laika isn't shot by sprays
-    grappleSound:
-      collection: VulpkaninGrowls
+
 
 - type: entity
   parent: MobCarp


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Removed Laika's win button

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Laika's grapple has needed to go for a very long time. Sec doesn't need an option that knocks you down + stuns you + disarms you + immobilizes you at the low cost of guaranteed and free. Laika should not have the ability to effectively RPG you with her bite. Every time I'm sec and I see Laika knock someone down, it feels lame. Every time I'm an antag and I get knocked down, it's lame. It's lame as hell for everyone. I know the original contributor has mentioned they're going to rework it once theyre done with their current PR, but their current PR is still open and over a month old. I think it's reasonable to just remove it until the original contributor is done reworking it so we can stop ruining antag rounds in the mean time.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed grapple component from Laika .yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Temporarily removed laika's knockdown until it can be reworked
