### PR TITLE
fix: give O2/N2 mime boxes breathe masks

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -217,7 +217,8 @@
   components:
   - type: StorageFill
     contents:
-    - id: SpaceMedipen # DeltaV - keep spacepen, replaces breath mask
+    - id: ClothingMaskBreath # DeltaV
+    - id: SpaceMedipen # DeltaV - keep spacepen
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -231,7 +232,8 @@
   components:
   - type: StorageFill
     contents:
-    - id: SpaceMedipen # DeltaV - keep spacepen, replaces breath mask
+    - id: ClothingMaskBreath # DeltaV
+    - id: SpaceMedipen # DeltaV - keep spacepen
     - id: EmergencyNitrogenTankFilled
     - id: EmergencyMedipen
     - id: Flare
@@ -252,6 +254,7 @@
   - type: StorageFill
     contents:
     - id: ClothingMaskBreath
+    - id: SpaceMedipen # DeltaV - keep spacepen
     - id: EmergencyOxygenTankFilled
     - id: EmergencyMedipen
     - id: Flare


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

With the change from baguettes to NutriBatards, there's now room for breathe masks in mime emergency boxes. This was addressed for feroxi, but not other humanoids (except moths, apparently??? who now get a space medipen)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Gets rid of "trawl-maints-for-spare-masks" meta

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Mime emergency boxes no longer missing breath maks