### PR TITLE
feat: people who turn off panicbunker can turn it back on

### DIFF
--- a/Content.Server/Administration/Commands/PanicBunkerCommand.cs
+++ b/Content.Server/Administration/Commands/PanicBunkerCommand.cs
@@ -5,8 +5,7 @@ using Robust.Shared.Console;
 
 namespace Content.Server.Administration.Commands;
 
-// DeltaV - Change required flag from Server to Ban. If you are able to ban, the panic bunker turns off on join. You should be able to turn it back on.
-[AdminCommand(AdminFlags.Ban)]
+[AdminCommand(AdminFlags.Ban)] // DeltaV - Change required flag from Server to Ban. If you are able to ban, the panic bunker turns off on join. You should be able to turn it back on.
 public sealed class PanicBunkerCommand : LocalizedCommands
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;

--- a/Content.Server/Administration/Commands/PanicBunkerCommand.cs
+++ b/Content.Server/Administration/Commands/PanicBunkerCommand.cs
@@ -5,7 +5,8 @@ using Robust.Shared.Console;
 
 namespace Content.Server.Administration.Commands;
 
-[AdminCommand(AdminFlags.Server)]
+// DeltaV - Change required flag from Server to Ban. If you are able to ban, the panic bunker turns off on join. You should be able to turn it back on.
+[AdminCommand(AdminFlags.Ban)]
 public sealed class PanicBunkerCommand : LocalizedCommands
 {
     [Dependency] private readonly IConfigurationManager _cfg = default!;


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Curators have the ban permission, so the panic bunker turns off when they join. Since they don't have the Server flag, they can't turn it back on if they are occupied and can't watch for raiders though. Same goes for trialmins.

## Why / Balance
They should be able to do so.

## Technical details
Changed required flag.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: DisposableCrewmember42
DeltaVAdmin:
- tweak: Curators and trialmins can now turn the panic bunker back on after joining using the panicbunker command.
