### PR TITLE
fix: conspirators shouldn't require 28 readied players

### DIFF
--- a/Resources/Prototypes/_Harmony/game_presets.yml
+++ b/Resources/Prototypes/_Harmony/game_presets.yml
@@ -6,7 +6,7 @@
   name: conspiracy-title
   description: conspiracy-description
   showInVote: false # secret
-  minPlayers: 28 # DeltaV - Added attribute to preset since selection method changed
+  minTotalPlayers: 28 # DeltaV - Added attribute to preset since selection method changed
   rules:
   - Conspirators
   - ThiefChance


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
I set the minPlayers attribute in the original PR when I should've set minTotalPlayers, guh. 

## Why / Balance
unintended, makes conspirators really rare because it requires 28 ready players

## Technical details
changed attribute in preset yml

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Conspirators no longer require 28 ready players, just 28 connected players.