### PR TITLE
Blast door buff

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: BlastDoor
   parent: BaseShutter
   name: blast door
@@ -33,7 +33,9 @@
     resistance: 8
   - type: Damageable
     damageContainer: StructuralInorganic
-    damageModifierSet: StrongMetallic
+    damageModifierSet: BlastDoor #DeltaV
+  - type: ExplosionResistance #DeltaV
+    damageCoefficient: 0.25
   - type: ContainerFill
     containers:
       board: [ DoorElectronics ]

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door_autolink.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door_autolink.yml
@@ -127,3 +127,24 @@
     - type: AutoLinkReceiver
       channel: Windows
 
+# Start DeltaV Additions
+
+- type: entity
+  id: BlastDoorAI
+  parent: BlastDoor
+  suffix: AI
+  components:
+  - type: AccessReader
+    access: [["StationAi"]]
+
+- type: entity
+  id: BlastDoorAIOpen
+  parent: BlastDoorOpen
+  suffix: Open, AI
+  components:
+  - type: AccessReader
+    access: [["StationAi"]]
+
+# End DeltaV Additions
+
+

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -168,3 +168,19 @@
     Slash: 40
     Piercing: 15
     Heat: 10
+
+- type: damageModifierSet
+  id: BlastDoor
+  coefficients:
+   Blunt: 0.5
+   Slash: 0.3
+   Piercing: 0.5
+   Heat: 0.3
+   Shock: 0.8
+   Structural: 0.7
+  flatReductions:
+    Structural: 5
+    Blunt: 10
+    Slash: 10
+    Piercing: 10
+    Heat: 10

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -179,8 +179,8 @@
    Shock: 0.8
    Structural: 0.7
   flatReductions:
-    Structural: 5
     Blunt: 10
     Slash: 10
     Piercing: 10
     Heat: 10
+    Structural: 5


### PR DESCRIPTION
## About the PR
So fun fact blast doors have no explosion resistance at all

Also add an ai only blast door

## Why / Balance
The issue i have found is for being a blast door they are weak for it even zombies can just bite past them with ease this pr is to fix the first issue and semi fix the second issue as the zombie thing is just an issue with zombies doing ungodly structural damage

Blast doors are meant as a way to defend against bombs and other things at this point they are not. Also added an ai only blast door so door remotes do not work on it so command can not open them with there remote

## Technical details
Blast doors now have the following resistances
- takes 50% less blunt
- takes 70% less slash
- takes 50% less piercing
- takes 70% less heat
- takes 20% less shock
- takes 30% less Structural
- takes 75% less explosions (takes two breaching charges or one c4 ya c4 does an ungodly amount of damage)
Flat reductions
- Blunt 10
- Slash 10
- Piercing 10
- Heat 10
- Structural 5

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- add: Added ai only access blast doors 
- tweak: Blast doors are now a lot stronger 
- fix: Blast doors now have explosion resistance
-->
