### PR TITLE
Fix IPCs losing access to radio implants when locked/unlocked

### DIFF
--- a/Content.Server/_EE/Radio/IntrinsicRadioKeySystem.cs
+++ b/Content.Server/_EE/Radio/IntrinsicRadioKeySystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._DV.CosmicCult.Components;
+using Content.Shared.Implants.Components; // DeltaV
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
 using Robust.Shared.Prototypes;
@@ -25,9 +26,26 @@ public sealed class IntrinsicRadioKeySystem : EntitySystem
         UpdateChannels(uid, args.Component, ref component.Channels);
     }
 
-    private void UpdateChannels(EntityUid _, EncryptionKeyHolderComponent keyHolderComp, ref HashSet<ProtoId<RadioChannelPrototype>> channels)
+    private void UpdateChannels(EntityUid uid, EncryptionKeyHolderComponent keyHolderComp, ref HashSet<ProtoId<RadioChannelPrototype>> channels) // DeltaV - passthrough uid
     {
         channels.Clear();
         channels.UnionWith(keyHolderComp.Channels);
+
+        // Begin DeltaV Additions - Ensure radio implants continue to function
+        if (TryComp<ImplantedComponent>(uid, out var implantedComp))
+        {
+            foreach (var implant in implantedComp.ImplantContainer.ContainedEntities)
+            {
+                if (!TryComp<RadioImplantComponent>(implant, out var radio))
+                    continue;
+
+                /*
+                    Active added channels should already contain everything this implant
+                    has added, so we can simply just add them back.
+                */
+                channels.UnionWith(radio.ActiveAddedChannels);
+            }
+        }
+        // End DeltaV Additions
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Made it so that the channels updated when an IPC is locked/unlocked include channels active from a Radio implant.

## Why / Balance
Any IPC with a syndie, centcomm, or conspirator implant would lose access to that radio channel if they ever unlocked or locked their chassis.

## Technical details
Looked like just a missing bit here, simply fix I think

## Media
<img width="542" height="224" alt="image" src="https://github.com/user-attachments/assets/cace54f4-f6e5-441d-967a-7d5d04870947" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Fixed an issue where IPCs would lose access to any radio channels given by implants.
