### PR TITLE
Shock Collars Fix

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -355,8 +355,7 @@
     damage: 10
     duration: 3
   - type: AccessReader
-    access:
-    - - Security
+    access: [["Security"]]
   # End DeltaV Additions
   - type: ShockOnTrigger
     targetContainer: true

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -352,7 +352,7 @@
   - type: SelfUnremovableClothing
   # Start DeltaV Additions
   - type: ShockOnUnequip
-    damage: 10
+    damage: 5
     duration: 3
   - type: AccessReader
     access: [["Security"]]

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -350,6 +350,14 @@
     stripDelay: 10
     equipDelay: 5 # to avoid accidentally falling into the trap associated with SelfUnremovableClothing
   - type: SelfUnremovableClothing
+  # Start DeltaV Additions
+  - type: ShockOnUnequip
+    damage: 10
+    duration: 3
+  - type: AccessReader
+    access:
+    - - Security
+  # End DeltaV Additions
   - type: ShockOnTrigger
     targetContainer: true
     damage: 5

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
@@ -19,7 +19,7 @@
     - neck
   - type: SelfUnremovableClothing
   - type: ShockOnUnequip
-    damage: 10
+    damage: 5
     duration: 3
   - type: AccessReader
     access: [["Security"]]

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
@@ -22,8 +22,7 @@
     damage: 10
     duration: 3
   - type: AccessReader
-    access:
-    - - Security
+    access: [["Security"]]
   - type: ShockOnTrigger
     targetContainer: true
     damage: 5

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/shock_collar.yml
@@ -25,6 +25,7 @@
     access:
     - - Security
   - type: ShockOnTrigger
+    targetContainer: true
     damage: 5
     duration: 3
   - type: TriggerOnSignal


### PR DESCRIPTION
## About the PR

- Fixes shock collars not working, caused by the trigger refactor from a while ago.
- Also Electropacks can no longer be removed by non-Security, which the shock collars had but this didn't for some reason.

## Why / Balance

Bugfix + parity with the shock collar and Electropack.

## Technical details

- Adds targetContainer component to shock collar
- Adds ShockOnUnequip and AccessReader to Electropack

## Media

N/A

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing

- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**

:cl:
- tweak: Electropacks can no longer be removed by non-Security.
- fix: Shock collars work once more.
