### PR TITLE
fix: make sure there isn't a solo conspirator

### DIFF
--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -12,11 +12,10 @@
   id: Conspirators
   components:
   - type: GameRule
-    # DeltaV - minPlayers now set on Preset
-    # minPlayers: 28 # minimum of 4 conspirators
-    delay: # DeltaV - add delay
-      min: 60
-      max: 120
+    minTotalPlayers: 32 # DeltaV - changed from minPlayers to minTotalPlayers, increased value to 32
+    delay: # DeltaV - add delay to make sure as many people as possible join the round
+      min: 600
+      max: 900
   - type: ConspiratorRule
   - type: AntagSelection
     selectionTime: PostPlayerSpawn # DeltaV - previously IntraPlayerSpawn

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -12,7 +12,8 @@
   id: Conspirators
   components:
   - type: GameRule
-    minTotalPlayers: 32 # DeltaV - changed from minPlayers to minTotalPlayers, increased value to 32
+    minPlayers: 15 # DeltaV - changed from 28 to 15
+    minTotalPlayers: 32 # DeltaV - added attribute
     delay: # DeltaV - add delay to make sure as many people as possible join the round
       min: 600
       max: 900

--- a/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Harmony/GameRules/roundstart.yml
@@ -13,7 +13,7 @@
   components:
   - type: GameRule
     minPlayers: 15 # DeltaV - changed from 28 to 15
-    minTotalPlayers: 32 # DeltaV - added attribute
+    minTotalPlayers: 40 # DeltaV - added attribute
     delay: # DeltaV - add delay to make sure as many people as possible join the round
       min: 600
       max: 900

--- a/Resources/Prototypes/_Harmony/game_presets.yml
+++ b/Resources/Prototypes/_Harmony/game_presets.yml
@@ -6,7 +6,6 @@
   name: conspiracy-title
   description: conspiracy-description
   showInVote: false # secret
-  minPlayers: 28 # DeltaV - Added attribute to preset since selection method changed
   rules:
   - Conspirators
   - ThiefChance


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added minTotalPlayers to Conspirators, 32 players need to be connected (not ready) for it to roll. Also increased the delay to make sure people who wait in the loby and then decide which role they want to play and late joiners in general increase the crew size.

## Why / Balance
as it turns out, minPlayers on the gamepreset does basically nothing. it's only checked when deciding which presets to display in the preset vote. i don't remember why i thought moving this to preset was necessary, but i wasn't familiar with the secretrulesystem yet when i was porting conspirators.

## Technical details
simpl yml changes

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Conspirators now requires 32 connected players to roll. The ingame delay before choosing conspirators is increased.

