### PR TITLE
Updates random solar panel spawner

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
@@ -41,11 +41,4 @@
     offset: 0
     table: !type:GroupSelector
       prob: 0.33
-      children:
-      - id: SolarPanel
-        weight: 3
-      - id: SolarPanelBroken
-      - id: SolarPanelPlasma
-        weight: .10
-      - id: SolarPanelUranium
-        weight: .01
+      children: *solarWeights

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
@@ -30,14 +30,7 @@
     offset: 0
     table: !type:GroupSelector
       prob: 0.50
-      children:
-      - id: SolarPanel
-        weight: 3
-      - id: SolarPanelBroken
-      - id: SolarPanelPlasma
-        weight: .10
-      - id: SolarPanelUranium
-        weight: .01
+      children: *solarWeights
 
 - type: entity
   parent: RandomSolarPanelState

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
@@ -2,14 +2,57 @@
   parent: MarkerBase
   id: RandomSolarPanelState
   name: Random solar panel
+  suffix: 90%
   components:
   - type: Sprite
     layers:
       - sprite: _DV/Structures/Power/Generation/solar_panel.rsi
         state: random_solar
-  - type: RandomSpawner
+  - type: EntityTableSpawner
     offset: 0
-    prototypes:
-      - SolarPanel
-      - SolarPanelBroken
-    chance: 0.83
+    table: !type:GroupSelector
+      prob: 0.90
+      children:
+      - id: SolarPanel
+        weight: 3
+      - id: SolarPanelBroken
+      - id: SolarPanelPlasma
+        weight: .10
+      - id: SolarPanelUranium
+        weight: .01
+
+- type: entity
+  parent: RandomSolarPanelState
+  id: RandomSolarPanelStateMid
+  suffix: 50%
+  components:
+  - type: EntityTableSpawner
+    offset: 0
+    table: !type:GroupSelector
+      prob: 0.50
+      children:
+      - id: SolarPanel
+        weight: 3
+      - id: SolarPanelBroken
+      - id: SolarPanelPlasma
+        weight: .10
+      - id: SolarPanelUranium
+        weight: .01
+
+- type: entity
+  parent: RandomSolarPanelState
+  id: RandomSolarPanelStateLow
+  suffix: 33%
+  components:
+  - type: EntityTableSpawner
+    offset: 0
+    table: !type:GroupSelector
+      prob: 0.33
+      children:
+      - id: SolarPanel
+        weight: 3
+      - id: SolarPanelBroken
+      - id: SolarPanelPlasma
+        weight: .10
+      - id: SolarPanelUranium
+        weight: .01

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/solar.yml
@@ -12,7 +12,7 @@
     offset: 0
     table: !type:GroupSelector
       prob: 0.90
-      children:
+      children: &solarWeights
       - id: SolarPanel
         weight: 3
       - id: SolarPanelBroken


### PR DESCRIPTION
## About the PR
- Expands the spawner into 3 tiers (low-33%, mid-50%, high-90%)
- Updates to use EntityTableSpawner
- Adds small chance for upgraded solars

## Why / Balance
More mapping options and previous probabilities were not great.

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) 
  - [ ] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) 

**Changelog**
n/a
