### PR TITLE
Set arena_weapons.yml back to using probability

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/arena_weapons.yml
@@ -48,10 +48,10 @@
             rolls: 16
             children:
             - id: ArrowRegular
-              weight: 0.8
+              prob: 0.8
             - id: ArrowImprovised
-              weight: 0.9
+              prob: 0.9
             - id: ArrowImprovisedPlasma
-              weight: 0.7
+              prob: 0.7
             - id: ArrowImprovisedUranium
-              weight: 0.6
+              prob: 0.6


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Reverts the change for using `weight` over `prob` for the random arrow selection in arena weapons.

I couldn't see any other usages of `roll` under _DV, so I assume that everything else is ok.

## Why / Balance
It was meant to pick a random assortment of arrows between 0-16, not always 16 of a random assortment of arrows.

## Technical details
Weighting affects whether or not the child is selected, probability affects whether the selector is even ran at all. I'm guessing that it first selects a weighted child and then runs the prob effect afterwards.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Arena bows will randomly spawn with up to 16 arrows again, rather than always 16.

