### PR TITLE
feat: Various Admin QOL features

### DIFF
--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -196,8 +196,22 @@ internal sealed class AdminNameOverlay : Overlay
             // Username
             color = Color.Yellow;
             color.A = alpha;
-            args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.Username, uiScale, playerInfo.Connected ? color : colorDisconnected);
-            currentOffset += lineoffset;
+            var usernameSpace = args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, playerInfo.Username, uiScale, playerInfo.Connected ? color : colorDisconnected); // DeltaV - store return value
+
+            // DeltaV - add watchlist suffix START
+            if (playerInfo.Watchlisted)
+            {
+                color = Color.Red;
+                color.A = alpha;
+                args.ScreenHandle.DrawString(_fontBold,
+                    screenCoordinates + currentOffset + usernameSpace with { Y = 0 },
+                    " " + Loc.GetString("admin-overlay-watchlisted-username-suffix"),
+                    uiScale,
+                    color);
+            }
+            // DeltaV - add watchlist suffix END
+
+            currentOffset += lineoffset; // DeltaV - moved down from username block
 
             // Playtime
             if (!string.IsNullOrEmpty(playerInfo.PlaytimeString) && _overlayPlaytime)

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -68,10 +68,12 @@ public sealed partial class PlayerTab : Control
         RefreshPlayerList(_adminSystem.PlayerList);
     }
 
+    // DeltaV - mark ghosted START
     private void MarkGhostedChanged(bool value)
     {
         _markGhosted = value;
     }
+    // DeltaV - mark ghosted END
 
     #region Antag Overlay
 

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -74,11 +74,13 @@ public sealed partial class PlayerTab : Control
     private void MarkGhostedChanged(bool value)
     {
         _markGhosted = value;
+        RefreshPlayerList(_players);
     }
 
     private void MarkWatchlistedChanged(bool value)
     {
         _markWatchlisted = value;
+        RefreshPlayerList(_players);
     }
     // DeltaV - mark ghosted, watchlisted END
 

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -168,13 +168,15 @@ public sealed partial class PlayerTab : Control
 
         UpdateHeaderSymbols();
 
-
         SearchList.PopulateList(sortedPlayers.Select(info =>
             {
                 // DeltaV - additions START
                 var filteringStringAdditions = "";
                 if (_markGhosted && info.Ghost)
+                {
                     filteringStringAdditions += " (G)";
+                }
+
                 if (_markWatchlisted && info.Watchlisted)
                 {
                     filteringStringAdditions += " (WL)";

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTab.xaml.cs
@@ -36,6 +36,7 @@ public sealed partial class PlayerTab : Control
     private AdminPlayerTabRoleTypeOption _playerTabRoleSetting;
     private AdminPlayerTabSymbolOption _playerTabSymbolSetting;
     private bool _markGhosted; // DeltaV
+    private bool _markWatchlisted; // DeltaV
 
     public event Action<GUIBoundKeyEventArgs, ListData>? OnEntryKeyBindDown;
 
@@ -53,6 +54,7 @@ public sealed partial class PlayerTab : Control
         _config.OnValueChanged(CCVars.AdminPlayerTabColorSetting, ColorSettingChanged, true);
         _config.OnValueChanged(CCVars.AdminPlayerTabSymbolSetting, SymbolSettingChanged, true);
         _config.OnValueChanged(CCVars.AdminPlayerTabMarkGhosted, MarkGhostedChanged, true); // DeltaV
+        _config.OnValueChanged(CCVars.AdminPlayerTabMarkWatchlisted, MarkWatchlistedChanged, true); // DeltaV
 
         OverlayButton.OnPressed += OverlayButtonPressed;
         ShowDisconnectedButton.OnPressed += ShowDisconnectedPressed;
@@ -68,12 +70,17 @@ public sealed partial class PlayerTab : Control
         RefreshPlayerList(_adminSystem.PlayerList);
     }
 
-    // DeltaV - mark ghosted START
+    // DeltaV - mark ghosted, watchlisted START
     private void MarkGhostedChanged(bool value)
     {
         _markGhosted = value;
     }
-    // DeltaV - mark ghosted END
+
+    private void MarkWatchlistedChanged(bool value)
+    {
+        _markWatchlisted = value;
+    }
+    // DeltaV - mark ghosted, watchlisted END
 
     #region Antag Overlay
 
@@ -168,6 +175,10 @@ public sealed partial class PlayerTab : Control
                 var filteringStringAdditions = "";
                 if (_markGhosted && info.Ghost)
                     filteringStringAdditions += " (G)";
+                if (_markWatchlisted && info.Watchlisted)
+                {
+                    filteringStringAdditions += " (WL)";
+                }
                 // DeltaV - additions END
 
                 return new PlayerListData(info,
@@ -188,7 +199,8 @@ public sealed partial class PlayerTab : Control
             _playerTabColorSetting,
             _playerTabRoleSetting,
             _playerTabSymbolSetting,
-            _markGhosted // DeltaV - Add _markGhosted
+            _markGhosted, // DeltaV - Add _markGhosted
+            _markWatchlisted // DeltaV - Add _markWatchlisted
         );
         button.AddChild(entry);
         button.ToolTip = $"{player.Username}, {player.CharacterName}, {player.IdentityName}, {player.StartingJob}";

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml.cs
@@ -20,7 +20,9 @@ public sealed partial class PlayerTabEntry : PanelContainer
         StyleBoxFlat styleBoxFlat,
         AdminPlayerTabColorOption colorOption,
         AdminPlayerTabRoleTypeOption roleSetting,
-        AdminPlayerTabSymbolOption symbolSetting)
+        AdminPlayerTabSymbolOption symbolSetting,
+        bool markGhosted // DeltaV - Add markGhosted
+        )
     {
         IoCManager.InjectDependencies(this);
         RobustXamlLoader.Load(this);
@@ -72,6 +74,13 @@ public sealed partial class PlayerTabEntry : PanelContainer
             CharacterLabel.FontColorOverride = rolePrototype?.Color ?? RoleTypePrototype.FallbackColor;
         if (player.IdentityName != player.CharacterName)
             CharacterLabel.Text += $" [{player.IdentityName}]";
+
+        // DeltaV - Mark ghosted players START
+        if (player.Ghost && markGhosted)
+        {
+            CharacterLabel.Text = $"(G) {CharacterLabel.Text}";
+        }
+        // DeltaV - Mark ghosted players END
 
         var roletype = RoleTypeLabel.Text = Loc.GetString(rolePrototype?.Name ?? RoleTypePrototype.FallbackName);
         var subtype = roles.GetRoleSubtypeLabel(rolePrototype?.Name ?? RoleTypePrototype.FallbackName, player.Subtype);

--- a/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml.cs
+++ b/Content.Client/Administration/UI/Tabs/PlayerTab/PlayerTabEntry.xaml.cs
@@ -21,7 +21,8 @@ public sealed partial class PlayerTabEntry : PanelContainer
         AdminPlayerTabColorOption colorOption,
         AdminPlayerTabRoleTypeOption roleSetting,
         AdminPlayerTabSymbolOption symbolSetting,
-        bool markGhosted // DeltaV - Add markGhosted
+        bool markGhosted, // DeltaV - Add markGhosted
+        bool markWatchlisted // DeltaV - Add markWatchlisted
         )
     {
         IoCManager.InjectDependencies(this);
@@ -75,12 +76,16 @@ public sealed partial class PlayerTabEntry : PanelContainer
         if (player.IdentityName != player.CharacterName)
             CharacterLabel.Text += $" [{player.IdentityName}]";
 
-        // DeltaV - Mark ghosted players START
+        // DeltaV - Mark ghosted/watchlisted players START
         if (player.Ghost && markGhosted)
         {
             CharacterLabel.Text = $"(G) {CharacterLabel.Text}";
         }
-        // DeltaV - Mark ghosted players END
+        if (player.Watchlisted && markWatchlisted)
+        {
+            CharacterLabel.Text = $"(WL) {CharacterLabel.Text}";
+        }
+        // DeltaV - Mark ghosted/watchlisted players END
 
         var roletype = RoleTypeLabel.Text = Loc.GetString(rolePrototype?.Name ?? RoleTypePrototype.FallbackName);
         var subtype = roles.GetRoleSubtypeLabel(rolePrototype?.Name ?? RoleTypePrototype.FallbackName, player.Subtype);

--- a/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml
@@ -9,6 +9,7 @@
                 <ui:OptionDropDown Name="DropDownPlayerTabSymbolSetting" Title="{Loc 'ui-options-admin-player-tab-symbol-setting'}" />
                 <ui:OptionDropDown Name="DropDownPlayerTabRoleSetting" Title="{Loc 'ui-options-admin-player-tab-role-setting'}" />
                 <ui:OptionDropDown Name="DropDownPlayerTabColorSetting" Title="{Loc 'ui-options-admin-player-tab-color-setting'}" />
+                <CheckBox Name="EnablePlayerTabMarkGhosted" Text="{Loc 'ui-options-admin-player-tab-mark-ghosted'}" ToolTip="{Loc 'ui-options-admin-player-tab-mark-ghosted-tooltip'}" /> <!-- DeltaV - Add MarkGhosted -->
                 <Label Text="{Loc 'ui-options-admin-logs-title'}"
                        StyleClasses="LabelKeyText"/>
                 <ui:OptionColorSlider Name="ColorSliderLogsHighlight" Title="{Loc 'ui-options-admin-logs-highlight-color'}" />

--- a/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml
@@ -10,6 +10,7 @@
                 <ui:OptionDropDown Name="DropDownPlayerTabRoleSetting" Title="{Loc 'ui-options-admin-player-tab-role-setting'}" />
                 <ui:OptionDropDown Name="DropDownPlayerTabColorSetting" Title="{Loc 'ui-options-admin-player-tab-color-setting'}" />
                 <CheckBox Name="EnablePlayerTabMarkGhosted" Text="{Loc 'ui-options-admin-player-tab-mark-ghosted'}" ToolTip="{Loc 'ui-options-admin-player-tab-mark-ghosted-tooltip'}" /> <!-- DeltaV - Add MarkGhosted -->
+                <CheckBox Name="EnablePlayerTabMarkWatchlisted" Text="{Loc 'ui-options-admin-player-tab-mark-watchlisted'}" ToolTip="{Loc 'ui-options-admin-player-tab-mark-watchlisted-tooltip'}" /> <!-- DeltaV - Add MarkWatchlisted -->
                 <Label Text="{Loc 'ui-options-admin-logs-title'}"
                        StyleClasses="LabelKeyText"/>
                 <ui:OptionColorSlider Name="ColorSliderLogsHighlight" Title="{Loc 'ui-options-admin-logs-highlight-color'}" />

--- a/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml.cs
@@ -56,6 +56,7 @@ public sealed partial class AdminOptionsTab : Control
         Control.AddOptionDropDown(CCVars.AdminPlayerTabSymbolSetting, DropDownPlayerTabSymbolSetting, playerTabSymbolSettings);
         Control.AddOptionDropDown(CCVars.AdminPlayerTabRoleSetting, DropDownPlayerTabRoleSetting, playerTabRoleSettings);
         Control.AddOptionDropDown(CCVars.AdminPlayerTabColorSetting, DropDownPlayerTabColorSetting, playerTabColorSettings);
+        Control.AddOptionCheckBox(CCVars.AdminPlayerTabMarkGhosted, EnablePlayerTabMarkGhosted); // DeltaV
 
         Control.AddOptionDropDown(CCVars.AdminOverlayAntagFormat, DropDownOverlayAntagFormat, antagFormats);
         Control.AddOptionDropDown(CCVars.AdminOverlaySymbolStyle, DropDownOverlayAntagSymbol, antagSymbolStyles);

--- a/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AdminOptionsTab.xaml.cs
@@ -57,6 +57,7 @@ public sealed partial class AdminOptionsTab : Control
         Control.AddOptionDropDown(CCVars.AdminPlayerTabRoleSetting, DropDownPlayerTabRoleSetting, playerTabRoleSettings);
         Control.AddOptionDropDown(CCVars.AdminPlayerTabColorSetting, DropDownPlayerTabColorSetting, playerTabColorSettings);
         Control.AddOptionCheckBox(CCVars.AdminPlayerTabMarkGhosted, EnablePlayerTabMarkGhosted); // DeltaV
+        Control.AddOptionCheckBox(CCVars.AdminPlayerTabMarkWatchlisted, EnablePlayerTabMarkWatchlisted); // DeltaV
 
         Control.AddOptionDropDown(CCVars.AdminOverlayAntagFormat, DropDownOverlayAntagFormat, antagFormats);
         Control.AddOptionDropDown(CCVars.AdminOverlaySymbolStyle, DropDownOverlayAntagSymbol, antagSymbolStyles);

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -495,7 +495,8 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
     /// <summary>
     /// Creates a list of tpto command links of the given players
     /// </summary>
-    private bool CreateTpLinks(List<(NetEntity NetEnt, string CharacterName)> players, out string outString)
+    // DeltaV - Make public static
+    public static bool CreateTpLinks(List<(NetEntity NetEnt, string CharacterName)> players, out string outString)
     {
         outString = string.Empty;
 
@@ -543,7 +544,8 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
     /// <summary>
     /// Escape the given text to not allow breakouts of the cmdlink tags.
     /// </summary>
-    private string EscapeText(string text)
+    // DeltaV - Make public static
+    public static string EscapeText(string text)
     {
         return FormattedMessage.EscapeText(text).Replace("\"", "\\\"").Replace("'", "\\'");
     }

--- a/Content.Server/Administration/Logs/AdminLogManager.cs
+++ b/Content.Server/Administration/Logs/AdminLogManager.cs
@@ -520,7 +520,8 @@ public sealed partial class AdminLogManager : SharedAdminLogManager, IAdminLogMa
     /// <summary>
     /// Creates a list of toto command links for the given map coordinates.
     /// </summary>
-    private bool CreateCordLinks(List<MapCoordinates> cords, out string outString)
+    // DeltaV - Make public static
+    public static bool CreateCordLinks(List<MapCoordinates> cords, out string outString)
     {
         outString = string.Empty;
 

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -4,7 +4,7 @@ using Content.Server.Administration.Commands;
 using Content.Server.Administration.Systems; // DeltaV - Admin QOL
 using Content.Server.Chat.Managers;
 using Content.Server.EUI;
-using Content.Shared.Administration.Notes;
+using Content.Shared.Administration.Notes; // DeltaV - Admin QOL
 using Content.Shared.Database;
 using Content.Shared.Verbs;
 using Robust.Server.Player;

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Content.Server.Administration.Commands;
+using Content.Server.Administration.Systems;
 using Content.Server.Chat.Managers;
 using Content.Server.EUI;
 using Content.Shared.Administration.Notes;
@@ -22,6 +23,7 @@ public sealed class AdminNotesSystem : EntitySystem
     [Dependency] private readonly IPlayerManager _playerManager = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly EuiManager _euis = default!;
+    [Dependency] private readonly AdminSystem _admin = default!; // DeltaV
 
 
     // DeltaV - watchlist cache defs START
@@ -62,6 +64,9 @@ public sealed class AdminNotesSystem : EntitySystem
             _connectedPlayerWatchlists[note.Player] = new();
 
         _connectedPlayerWatchlists[note.Player].Add(note);
+
+        if (_playerManager.TryGetSessionById(note.Player, out var session))
+            _admin.UpdatePlayerList(session);
     }
 
     private void OnNoteModified(SharedAdminNote note)
@@ -72,6 +77,9 @@ public sealed class AdminNotesSystem : EntitySystem
         var modifiedIndex = _connectedPlayerWatchlists[note.Player].FindIndex(n => n.Id == note.Id);
         if (modifiedIndex != -1)
             _connectedPlayerWatchlists[note.Player][modifiedIndex] = note;
+
+        if (_playerManager.TryGetSessionById(note.Player, out var session))
+            _admin.UpdatePlayerList(session);
     }
 
     private void OnNoteDeleted(SharedAdminNote note)
@@ -85,6 +93,9 @@ public sealed class AdminNotesSystem : EntitySystem
 
         if (_connectedPlayerWatchlists[note.Player].Count == 0)
             _connectedPlayerWatchlists.Remove(note.Player);
+
+        if (_playerManager.TryGetSessionById(note.Player, out var session))
+            _admin.UpdatePlayerList(session);
     }
     // DeltaV - track watchlist changes END
 

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -1,7 +1,7 @@
-using System.Collections.ObjectModel;
+using System.Collections.ObjectModel; // DeltaV - Admin QOL
 using System.Linq;
 using Content.Server.Administration.Commands;
-using Content.Server.Administration.Systems;
+using Content.Server.Administration.Systems; // DeltaV - Admin QOL
 using Content.Server.Chat.Managers;
 using Content.Server.EUI;
 using Content.Shared.Administration.Notes;
@@ -10,7 +10,7 @@ using Content.Shared.Verbs;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
-using Robust.Shared.Network;
+using Robust.Shared.Network; // DeltaV - Admin QOL
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -25,7 +25,6 @@ public sealed class AdminNotesSystem : EntitySystem
     [Dependency] private readonly EuiManager _euis = default!;
     [Dependency] private readonly AdminSystem _admin = default!; // DeltaV
 
-
     // DeltaV - watchlist cache defs START
     // For use by other systems
     // Used by lswatchlisted command to avoid querying database for every connected user every time it's invoked.

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -58,6 +58,9 @@ public sealed class AdminNotesSystem : EntitySystem
         if (note.NoteType != NoteType.Watchlist)
             return;
 
+        if (!_connectedPlayerWatchlists.ContainsKey(note.Player))
+            _connectedPlayerWatchlists[note.Player] = new();
+
         _connectedPlayerWatchlists[note.Player].Add(note);
     }
 
@@ -79,6 +82,9 @@ public sealed class AdminNotesSystem : EntitySystem
         var deletedIndex = _connectedPlayerWatchlists[note.Player].FindIndex(n => n.Id == note.Id);
         if (deletedIndex != -1)
             _connectedPlayerWatchlists[note.Player].RemoveAt(deletedIndex);
+
+        if (_connectedPlayerWatchlists[note.Player].Count == 0)
+            _connectedPlayerWatchlists.Remove(note.Player);
     }
     // DeltaV - track watchlist changes END
 

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -1,12 +1,15 @@
+using System.Collections.ObjectModel;
 using System.Linq;
 using Content.Server.Administration.Commands;
 using Content.Server.Chat.Managers;
 using Content.Server.EUI;
+using Content.Shared.Administration.Notes;
 using Content.Shared.Database;
 using Content.Shared.Verbs;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Enums;
+using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Utility;
 
@@ -20,11 +23,64 @@ public sealed class AdminNotesSystem : EntitySystem
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly EuiManager _euis = default!;
 
+
+    // DeltaV - watchlist cache defs START
+    // For use by other systems
+    // Used by lswatchlisted command to avoid querying database for every connected user every time it's invoked.
+    public ReadOnlyDictionary<NetUserId, List<SharedAdminNote>> ConnectedPlayerWatchlists => _connectedPlayerWatchlists.AsReadOnly();
+    private readonly Dictionary<NetUserId, List<SharedAdminNote>> _connectedPlayerWatchlists = new();
+    // DeltaV - watchlist cache defs END
+
     public override void Initialize()
     {
         SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddVerbs);
         _playerManager.PlayerStatusChanged += OnPlayerStatusChanged;
+
+        // DeltaV - track watchlist changes START
+        _notes.NoteAdded += OnNoteAdded;
+        _notes.NoteModified += OnNoteModified;
+        _notes.NoteDeleted += OnNoteDeleted;
+        // DeltaV - track watchlist changes END
     }
+
+    // DeltaV - track watchlist changes START
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _notes.NoteAdded -= OnNoteAdded;
+        _notes.NoteModified -= OnNoteModified;
+        _notes.NoteDeleted -= OnNoteDeleted;
+    }
+
+    private void OnNoteAdded(SharedAdminNote note)
+    {
+        if (note.NoteType != NoteType.Watchlist)
+            return;
+
+        _connectedPlayerWatchlists[note.Player].Add(note);
+    }
+
+    private void OnNoteModified(SharedAdminNote note)
+    {
+        if (note.NoteType != NoteType.Watchlist)
+            return;
+
+        var modifiedIndex = _connectedPlayerWatchlists[note.Player].FindIndex(n => n.Id == note.Id);
+        if (modifiedIndex != -1)
+            _connectedPlayerWatchlists[note.Player][modifiedIndex] = note;
+    }
+
+    private void OnNoteDeleted(SharedAdminNote note)
+    {
+        if (note.NoteType != NoteType.Watchlist)
+            return;
+
+        var deletedIndex = _connectedPlayerWatchlists[note.Player].FindIndex(n => n.Id == note.Id);
+        if (deletedIndex != -1)
+            _connectedPlayerWatchlists[note.Player].RemoveAt(deletedIndex);
+    }
+    // DeltaV - track watchlist changes END
 
     private void AddVerbs(GetVerbsEvent<Verb> ev)
     {
@@ -53,11 +109,24 @@ public sealed class AdminNotesSystem : EntitySystem
 
     private async void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)
     {
+        // DeltaV - clear watchlist cache on disconnect START
+        if (e.NewStatus == SessionStatus.Disconnected)
+        {
+            _connectedPlayerWatchlists.Remove(e.Session.UserId);
+            return;
+        }
+        // DeltaV - clear watchlist cache on disconnect END
+
         if (e.NewStatus != SessionStatus.InGame)
             return;
 
         var messages = await _notes.GetNewMessages(e.Session.UserId);
         var watchlists = await _notes.GetActiveWatchlists(e.Session.UserId);
+
+        // DeltaV - write to cache START
+        if (watchlists.Count != 0)
+            _connectedPlayerWatchlists[e.Session.UserId] = watchlists.Select(r => r.ToShared()).ToList();
+        // DeltaV - write to cache END
 
         if (!_playerManager.TryGetPlayerData(e.Session.UserId, out var playerData))
         {

--- a/Content.Server/Administration/Notes/AdminNotesSystem.cs
+++ b/Content.Server/Administration/Notes/AdminNotesSystem.cs
@@ -59,10 +59,8 @@ public sealed class AdminNotesSystem : EntitySystem
         if (note.NoteType != NoteType.Watchlist)
             return;
 
-        if (!_connectedPlayerWatchlists.ContainsKey(note.Player))
-            _connectedPlayerWatchlists[note.Player] = new();
-
-        _connectedPlayerWatchlists[note.Player].Add(note);
+        var notes = _connectedPlayerWatchlists.GetOrNew(note.Player);
+        notes.Add(note);
 
         if (_playerManager.TryGetSessionById(note.Player, out var session))
             _admin.UpdatePlayerList(session);

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -12,6 +12,7 @@ using Content.Shared.Administration.Events;
 using Content.Shared.CCVar;
 using Content.Shared.Forensics.Components;
 using Content.Shared.GameTicking;
+using Content.Shared.Ghost;
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;
@@ -220,12 +221,14 @@ public sealed class AdminSystem : EntitySystem
         var entityName = string.Empty;
         var identityName = string.Empty;
         var sortWeight = 0;
+        var ghost = false; // DeltaV
 
         // Visible (identity) name can be different from real name
         if (session?.AttachedEntity != null)
         {
             entityName = Comp<MetaDataComponent>(session.AttachedEntity.Value).EntityName;
             identityName = Identity.Name(session.AttachedEntity.Value, EntityManager);
+            ghost = HasComp<GhostComponent>(session.AttachedEntity.Value); // DeltaV
         }
 
         var antag = false;
@@ -277,7 +280,9 @@ public sealed class AdminSystem : EntitySystem
             data.UserId,
             connected,
             _roundActivePlayers.Contains(data.UserId),
-            overallPlaytime);
+            overallPlaytime,
+            ghost // DeltaV - Add ghost
+        );
     }
 
     private void OnPanicBunkerChanged(bool enabled)

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.PDA;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
+using Content.Shared.Roles.Components;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.StationRecords;
 using Content.Shared.Throwing;

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Server.Administration.Managers;
+using Content.Server.Administration.Notes;
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
@@ -56,6 +57,7 @@ public sealed class AdminSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
+    [Dependency] private readonly AdminNotesSystem _notes = default!; // DeltaV
 
     private readonly Dictionary<NetUserId, PlayerInfo> _playerList = new();
 
@@ -255,6 +257,7 @@ public sealed class AdminSystem : EntitySystem
 
         // Connection status and playtime
         var connected = session != null && session.Status is SessionStatus.Connected or SessionStatus.InGame;
+        var watchlisted = connected && _notes.ConnectedPlayerWatchlists.ContainsKey(session!.UserId); // DeltaV
 
         // Start with the last available playtime data
         var cachedInfo = GetCachedPlayerInfo(data.UserId);
@@ -281,7 +284,8 @@ public sealed class AdminSystem : EntitySystem
             connected,
             _roundActivePlayers.Contains(data.UserId),
             overallPlaytime,
-            ghost // DeltaV - Add ghost
+            ghost, // DeltaV - Add ghost
+            watchlisted // DeltaV - Add watchlisted
         );
     }
 

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -10,7 +10,9 @@ using Content.Server.Popups;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Events;
+using Content.Shared.Administration.Notes;
 using Content.Shared.CCVar;
+using Content.Shared.Database;
 using Content.Shared.Forensics.Components;
 using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
@@ -58,6 +60,7 @@ public sealed class AdminSystem : EntitySystem
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly AdminNotesSystem _notes = default!; // DeltaV
+    [Dependency] private readonly IAdminNotesManager _notesManager = default!; // DeltaV
 
     private readonly Dictionary<NetUserId, PlayerInfo> _playerList = new();
 
@@ -77,6 +80,12 @@ public sealed class AdminSystem : EntitySystem
         _adminManager.OnPermsChanged += OnAdminPermsChanged;
         _playTime.SessionPlayTimeUpdated += OnSessionPlayTimeUpdated;
 
+        // DeltaV - track watchlist changes START
+        _notesManager.NoteAdded += OnNoteChange;
+        _notesManager.NoteModified += OnNoteChange;
+        _notesManager.NoteDeleted += OnNoteChange;
+        // DeltaV - track watchlist changes END
+
         // Panic Bunker Settings
         Subs.CVar(_config, CCVars.PanicBunkerEnabled, OnPanicBunkerChanged, true);
         Subs.CVar(_config, CCVars.PanicBunkerDisableWithAdmins, OnPanicBunkerDisableWithAdminsChanged, true);
@@ -95,6 +104,14 @@ public sealed class AdminSystem : EntitySystem
         SubscribeLocalEvent<ActorComponent, EntityRenamedEvent>(OnPlayerRenamed);
         SubscribeLocalEvent<ActorComponent, IdentityChangedEvent>(OnIdentityChanged);
     }
+
+    // DeltaV - update on watchlist change START
+    private void OnNoteChange(SharedAdminNote note)
+    {
+        if (note.NoteType == NoteType.Watchlist && _playerManager.TryGetSessionById(note.Player, out var session))
+            UpdatePlayerList(session);
+    }
+    // DeltaV - update on watchlist change END
 
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
     {
@@ -200,6 +217,12 @@ public sealed class AdminSystem : EntitySystem
         _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
         _adminManager.OnPermsChanged -= OnAdminPermsChanged;
         _playTime.SessionPlayTimeUpdated -= OnSessionPlayTimeUpdated;
+
+        // DeltaV - track watchlist changes START
+        _notesManager.NoteAdded -= OnNoteChange;
+        _notesManager.NoteModified -= OnNoteChange;
+        _notesManager.NoteDeleted -= OnNoteChange;
+        // DeltaV - track watchlist changes END
     }
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Content.Server.Administration.Managers;
-using Content.Server.Administration.Notes;
+using Content.Server.Administration.Notes; // DeltaV - Admin QOL
 using Content.Server.Chat.Managers;
 using Content.Server.GameTicking;
 using Content.Server.Hands.Systems;
@@ -13,7 +13,7 @@ using Content.Shared.Administration.Events;
 using Content.Shared.CCVar;
 using Content.Shared.Forensics.Components;
 using Content.Shared.GameTicking;
-using Content.Shared.Ghost;
+using Content.Shared.Ghost; // DeltaV - Admin QOL
 using Content.Shared.Hands.Components;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Inventory;

--- a/Content.Server/Administration/Systems/AdminSystem.cs
+++ b/Content.Server/Administration/Systems/AdminSystem.cs
@@ -10,9 +10,7 @@ using Content.Server.Popups;
 using Content.Server.StationRecords.Systems;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Events;
-using Content.Shared.Administration.Notes;
 using Content.Shared.CCVar;
-using Content.Shared.Database;
 using Content.Shared.Forensics.Components;
 using Content.Shared.GameTicking;
 using Content.Shared.Ghost;
@@ -24,7 +22,6 @@ using Content.Shared.PDA;
 using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
-using Content.Shared.Roles.Components;
 using Content.Shared.Roles.Jobs;
 using Content.Shared.StationRecords;
 using Content.Shared.Throwing;
@@ -60,7 +57,6 @@ public sealed class AdminSystem : EntitySystem
     [Dependency] private readonly StationRecordsSystem _stationRecords = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly AdminNotesSystem _notes = default!; // DeltaV
-    [Dependency] private readonly IAdminNotesManager _notesManager = default!; // DeltaV
 
     private readonly Dictionary<NetUserId, PlayerInfo> _playerList = new();
 
@@ -80,12 +76,6 @@ public sealed class AdminSystem : EntitySystem
         _adminManager.OnPermsChanged += OnAdminPermsChanged;
         _playTime.SessionPlayTimeUpdated += OnSessionPlayTimeUpdated;
 
-        // DeltaV - track watchlist changes START
-        _notesManager.NoteAdded += OnNoteChange;
-        _notesManager.NoteModified += OnNoteChange;
-        _notesManager.NoteDeleted += OnNoteChange;
-        // DeltaV - track watchlist changes END
-
         // Panic Bunker Settings
         Subs.CVar(_config, CCVars.PanicBunkerEnabled, OnPanicBunkerChanged, true);
         Subs.CVar(_config, CCVars.PanicBunkerDisableWithAdmins, OnPanicBunkerDisableWithAdminsChanged, true);
@@ -104,14 +94,6 @@ public sealed class AdminSystem : EntitySystem
         SubscribeLocalEvent<ActorComponent, EntityRenamedEvent>(OnPlayerRenamed);
         SubscribeLocalEvent<ActorComponent, IdentityChangedEvent>(OnIdentityChanged);
     }
-
-    // DeltaV - update on watchlist change START
-    private void OnNoteChange(SharedAdminNote note)
-    {
-        if (note.NoteType == NoteType.Watchlist && _playerManager.TryGetSessionById(note.Player, out var session))
-            UpdatePlayerList(session);
-    }
-    // DeltaV - update on watchlist change END
 
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
     {
@@ -217,12 +199,6 @@ public sealed class AdminSystem : EntitySystem
         _playerManager.PlayerStatusChanged -= OnPlayerStatusChanged;
         _adminManager.OnPermsChanged -= OnAdminPermsChanged;
         _playTime.SessionPlayTimeUpdated -= OnSessionPlayTimeUpdated;
-
-        // DeltaV - track watchlist changes START
-        _notesManager.NoteAdded -= OnNoteChange;
-        _notesManager.NoteModified -= OnNoteChange;
-        _notesManager.NoteDeleted -= OnNoteChange;
-        // DeltaV - track watchlist changes END
     }
 
     private void OnPlayerStatusChanged(object? sender, SessionStatusEventArgs e)

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Content.Server._DV.Administration;
+using Content.Server._DV.Administration; // DeltaV - Admin QOL
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;

--- a/Content.Server/Destructible/DestructibleSystem.cs
+++ b/Content.Server/Destructible/DestructibleSystem.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Content.Server._DV.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;
@@ -83,6 +84,8 @@ namespace Content.Server.Destructible
 
                     if (args.Origin != null)
                     {
+                        RaiseLocalEvent(uid, new EventAlertSystem.BrokenWithOriginEvent(args.Origin.Value), true); // DeltaV
+
                         AdminLogger.Add(LogType.Damaged,
                             logImpact,
                             $"{ToPrettyString(args.Origin.Value):actor} caused {ToPrettyString(uid):subject} to trigger [{triggeredBehaviors}]");

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -254,9 +254,9 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         // just in case: is the user on station?
         if (station is null && user is not null)
         {
-            station = _stationSystem.GetOwningStation(gridPos?.EntityId);
+            station = _stationSystem.GetOwningStation(user);
         }
-;
+
         if (station is not null)
         {
             if (_stationSystem.TryGetNetEntity(station, out var stationNetEnt))

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -268,8 +268,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
 
         if (user == null)
         {
-            // DeltaV - Set to Extreme if onStation (always alert), add station name if available
-            _adminLogger.Add(LogType.Explosion, station is not null ? LogImpact.Extreme : LogImpact.High,
+            _adminLogger.Add(LogType.Explosion, station is not null ? LogImpact.Extreme : LogImpact.High, // DeltaV - Set to Extreme if onStation (always alert), add station name if available
                 $"{ToPrettyString(uid):entity} exploded ({typeId}) at {(stationName != null ? $"{stationName} " : "")}Pos:{(posFound ? $"{gridPos:coordinates}" : "[Grid or Map not found]")} with intensity {totalIntensity} slope {slope}");
         }
         else
@@ -286,10 +285,9 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
 
             if (posFound)
             {
-                // DeltaV - Add stationName to log message if available
                 _adminLogger.Add(LogType.Explosion,
                     logImpact,
-                    $"{ToPrettyString(user.Value):user} caused {ToPrettyString(uid):entity} to explode ({typeId}) at {(stationName != null ? $"{stationName} " : "")}Pos:{gridPos:coordinates} with intensity {totalIntensity} slope {slope}");
+                    $"{ToPrettyString(user.Value):user} caused {ToPrettyString(uid):entity} to explode ({typeId}) at {(stationName != null ? $"{stationName} " : "")}Pos:{gridPos:coordinates} with intensity {totalIntensity} slope {slope}"); // DeltaV - Add stationName to log message if available
             }
             else
                 _adminLogger.Add(LogType.Explosion, logImpact, $"{ToPrettyString(user.Value):user} caused {ToPrettyString(uid):entity} to explode ({typeId}) at Pos:[Grid or Map not found] with intensity {totalIntensity} slope {slope}");

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -6,7 +6,7 @@ using Content.Server.Atmos.EntitySystems;
 using Content.Server.Destructible;
 using Content.Server.NodeContainer.EntitySystems;
 using Content.Server.NPC.Pathfinding;
-using Content.Server.Station.Systems;
+using Content.Server.Station.Systems; // DeltaV - Admin QOL
 using Content.Shared.Atmos.Components;
 using Content.Shared.Camera;
 using Content.Shared.CCVar;

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -81,9 +81,9 @@ namespace Content.Server.Objectives.Commands
                     _players.TryGetSessionByEntity(mind.Comp.OwnedEntity.Value, out player);
                 }
 
-                _entities.TryGetComponent<MetaDataComponent>(mind.Comp.OwnedEntity, out var metaData);
                 if (mind.Comp.Objectives.Count > 0)
                 {
+                    _entities.TryGetComponent<MetaDataComponent>(mind.Comp.OwnedEntity, out var metaData);
                     shell.WriteMarkup($"\n[bold]{metaData?.EntityName}[/bold] ({player?.Name})");
 
                     var objectivesSystem = _entities.System<SharedObjectivesSystem>();

--- a/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
+++ b/Content.Server/Objectives/Commands/ListObjectivesCommand.cs
@@ -3,6 +3,7 @@ using Content.Server.Administration;
 using Content.Shared.Administration;
 using Content.Shared.Mind;
 using Content.Shared.Objectives.Systems;
+using Content.Shared.Players;
 using Robust.Server.Player;
 using Robust.Shared.Console;
 using Robust.Shared.Player;
@@ -72,26 +73,26 @@ namespace Content.Server.Objectives.Commands
         // DeltaV - Added function START
         private void ListAllObjectives(IConsoleShell shell)
         {
-            var minds = _entities.System<SharedMindSystem>();
-            foreach (var mind in minds.GetAliveHumans())
+            var minds = _entities.EntityQueryEnumerator<MindComponent>();
+            while (minds.MoveNext(out var mindId, out var mindComp))
             {
                 ICommonSession? player = null;
-                if (mind.Comp.OwnedEntity is not null)
+                if (mindComp.OwnedEntity is not null)
                 {
-                    _players.TryGetSessionByEntity(mind.Comp.OwnedEntity.Value, out player);
+                    _players.TryGetSessionByEntity(mindComp.OwnedEntity.Value, out player);
                 }
 
-                if (mind.Comp.Objectives.Count > 0)
+                if (mindComp.Objectives.Count > 0)
                 {
-                    _entities.TryGetComponent<MetaDataComponent>(mind.Comp.OwnedEntity, out var metaData);
-                    shell.WriteMarkup($"\n[bold]{metaData?.EntityName}[/bold] ({player?.Name})");
+                    _entities.TryGetComponent<MetaDataComponent>(mindComp.OwnedEntity, out var metaData);
+                    shell.WriteMarkup($"\n[bold]{metaData?.EntityName}[/bold] ({player?.Name ?? "No player attached?"})");
 
                     var objectivesSystem = _entities.System<SharedObjectivesSystem>();
-                    var objectives = mind.Comp.Objectives;
+                    var objectives = mindComp.Objectives;
 
                     for (var i = 0; i < objectives.Count; i++)
                     {
-                        var info = objectivesSystem.GetInfo(objectives[i], mind);
+                        var info = objectivesSystem.GetInfo(objectives[i], mindId);
                         if (info == null)
                         {
                             shell.WriteLine($"- [{i}] {objectives[i]} - INVALID");

--- a/Content.Server/Prayer/PrayerSystem.cs
+++ b/Content.Server/Prayer/PrayerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._DV.Administration;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Bible.Components;
@@ -24,6 +25,7 @@ public sealed class PrayerSystem : EntitySystem
     [Dependency] private readonly PopupSystem _popupSystem = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly QuickDialogSystem _quickDialog = default!;
+    [Dependency] private readonly EventAlertSystem _eventAlert = default!; // DeltaV
 
     public override void Initialize()
     {
@@ -105,6 +107,7 @@ public sealed class PrayerSystem : EntitySystem
         _popupSystem.PopupEntity(Loc.GetString(comp.SentMessage), sender.AttachedEntity.Value, sender, PopupType.Medium);
 
         _chatManager.SendAdminAnnouncement($"{Loc.GetString(comp.NotificationPrefix)} <{sender.Name}>: {message}");
+        _eventAlert.SendLinks(sender.AttachedEntity); // DeltaV - send tp links for prayers
         _adminLogger.Add(LogType.AdminMessage, LogImpact.Low, $"{ToPrettyString(sender.AttachedEntity.Value):player} sent prayer ({Loc.GetString(comp.NotificationPrefix)}): {message}");
     }
 }

--- a/Content.Server/Prayer/PrayerSystem.cs
+++ b/Content.Server/Prayer/PrayerSystem.cs
@@ -1,4 +1,4 @@
-using Content.Server._DV.Administration;
+using Content.Server._DV.Administration; // DeltaV - Admin QOL
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;
 using Content.Server.Bible.Components;

--- a/Content.Server/_DV/Administration/Commands/GetPingCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/GetPingCommand.cs
@@ -25,6 +25,8 @@ public sealed class GetPingCommand : LocalizedEntityCommands
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
-        return args.Length == 1 ? CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), "username") : CompletionResult.Empty;
+        return args.Length == 1
+            ? CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), "username")
+            : CompletionResult.Empty;
     }
 }

--- a/Content.Server/_DV/Administration/Commands/GetPingCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/GetPingCommand.cs
@@ -1,0 +1,30 @@
+using Content.Server.Administration;
+using Content.Shared.Administration;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+
+namespace Content.Server._DV.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class GetPingCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    public override string Command => "getping";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1 || !_player.TryGetSessionByUsername(args[0], out var session))
+        {
+            shell.WriteError(Loc.GetString("cmd-getping-err"));
+            return;
+        }
+
+        shell.WriteLine($"{session.Name}'s ping: {session.Ping}");
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length == 1 ? CompletionResult.FromHintOptions(CompletionHelper.SessionNames(), "username") : CompletionResult.Empty;
+    }
+}

--- a/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
@@ -1,0 +1,83 @@
+using Content.Server.Administration;
+using Content.Server.Commands;
+using Content.Server.Preferences.Managers;
+using Content.Shared.Administration;
+using Content.Shared.Mind;
+using Content.Shared.Silicons.Laws.Components;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class ListLawsCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+
+    public override string Command => "lslaws";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length > 1)
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        switch (args.Length)
+        {
+            case 0:
+                foreach (var (ent, lawProvider) in _entityManager.AllEntities<SiliconLawProviderComponent>())
+                {
+                    WriteLawReport(shell, ent, lawProvider);
+                }
+                break;
+            case 1:
+                if (!_player.TryGetSessionByUsername(args[0], out var session) || !_entityManager.TryGetComponent<SiliconLawProviderComponent>(session.AttachedEntity, out var provider))
+                {
+                    shell.WriteError(Loc.GetString("cmd-lslaws-error-bad-player"));
+                    return;
+                }
+
+                WriteLawReport(shell, session.AttachedEntity.Value, provider);
+                break;
+            default:
+                shell.WriteLine(Help);
+                break;
+        }
+
+
+    }
+
+    private void WriteLawReport(IConsoleShell shell, EntityUid ent, SiliconLawProviderComponent lawProvider)
+    {
+        shell.WriteLine("");
+        _entityManager.TryGetComponent<MetaDataComponent>(ent, out var metaData);
+        var entityName = metaData?.EntityName;
+
+        shell.WriteLine(_player.TryGetSessionByEntity(ent, out var session)
+            ? $"{entityName} ({ent.Id}, {session.Name}, subverted: {lawProvider.Subverted})"
+            : $"{entityName} ({ent.Id}, subverted: {lawProvider.Subverted})");
+
+        shell.WriteLine($"Base Lawset: {lawProvider.Laws.Id}");
+        if (lawProvider.Lawset is {} lawset)
+        {
+            foreach (var siliconLaw in lawset.Laws)
+            {
+                shell.WriteLine($"{siliconLaw.Order}: {Loc.GetString(siliconLaw.LawString)}");
+            }
+        }
+        else
+        {
+            shell.WriteLine("Unable to retrieve laws.");
+        }
+    }
+
+    public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length == 1 ? CompletionResult.FromOptions(CompletionHelper.SessionNames()) : CompletionResult.Empty;
+    }
+}

--- a/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
@@ -58,9 +58,9 @@ public sealed class ListLawsCommand : LocalizedEntityCommands
         _entityManager.TryGetComponent<MetaDataComponent>(ent, out var metaData);
         var entityName = metaData?.EntityName;
 
-        shell.WriteLine(_player.TryGetSessionByEntity(ent, out var session)
-            ? $"{entityName} ({ent.Id}, {session.Name}, subverted: {lawProvider.Subverted})"
-            : $"{entityName} ({ent.Id}, subverted: {lawProvider.Subverted})");
+        shell.WriteMarkup(_player.TryGetSessionByEntity(ent, out var session)
+            ? $"[bold]{entityName}[/bold] ({ent.Id}, [color=red]{session.Name}[/color], subverted: {lawProvider.Subverted})"
+            : $"[bold]{entityName}[/bold] ({ent.Id}, subverted: {lawProvider.Subverted})");
 
         shell.WriteLine($"Base Lawset: {lawProvider.Laws.Id}");
         if (lawProvider.Lawset is {} lawset)

--- a/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
@@ -1,12 +1,8 @@
 using Content.Server.Administration;
-using Content.Server.Commands;
-using Content.Server.Preferences.Managers;
 using Content.Shared.Administration;
-using Content.Shared.Mind;
 using Content.Shared.Silicons.Laws.Components;
 using Robust.Server.Player;
 using Robust.Shared.Console;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server._DV.Administration.Commands;
 
@@ -34,9 +30,12 @@ public sealed class ListLawsCommand : LocalizedEntityCommands
                 {
                     WriteLawReport(shell, ent, lawProvider);
                 }
+
                 break;
             case 1:
-                if (!_player.TryGetSessionByUsername(args[0], out var session) || !_entityManager.TryGetComponent<SiliconLawProviderComponent>(session.AttachedEntity, out var provider))
+                if (!_player.TryGetSessionByUsername(args[0], out var session) ||
+                    !_entityManager.TryGetComponent<SiliconLawProviderComponent>(session.AttachedEntity,
+                        out var provider))
                 {
                     shell.WriteError(Loc.GetString("cmd-lslaws-error-bad-player"));
                     return;
@@ -48,8 +47,6 @@ public sealed class ListLawsCommand : LocalizedEntityCommands
                 shell.WriteLine(Help);
                 break;
         }
-
-
     }
 
     private void WriteLawReport(IConsoleShell shell, EntityUid ent, SiliconLawProviderComponent lawProvider)
@@ -63,7 +60,7 @@ public sealed class ListLawsCommand : LocalizedEntityCommands
             : $"[bold]{entityName}[/bold] ({ent.Id}, subverted: {lawProvider.Subverted})");
 
         shell.WriteLine($"Base Lawset: {lawProvider.Laws.Id}");
-        if (lawProvider.Lawset is {} lawset)
+        if (lawProvider.Lawset is { } lawset)
         {
             foreach (var siliconLaw in lawset.Laws)
             {
@@ -78,6 +75,8 @@ public sealed class ListLawsCommand : LocalizedEntityCommands
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
-        return args.Length == 1 ? CompletionResult.FromOptions(CompletionHelper.SessionNames()) : CompletionResult.Empty;
+        return args.Length == 1
+            ? CompletionResult.FromOptions(CompletionHelper.SessionNames())
+            : CompletionResult.Empty;
     }
 }

--- a/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+using Content.Server.Administration;
+using Content.Server.Administration.Notes;
+using Content.Server.Commands;
+using Content.Server.Preferences.Managers;
+using Content.Shared.Administration;
+using Content.Shared.Mind;
+using Content.Shared.Silicons.Laws.Components;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._DV.Administration.Commands;
+
+[AdminCommand(AdminFlags.Admin)]
+public sealed class ListWatchlistedCommand : LocalizedEntityCommands
+{
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IAdminNotesManager _notes = default!;
+
+    public override string Command => "lswatchlisted";
+
+    public override async void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var found = false;
+        foreach (var sessionData in _player.GetAllPlayerData())
+        {
+            var watchlists = await _notes.GetActiveWatchlists(sessionData.UserId.UserId);
+            if (watchlists.Count == 0)
+                return;
+
+            found = true;
+
+            shell.WriteLine("");
+            shell.WriteLine(sessionData.UserName);
+            foreach (var record in watchlists)
+            {
+                shell.WriteLine("");
+                record.CreatedAt.Deconstruct(out var date, out _, out _);
+                shell.WriteLine($"Created: {date.ToString("O", CultureInfo.InvariantCulture)}");
+                if (record.ExpirationTime is { } expirationTime)
+                {
+                    expirationTime.Deconstruct(out var expirationDate, out _, out _);
+                    shell.WriteLine($"Expires: {expirationDate.ToString("O", CultureInfo.InvariantCulture)}");
+                }
+                else
+                {
+                    shell.WriteLine("Expires: PERMANENT");
+                }
+                foreach (var line in record.Message.Split('\n', StringSplitOptions.TrimEntries))
+                {
+                   shell.WriteLine($">  {line}");
+                }
+            }
+        }
+
+        if (!found)
+        {
+            shell.WriteLine("No watchlisted players online.");
+        }
+    }
+}

--- a/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
@@ -32,7 +32,7 @@ public sealed class ListWatchlistedCommand : LocalizedEntityCommands
             found = true;
 
             shell.WriteLine("");
-            shell.WriteLine(sessionData.UserName);
+            shell.WriteMarkup($"[bold]{sessionData.UserName}[/bold]");
             foreach (var record in watchlists)
             {
                 shell.WriteLine("");
@@ -49,7 +49,7 @@ public sealed class ListWatchlistedCommand : LocalizedEntityCommands
                 }
                 foreach (var line in record.Message.Split('\n', StringSplitOptions.TrimEntries))
                 {
-                   shell.WriteLine($">  {line}");
+                   shell.WriteLine($"> {line}");
                 }
             }
         }

--- a/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
@@ -23,7 +23,6 @@ public sealed class ListWatchlistedCommand : LocalizedEntityCommands
             return;
         }
 
-
         foreach (var (playerId, records) in _notes.ConnectedPlayerWatchlists)
         {
             if (!_player.TryGetSessionById(playerId, out var sessionData))

--- a/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
@@ -11,31 +11,33 @@ namespace Content.Server._DV.Administration.Commands;
 public sealed class ListWatchlistedCommand : LocalizedEntityCommands
 {
     [Dependency] private readonly IPlayerManager _player = default!;
-    [Dependency] private readonly IAdminNotesManager _notes = default!;
+    [Dependency] private readonly AdminNotesSystem _notes = default!;
 
     public override string Command => "lswatchlisted";
 
-    public override async void Execute(IConsoleShell shell, string argStr, string[] args)
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
-        var found = false;
-        foreach (var sessionData in _player.GetAllPlayerData())
+        if (_notes.ConnectedPlayerWatchlists.Count == 0)
         {
-            var watchlists = await _notes.GetActiveWatchlists(sessionData.UserId.UserId);
-            if (watchlists.Count == 0)
+            shell.WriteLine("No watchlisted players online.");
+            return;
+        }
+
+
+        foreach (var (playerId, records) in _notes.ConnectedPlayerWatchlists)
+        {
+            if (!_player.TryGetSessionById(playerId, out var sessionData))
                 return;
 
-            found = true;
-
-            shell.WriteLine("");
-            shell.WriteMarkup($"[bold]{sessionData.UserName}[/bold]");
-            foreach (var record in watchlists)
+            shell.WriteMarkup($"\n[bold]{sessionData.Name}[/bold]\n");
+            foreach (var record in records)
             {
                 shell.WriteLine("");
-                record.CreatedAt.Deconstruct(out var date, out _, out _);
+                record.CreatedAt.Deconstruct(out var date, out _);
                 shell.WriteLine($"Created: {date.ToString("O", CultureInfo.InvariantCulture)}");
-                if (record.ExpirationTime is { } expirationTime)
+                if (record.ExpiryTime is { } expirationTime)
                 {
-                    expirationTime.Deconstruct(out var expirationDate, out _, out _);
+                    expirationTime.Deconstruct(out var expirationDate, out _);
                     shell.WriteLine($"Expires: {expirationDate.ToString("O", CultureInfo.InvariantCulture)}");
                 }
                 else
@@ -48,11 +50,6 @@ public sealed class ListWatchlistedCommand : LocalizedEntityCommands
                     shell.WriteLine($"> {line}");
                 }
             }
-        }
-
-        if (!found)
-        {
-            shell.WriteLine("No watchlisted players online.");
         }
     }
 }

--- a/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
@@ -1,14 +1,9 @@
 using System.Globalization;
 using Content.Server.Administration;
 using Content.Server.Administration.Notes;
-using Content.Server.Commands;
-using Content.Server.Preferences.Managers;
 using Content.Shared.Administration;
-using Content.Shared.Mind;
-using Content.Shared.Silicons.Laws.Components;
 using Robust.Server.Player;
 using Robust.Shared.Console;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server._DV.Administration.Commands;
 
@@ -47,9 +42,10 @@ public sealed class ListWatchlistedCommand : LocalizedEntityCommands
                 {
                     shell.WriteLine("Expires: PERMANENT");
                 }
+
                 foreach (var line in record.Message.Split('\n', StringSplitOptions.TrimEntries))
                 {
-                   shell.WriteLine($"> {line}");
+                    shell.WriteLine($"> {line}");
                 }
             }
         }

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
 using Content.Server.Database;
 using Content.Server.Players.PlayTimeTracking;
+using Content.Shared.Destructible;
 using Content.Shared.GameTicking;
 
 namespace Content.Server._DV.Administration;
@@ -12,8 +13,7 @@ public sealed class EventAlertSystem : EntitySystem
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IEntityManager _entity = default!;
 
-    // Alert when overall playtime is lower than this and player latejoins.
-    // Useful for raiders that first-join and then wait in Lobby for a while to slip in.
+
     private static readonly double LateJoinAlertMaxHours = 2.0;
 
     public override void Initialize()
@@ -23,7 +23,9 @@ public sealed class EventAlertSystem : EntitySystem
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
     }
 
-    private async void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
+    // Alert when overall playtime is lower than this and player latejoins.
+    // Useful for raiders that first-join and then wait in Lobby for a while to slip in or briefly join to get a bit of playtime.
+    private void OnSpawnComplete(ref PlayerSpawnCompleteEvent ev)
     {
         var playtimeHours = _playTime.GetOverallPlaytime(ev.Player).TotalHours;
         if (playtimeHours < LateJoinAlertMaxHours && ev.LateJoin)

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -4,11 +4,9 @@ using Content.Server.Destructible;
 using Content.Server.GameTicking;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Shared.GameTicking;
-using Content.Shared.Item;
 using Content.Shared.Trigger;
 using Content.Shared.Trigger.Components;
 using Content.Shared.Weapons.Melee.Events;
-using Robust.Server.Player;
 using Robust.Shared.Player;
 
 namespace Content.Server._DV.Administration;

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -7,6 +7,8 @@ using Content.Shared.GameTicking;
 using Content.Shared.Trigger;
 using Content.Shared.Trigger.Components;
 using Content.Shared.Weapons.Melee.Events;
+using Robust.Server.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Player;
 
 namespace Content.Server._DV.Administration;
@@ -17,6 +19,7 @@ public sealed class EventAlertSystem : EntitySystem
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IEntityManager _entity = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
+    [Dependency] private readonly TransformSystem _transform = default!;
 
 
     private static readonly double LateJoinAlertMaxHours = 2.0;
@@ -56,7 +59,7 @@ public sealed class EventAlertSystem : EntitySystem
         if (_eorgAlerted.Add(ev.Origin))
         {
             AlertWithLink($"[EORG] {ToPrettyString(ev.Origin):player} destroyed {ToPrettyString(target):entity}.",
-                ev.Origin);
+                ev.Origin, _transform.GetMapCoordinates(ev.Origin));
         }
     }
 
@@ -94,7 +97,7 @@ public sealed class EventAlertSystem : EntitySystem
         }
     }
 
-    private void AlertWithLink(string message, EntityUid playerEnt)
+    private void AlertWithLink(string message, EntityUid playerEnt, MapCoordinates? coords = null)
     {
         var originName = "Actor";
         if (TryComp(playerEnt, out MetaDataComponent? meta))
@@ -107,6 +110,11 @@ public sealed class EventAlertSystem : EntitySystem
             AdminLogManager.CreateTpLinks([(netEnt, originName)], out var tpLinks))
         {
             _chat.SendAdminAlertNoFormatOrEscape(tpLinks);
+        }
+
+        if (coords is { } mapCoords && coords != MapCoordinates.Nullspace && AdminLogManager.CreateCordLinks([mapCoords], out var coordLinks))
+        {
+            _chat.SendAdminAlertNoFormatOrEscape(coordLinks);
         }
     }
 

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -59,7 +59,7 @@ public sealed class EventAlertSystem : EntitySystem
         if (_eorgAlerted.Add(ev.Origin))
         {
             AlertWithLink($"[EORG] {ToPrettyString(ev.Origin):player} destroyed {ToPrettyString(target):entity}.",
-                ev.Origin, _transform.GetMapCoordinates(ev.Origin));
+                ev.Origin);
         }
     }
 
@@ -97,22 +97,36 @@ public sealed class EventAlertSystem : EntitySystem
         }
     }
 
-    private void AlertWithLink(string message, EntityUid playerEnt, MapCoordinates? coords = null)
+    public void AlertWithLink(string message, EntityUid playerEnt, MapCoordinates? coords = null)
     {
-        var originName = "Actor";
-        if (TryComp(playerEnt, out MetaDataComponent? meta))
-        {
-            originName = meta.EntityName;
-        }
-
         _chat.SendAdminAlert(message);
-        if (_entity.GetNetEntity(playerEnt) is { } netEnt &&
-            AdminLogManager.CreateTpLinks([(netEnt, originName)], out var tpLinks))
+        SendLinks(playerEnt, coords);
+    }
+
+    public void SendLinks(EntityUid? playerEnt = null, MapCoordinates? mapCoords = null)
+    {
+        List<MapCoordinates> coords = new();
+        if (playerEnt is not null)
         {
-            _chat.SendAdminAlertNoFormatOrEscape(tpLinks);
+            var originName = "Actor";
+            if (TryComp(playerEnt, out MetaDataComponent? meta))
+            {
+                originName = meta.EntityName;
+            }
+
+            if (_entity.GetNetEntity(playerEnt) is { } netEnt &&
+                AdminLogManager.CreateTpLinks([(netEnt, originName)], out var tpLinks))
+            {
+                _chat.SendAdminAlertNoFormatOrEscape(tpLinks);
+                coords.Add(_transform.GetMapCoordinates(playerEnt.Value));
+            }
         }
 
-        if (coords is { } mapCoords && coords != MapCoordinates.Nullspace && AdminLogManager.CreateCordLinks([mapCoords], out var coordLinks))
+        if (mapCoords is not null && mapCoords.Value != MapCoordinates.Nullspace)
+        {
+            coords.Add(mapCoords.Value);
+        }
+        if (coords.Count != 0 && AdminLogManager.CreateCordLinks(coords, out var coordLinks))
         {
             _chat.SendAdminAlertNoFormatOrEscape(coordLinks);
         }

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -84,8 +84,11 @@ public sealed class EventAlertSystem : EntitySystem
     // Useful for raiders that first-join and then wait in Lobby for a while to slip in or briefly join to get a bit of playtime.
     private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
     {
+        if (!ev.LateJoin)
+            return;
+
         var playtimeHours = _playTime.GetOverallPlaytime(ev.Player).TotalHours;
-        if (playtimeHours < LateJoinAlertMaxHours && ev.LateJoin)
+        if (playtimeHours < LateJoinAlertMaxHours)
         {
             AlertWithLink($"New player {ev.Player.Name} [{playtimeHours:0.#} hours] joined the round.", ev.Mob);
         }

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -1,9 +1,15 @@
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
-using Content.Server.Database;
+using Content.Server.Destructible;
+using Content.Server.GameTicking;
 using Content.Server.Players.PlayTimeTracking;
-using Content.Shared.Destructible;
 using Content.Shared.GameTicking;
+using Content.Shared.Item;
+using Content.Shared.Trigger;
+using Content.Shared.Trigger.Components;
+using Content.Shared.Weapons.Melee.Events;
+using Robust.Server.Player;
+using Robust.Shared.Player;
 
 namespace Content.Server._DV.Administration;
 
@@ -12,31 +18,104 @@ public sealed class EventAlertSystem : EntitySystem
     [Dependency] private readonly PlayTimeTrackingManager _playTime = default!;
     [Dependency] private readonly IChatManager _chat = default!;
     [Dependency] private readonly IEntityManager _entity = default!;
+    [Dependency] private readonly GameTicker _gameTicker = default!;
 
 
     private static readonly double LateJoinAlertMaxHours = 2.0;
+    private HashSet<EntityUid> _eorgAlerted = new();
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
+        SubscribeLocalEvent<DestructibleComponent, BrokenWithOriginEvent>(OnBrokenWithOrigin);
+        SubscribeLocalEvent<TimerTriggerComponent, ActiveTimerTriggerEvent>(OnTimerTrigger);
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
+        SubscribeLocalEvent<ActorComponent, AttackedEvent>(OnPlayerAttacked);
+    }
+
+    private void OnTimerTrigger(Entity<TimerTriggerComponent> ent, ref ActiveTimerTriggerEvent args)
+    {
+        if (_gameTicker.RunLevel != GameRunLevel.PostRound || args.User is not { } user)
+            return;
+
+        if (_eorgAlerted.Add(user))
+        {
+            AlertWithLink(
+                $"[EORG] {ToPrettyString(user):player} activated timer trigger of {ToPrettyString(ent):item}.",
+                user);
+        }
+    }
+
+    // Alert if player starts destroying stuff at EOR.
+    // Only sent if it's the first instance of possible EORG for that player to avoid spam.
+    private void OnBrokenWithOrigin(Entity<DestructibleComponent> target, ref BrokenWithOriginEvent ev)
+    {
+        if (_gameTicker.RunLevel != GameRunLevel.PostRound || !HasComp<ActorComponent>(ev.Origin))
+            return;
+
+        if (_eorgAlerted.Add(ev.Origin))
+        {
+            AlertWithLink($"[EORG] {ToPrettyString(ev.Origin):player} destroyed {ToPrettyString(target):entity}.",
+                ev.Origin);
+        }
+    }
+
+    // Alert if player starts attacking others at EOR.
+    // Only sent if it's the first instance of possible EORG for that player to avoid spam.
+    private void OnPlayerAttacked(Entity<ActorComponent> targetPlayer, ref AttackedEvent ev)
+    {
+        if (_gameTicker.RunLevel != GameRunLevel.PostRound)
+            return;
+
+        if (_eorgAlerted.Add(ev.User))
+        {
+            AlertWithLink(
+                $"[EORG] {ToPrettyString(ev.User)} attacked {ToPrettyString(targetPlayer):player} using {(ev.Used == ev.User ? "Hands" : ToPrettyString(ev.Used))}.",
+                ev.User);
+        }
+    }
+
+    private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
+    {
+        _eorgAlerted.Clear();
     }
 
     // Alert when overall playtime is lower than this and player latejoins.
     // Useful for raiders that first-join and then wait in Lobby for a while to slip in or briefly join to get a bit of playtime.
-    private void OnSpawnComplete(ref PlayerSpawnCompleteEvent ev)
+    private void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
     {
         var playtimeHours = _playTime.GetOverallPlaytime(ev.Player).TotalHours;
         if (playtimeHours < LateJoinAlertMaxHours && ev.LateJoin)
         {
-            _chat.SendAdminAlert($"New player {ev.Player.Name} [{playtimeHours:0.#} hours] joined the round.");
+            AlertWithLink($"New player {ev.Player.Name} [{playtimeHours:0.#} hours] joined the round.", ev.Mob);
+        }
+    }
 
-            if (_entity.GetNetEntity(ev.Mob) is { } netEnt &&
-                AdminLogManager.CreateTpLinks([(netEnt, ev.Profile.Name)], out var tpLinks))
-            {
-                _chat.SendAdminAlertNoFormatOrEscape(tpLinks);
-            }
+    private void AlertWithLink(string message, EntityUid playerEnt)
+    {
+        var originName = "Actor";
+        if (TryComp(playerEnt, out MetaDataComponent? meta))
+        {
+            originName = meta.EntityName;
+        }
+
+        _chat.SendAdminAlert(message);
+        if (_entity.GetNetEntity(playerEnt) is { } netEnt &&
+            AdminLogManager.CreateTpLinks([(netEnt, originName)], out var tpLinks))
+        {
+            _chat.SendAdminAlertNoFormatOrEscape(tpLinks);
+        }
+    }
+
+    public sealed class BrokenWithOriginEvent : EntityEventArgs
+    {
+        public readonly EntityUid Origin;
+
+        public BrokenWithOriginEvent(EntityUid origin)
+        {
+            Origin = origin;
         }
     }
 }

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -1,0 +1,40 @@
+using Content.Server.Administration.Logs;
+using Content.Server.Chat.Managers;
+using Content.Server.Database;
+using Content.Server.Players.PlayTimeTracking;
+using Content.Shared.GameTicking;
+
+namespace Content.Server._DV.Administration;
+
+public sealed class EventAlertSystem : EntitySystem
+{
+    [Dependency] private readonly PlayTimeTrackingManager _playTime = default!;
+    [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly IEntityManager _entity = default!;
+
+    // Alert when overall playtime is lower than this and player latejoins.
+    // Useful for raiders that first-join and then wait in Lobby for a while to slip in.
+    private static readonly double LateJoinAlertMaxHours = 2.0;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnSpawnComplete);
+    }
+
+    private async void OnSpawnComplete(PlayerSpawnCompleteEvent ev)
+    {
+        var playtimeHours = _playTime.GetOverallPlaytime(ev.Player).TotalHours;
+        if (playtimeHours < LateJoinAlertMaxHours && ev.LateJoin)
+        {
+            _chat.SendAdminAlert($"New player {ev.Player.Name} [{playtimeHours:0.#} hours] joined the round.");
+
+            if (_entity.GetNetEntity(ev.Mob) is { } netEnt &&
+                AdminLogManager.CreateTpLinks([(netEnt, ev.Profile.Name)], out var tpLinks))
+            {
+                _chat.SendAdminAlertNoFormatOrEscape(tpLinks);
+            }
+        }
+    }
+}

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -3,11 +3,13 @@ using Content.Server.Chat.Managers;
 using Content.Server.Destructible;
 using Content.Server.GameTicking;
 using Content.Server.Players.PlayTimeTracking;
+using Content.Shared._DV.CCVars;
 using Content.Shared.GameTicking;
 using Content.Shared.Trigger;
 using Content.Shared.Trigger.Components;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Server.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 
@@ -17,11 +19,12 @@ public sealed class EventAlertSystem : EntitySystem
 {
     [Dependency] private readonly PlayTimeTrackingManager _playTime = default!;
     [Dependency] private readonly IChatManager _chat = default!;
+    [Dependency] private readonly IConfigurationManager _config = default!;
     [Dependency] private readonly IEntityManager _entity = default!;
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
 
-    private static readonly double LateJoinAlertMaxHours = 2.0;
+    private double _lateJoinAlertMaxHours;
     private HashSet<EntityUid> _eorgAlerted = new();
 
     public override void Initialize()
@@ -33,6 +36,13 @@ public sealed class EventAlertSystem : EntitySystem
         SubscribeLocalEvent<TimerTriggerComponent, ActiveTimerTriggerEvent>(OnTimerTrigger);
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
         SubscribeLocalEvent<ActorComponent, AttackedEvent>(OnPlayerAttacked);
+
+        _config.OnValueChanged(DCCVars.LateJoinAlertMaxHours, OnMaxHoursCvarChanged, true); // DeltaV
+    }
+
+    private void OnMaxHoursCvarChanged(double hours)
+    {
+        _lateJoinAlertMaxHours = hours;
     }
 
     private void OnTimerTrigger(Entity<TimerTriggerComponent> ent, ref ActiveTimerTriggerEvent args)
@@ -90,7 +100,7 @@ public sealed class EventAlertSystem : EntitySystem
             return;
 
         var playtimeHours = _playTime.GetOverallPlaytime(ev.Player).TotalHours;
-        if (playtimeHours < LateJoinAlertMaxHours)
+        if (playtimeHours < _lateJoinAlertMaxHours)
         {
             AlertWithLink($"New player {ev.Player.Name} [{playtimeHours:0.#} hours] joined the round.", ev.Mob);
         }

--- a/Content.Server/_DV/Administration/EventAlertSystem.cs
+++ b/Content.Server/_DV/Administration/EventAlertSystem.cs
@@ -21,7 +21,6 @@ public sealed class EventAlertSystem : EntitySystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
     [Dependency] private readonly TransformSystem _transform = default!;
 
-
     private static readonly double LateJoinAlertMaxHours = 2.0;
     private HashSet<EntityUid> _eorgAlerted = new();
 

--- a/Content.Shared/Administration/PlayerInfo.cs
+++ b/Content.Shared/Administration/PlayerInfo.cs
@@ -19,7 +19,9 @@ public sealed record PlayerInfo(
     NetUserId SessionId,
     bool Connected,
     bool ActiveThisRound,
-    TimeSpan? OverallPlaytime)
+    TimeSpan? OverallPlaytime,
+    bool Ghost // DeltaV - Add Ghost
+    )
 {
     private string? _playtimeString;
 

--- a/Content.Shared/Administration/PlayerInfo.cs
+++ b/Content.Shared/Administration/PlayerInfo.cs
@@ -20,7 +20,8 @@ public sealed record PlayerInfo(
     bool Connected,
     bool ActiveThisRound,
     TimeSpan? OverallPlaytime,
-    bool Ghost // DeltaV - Add Ghost
+    bool Ghost, // DeltaV - Add Ghost
+    bool Watchlisted // DeltaV - Add Watchlisted
     )
 {
     private string? _playtimeString;

--- a/Content.Shared/CCVar/CCVars.Admin.cs
+++ b/Content.Shared/CCVar/CCVars.Admin.cs
@@ -108,7 +108,7 @@ public sealed partial class CCVars
     ///     Minimum explosion intensity to create an admin alert message. -1 to disable the alert.
     /// </summary>
     public static readonly CVarDef<int> AdminAlertExplosionMinIntensity =
-        CVarDef.Create("admin.alert.explosion_min_intensity", 60, CVar.SERVERONLY);
+        CVarDef.Create("admin.alert.explosion_min_intensity", -1, CVar.SERVERONLY); // DeltaV - disable, previously set to 60
 
     /// <summary>
     ///     Minimum particle accelerator strength to create an admin alert message.

--- a/Content.Shared/CCVar/CCVars.Interface.cs
+++ b/Content.Shared/CCVar/CCVars.Interface.cs
@@ -93,6 +93,16 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> AdminPlayerTabRoleSetting =
         CVarDef.Create("ui.admin_player_tab_role", "Subtype", CVar.CLIENTONLY | CVar.ARCHIVE);
 
+    // DeltaV - Add MarkGhosted START
+
+    /// <summary>
+    /// Whether to prepend "(G)" to player usernames in the players tab
+    /// </summary>
+    public static readonly CVarDef<bool> AdminPlayerTabMarkGhosted =
+        CVarDef.Create("ui.admin_player_tab_mark_ghosted", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    // DeltaV - Add MarkGhosted END
+
     /// <summary>
     /// Determines how antagonist status/roletype is displayed. Based on AdminOverlayAntagSymbolStyles enum
     /// Off: No symbol is shown.

--- a/Content.Shared/CCVar/CCVars.Interface.cs
+++ b/Content.Shared/CCVar/CCVars.Interface.cs
@@ -93,15 +93,20 @@ public sealed partial class CCVars
     public static readonly CVarDef<string> AdminPlayerTabRoleSetting =
         CVarDef.Create("ui.admin_player_tab_role", "Subtype", CVar.CLIENTONLY | CVar.ARCHIVE);
 
-    // DeltaV - Add MarkGhosted START
+    // DeltaV - Additions START
 
     /// <summary>
-    /// Whether to prepend "(G)" to player usernames in the players tab
+    /// Whether to prepend "(G)" to player character names in the players tab
     /// </summary>
     public static readonly CVarDef<bool> AdminPlayerTabMarkGhosted =
         CVarDef.Create("ui.admin_player_tab_mark_ghosted", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 
-    // DeltaV - Add MarkGhosted END
+    /// <summary>
+    /// Whether to prepend "(WL)" to player character names in the players tab
+    /// </summary>
+    public static readonly CVarDef<bool> AdminPlayerTabMarkWatchlisted =
+        CVarDef.Create("ui.admin_player_tab_mark_watchlisted", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+    // DeltaV - Additions END
 
     /// <summary>
     /// Determines how antagonist status/roletype is displayed. Based on AdminOverlayAntagSymbolStyles enum

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -21,6 +21,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
+using Content.Shared.Mindshield.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Popups;
@@ -665,8 +666,11 @@ namespace Content.Shared.Cuffs
             if (!_doAfter.TryStartDoAfter(doAfterEventArgs))
                 return;
 
-            // DeltaV - Only alert if new user tries to uncuff someone else, stop spam during escape attempts. LogImpact previously always High.
-            _adminLog.Add(LogType.Action, isOwner ? LogImpact.Medium : LogImpact.High, $"{ToPrettyString(user):player} is trying to uncuff {ToPrettyString(target):subject}");
+            // DeltaV - Conditional Impact START
+            var isMindShielded = HasComp<MindShieldComponent>(user);
+            // Only alert if new user tries to uncuff someone else and if they aren't mindshielded, stops spam during escape attempts or for cadets. LogImpact previously always High.
+            _adminLog.Add(LogType.Action, isOwner || isMindShielded ? LogImpact.Medium : LogImpact.High, $"{ToPrettyString(user):player} is trying to uncuff {ToPrettyString(target):subject}");
+            // DeltaV - Conditional impact END
 
             var popupText = user == target.Owner
                 ? "cuffable-component-start-uncuffing-self-observer"
@@ -766,7 +770,7 @@ namespace Content.Shared.Cuffs
                 {
                     _popup.PopupEntity(Loc.GetString("cuffable-component-remove-cuffs-by-other-success-message",
                         ("otherName", Identity.Name(user.Value, EntityManager, user))), target, target);
-                    _adminLog.Add(LogType.Action, LogImpact.High,
+                    _adminLog.Add(LogType.Action, HasComp<MindShieldComponent>(user) ? LogImpact.Medium : LogImpact.High, // DeltaV - make impact conditional, previously always high
                         $"{ToPrettyString(user):player} has successfully uncuffed {ToPrettyString(target):player}");
                 }
                 else

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -21,7 +21,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Item;
-using Content.Shared.Mindshield.Components;
+using Content.Shared.Mindshield.Components; // DeltaV - Admin QOL
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Pulling.Events;
 using Content.Shared.Popups;

--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -665,7 +665,8 @@ namespace Content.Shared.Cuffs
             if (!_doAfter.TryStartDoAfter(doAfterEventArgs))
                 return;
 
-            _adminLog.Add(LogType.Action, LogImpact.High, $"{ToPrettyString(user):player} is trying to uncuff {ToPrettyString(target):subject}");
+            // DeltaV - Only alert if new user tries to uncuff someone else, stop spam during escape attempts. LogImpact previously always High.
+            _adminLog.Add(LogType.Action, isOwner ? LogImpact.Medium : LogImpact.High, $"{ToPrettyString(user):player} is trying to uncuff {ToPrettyString(target):subject}");
 
             var popupText = user == target.Owner
                 ? "cuffable-component-start-uncuffing-self-observer"

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -15,13 +15,13 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Item;
 using Content.Shared.Kitchen.Components;
-using Content.Shared.Mind.Components;
+using Content.Shared.Mind.Components; // DeltaV - Admin QOL
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Events;
 using Content.Shared.Nutrition.Components;
 using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
-using Content.Shared.SSDIndicator;
+using Content.Shared.SSDIndicator; // DeltaV - Admin QOL
 using Content.Shared.Throwing;
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -377,9 +377,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         }
         // DeltaV - LogImpact Additions END
 
-        // DeltaV - replace default LogImpact, insert SSD indicator
-        _adminLogger.Add(LogType.Stripping, logImpact, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {(isSsd ? "[SSD] " : "")}{ToPrettyString(target):target}'s {slot} slot");
-
+        _adminLogger.Add(LogType.Stripping, logImpact, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {(isSsd ? "[SSD] " : "")}{ToPrettyString(target):target}'s {slot} slot"); // DeltaV - replace default LogImpact, insert SSD indicator
     }
 
     /// <summary>

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -14,9 +14,8 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
-using Content.Shared.Players;
 using Content.Shared.Popups;
-using Content.Shared.SSDIndicator;
+using Content.Shared.SSDIndicator; // DeltaV - Admin QOL
 using Content.Shared.Strip.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Utility;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -594,8 +594,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         _handsSystem.TryDrop(target, item, checkActionBlocker: false);
         _handsSystem.PickupOrDrop(user, item, animateUser: stealth, animate: !stealth, handsComp: user.Comp);
 
-        // DeltaV - Lower LogImpact to Medium, if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice.
-        _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands");
+        _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Lower LogImpact to Medium, if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice.
 
         // Hand update will trigger strippable update.
     }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -593,7 +593,6 @@ public abstract class SharedStrippableSystem : EntitySystem
         _handsSystem.PickupOrDrop(user, item, animateUser: stealth, animate: !stealth, handsComp: user.Comp);
 
         _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Lower LogImpact to Medium, if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice.
-
         // Hand update will trigger strippable update.
     }
 

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -197,6 +197,12 @@ public sealed partial class DCCVars
         CVarDef.Create("admin.discord_reply_color", string.Empty, CVar.SERVERONLY);
 
     /// <summary>
+    ///     The maximum amount of hours that will trigger an admin alert on late join.
+    /// </summary>
+    public static readonly CVarDef<double> LateJoinAlertMaxHours =
+        CVarDef.Create("admin.alerts.latejoin_max_hours", 2.0, CVar.SERVERONLY);
+
+    /// <summary>
     ///    Whether or not to disable the preset selecting test rule from running. Should be disabled in production. DeltaV specific, attached to Impstation Secret concurrent feature.
     /// </summary>
     public static readonly CVarDef<bool> EnableBacktoBack =

--- a/Resources/Locale/en-US/_DV/administration/admin-qol.ftl
+++ b/Resources/Locale/en-US/_DV/administration/admin-qol.ftl
@@ -1,3 +1,4 @@
+# Commands
 cmd-lslaws-desc = Lists laws of all lawbound entities or a specific player if specified
 cmd-lslaws-help = lslaws [username]
 cmd-lslaws-error-bad-player = Unable to find lawbound entity attached to that user.
@@ -8,3 +9,10 @@ cmd-lswatchlisted-help = lswatchlisted
 cmd-getping-desc = Prints the specified player's current ping
 cmd-getping-help = getping <username>
 cmd-getping-err = Unable to find specified player
+
+# UI
+ui-options-admin-player-tab-mark-ghosted = Mark ghosted players
+ui-options-admin-player-tab-mark-ghosted-tooltip = Ghosts will have a "(G)" added to their character names (e.g. "(G) Glip-Glub")
+
+ui-options-admin-player-tab-mark-watchlisted = Mark watchlisted players
+ui-options-admin-player-tab-mark-watchlisted-tooltip = Watchlisted players will have a "(WL)" added to their character names (e.g. "(WL) Confusion Bot 2007")

--- a/Resources/Locale/en-US/_DV/administration/commands/admin-qol.ftl
+++ b/Resources/Locale/en-US/_DV/administration/commands/admin-qol.ftl
@@ -1,0 +1,3 @@
+cmd-lslaws-desc = Lists laws of all lawbound entities or a specific player if specified
+cmd-lslaws-help = lslaws [username]
+cmd-lslaws-error-bad-player = Unable to find lawbound entity attached to that user.

--- a/Resources/Locale/en-US/_DV/administration/commands/admin-qol.ftl
+++ b/Resources/Locale/en-US/_DV/administration/commands/admin-qol.ftl
@@ -1,3 +1,6 @@
 cmd-lslaws-desc = Lists laws of all lawbound entities or a specific player if specified
 cmd-lslaws-help = lslaws [username]
 cmd-lslaws-error-bad-player = Unable to find lawbound entity attached to that user.
+
+cmd-lswatchlisted-desc = Prints an overview of all connected players with watchlists
+cmd-lswatchlisted-help = lswatchlisted

--- a/Resources/Locale/en-US/_DV/administration/commands/admin-qol.ftl
+++ b/Resources/Locale/en-US/_DV/administration/commands/admin-qol.ftl
@@ -4,3 +4,7 @@ cmd-lslaws-error-bad-player = Unable to find lawbound entity attached to that us
 
 cmd-lswatchlisted-desc = Prints an overview of all connected players with watchlists
 cmd-lswatchlisted-help = lswatchlisted
+
+cmd-getping-desc = Prints the specified player's current ping
+cmd-getping-help = getping <username>
+cmd-getping-err = Unable to find specified player

--- a/Resources/Locale/en-US/_DV/administration/ui/admin-overlay.ftl
+++ b/Resources/Locale/en-US/_DV/administration/ui/admin-overlay.ftl
@@ -1,0 +1,1 @@
+admin-overlay-watchlisted-username-suffix = [WL]

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -393,6 +393,11 @@ ui-options-admin-player-tab-color-setting-character = Colorize antag character n
 ui-options-admin-player-tab-color-setting-roletype = Colorize all role types
 ui-options-admin-player-tab-color-setting-both = Colorize both
 
+# DeltaV - Additions START
+ui-options-admin-player-tab-mark-ghosted = Mark ghosted players
+ui-options-admin-player-tab-mark-ghosted-tooltip = Ghosts will have a "(G)" added to their character names (e.g. "(G) Glip-Glub")
+# DeltaV - Additions END
+
 ui-options-admin-logs-title = Admin Logs
 ui-options-admin-logs-highlight-color = Highlight Color
 

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -396,6 +396,8 @@ ui-options-admin-player-tab-color-setting-both = Colorize both
 # DeltaV - Additions START
 ui-options-admin-player-tab-mark-ghosted = Mark ghosted players
 ui-options-admin-player-tab-mark-ghosted-tooltip = Ghosts will have a "(G)" added to their character names (e.g. "(G) Glip-Glub")
+ui-options-admin-player-tab-mark-watchlisted = Mark watchlisted players
+ui-options-admin-player-tab-mark-watchlisted-tooltip = Watchlisted players will have a "(WL)" added to their character names (e.g. "(WL) Confusion Bot 2007")
 # DeltaV - Additions END
 
 ui-options-admin-logs-title = Admin Logs

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -393,13 +393,6 @@ ui-options-admin-player-tab-color-setting-character = Colorize antag character n
 ui-options-admin-player-tab-color-setting-roletype = Colorize all role types
 ui-options-admin-player-tab-color-setting-both = Colorize both
 
-# DeltaV - Additions START
-ui-options-admin-player-tab-mark-ghosted = Mark ghosted players
-ui-options-admin-player-tab-mark-ghosted-tooltip = Ghosts will have a "(G)" added to their character names (e.g. "(G) Glip-Glub")
-ui-options-admin-player-tab-mark-watchlisted = Mark watchlisted players
-ui-options-admin-player-tab-mark-watchlisted-tooltip = Watchlisted players will have a "(WL)" added to their character names (e.g. "(WL) Confusion Bot 2007")
-# DeltaV - Additions END
-
 ui-options-admin-logs-title = Admin Logs
 ui-options-admin-logs-highlight-color = Highlight Color
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- Added Commands: lslaws, lswatchlisted, getping
- Changed lsobjectives to list all players with objectives when invoked without specifying username
- Ghosted players are now optionally marked in the F7 players tab
  - Configurable via regular Options UI
  - The "(G)" prepended to character name labels can be filtered for to see all ghosted players
- Watchlisted players now marked in admin overlay and optionally marked in the F7 players tab
  - players tab label can be turned off in options ui 
-  Tweaked Admin Alerts
   - Meatspiking now only alerts admins if an actual player character gets meatspiked. Monkeys and Kobolds won't spam alerts anymore unless a player is controlling them.
   - On-station explosions now always send alerts. Off-station explosions will not trigger alerts, so salvs won't spam admin chat with seismic charges.
   - Item stripping alerts are now Medium by default (no alert)
     - High if Back, Belt or ID slot (only alerts when new players do it)
     - Extreme if Jumpsuit (always alerts)
     - Extreme if the target is SSD (always alerts, also indicates target is SSD in message)
   - uncuff attempts no longer alert if trying to self-uncuff
   - mindshielded people uncuffing someone else no longer triggers alert
- Added Admin Alerts
  - Players with less than 2 hours of playtime latejoining will now send an admin alert.
  - EORG Alerts (only one of any of these alerts will be sent about each player to avoid spam)
    - Attacking other players at EOR
    - Destroying stuff at EOR
    - Triggering timers on items like grenades at EOR
- Added teleport links to prayer messages

## Why / Balance
- These features were either missing or only accessible via Verb UI
- The default behavior of lsobjectives was to list the calling player's objectives. You won't be able to use the command while playing as an antag anyway; I don't see how that's useful outside of debugging the objectives system, but even then you can just specify your own username.

## Technical details
- lslaws: EntityManager is used to query for entities with SiliconLawProvider
- lswatchlisted: caching whitelists in AdminNotesSystem to avoid calling db for every user for every invocation
- lsobjectives: SharedMindSystem used to check all humanoid minds for objectives 
- ghost marking: changed PlayerInfo record to include Ghost bool, set in AdminSystem by checking AttachedEntity for GhostComponent
- watchlist marking: same as ghost marking, making use of lswatchlisted cache, additionally patched AdminNameOverlay to display an indicator
- meatspiking alert: check for SsdIndicator instead of HumanoidAppearance, also indicate if a mind is attached 
- explosion alert: checks whether the grid of the exploding entity or responsible player is part of a station
- stripping alert: check hardcoded lists for specific slots, check SsdIndicator for ssd status
- latejoin alert: New system listening to join event. Made tp link utility functions in AdminAlertManager public static.
- eorg alerts: added EventAlertSystem to alert on specific events when PostRound, added event for entity being broken with known origin
- prayer links: use method added with EventAlertSystem to send links

## Media
<img width="186" height="236" alt="image" src="https://github.com/user-attachments/assets/e04df3ae-6107-459d-92ba-b8655cf07034" />

<img width="1017" height="420" alt="image" src="https://github.com/user-attachments/assets/1eff7828-2f1f-4d9a-a953-c01efd390f7b" />

<img width="296" height="68" alt="image" src="https://github.com/user-attachments/assets/4277877f-55e7-4453-ad9d-1b8ce7d2f2e9" />

<img width="512" height="107" alt="image" src="https://github.com/user-attachments/assets/845eeae3-dc2b-4c3f-8fc0-f278163b899d" />

<img width="487" height="179" alt="image" src="https://github.com/user-attachments/assets/a3a5f1e2-0b63-4dff-8dea-3f720a74ad85" />

<img width="385" height="154" alt="image" src="https://github.com/user-attachments/assets/0ae4254b-209b-46a0-b34c-ca096ae537d5" />

<img width="393" height="113" alt="image" src="https://github.com/user-attachments/assets/a418852c-3292-43bd-86f5-ac252407324b" />

<img width="392" height="64" alt="image" src="https://github.com/user-attachments/assets/e08070d3-2f6c-4ccb-9368-97fd74da16ea" />

<img width="388" height="45" alt="image" src="https://github.com/user-attachments/assets/15d847a6-9a69-40f8-bec7-2cb344fe078a" />

<img width="379" height="64" alt="image" src="https://github.com/user-attachments/assets/9f48a457-b47a-4220-86db-f360502b2721" />

<img width="362" height="88" alt="image" src="https://github.com/user-attachments/assets/74d1a0ec-d1fa-4d99-a2c6-5f904a3eb199" />

<img width="377" height="73" alt="image" src="https://github.com/user-attachments/assets/f17ea9f5-1be6-436a-a176-09599b5dbafd" />

<img width="266" height="42" alt="image" src="https://github.com/user-attachments/assets/be47c634-4b17-4462-99c7-dbbfac62b719" />

<img width="249" height="199" alt="image" src="https://github.com/user-attachments/assets/f3256717-fa65-4253-abcc-05dc92c2240f" />

<img width="1053" height="28" alt="image" src="https://github.com/user-attachments/assets/8ec015e4-05d5-4b36-ad25-1db3a9d684ed" />

<img width="381" height="52" alt="image" src="https://github.com/user-attachments/assets/d65b7fe9-1e56-4c30-a0b6-aa14f88f2956" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: DisposableCrewmember42
DeltaVAdmin:
- add: lslaws command
- add: lswatchlisted command
- add: getping command
- tweak: lsobjectives now lists objectives of every antag if no username is specified
- add: ghosted players are now optionally marked with "(G)" in the F7 Players tab (on by default, configurable via settings menu). While enabled, you can search for the "(G)" tag to see all ghosted players.
- tweak: Off-station explosions no longer send alerts. On-station explosions now always send alerts.
- tweak: Only meatspiking actual player characters or mobs being actively controlled by players will send alerts.
- tweak: New players stripping items will only send alerts for slots holding key items (back, id, belt)
- tweak: Stripping jumpsuits from others always sends alerts
- tweak: Stripping from SSD people always sends alerts and the target's SSD status is indicated in the message
- add: New players (< 2 hours) latejoining will now send an admin alert.
- add: EORG alerts sent only once for each player (attacking players, destroying, activating grenades in PostRound)
- add: watchlisted players are now marked with the [WL] suffix in the admin overlay and (WL) in the Players tab (on by default, configurable via settings menu)
- add: Prayer messages now come with clickable links