### PR TITLE
Revert Space Pens, slightly reduce avali suffering

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -556,7 +556,7 @@
       pen:
         maxVol: 30
         reagents:
-          - ReagentId: Stabilizine # DeltaV - replace lepo
+          - ReagentId: Leporazine
             Quantity: 10
           - ReagentId: Barozine
             Quantity: 20

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
@@ -90,7 +90,7 @@
     heatDamageThreshold: 310
     coldDamageThreshold: 223
     currentTemperature: 296.15 # lower natural body temp
-    specificHeat: 25 # makes temp more lethal
+    specificHeat: 33 # makes temp more lethal
     coldDamage:
       types:
         Cold : 0.05

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
@@ -90,7 +90,7 @@
     heatDamageThreshold: 310
     coldDamageThreshold: 223
     currentTemperature: 296.15 # lower natural body temp
-    specificHeat: 33 # makes temp more lethal
+    specificHeat: 34 # makes temp more lethal
     coldDamage:
       types:
         Cold : 0.05


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Space pens now have their Leporazine back. Space pens are now much less lethal to Avali.

## Why / Balance
While Avali were intended to be hurt by space pens, as a species downside, space pens were *not* intended to kill them with one inject. Not sure if that had even been happening, but the targeted 80 heat damage did end up being too much. This PR re-adjusts how avali are affected by temperature, effectively making it so one Lepo-filled space pen will deal **roughly 40-42 heat damage**. (Note: This will vary WILDLY depending on the current temperature). This probably also has some minor side effect of making avali *sliiiightly* more resilient to heat changes, but that's negligible.

And I love my leporazine.

## Technical details
god's strongest yamlop, not sure if you want stabilizine removed but I'll do that if requested

## Media
<img width="683" height="380" alt="image" src="https://github.com/user-attachments/assets/ae21bea0-2ce4-4977-96a4-b364e8a86f7e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Space pens now have their Leporazine back.
- tweak: Avali are now substantially more resilient towards Leporazine, although it's still very dangerous for them.
