### PR TITLE
Make the chemvend's bluespace beaker only available through an emag

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -29,6 +29,7 @@
     DrinkLithiumFlask: 1
     StrangePill: 3
     ChemistryBottleToxin: 1
+emaggedInventory: # DeltaV
     ChemistryBottleLead: 2 # DeltaV - Added lead to standard chemvend
     BluespaceBeaker: 1 # Funkychem - let traitor chemists make nefarious batches
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -29,7 +29,7 @@
     DrinkLithiumFlask: 1
     StrangePill: 3
     ChemistryBottleToxin: 1
-emaggedInventory: # DeltaV
+  emaggedInventory: # DeltaV
     ChemistryBottleLead: 2 # DeltaV - Added lead to standard chemvend
     BluespaceBeaker: 1 # Funkychem - let traitor chemists make nefarious batches
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I made the chemvend's bluespace beaker and lead only be available through an emag. Mute toxin, pax, and strange pills are still available by cutting the machine's manager wire. Chemists rejoice/despair!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
From what I can find, I'm honestly not sure if making these items available to everyone by cutting the manager wire was intentional. Lead was _definitely_ unintentional, as the PR which added them (#2079) explicitly mentioned emagging. I'm not sure about bluespace beakers. Either way, giving chemists late game equipment through cutting one (1) wire a minute into the round seems silly. A [community feedback thread](https://discord.com/channels/968983104247185448/1473349466193920214) was made about it, so it seemed worth PRing.


## Technical details
<!-- Summary of code changes for easier review. -->
one (1) (i) line of yaml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/4ca54c96-2a38-4a3f-812c-058258bc0701



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Bluespace beakers and lead bottles can now only be obtained by emagging the chemvend, instead of cutting the manager wire.