### PR TITLE
tweak: enable preset cooldowns

### DIFF
--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -53,7 +53,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
         Log.Info($"Selected {preset.ID} as the secret preset.");
         _adminLogger.Add(LogType.EventStarted, $"Selected {preset.ID} as the secret preset.");
 
-        if (_configurationManager.GetCVar(DCCVars.EnableBacktoBack) == true) // DeltaV
+        if (_configurationManager.GetCVar(DCCVars.EnablePresetCooldowns)) // DeltaV
         {
             if (preset.Cooldown > 0) // Begin Imp
             {
@@ -187,7 +187,7 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
             if (ruleComp.MinTotalPlayers > totalPlayers) return false; // DeltaV
         }
 
-        if (_configurationManager.GetCVar(DCCVars.EnableBacktoBack) == true) // DeltaV
+        if (_configurationManager.GetCVar(DCCVars.EnablePresetCooldowns)) // DeltaV
         {
             if (_nextRoundAllowed.ContainsKey(selected.ID) && _nextRoundAllowed[selected.ID] > _ticker.RoundId) // Begin Imp
             {

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -209,10 +209,12 @@ public sealed partial class DCCVars
         CVarDef.Create("admin.alerts.latejoin_max_hours", 2.0, CVar.SERVERONLY);
 
     /// <summary>
-    ///    Whether or not to disable the preset selecting test rule from running. Should be disabled in production. DeltaV specific, attached to Impstation Secret concurrent feature.
+    ///    Whether preset cooldowns should be considered by the SecretRuleSystem. Should be true in production.
+    ///    False by default to avoid breaking unit tests
+    ///    DeltaV specific, but ImpStation preset cooldown code is gated behind this.
     /// </summary>
-    public static readonly CVarDef<bool> EnableBacktoBack =
-        CVarDef.Create("game.disable_preset_test", false, CVar.SERVERONLY);
+    public static readonly CVarDef<bool> EnablePresetCooldowns =
+        CVarDef.Create("game.enable_preset_cooldowns", false, CVar.SERVERONLY);
 
     /// <summary>
     /// A string containing a list of newline-separated strings to be highlighted in the chat. Use this instead of Wizden's CVar.

--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -9,6 +9,7 @@ secret_weight_prototype = "SecretDeltaV"
 role_timer_override = "DeltaV"
 showgreentext = false # focus more on telling a story
 round_end_pvs_overrides = false # Fix EOR lag due to sending every player model to every player on the server (80 times 80 on highpop)
+enable_preset_cooldowns = true
 
 [movement]
 mob_pushing = false

--- a/Resources/Prototypes/_Harmony/game_presets.yml
+++ b/Resources/Prototypes/_Harmony/game_presets.yml
@@ -6,6 +6,7 @@
   name: conspiracy-title
   description: conspiracy-description
   showInVote: false # secret
+  cooldown: 1 # DeltaV
   rules:
   - Conspirators
   - ThiefChance

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -5,7 +5,7 @@
   name: survival-title
   showInVote: true # secret # DeltaV - Me when the survival. Used for periapsis.
   description: survival-description
-  cooldown: 2 # Imp - Can't occur thrice
+  cooldown: 1 # DeltaV
   rules:
     - MeteorSwarmScheduler
     - RampingStationEventScheduler
@@ -153,7 +153,7 @@
     - tator
   name: traitor-title
   description: traitor-description
-  cooldown: 2 # Imp - Can't occur thrice
+  cooldown: 1 # DeltaV
   showInVote: false
   rules:
   - DummyNonAntagChance
@@ -185,7 +185,7 @@
   name: nukeops-title
   description: nukeops-description
   showInVote: false
-  cooldown: 2 # Imp - Can't occur thrice
+  cooldown: 2 # DeltaV
   rules:
   - Nukeops
   - DummyNonAntagChance
@@ -258,7 +258,7 @@
   - zomber
   name: zombie-title
   description: zombie-description
-  cooldown: 2 # Imp - Can't occur thrice
+  cooldown: 2 # DeltaV
   showInVote: false
   rules:
   - Zombie


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR enables the preset cooldown system added by #2744 and adjusts the cooldown values on game presets, such that none will be run twice back-to-back. Nukeops and Zeds are on cooldown for two shifts after running.

## Why / Balance
While the code added by #2744 is believed to be broken, I think that it was never actually run on the production server for the following reasons:
- It was a port from ImpStation and **they are still using it unchanged** in production to this day. The only difference is that it was gated behind a CVar because deltanedas was concerned about it breaking tests if enabled in dev env.
- The CVar behind which it is gated was confusingly named and documented in DCCVars.cs, and it was never set to true in the config preset ``deltav.toml`` according to git history. The server host would've had to manually set it to true.
- The comments added next to the cooldown values in the initial PR suggest Lyndo misunderstood how the patch was supposed to work when porting it. They expected a cooldown of 2 would stop the preset from being rolled more than 2x in a row, when it actually prevents it from rolling for two rounds after being played. Surely this would've been noticed if it was tested locally or on the server?
- It was reported broken in #2811 because NukeOps ran 5x back-to-back, which could just be caused by the cvar not being set. This revert PR wasn't merged because NukeOps wasn't chosen after a server restart
- I tested the code locally in multiple configurations to verify it works as it should:
```
# Test with traitors 2 cooldown, survival 2 cooldown, nukeops 3 cooldown, all others unrollable
Survival
traitor
nukeops
survival
traitor
[Secret (pending), correct since all on cooldown. golobby]
nukeops
traitor
survival
[Secret (pending), correct since all on cooldown. golobby]
traitor
survival
nukeops
traitor
[accidental golobby]
survival
traitor
nukeops
survival
traitor
[Secret (pending), correct since all on cooldown. golobby]
nukeops
traitor
survival
[Secret (pending), correct since all on cooldown. golobby]

# Test with traitors 2 cooldown, survival 2 cooldown, nukeops 2 cooldown, all others unrollable
traitor
survival
nukeops
traitor
survival
nukeops
traitor
survival
nukeops
traitor
survival
nukeops
traitor
survival
nukeops

looping as expected

# Test with minPlayer limits removed and adjusted cooldowns 
(not the same cooldown values as in this PR, this was the first test I did just to see if it would somehow force NukeOps)
-- 1st
Survival
Conspirators
Zombie
Traitor
Nukeops
Traitor
Zombie
Survival
traitor

-- 2nd
Survival
traitor
zombie
survival
conspirators
nukeops
traitor
survival

no duplicates as expected
```

## Technical details
renamed DCCVars field and documented it, renamed cvar, removed redundant == true, added cvar to deltav.toml config preset, adjusted/added cooldown attribute values on presets

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Gamemodes now have cooldowns. They shouldn't be chosen twice back-to-back anymore. Nukeops and Zeds are on cooldown for two shifts after rolling.