### PR TITLE
Of Hats and Hardsuit Helmets

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ToggleableClothingSystem.cs
@@ -16,7 +16,7 @@ using Robust.Shared.Utility;
 
 namespace Content.Shared.Clothing.EntitySystems;
 
-public sealed class ToggleableClothingSystem : EntitySystem
+public sealed partial class ToggleableClothingSystem : EntitySystem // DeltaV - Made Partial
 {
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _netMan = default!;
@@ -140,10 +140,12 @@ public sealed class ToggleableClothingSystem : EntitySystem
             || toggleCom.Container == null)
             return;
 
+        var parent = Transform(uid).ParentUid; // DeltaV - Allow hats under toggleable helms 
         if (!_inventorySystem.TryUnequip(Transform(uid).ParentUid, toggleCom.Slot, force: true))
             return;
 
         _containerSystem.Insert(uid, toggleCom.Container);
+        TryEquipUnderClothing(parent, component); // DeltaV - Allow hats under toggleable helms 
         args.Handled = true;
     }
 
@@ -156,11 +158,17 @@ public sealed class ToggleableClothingSystem : EntitySystem
         if (_timing.ApplyingState)
             return;
 
+        var wasAttachedUnequipped = false; // DeltaV - Allow hats under toggleable helms
+
         // If the attached clothing is not currently in the container, this just assumes that it is currently equipped.
         // This should maybe double check that the entity currently in the slot is actually the attached clothing, but
         // if its not, then something else has gone wrong already...
         if (component.Container != null && component.Container.ContainedEntity == null && component.ClothingUid != null)
-            _inventorySystem.TryUnequip(args.Equipee, component.Slot, force: true, triggerHandContact: true);
+            wasAttachedUnequipped = _inventorySystem.TryUnequip(args.Equipee, component.Slot, force: true, triggerHandContact: true); // DeltaV - Allow hats under toggleable helms
+
+        // DeltaV - If the toggleable helm was uneqipped, try to equip whats in the under clothing container
+        if (wasAttachedUnequipped && !TryEquipUnderClothing(args.Equipee, component))
+            TryDropUnderClothing(component);
     }
 
     private void OnRemoveToggleable(EntityUid uid, ToggleableClothingComponent component, ComponentRemove args)
@@ -240,15 +248,30 @@ public sealed class ToggleableClothingSystem : EntitySystem
             return;
 
         var parent = Transform(target).ParentUid;
+
+        // Begin DeltaV - Allow hats under toggleable helms!
+        var wasAttachedUnequipped = false; // We want to track if the toggleable item was unequipped, assume false for now.
+
         if (component.Container.ContainedEntity == null)
-            _inventorySystem.TryUnequip(user, parent, component.Slot, force: true);
-        else if (_inventorySystem.TryGetSlotEntity(parent, component.Slot, out var existing))
-        {
-            _popupSystem.PopupClient(Loc.GetString("toggleable-clothing-remove-first", ("entity", existing)),
-                user, user);
-        }
+            wasAttachedUnequipped = _inventorySystem.TryUnequip(user, parent, component.Slot, force: true);
+
         else
+        {
+            if (_inventorySystem.TryGetSlotEntity(parent, component.Slot, out var existing)
+                && !TryStoreUnderClothing(existing.Value, component))
+            {
+                _popupSystem.PopupClient(Loc.GetString("toggleable-clothing-remove-first", ("entity", existing)),
+                    user, user);
+                return;
+            }
+
             _inventorySystem.TryEquip(user, parent, component.ClothingUid.Value, component.Slot, triggerHandContact: true);
+        }
+
+        // If the toggleable clothing was uneqipped, try to equip whats in the under clothing container
+        if (wasAttachedUnequipped && !TryEquipUnderClothing(user, parent, component))
+            TryDropUnderClothing(component);
+        // END DeltaV
     }
 
     private void OnGetActions(EntityUid uid, ToggleableClothingComponent component, GetItemActionsEvent args)
@@ -264,6 +287,7 @@ public sealed class ToggleableClothingSystem : EntitySystem
     private void OnInit(EntityUid uid, ToggleableClothingComponent component, ComponentInit args)
     {
         component.Container = _containerSystem.EnsureContainer<ContainerSlot>(uid, component.ContainerId);
+        component.UnderClothingContainer = _containerSystem.EnsureContainer<ContainerSlot>(uid, component.UnderClothingContainerId); // Wayfarer - Allow hats under toggleable helms!
     }
 
     /// <summary>

--- a/Content.Shared/_DV/Clothing/Components/ToggleableClothingComponent.UnderClothing.cs
+++ b/Content.Shared/_DV/Clothing/Components/ToggleableClothingComponent.UnderClothing.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.Containers;
+
+namespace Content.Shared.Clothing.Components;
+
+/// <summary>
+///     Extends upstream's ToggleableClothingComponent.
+/// 
+///     This portion of the ToggleableClothingComponent stores the clothing item under the toggled piece. 
+///     Currently only supports a single piece of clothing, but pretty much all entities with ToggleableClothing
+///     are just hardsuit helmets.
+/// </summary>
+public sealed partial class ToggleableClothingComponent : Component
+{
+    public const string DefaultUnderneathClothingContainerId = "under-clothing";
+
+    /// <summary>
+    ///     The container ID of <see cref="UnderClothingContainer"/>.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string UnderClothingContainerId = DefaultUnderneathClothingContainerId;
+
+    /// <summary>
+    ///     The container where the item that the toggled clothing replaced is put.
+    /// </summary>
+    [ViewVariables]
+    public ContainerSlot? UnderClothingContainer;
+}

--- a/Content.Shared/_DV/Clothing/Components/ToggleableClothingComponent.UnderClothing.cs
+++ b/Content.Shared/_DV/Clothing/Components/ToggleableClothingComponent.UnderClothing.cs
@@ -4,8 +4,8 @@ namespace Content.Shared.Clothing.Components;
 
 /// <summary>
 ///     Extends upstream's ToggleableClothingComponent.
-/// 
-///     This portion of the ToggleableClothingComponent stores the clothing item under the toggled piece. 
+///
+///     This portion of the ToggleableClothingComponent stores the clothing item under the toggled piece.
 ///     Currently only supports a single piece of clothing, but pretty much all entities with ToggleableClothing
 ///     are just hardsuit helmets.
 /// </summary>

--- a/Content.Shared/_DV/Clothing/Components/ToggleableClothingComponent.UnderClothing.cs
+++ b/Content.Shared/_DV/Clothing/Components/ToggleableClothingComponent.UnderClothing.cs
@@ -11,7 +11,7 @@ namespace Content.Shared.Clothing.Components;
 /// </summary>
 public sealed partial class ToggleableClothingComponent : Component
 {
-    public const string DefaultUnderneathClothingContainerId = "under-clothing";
+    public const string DefaultUnderneathClothingContainerId = "toggleable-under-clothing";
 
     /// <summary>
     ///     The container ID of <see cref="UnderClothingContainer"/>.

--- a/Content.Shared/_DV/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
+++ b/Content.Shared/_DV/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
@@ -1,0 +1,94 @@
+using Content.Shared.Clothing.Components;
+
+namespace Content.Shared.Clothing.EntitySystems;
+
+/// <summary>
+/// Extends upstream's ToggleableClothingSystem.
+/// 
+/// Provides methods that store and re-equip clothing when toggleable clothing is put on or taken off. 
+/// Sidenote; god, I hate naming things.
+/// </summary>
+public sealed partial class ToggleableClothingSystem : EntitySystem
+{
+    /// <summary>
+    ///     Tries to store clothing in <see cref="ToggleableClothingComponent.UnderClothingContainer"/> 
+    /// </summary>
+    /// <param name="clothing">The clothing to be stored.</param>
+    /// <param name="component">The ToggleableClothingComponent to store the clothing in.</param>
+    /// <returns>True if clothing can be inserted and was inserted.</returns>
+    private bool TryStoreUnderClothing(EntityUid clothing, ToggleableClothingComponent component)
+    {
+        if (component.UnderClothingContainer == null)
+            return false;
+
+        // There is already something in there? Either way, return false because we
+        // expect one thing.
+        if (component.UnderClothingContainer.ContainedEntity.HasValue)
+            return false;
+
+        return _containerSystem.Insert(clothing, component.UnderClothingContainer);
+    }
+
+    /// <summary>
+    ///     Tries to equip any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="actor">The person wearing the ToggleableClothing.</param>
+    /// <param name="component">The ToggleableClothingComponent to check for an stored items.</param>
+    /// <returns>True if something was equipped OR if there is nothing to equip.</returns>
+    private bool TryEquipUnderClothing(EntityUid actor, ToggleableClothingComponent component)
+    {
+        return TryEquipUnderClothing(actor, actor, component);
+    }
+
+    /// <summary>
+    ///     Tries to equip any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="actor">The person trying to equip the clothing.</param>
+    /// <param name="target">The person who to equip the clothing on.</param>
+    /// <param name="component">The ToggleableClothingComponent to check for an stored items.</param>
+    /// <returns>True if something was equipped OR if there is nothing to equip.</returns>
+    private bool TryEquipUnderClothing(EntityUid actor, EntityUid target, ToggleableClothingComponent component)
+    {
+        // if there is no UnderClothingContainer, then why are we here?
+        if (component.UnderClothingContainer == null)
+            return true;
+
+        // if nothing is contained so technically dropping nothing counts as a success
+        if (!component.UnderClothingContainer.ContainedEntity.HasValue)
+            return true;
+
+        return _inventorySystem.TryEquip(actor, target, component.UnderClothingContainer.ContainedEntity.Value, component.Slot, force: true);
+    }
+
+    /// <summary>
+    ///     Tries to equip any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="actor">The person trying to equip the clothing.</param>
+    /// <param name="component">The AttachedClothing of the ToggleableClothing to check for an stored items.</param>
+    /// <returns>True if something was equipped OR if there is nothing to equip.</returns>
+    private bool TryEquipUnderClothing(EntityUid actor, AttachedClothingComponent component)
+    {
+        if (!TryComp<ToggleableClothingComponent>(component.AttachedUid, out var toggleableComp))
+            return false;
+
+        return TryEquipUnderClothing(actor, toggleableComp);
+    }
+
+    /// <summary>
+    ///     Tries to drop any stored clothing kept in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>.
+    /// </summary>
+    /// <param name="component">The ToggleableClothingComponent that is holding the item to be dropped.</param>
+    /// <returns>True if there is not an item to be dropped OR it was successfully dropped.</returns>
+    private bool TryDropUnderClothing(ToggleableClothingComponent component)
+    {
+        // if there is no UnderClothingContainer, then why are we here?
+        if (component.UnderClothingContainer == null)
+            return true;
+
+        // if nothing is contained so technically dropping nothing counts as a success
+        if (!component.UnderClothingContainer.ContainedEntity.HasValue)
+            return true;
+
+        return _containerSystem.TryRemoveFromContainer(component.UnderClothingContainer.ContainedEntity.Value);
+    }
+}

--- a/Content.Shared/_DV/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
+++ b/Content.Shared/_DV/Clothing/EntitySystems/ToggleableClothingSystem.UnderClothing.cs
@@ -4,14 +4,14 @@ namespace Content.Shared.Clothing.EntitySystems;
 
 /// <summary>
 /// Extends upstream's ToggleableClothingSystem.
-/// 
-/// Provides methods that store and re-equip clothing when toggleable clothing is put on or taken off. 
+///
+/// Provides methods that store and re-equip clothing when toggleable clothing is put on or taken off.
 /// Sidenote; god, I hate naming things.
 /// </summary>
 public sealed partial class ToggleableClothingSystem : EntitySystem
 {
     /// <summary>
-    ///     Tries to store clothing in <see cref="ToggleableClothingComponent.UnderClothingContainer"/> 
+    ///     Tries to store clothing in <see cref="ToggleableClothingComponent.UnderClothingContainer"/>
     /// </summary>
     /// <param name="clothing">The clothing to be stored.</param>
     /// <param name="component">The ToggleableClothingComponent to store the clothing in.</param>

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -190,8 +190,6 @@
     containers:
       toggleable-clothing: !type:ContainerSlot {}
       toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
-      toggleable-clothing: !type:ContainerSlot {}
-      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: TypingIndicatorClothing
     proto: moth
 

--- a/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/cloaks.yml
@@ -162,6 +162,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
 
 - type: entity
   parent: ClothingNeckBase
@@ -188,6 +189,9 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
+      toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: TypingIndicatorClothing
     proto: moth
 
@@ -207,6 +211,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: TypingIndicatorClothing
     proto: alien
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -100,6 +100,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
       storagebase: !type:Container
         ents: []
 
@@ -137,6 +138,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: GroupExamine
   - type: Tag
     tags:
@@ -201,6 +203,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
       storagebase: !type:Container
         ents: []
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1189,6 +1189,7 @@
   - type: ContainerContainer # Delta V-Brings back clownsuit but make it make sense
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
 
 #Mime Hardsuit
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -60,6 +60,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: Tag
     tags:
     - CorgiWearable
@@ -173,6 +174,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: Tag
     tags:
     - CorgiWearable

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -136,6 +136,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
   - type: Tag
@@ -255,6 +256,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
 
@@ -275,6 +277,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
   - type: Construction
     graph: ClothingOuterSuitIan
     node: suit
@@ -308,6 +311,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
 
 - type: entity
   parent: ClothingOuterSuitCarp

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -50,6 +50,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {} # DeltaV - Allow hats under toggleable clothing
       storagebase: !type:Container
         ents: []
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -19,13 +19,8 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot
-        showEnts: false
-        occludes: true
-        ent: null
+      toggleable-under-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
-        showEnts: false
-        occludes: true
-        ents: []
 
 - type: entity
   parent: ClothingOuterHardsuitSyndie

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -43,14 +43,9 @@
       clothingPrototype: ClothingHeadHatHoodWinterMailCarrier 
     - type: ContainerContainer
       containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents: []
         toggleable-clothing: !type:ContainerSlot
-          showEnts: False
-          occludes: True
-          ent: null
+        toggleable-under-clothing: !type:ContainerSlot {}
+        storagebase: !type:Container
     - type: Sprite
       sprite: Nyanotrasen/Clothing/OuterClothing/WinterCoats/mail_winter_coat.rsi
     - type: Clothing

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/softsuits.yml
@@ -14,6 +14,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot { }
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: Armor
     modifiers:
       coefficients:
@@ -96,6 +97,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
   - type: Tag
     tags:
     - CorgiWearable

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -22,6 +22,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+      toggleable-under-clothing: !type:ContainerSlot {}
       storagebase: !type:Container
         ents: []
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
You can now toggle your hardsuit helmet while you have something on your head and it will unequip and store your hat in a hidden slot in the component until you remove the suit or toggle the hardsuit helmet off. 

Related Wayferer14 PR: https://github.com/project-wayfarer/wayfarer-14/pull/314 (I did it both places)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because I like drip. And I want the beret to stay on because it looks good!

## Technical details
<!-- Summary of code changes for easier review. -->
Made ToggleableClothingSystem partial and extended it. Added another container to ToggleableClothingComponent to store the item, and then just manage that container based on if it was unequipped or equipped.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/607072a5-2e47-4164-a4a4-8cfba5b5089e


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: You can now toggle your hardsuit helmet on over your hat or beret!