### PR TITLE
Eat the world, chicken

### DIFF
--- a/Content.Server/_DV/Abilities/Vox/VoxComponent.cs
+++ b/Content.Server/_DV/Abilities/Vox/VoxComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.Item;
+using Robust.Shared.Serialization;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.Abilities.Vox;
+
+/// <summary>
+/// Enables vox to eat normal sized objects containing MatterComposition, which then uses <c>ItemCougherComponent</c> to cough up sheets.
+/// </summary>
+[RegisterComponent, Access(typeof(VoxSystem))]
+[AutoGenerateComponentPause]
+public sealed partial class VoxComponent : Component
+{
+    [DataField] public Dictionary<string, float> StoredMatter = new();
+
+    [DataField] public float MaterialUnitPerSheet = 100f;
+
+    /// <summary>
+    /// The base amount of material lost to heat/grinding friction (30-40%).
+    /// </summary>
+    [DataField] public float BaseWasteRate = 0.35f;
+
+    /// <summary>
+    /// At what hunger percentage do we stop extracting nutrition? (80%)
+    /// </summary>
+    [DataField] public float NutritionThreshold = 0.8f;
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<ItemSizePrototype>? MaxSwallowSize = "Normal";
+
+    public EntityUid? CoughActionEntity;
+}

--- a/Content.Server/_DV/Abilities/Vox/VoxSystem.cs
+++ b/Content.Server/_DV/Abilities/Vox/VoxSystem.cs
@@ -1,0 +1,119 @@
+using Content.Shared._DV.Abilities;
+using Content.Shared.Actions;
+using Content.Shared.Body.Organ;
+using Content.Shared.Interaction;
+using Content.Shared.Item;
+using Content.Shared.Materials;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Popups;
+using Content.Shared.Stacks;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.Abilities.Vox;
+
+public sealed class VoxSystem : EntitySystem
+{
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly HungerSystem _hunger = default!;
+    [Dependency] private readonly SharedStackSystem _stack = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ItemCougherSystem _cougher = default!;
+    [Dependency] private readonly SharedItemSystem _item = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<VoxComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<VoxComponent, AfterInteractEvent>(OnAfterInteract);
+    }
+
+    private void OnAfterInteract(EntityUid uid, VoxComponent comp, AfterInteractEvent args)
+    {
+        if (args.Target == null || !args.CanReach || args.Handled)
+            return;
+
+        var target = args.Target.Value;
+
+        if (!TryComp<OrganComponent>(uid, out var organ) || organ.Body is not { } body)
+            return;
+
+        if (!TryComp<ItemComponent>(target, out var itemComp) ||
+            _item.GetSizePrototype(itemComp.Size).Weight > _prototype.Index(comp.MaxSwallowSize).Weight)
+        {
+            _popup.PopupEntity("Too large to swallow!", body, body);
+            return;
+        }
+
+        if (!TryComp<PhysicalCompositionComponent>(target, out var composition) ||
+            composition.MaterialComposition.Count == 0)
+            return;
+
+        // --- DYNAMIC DIGESTION LOGIC ---
+        float nutriBurnRate = 0f;
+        if (TryComp<HungerComponent>(body, out var hunger))
+        {
+            // Calculate how "full" the Vox is (0.0 to 1.0+)
+            var hungerRatio = HungerSystem.GetHunger(hunger) / HungerComponent.Thresholds[HungerThreshold.Okay];
+
+            // If we are below the threshold, calculate additional burn for nutrition
+            if (hungerRatio < comp.NutritionThreshold)
+            {
+                // Scaling: The hungrier you are, the more you burn.
+                // Max additional burn is 30% when hunger is 0.
+                nutriBurnRate = (comp.NutritionThreshold - hungerRatio) * 0.375f;
+            }
+        }
+
+        foreach (var (matId, amount) in composition.MaterialComposition)
+        {
+            // Logic partitioning:
+            // 1. Waste (BaseWasteRate) is always gone.
+            // 2. NutriBurn is taken if hungry.
+            // 3. Remainder is stored.
+
+            float nutritionValue = amount * nutriBurnRate;
+            float wastedValue = amount * comp.BaseWasteRate;
+            float storedValue = amount - nutritionValue - wastedValue;
+
+            if (nutritionValue > 0)
+                _hunger.ModifyHunger(body, nutritionValue / 10f);
+
+            comp.StoredMatter[matId] = comp.StoredMatter.GetValueOrDefault(matId) + MathF.Max(0, storedValue);
+        }
+
+        _popup.PopupEntity("You swallow the item and feel your gizzard grinding.", body, body);
+        QueueDel(target);
+        CheckActionAvailability(body, comp);
+        args.Handled = true;
+    }
+
+    private void CheckActionAvailability(EntityUid body, VoxComponent comp)
+    {
+        bool hasEnough = false;
+        foreach (var amount in comp.StoredMatter.Values)
+        {
+            if (amount >= comp.MaterialUnitPerSheet)
+            {
+                hasEnough = true;
+                break;
+            }
+        }
+
+        if (hasEnough && comp.CoughActionEntity == null)
+            _actions.AddAction(body, ref comp.CoughActionEntity, "ActionVoxRegurgitate");
+        else if (!hasEnough && comp.CoughActionEntity != null)
+        {
+            _actions.RemoveAction(body, comp.CoughActionEntity);
+            comp.CoughActionEntity = null;
+        }
+    }
+
+
+    private void OnMapInit(Entity<VoxComponent> ent, ref MapInitEvent args)
+    {
+        ent.Comp.NextUpdate = _timing.CurTime + ent.Comp.UpdateInterval;
+    }
+
+}

--- a/Resources/Prototypes/Body/Organs/vox.yml
+++ b/Resources/Prototypes/Body/Organs/vox.yml
@@ -18,7 +18,7 @@
 - type: entity
   parent: OrganHumanStomach
   id: OrganVoxStomach
-  name: vox stomach # DeltaV
+  name: vox gizzard # DeltaV
   description: "A stomach that smells of ammonia."
   components:
   - type: Metabolizer #Skreeeee!

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -3,6 +3,7 @@
   id: BaseMobVox
   abstract: true
   components:
+  - type: Vox
   - type: Hunger
   - type: Thirst
   - type: Icon
@@ -42,7 +43,7 @@
     #- trigger: # DeltaV - Sadly no KFV :(
     #    !type:DamageTypeTrigger
     #    damageType: Heat
-    #    damage: 1500 
+    #    damage: 1500
     #  behaviors:
     #  - !type:SpawnEntitiesBehavior
     #    spawnInContainer: true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Re-adding the old mechanic that allowed vox to consume most small/normal sized items with material compositions.

TODO: A lot, make it universal, etc.

## Why / Balance
While trash eating is novel, vox were designed for deep space life, meaning eating iron ore, glass shards, etc was a viable way to survive. As well as drinking welding fuel.

## Technical details
See above

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
I don't license anything because I believe in a free world where code and design is made to improve the world, not benefit the individual

