### PR TITLE
small storage implant fixes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -56,6 +56,9 @@
           tags:
           - Knife
           - ConcealCarry # DeltaV - replace Sidearm tag
+  - type: Tag
+    tags:
+    - HighRiskItem # Delta V - me when boots can hold objective items...
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/base_clothingshoes.yml
@@ -56,9 +56,9 @@
           tags:
           - Knife
           - ConcealCarry # DeltaV - replace Sidearm tag
-  - type: Tag
+  - type: Tag # Delta V - me when boots can hold objective items...
     tags:
-    - HighRiskItem # Delta V - me when boots can hold objective items...
+    - HighRiskItem
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -680,7 +680,7 @@
   - type: UseDelayOnShoot # DeltaV - No taser spam (provides a cooldown indicator)
   - type: UseDelay # DeltaV - No taser spam (provides a cooldown indicator)
     delay: 5
-    
+
 
 - type: entity
   name: elite taser
@@ -943,6 +943,7 @@
     tags:
     - HighRiskItem
     - Sidearm
+    - ConcealCarry # Delta V - boot storage yay
   - type: StealTarget
     stealGroup: HoSSidearm # Delta V - to work along side the X-01
   - type: Gun

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -680,7 +680,7 @@
   - type: UseDelayOnShoot # DeltaV - No taser spam (provides a cooldown indicator)
   - type: UseDelay # DeltaV - No taser spam (provides a cooldown indicator)
     delay: 5
-
+    
 
 - type: entity
   name: elite taser

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/HoS_Briefcase.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/HoS_Briefcase.yml
@@ -12,3 +12,6 @@
     possibleSets:
     - X01bundle
     - EnergyMagnumBundle
+  - type: Tag
+    tags:
+    - HighRiskItem

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/HoS_Briefcase.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/HoS_Briefcase.yml
@@ -12,6 +12,6 @@
     possibleSets:
     - X01bundle
     - EnergyMagnumBundle
-  - type: Tag
+  - type: Tag # DeltaV - can't go in storage implants
     tags:
     - HighRiskItem


### PR DESCRIPTION
## About the PR
made it so the HoS' sidearm briefcase doesn't fit in implants
also made it so the energy magnum can go in boots with the sidearm slot, and made boots with a sidearm slot not be able to fit inside the implants either (as they can essentially circumvent not fitting in the implant)

## Why / Balance
i saw it mentioned in a round and figured should fix it

## Technical details
just some yaml

## Media
think it makes sense without or so i hope

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: storage implants can no longer hold the hos' briefcase, or boots that are capable of holding guns
- tweak: the energy magnum can now fit in boots that can hold guns