### PR TITLE
Brigmed Beret

### DIFF
--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/brigmedic.yml
@@ -4,6 +4,11 @@
   equipment:
       head: ClothingHeadHatBeretCorpsman
 
+- type: loadout
+  id: BrigMedicalBeret
+  equipment:
+      head: ClothingHeadHatBeretBrigmedic
+
 # Jumpsuit
 - type: loadout
   id: BrigMedicJumpsuit

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -259,6 +259,7 @@
   minLimit: 0
   loadouts:
   - CorpsmanBeret
+  - BrigMedicalBeret
 
 - type: loadoutGroup
   id: BrigMedicNeck


### PR DESCRIPTION
## About the PR

Adds the Brigmed beret to the Corpsman loadout.

## Why / Balance

I like the Brigmed beret, and others might as well hopefully. 
Also more variety or something.

## Technical details

Brigmedical beret added to Loadouts/Jobs/Security/brigmedic.yml 
and _DV/Loadouts/loadout_groups.yml

## Media

<img width="967" height="561" alt="image" src="https://github.com/user-attachments/assets/12f4e29d-23e0-43fa-9a01-e7674fa29b7b" />

## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing

- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**

:cl:
- add: The Brigmed beret is now avaliable in the Corpsman loadout.
