### PR TITLE
Migrate MassSleep over to new status effect system

### DIFF
--- a/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/MassSleep/MassSleepPowerSystem.cs
+++ b/Content.Shared/Nyanotrasen/Abilities/Psionics/Abilities/MassSleep/MassSleepPowerSystem.cs
@@ -8,14 +8,14 @@ using Content.Shared.Actions.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Psionics.Events;
-using Content.Shared.StatusEffect;
+using Content.Shared.StatusEffectNew; // DeltaV
 using Content.Shared.Stunnable;
 
 namespace Content.Shared.Abilities.Psionics
 {
     public sealed class MassSleepPowerSystem : EntitySystem
     {
-        public ProtoId<StatusEffectPrototype> StatusEffectKey = "ForcedSleep";
+        public EntProtoId StatusEffectKey = "StatusEffectForcedSleeping"; // DeltaV
         [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
         [Dependency] private readonly SharedActionsSystem _actions = default!;
         [Dependency] private readonly EntityLookupSystem _lookup = default!;
@@ -92,11 +92,20 @@ namespace Content.Shared.Abilities.Psionics
 
             foreach (var entity in _lookup.GetEntitiesInRange(args.User, ent.Comp.Radius))
             {
-                if (HasComp<MobStateComponent>(entity) && entity != (EntityUid)ent && !HasComp<PsionicInsulationComponent>(entity))
+                // Begin DeltaV Additions - Update mass sleep to new status effects
+                if (HasComp<MobStateComponent>(entity) &&
+                    entity != (EntityUid)ent &&
+                    !HasComp<PsionicInsulationComponent>(entity))
                 {
-                    if (TryComp<DamageableComponent>(entity, out var damageable) && damageable.DamageContainerID == "Biological")
-                        _statusEffects.TryAddStatusEffect<ForcedSleepingStatusEffectComponent>(entity, StatusEffectKey, TimeSpan.FromSeconds(ent.Comp.Duration), false);
+                    if (TryComp<DamageableComponent>(entity, out var damageable) &&
+                        damageable.DamageContainerID == "Biological")
+                        _statusEffects.TryUpdateStatusEffectDuration(
+                            entity,
+                            StatusEffectKey,
+                            TimeSpan.FromSeconds(ent.Comp.Duration)
+                        );
                 }
+                // End DeltaV Additions - Update mass sleep to new status effects
             }
 
             ent.Comp.DoAfter = null;


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Fixed a bug where the MassSleep power would rely on the old ForcedSleep status effect prototype that has been removed a while ago. Now it uses the new StatusEffect system with basic entity prototypes. Fixes #5113

## Why / Balance
Errr, mass sleep as a power should work and bring terror.

## Technical details
Straightforward change, it seems. Works and tested it against multiple bodies and as both the sleeper and sleepee.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: MassSleep as a power now correctly puts people to sleep, a mass amount of them.

