### PR TITLE
Remove Kitsune actions when they become Zombies

### DIFF
--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Charges.Systems;
 using Content.Shared.Hands.Components;
 using Content.Shared.Humanoid;
 using Content.Shared.Popups;
+using Content.Shared.Zombies;
 
 namespace Content.Shared._DV.Abilities.Kitsune;
 
@@ -23,6 +24,8 @@ public abstract class SharedKitsuneSystem : EntitySystem
         SubscribeLocalEvent<FoxfireComponent, ComponentShutdown>(OnFoxfireShutdown);
         SubscribeLocalEvent<KitsuneComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<KitsuneComponent, AppearanceLoadedEvent>(OnProfileLoadFinished);
+
+        SubscribeLocalEvent<ZombieComponent, ComponentInit>(OnZombieStartup);
     }
 
     private void OnProfileLoadFinished(Entity<KitsuneComponent> ent, ref AppearanceLoadedEvent args)
@@ -56,6 +59,20 @@ public abstract class SharedKitsuneSystem : EntitySystem
         if (!HasComp<KitsuneFoxComponent>(ent))
             _actions.AddAction(ent, ref ent.Comp.KitsuneActionEntity, ent.Comp.KitsuneAction);
         ent.Comp.FoxfireAction = _actions.AddAction(ent, ent.Comp.FoxfireActionId);
+    }
+
+    /// <summary>
+    /// Handles when a Kitsune becomes a zombie, removing their abilities.
+    /// </summary>
+    /// <param name="ent">The Zombie that has just spawned.</param>
+    /// <param name="args">Args for the event.</param>
+    private void OnZombieStartup(Entity<ZombieComponent> ent, ref ComponentInit args)
+    {
+        if (!TryComp<KitsuneComponent>(ent, out var kitsune))
+            return; // Not a Kitsune, nothing to do.
+
+        _actions.RemoveAction(kitsune.KitsuneActionEntity);
+        _actions.RemoveAction(kitsune.FoxfireAction);
     }
 
     private void OnCreateFoxfire(Entity<KitsuneComponent> ent, ref CreateFoxfireActionEvent args)

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -25,7 +25,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         SubscribeLocalEvent<KitsuneComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<KitsuneComponent, AppearanceLoadedEvent>(OnProfileLoadFinished);
 
-        SubscribeLocalEvent<ZombieComponent, ComponentInit>(OnZombieStartup);
+        SubscribeLocalEvent<ZombieComponent, EntityZombifiedEvent>(OnKitsuneZombified);
     }
 
     private void OnProfileLoadFinished(Entity<KitsuneComponent> ent, ref AppearanceLoadedEvent args)
@@ -66,7 +66,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
     /// </summary>
     /// <param name="ent">The Zombie that has just spawned.</param>
     /// <param name="args">Args for the event.</param>
-    private void OnZombieStartup(Entity<ZombieComponent> ent, ref ComponentInit args)
+    private void OnKitsuneZombified(Entity<ZombieComponent> ent, ref EntityZombifiedEvent args)
     {
         if (!TryComp<KitsuneComponent>(ent, out var kitsune))
             return; // Not a Kitsune, nothing to do.

--- a/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
+++ b/Content.Shared/_DV/Abilities/Kitsune/SharedKitsuneSystem.cs
@@ -25,7 +25,7 @@ public abstract class SharedKitsuneSystem : EntitySystem
         SubscribeLocalEvent<KitsuneComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<KitsuneComponent, AppearanceLoadedEvent>(OnProfileLoadFinished);
 
-        SubscribeLocalEvent<ZombieComponent, EntityZombifiedEvent>(OnKitsuneZombified);
+        SubscribeLocalEvent<KitsuneComponent, EntityZombifiedEvent>(OnKitsuneZombified);
     }
 
     private void OnProfileLoadFinished(Entity<KitsuneComponent> ent, ref AppearanceLoadedEvent args)
@@ -64,15 +64,12 @@ public abstract class SharedKitsuneSystem : EntitySystem
     /// <summary>
     /// Handles when a Kitsune becomes a zombie, removing their abilities.
     /// </summary>
-    /// <param name="ent">The Zombie that has just spawned.</param>
+    /// <param name="kitsune">The Kitsune zombie that has just spawned.</param>
     /// <param name="args">Args for the event.</param>
-    private void OnKitsuneZombified(Entity<ZombieComponent> ent, ref EntityZombifiedEvent args)
+    private void OnKitsuneZombified(Entity<KitsuneComponent> kitsune, ref EntityZombifiedEvent args)
     {
-        if (!TryComp<KitsuneComponent>(ent, out var kitsune))
-            return; // Not a Kitsune, nothing to do.
-
-        _actions.RemoveAction(kitsune.KitsuneActionEntity);
-        _actions.RemoveAction(kitsune.FoxfireAction);
+        _actions.RemoveAction(kitsune.Comp.KitsuneActionEntity);
+        _actions.RemoveAction(kitsune.Comp.FoxfireAction);
     }
 
     private void OnCreateFoxfire(Entity<KitsuneComponent> ent, ref CreateFoxfireActionEvent args)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removed Kitsune actions when they become Zombies. Fixes #5269

## Why / Balance
Kitsunes ability to polymorph while a zombie can lead to weird powergaming, but also just general bugs as the entity they attach to as a fox is not an antag. So you get odd spams going back and forth.

## Technical details
Simple removal of actions.
I've checked cloning and the cloned entity keeps their actions as normal.

There's nothing to be done about them pausing the Zombification time as a Kitsune, since the entity they were (their original form) is stuck in null space and paused. We could push the Component over to the Kitsune as well, but that requires a bit more book keeping.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Kitsunes can no longer polymorph as Zombies
