### PR TITLE
jugsuit stamres and buy limit

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1803,10 +1803,13 @@
   - !type:StoreWhitelistCondition
     whitelist:
       tags:
-      - CommanderUplink #DeltaV - only commander and lone op can buy
-      - LoneOpUplink
-  - !type:ListingLimitedStockCondition #DeltaV - only one jug suit per team
+      # - NukeOpsUplink # DeltaV - Commented out as of #5462 (only commander and loneop can get suit)
+  # Begin DeltaV additions - Jugsuit buy limit #5462
+      - CommanderUplink 
+      - LoneOpUplink 
+  - !type:ListingLimitedStockCondition
     stock: 1
+  # End DeltaV additions
 
 - type: listing
   id: UplinkClothingEyesHudSyndicate

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1803,7 +1803,10 @@
   - !type:StoreWhitelistCondition
     whitelist:
       tags:
-      - NukeOpsUplink
+      - CommanderUplink #DeltaV - only commander and lone op can buy
+      - LoneOpUplink
+  - !type:ListingLimitedStockCondition #DeltaV - only one jug suit per team
+    stock: 1
 
 - type: listing
   id: UplinkClothingEyesHudSyndicate

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -958,7 +958,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.3
   - type: StaminaResistance # DeltaV
-    damageCoefficient: 0.1
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/syndicate.yml
@@ -40,7 +40,7 @@
     - type: Store
       balance:
         Telecrystal: 75 # not 65 but this is for nukies.
-    - type: Tag 
+    - type: Tag
       tags:
       - NukeOpsUplink
       - LoneOpUplink #DeltavV - lone op tag

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/syndicate.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/syndicate.yml
@@ -40,3 +40,7 @@
     - type: Store
       balance:
         Telecrystal: 75 # not 65 but this is for nukies.
+    - type: Tag 
+      tags:
+      - NukeOpsUplink
+      - LoneOpUplink #DeltavV - lone op tag

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -205,6 +205,9 @@
   id: AgentUplink # Used for allowing agent to buy their suit
 
 - type: Tag
+  id: LoneOpUplink # Used to allow loneop to buy jugsuit
+
+- type: Tag
   id: CleaningGrenade
 
 - type: Tag


### PR DESCRIPTION

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
-Only commander and lone op can buy jug suit
-reduced ranged stam res from 80% to 50%
-added loneop uplink tag so they could buy jugsuit

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Warops 3 jugsuit meta is atrocious, also I've seen agents with jug suit completely solo carry and it's relatively impossible for sec to counter this.
Other proposed change would be to not allow injections into jug suit which I think would be easily bypassed (we have instant suit removal), and I would rather add counterplay than make a whole injection system for one suit
Jug suits being weak to stamina is not as great of a downside as it might seem as they should be pushing with their team. Ideally they are in the front, and downing them with stamina would require the team to move up or pull them back while they recover.
Anyone can bring hyperzine, and the agents have ephedrine. Hyperzine almost completely nullifies the stamina weakness, they will still get up too fast to cuff. Generally sec is not using rubbers very much and they will have to choose their targets and prepare ammo accordingly. Disabler modes which are more accessible (do not need printed in advance) are much less effective and can be reflected with eswords and shields.
I did not touch stamina melee because (in my opinion) nukies should have melee advantage, and 6 baton swings seems possible already with jug suit having reduced movement speed.

## Technical details
<!-- Summary of code changes for easier review. -->
-Ranged stamina coefficient decreased to .5 from .1 in hardsuits.yml
-Add tags to restrict to one time purchase, and only from commander and loneop uplink
-added tag identifying loneop uplink in tags

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Testing time to stam crit with rubber, beanbag, disabler, taser, baton, oni truncheons, tranq, and again with hyperzine
[video](https://youtu.be/kA5Rowbw5nw)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Jug suits now have reduced stamina resistance, and can only bought by commanders and lone ops once.

