### PR TITLE
fix trait points bar rendering on ultrawide montiors

### DIFF
--- a/Content.Client/_DV/Traits/UI/TraitsTab.xaml.cs
+++ b/Content.Client/_DV/Traits/UI/TraitsTab.xaml.cs
@@ -207,7 +207,7 @@ public sealed partial class TraitsTab : BoxContainer
             // If parent width is 0 (not laid out yet), defer until layout happens
             if (parentWidth > 0)
             {
-                GlobalPointsBar.SetWidth = (int)(parentWidth * percentage);
+                GlobalPointsBar.SetWidth = (int)((parentWidth - 2 ) * percentage);
                 _awaitingLayoutUpdate = false;
             }
             else if (!_awaitingLayoutUpdate)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
previously it would go over the character preview since I didn’t account for the margins and it would just use the parent’s width

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

<img width="2560" height="1080" alt="image" src="https://github.com/user-attachments/assets/65d30738-42a8-4ce1-8d10-3716010a9d54" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: The traits points bar will now show up correctly.
