### PR TITLE
Buff Assualt Borg.

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -334,3 +334,13 @@
   id: ManifestedSpirit
   coefficients:
     Holy: 2
+
+# Slash and Blunt weaker rewarding smart play and ambushes, Pierce and heat for the guns and lasers that station has, Plus your a goddamn assault borg you SHOULD be reinforced against this. For Delta-V
+- type: damageModifierSet
+  id: SyndicateAssaultBorg
+  coefficients:
+    Blunt: 0.75
+    Slash: 0.75
+    Piercing: 0.65
+    Heat: 0.65
+    Cold: 0.65

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -110,6 +110,7 @@
   #  doAfterDelay: 10
   #  allowSelfRepair: false
   - type: WeldingHealable
+    doAfterDelay: 10 
     allowSelfHeal: true # DeltaV - was false
   # End DeltaV Changes
   - type: BorgChassis

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -112,6 +112,10 @@
       interactFailureString: petting-failure-syndicate-cyborg
       interactSuccessSound:
         path: /Audio/Ambience/Objects/periodic_beep.ogg
+    - type: Damageable
+      damageModifierSet: SyndicateAssaultBorg #DeltaV
+    - type: ExplosionResistance #DeltaV, RPG won't gib it.
+      damageCoefficient: 0.5
 
 - type: entity
   id: BorgChassisSyndicateMedical
@@ -392,3 +396,7 @@
     noMindState: synd_sec_derelict
   - type: Construction
     node: derelictcyborg
+  - type: Damageable
+    damageModifierSet: SyndicateAssaultBorg #DeltaV 
+  - type: ExplosionResistance #DeltaV, RPG won't gib it.
+    damageCoefficient: 0.5

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -1,4 +1,4 @@
-﻿# Be careful with these as they get removed on shutdown too!
+# Be careful with these as they get removed on shutdown too!
 - type: entity
   id: AiHeld
   description: Components added / removed from an entity that gets inserted into an AI core.
@@ -589,6 +589,7 @@
         - BorgModuleOperative
         - BorgModuleL6C
         - BorgModuleDoubleEsword
+        - BorgModuleTool
       borg_id_chip: # DeltaV - borg id chips
       - IdChipSyndie
   - type: ItemSlots


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Added armor and tool mod to the Assault borg.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Discord in Uplink Overhaul/General mentions of it. The assault borg comes in at 40 TC while the Sabo comes in at 13. The sabo has a infinitely recharging echis, can turn invisible and can heal brute forever and you can buy 3 of them for 1 less TC than the assault. After the fact borgs got their AA revoked and their perms reworked the assault borg has become USELESS, On the off chance a nukie team spends the TC for it 9/10 it ends up dead even if the player is smart about their positioning. The skill cap on the sabo borg being cheap but good if your smart is reasonable, A good assault borg player SHOULD have the same reward but since your more or less giving a tider a L6 and praying it works it's not good. Along with that a borg DESIGNED to raid and kill on stations should ideally be armored so it can y'know, fight the station. Anyway, More or less the idea is to make it a POSSIBLE option for nukies to buy once again and not just some random ass thing that'll never get bought.
## Technical details
<!-- Summary of code changes for easier review. -->
Added Modifier Set for Syndicate Assault   
Added Tool Module to Syndicate Assault
Attempted to fix a known issue/bug with welding for cyborgs but didn't work, Gonna make another PR for that one.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="300" height="200" alt="SyndicateAssualt1" src="https://github.com/user-attachments/assets/86c91e3a-d17b-4770-8296-86105186151a" />
<img width="250" height="200" alt="SyndicateAssualt2" src="https://github.com/user-attachments/assets/d6d015fa-5e11-48a3-a482-56b17743412b" />
<img width="1459" height="745" alt="SyndicateAssualt3" src="https://github.com/user-attachments/assets/9441317c-c327-42dc-9468-23be77ffccde" />
<img width="190" height="180" alt="image" src="https://github.com/user-attachments/assets/4c2e0f4a-05ff-40e2-9734-aadd6a68696f" />


Shitty photo's but it shows the idea, First one shows the new tool module, Second shows the borg after one RPG shot (No longer instagibbed) and third shows 1 shot from both the laser pistol and a MK32 Universal (17 heat and 35 Pierce for their respective guns)
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added a tool module to the Syndicate Assault Cyborg
- tweak: Changed the Syndicate Assault Cyborg to have some armor, It can now actually do it's job and raid the station!

