### PR TITLE
Reverts Arena weapon spawner change

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
@@ -48,10 +48,10 @@
             rolls: 16
             children:
             - id: ArrowRegular
-              weight: 0.8
+              prob: 0.8
             - id: ArrowImprovised
-              weight: 0.9
+              prob: 0.9
             - id: ArrowImprovisedPlasma
-              weight: 0.7
+              prob: 0.7
             - id: ArrowImprovisedUranium
-              weight: 0.6
+              prob: 0.6


### PR DESCRIPTION
## About the PR
Changes arrows back to probability from weight

## Why / Balance
Using weight it always spawns 16 arrows
Using prob it spawns 0-16

It is intended to spawn a different amount every time.

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) 

**Changelog**
n/a
