### PR TITLE
Fix Smile Recipe/Add Research Log

### DIFF
--- a/Resources/Migrations/deltaMigrations.yml
+++ b/Resources/Migrations/deltaMigrations.yml
@@ -229,3 +229,6 @@ BenchSofaCorpRight: BenchSofaCorpLeftDV
 
 # 2026-02-21
 HoloprojectorEngineering: HolotapeProjector
+
+# 2026-03-07
+SentientSmileCore: SpawnMobSmileCore

--- a/Resources/Migrations/deltaMigrations.yml
+++ b/Resources/Migrations/deltaMigrations.yml
@@ -128,8 +128,8 @@ AlwaysPoweredSmallLightMaintenanceRed: PoweredDimSmallLight
 # 2024-12-22
 VendingMachineRestockSalvageEquipment: null
 
-# 2025-01-11
-SpawnMobSmile: SentientSmileCore
+# 2025-01-11 Additional edit: 2026-03-07
+SpawnMobSmile: SpawnMobSmileCore
 
 #2025-01-12
 ForensicMantisPDA: PsionicMantisPDA

--- a/Resources/Prototypes/_DV/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/Animal/slimes.yml
@@ -10,6 +10,11 @@
     grindableSolutionName: organ
   - type: SolutionContainerManager
     solutions:
+      food:
+        maxVol: 5
+        reagents:
+        - ReagentId: GreyMatter
+          Quantity: 5
       organ:
         maxVol: 10
         reagents:

--- a/Resources/Prototypes/_DV/Body/Organs/Animal/slimes.yml
+++ b/Resources/Prototypes/_DV/Body/Organs/Animal/slimes.yml
@@ -10,13 +10,10 @@
     grindableSolutionName: organ
   - type: SolutionContainerManager
     solutions:
-      food:
-        maxVol: 5
-        reagents:
-        - ReagentId: GreyMatter
-          Quantity: 5
       organ:
-        maxVol: 5
+        maxVol: 10
         reagents:
         - ReagentId: Slime
+          Quantity: 5
+        - ReagentId: SentientGreyMatter
           Quantity: 5

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/pets.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/pets.yml
@@ -1,0 +1,16 @@
+- type: entity
+  parent: MarkerBase
+  id: SpawnMobSmileCore
+  name: Smile Core Spawner
+  suffix: Science Pet, Delta V
+  components:
+  - type: Sprite
+    layers:
+    - state: green
+    - state: brain-smile
+      sprite: _DV/Mobs/Pets/Smile/organs.rsi
+  - type: EntityTableSpawner
+    table: !type:AllSelector
+      children:
+      - id: SentientSmileCore
+      - id: PaperResearchSmileRecipe

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -618,7 +618,7 @@
       - 10u weh juice
       - 4u happiness
       - 1u slime core
-      [bold]Method used in this trial:[/bold] Mixing liquids at room temperature. Injecting mixture into core.
+      [bold]Method used in this trial:[/bold] Mixing liquids at room temperature. Injecting mixture into slime core.
       [bold]Results:[/bold] Negative
       [bold]Notes:[/bold] I feel like I am close. All previous tests have indicated the components are correct. However, it seems we have been missing a step.
       [bold]Synopsis:[/bold] Further testing and analysis needed.

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -595,3 +595,30 @@
     - HighRiskItem
   - type: StealTarget
     stealGroup: BoxFolderCeClipboard
+
+#Smile Recipe
+- type: entity
+  parent: Paper
+  id: PaperResearchSmileRecipe
+  name: epistemics test log
+  components:
+  - type: Paper
+    content: |2
+      [color=Purple]▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄[/color]
+      [color=Purple]
+      ░▀▄▄▀░ [head=2]Test Log Number: 979[/head]
+      ░█░░█░ [color=Black][bold]Research Lead:[/bold] Lydia Moon[/color]
+      ░▄▀▀▄░ [color=Black][bold]Subject:[/bold] Sentient Slime[/color]
+      ───────────────────────────────────────── [/color]
+      [bold]Hypothesis:[/bold] Near sentience has been observed multiple times in various slime organisms.
+      It is feasible to believe we can replicate a cognitive formula to produce a fully sentient slime organism.
+      [bold]Test Method:[/bold] Reagent Emulsification
+      [bold]Componenets used in this trial:[/bold]
+      - 20u slime
+      - 10u weh juice
+      - 4u happiness
+      - 1u slime core
+      [bold]Method used in this trial:[/bold] Mixing liquids at room temperature. Injecting mixture into core.
+      [bold]Results:[/bold] Negative
+      [bold]Notes:[/bold] I feel like I am close. All previous tests have indicated the components are correct. However, it seems we have been missing a step.
+      [bold]Synopsis:[/bold] Further testing and analysis needed.

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -613,7 +613,7 @@
       [bold]Hypothesis:[/bold] Near sentience has been observed multiple times in various slime organisms.
       It is feasible to believe we can replicate a cognitive formula to produce a fully sentient slime organism.
       [bold]Test Method:[/bold] Reagent Emulsification
-      [bold]Componenets used in this trial:[/bold]
+      [bold]Components used in this trial:[/bold]
       - 20u slime
       - 10u weh juice
       - 4u happiness


### PR DESCRIPTION
## About the PR
- Adds a proper spawner for the Smile core
- Adds research notes with clues to the recipe
- Reverts change that made Smile uncraftable 
- fixes #5480 

## Why / Balance
- Was broken
- Attempt to make the recipe more accessible/known to players

## Technical details
n/a

## Media
<img width="628" height="761" alt="image" src="https://github.com/user-attachments/assets/d87d3215-281f-4f97-a82f-d06bff3c3c41" />
<img width="949" height="327" alt="image" src="https://github.com/user-attachments/assets/bcce78ff-0725-4090-8ece-bd733d417cfa" />


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl: Velcroboy
- fix: Fixed Smile the slime being uncraftable.
