### PR TITLE
Revert Soretizone buff

### DIFF
--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -556,6 +556,11 @@
     Medicine:
       metabolismRate : 0.01
       effects:
+      - !type:GenericStatusEffect
+        key: PainNumbness
+        component: PainNumbness
+        time: 3.0
+        type: Add 
       - !type:ModifyStatusEffect
         effectProto: StatusEffectChronicPainSuppressed
         time: 3 # More effective than soretizone - 25 minutes of pain suppression per 5u (5u / 0.01 * 3 / 60)

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -558,7 +558,7 @@
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectChronicPainSuppressed
-        time: 1.5 # More effective than soretizone - 12.5 minutes of pain suppression per 5u (5u / 0.01 * 1.5 / 60)
+        time: 3 # More effective than soretizone - 25 minutes of pain suppression per 5u (5u / 0.01 * 3 / 60)
         type: Update
       - !type:SuppressAddiction
       - !type:PopupMessage

--- a/Resources/Prototypes/_CD/Reagents/medicine.yml
+++ b/Resources/Prototypes/_CD/Reagents/medicine.yml
@@ -448,7 +448,7 @@
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectChronicPainSuppressed
-        time: 2 # less effective than soretizone - 8.3 minutes of pain suppression per 5u (5u / 0.02 * 2 / 60)
+        time: 1 # less effective than soretizone - 4.1 minutes of pain suppression per 5u (5u / 0.02 * 1 / 60)
         type: Update
       - !type:PopupMessage
         type: Local
@@ -508,7 +508,7 @@
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectChronicPainSuppressed
-        time: 1.5 # 12.5 minutes of pain suppression per 5u (5u / 0.01 * 1.5 / 60)
+        time: 1 # 8.3 minutes of pain suppression per 5u (5u / 0.01 * 1 / 60)
         type: Add
       - !type:SuppressAddiction
       - !type:PopupMessage
@@ -558,7 +558,7 @@
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectChronicPainSuppressed
-        time: 3 # More effective than soretizone - 25 minutes of pain suppression per 5u (5u / 0.01 * 3 / 60)
+        time: 1.5 # More effective than soretizone - 12.5 minutes of pain suppression per 5u (5u / 0.01 * 1.5 / 60)
         type: Update
       - !type:SuppressAddiction
       - !type:PopupMessage


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR

    Stubantazine: Lasts ~4.1 minutes per 5u
    Soretizone: Lasts ~8.3 minutes per 5u
    Agonolexyne: Lasts ~12.5 minutes per 5u

This reverts Soretizone to the original metabolism.

## Why / Balance

Chronic Pain forces you and the chemist to interact and becomes an issue for you if you can't refill in time. After the changes that bumped Soretizone up to 12.5 minutes per 5u, the five 10u pills you start with would last you a total of 125 minutes, assuming a decent margin of error (forget to take your pills for like, a minute or so) this would easily last you til EOR in most cases without any need for a refill - the trait almost entirely cancels itself out.
This PR reverts Soretizone back to its original metabolism time, and adjusts the other painkillers to be more in line, preserving med interaction and mechanical pressure to refill your pills. I think it should be WORSE. But this is how it was

tl;dr: I want my suffering back please

## Technical details
yaml changes to painkiller values

## Media
big media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT --> (am i doing this right? it's three lines of yaml)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Reverted Soretizone's effectiveness to its original value
-->
