### PR TITLE
Change FTL times

### DIFF
--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -84,8 +84,7 @@ space_wind = true
 [shuttle]
 arrivals = false
 cooldown = 60 # 50 longer than the default
-startup_time = 10 # 4.5 seconds longer than the default
-travel_time = 5 # 15 seconds less than the default
+travel_time = 9.5 # 10.5 seconds less than the default
 emergency_dock_time = 240
 emergency_transit_time_min = 30
 auto_call_time = 120 # rounds are longer


### PR DESCRIPTION
## About the PR
Reduced FTL startup time by 4.5 seconds to align with the FTL startup sound.
Increased FTL travel time by 4.5 seconds so the overall time to FTL is the same.

## Why / Balance
This partially reverts #3309 because the changed startup_time made the FTL sound end way before FTL actually happens.

## Technical details
n/A

## Media
It is simply too much effort for me to record with sound :blunt:

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- tweak: FTL times have been adjusted. Startup is shorter, travel is longer.
- fix: The FTL startup sound now lines up with the duration of startup again!!!
