### PR TITLE
Crusher Right Click Wideswing

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -142,7 +142,11 @@
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
     fireRate: 1
-    useKey: false
+    # Begin DeltaV Removals - Shooting is now done with MB1
+    # useKey: false
+    # End DeltaV Removals
+  - type: AltFireMelee # DeltaV
+    attackType: Heavy
   - type: RechargeBasicEntityAmmo
     rechargeCooldown: 0.5
     rechargeSound:
@@ -235,7 +239,7 @@
     - Back
     - suitStorage
   - type: UseDelay
-    delay: 1.9
+    delay: 0.9 # DeltaV - Didn't match the firerate. This is just visuals.
   - type: LeechOnMarker
     leech:
       groups:


### PR DESCRIPTION
## About the PR

To wideswing with a crusher, it's required to hold down right click, which fires the projectile, and then wideswings.
This makes it hard to time a wideswing, and also makes it impossible to wideswing without firing a projectile first.

This makes the crusher function exactly like the astral razor, where once the weapon is wielded, you left click to fire the projectile, and right click to perform a wideswing.
There is still a delay between firing the projectile and wideswinging however, that hasn't changed.

## Why / Balance

This makes the crusher less frustrating to use, especially when fighting all the deadly space carps and snakes.

## Technical details

- useKey: false has been commented out from the Crusher entity
- AltFireMelee has been added to said entity
- UseDelay for the Glaive has been adjusted, which makes it's cooldown circle match it's firerate

## Media

https://github.com/user-attachments/assets/7f4045d9-c32b-48b1-bb35-6ccd92d1433c

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing

- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**

:cl:
- tweak: The Crusher can now Wideswing with right click.
