### PR TITLE
Re-add upstreams warden and HOS winter coats

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -86,11 +86,12 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.7
-        Heat: 0.7
-        Caustic: 0.9
+#Begin DeltaV additions
+        Blunt: 0.70 # Was 0.65
+        Slash: 0.70 # Was 0.65
+        Piercing: 0.70 # Was 0.7
+        Heat: 0.80 # Was 0.7
+#End DeltaV additions
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -86,12 +86,12 @@
   - type: Armor
     modifiers:
       coefficients:
-#Begin DeltaV additions
+#Begin DeltaV modifications
         Blunt: 0.70 # Was 0.65
         Slash: 0.70 # Was 0.65
         Piercing: 0.70 # Was 0.7
         Heat: 0.80 # Was 0.7
-#End DeltaV additions
+#End DeltaV modifications
   - type: ExplosionResistance
     damageCoefficient: 0.9
 

--- a/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/head_of_security.yml
@@ -75,5 +75,13 @@
 
 - type: loadout
   id: HeadofSecurityWinterCoat
+  #Begin DeltaV additions
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobHeadOfSecurity
+      time: 72000 # 20hr
+  #End DeltaV additions
   equipment:
     outerClothing: ClothingOuterWinterHoS

--- a/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/warden.yml
@@ -28,5 +28,12 @@
 
 - type: loadout
   id: WardenArmoredWinterCoat
+  #Begin DeltaV Additions
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobWarden
+      time: 72000 # 20hr
   equipment:
     outerClothing: ClothingOuterWinterWarden

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -470,6 +470,7 @@
   - WardenLongcoat
   - StasecWinterCoatWarden
   - ArmorVestSlim
+  - WardenArmoredWinterCoat
 
 ## Head of Security
 - type: loadoutGroup
@@ -482,6 +483,7 @@
   - StasecWinterCoatHoS
   - HeadOfSecurityTrenchcoat
   - ArmorVestSlim
+  - HeadofSecurityWinterCoat
 
 ## Detective
 - type: loadoutGroup


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
What the title does. Also changes the stats of warden coat. Also also, locks them behind 20 hours because it's funny.

## Why / Balance
Honestly, some of the styles look cooler (also you can find HOS coat in Glacier, the Warden coat in Tortuga)

Locked those two coats behind 20 hour requirement, because I wanted to make a funny thing about "veterancy". You've worked here for so long, that you've earned the upstreams coats.

Also changed warden's armored coat stats to similiar to this [PR](https://github.com/DeltaV-Station/Delta-v/pull/5448) (the winter coats)

Something something subtle red sec or something.

## Technical details
Touched upstream things. Hopefully I've commented everything correctly.

## Media
<img width="314" height="226" alt="image" src="https://github.com/user-attachments/assets/4672c820-a5f2-45fa-b9d9-2dcf06239678" />
<img width="1029" height="461" alt="image" src="https://github.com/user-attachments/assets/01baddb1-a1af-4d3a-a96e-621355df0cfa" />
<img width="1000" height="492" alt="image" src="https://github.com/user-attachments/assets/3aef20d8-5015-4426-bef9-37407eccf707" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: NanoTrasen has permitted Warden and HOS veterans to dawn Wizden's sector winter coats.