### PR TITLE
feat: show conspirator status icon to ghosts

### DIFF
--- a/Content.Client/_Harmony/Conspirators/EntitySystems/ConspiratorSystem.cs
+++ b/Content.Client/_Harmony/Conspirators/EntitySystems/ConspiratorSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Shared._Harmony.Conspirators.Components;
 using Content.Shared._Harmony.Conspirators.EntitySystems;
 using Content.Shared.Antag;
+using Content.Shared.Ghost; // DeltaV
 using Content.Shared.StatusIcon.Components;
 using Robust.Client.Player;
 using Robust.Shared.Prototypes;
@@ -24,7 +25,8 @@ public sealed class ConspiratorSystem : SharedConspiratorSystem
         if (_playerManager.LocalSession?.AttachedEntity is { } playerEntity)
         {
             if (!HasComp<ShowAntagIconsComponent>(playerEntity) &&
-                !HasComp<ConspiratorComponent>(playerEntity))
+                !HasComp<ConspiratorComponent>(playerEntity) &&
+                !HasComp<GhostComponent>(playerEntity)) // DeltaV - add GhostComponent
                 return;
         }
 

--- a/Content.Shared/_Harmony/Conspirators/EntitySystems/SharedConspiratorSystem.cs
+++ b/Content.Shared/_Harmony/Conspirators/EntitySystems/SharedConspiratorSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._Harmony.Conspirators.Components;
 using Content.Shared.Antag;
+using Content.Shared.Ghost; // DeltaV
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 
@@ -26,6 +27,6 @@ public abstract class SharedConspiratorSystem : EntitySystem // looking at blood
         if (player?.AttachedEntity is not { } uid)
             return true;
 
-        return HasComp<ConspiratorComponent>(uid) || HasComp<ShowAntagIconsComponent>(uid);
+        return HasComp<ConspiratorComponent>(uid) || HasComp<ShowAntagIconsComponent>(uid) || HasComp<GhostComponent>(uid); // DeltaV - add GhostComponent
     }
 }


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
ghosts can now see the conspirator status icon

## Why / Balance
it's immediately obvious to ghosts that it's conspirators because they will start talking in their radio. they'll also know who they are, so why not show them the icons as we do with Initial Infected?

## Technical details
added GhostComponent to related checks

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Ghosts can now see Conspirator status icons
