### PR TITLE
Reduce rodentia brute vulnerability.

### DIFF
--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -14,8 +14,6 @@
   id: Rodentia
   coefficients:
     Blunt: 1.3
-#    Slash: 1.15 # Removed slash vulnerability
-#    Piercing: 1.15 # Removed pierce vulnerability
 
 - type: damageModifierSet
   id: Feroxi

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -13,9 +13,9 @@
 - type: damageModifierSet
   id: Rodentia
   coefficients:
-    Blunt: 1.2 # Reduced from 1.3 to 1.2
-    Slash: 1 # Reduced from 1.15 to 1
-    Piercing: 1 # Reduced from 1.15 to 1
+    Blunt: 1.3
+#    Slash: 1.15 # Removed slash vulnerability
+#    Piercing: 1.15 # Removed pierce vulnerability
 
 - type: damageModifierSet
   id: Feroxi

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -13,9 +13,9 @@
 - type: damageModifierSet
   id: Rodentia
   coefficients:
-    Blunt: 1.2
-    Slash: 1
-    Piercing: 1
+    Blunt: 1.2 # Reduced from 1.3 to 1.2
+    Slash: 1 # Reduced from 1.15 to 1
+    Piercing: 1 # Reduced from 1.15 to 1
 
 - type: damageModifierSet
   id: Feroxi

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -13,9 +13,9 @@
 - type: damageModifierSet
   id: Rodentia
   coefficients:
-    Blunt: 1.3
-    Slash: 1.15
-    Piercing: 1.15
+    Blunt: 1.2
+    Slash: 1
+    Piercing: 1
 
 - type: damageModifierSet
   id: Feroxi

--- a/Resources/ServerInfo/Guidebook/Mobs/_DV/Rodentia.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/_DV/Rodentia.xml
@@ -26,7 +26,7 @@
 
   ## Drawbacks
 
-  - They take [color=#ffa500]30% more Blunt damage[/color], and [color=#ffa500]15% more Slash and Piercing damage[/color].
+  - They take [color=#ffa500]30% more Blunt damage[/color]
   - Always triggers mousetraps, regardless of whether or not they are wearing shoes.
   - Gets hungry 33% faster.
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

I reduced the brute vulnerability of rodentia to match felinids. Rodentia now take 1.2x blunt, and 1.0x pierce & slash.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Rodentia get kind of shafted in DV. They have no real 'pros' to playing them that justify their massive blunt vulnerability. They can rummage through trash, move slower in order to hide under tables (circumstantially useful), and fit in duffel bags. The last of which isn't even unique to them. In return for this, they get hungry 33% faster and then take a WHOPPING 30% more blunt damage, as well as 15% more pierce and slash. For comparison, rodentia take 3/5 as much extra blunt damage as diona's take extra _heat_ damage. The species immune to slipping that comes with _built-in_ plate carrier + durathread protection. 

I think with how comparable rodentia are to felinids, it's only fair they have the same vulnerability.

## Technical details
<!-- Summary of code changes for easier review. -->

tiny yaml changes

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- tweak: Rodentia no longer take extra pierce and slash damage & guidebook updated for this.
