### PR TITLE
DRAFT: (Lavaland) Ruin Generation

### DIFF
--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -149,6 +149,10 @@ public sealed class PlanetSystem : EntitySystem
 
         // Ruin placement prediction, keeps track of the ruins that will be placed to ensure no overlap or ruins that generate too closely.
         List<(Vector2 Center, float Radius)> placedRuins = new List<(Vector2 Center, float Radius)>();
+        float minDistance = planet.RuinMinDistance;
+        float maxDistance = planet.RuinMaxDistance;
+        float minSeparation = planet.RuinMinSeparation;
+        int maxPlacementAttempts = planet.RuinPlacementAttempts;
 
         for (int i = 0; i < selectedRuins.Count; i++)
         {
@@ -158,7 +162,7 @@ public sealed class PlanetSystem : EntitySystem
             EntityUid probeMap = _map.CreateMap(out MapId probeMapId, runMapInit: false);
             float ruinRadius = 0f;
 
-            bool probeSuccess = _mapLoader.TryLoadGrid(probeMapId, ruinPath, out EntityUid? probeGrid, offset: Vector2.Zero);
+            bool probeSuccess = _mapLoader.TryLoadGrid(probeMapId, ruinPath, out var probeGrid, offset: Vector2.Zero);
 
             if (probeSuccess)
             {

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -9,6 +9,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Robust.Shared.Random;
 using Robust.Shared.Maths;
+using System;
+
 namespace Content.Server._DV.Planet;
 
 public sealed class PlanetSystem : EntitySystem
@@ -112,7 +114,7 @@ public sealed class PlanetSystem : EntitySystem
                 break;
 
             ResPath ruin = rareRuins[rareRuins.Count - 1];
-            rareRuins.RemoveAt(rareRuins.Count -1)
+            rareRuins.RemoveAt(rareRuins.Count -1);
             selectedRuins.Add(ruin);
         }
         // Chance to select ruin from rare pool when filling up the slots.
@@ -130,7 +132,7 @@ public sealed class PlanetSystem : EntitySystem
                     pickRare = true;
             }
 
-            List<ResPath> pool = pickRare ? rareRuins : Ruins
+            List<ResPath> pool = pickRare ? rareRuins : Ruins;
 
             if (pool.Count > 0)
                 continue;
@@ -138,6 +140,77 @@ public sealed class PlanetSystem : EntitySystem
             ResPath ruin = pool[pool.Count - 1];
             pool.RemoveAt(pool.Count - 1);
             selectedRuins.Add(ruin);
+        }
+
+        // Ruin placement prediction, keeps track of here ruins will be place to ensure no overlap or ruins that generate too closely.
+        List<(Vector2 Center, float Radius)> placedRuins = new List<(Vector2 Center, float Radius)>();
+
+        // TO-DO: Move these to PlanetPrototype fields
+        float minDistance = 80f;
+        float maxDistance = 450f;
+        float minSeparation = 50f;
+        int maxPlacementAttempts = 10;
+
+        for (int i = 0; i < selectedRuins.Count; i++)
+        {
+            ResPath ruinPath = selectedRuins[i];
+
+            // load the ruin onto a temp map first to calculate its bounding box for sepeartion.
+            EntityUid probeMap = _map.CreateMap(out MapId probeMapId, runMapInit: false);
+            float ruinRadius = 0f;
+
+            bool probeSuccess = _mapLoader.TryLoadGrid(probeMapId, ruinPath, out EntityUid? probeGrid, offset: Vector2.Zero);
+
+            if (probeSuccess)
+            {
+                Box2 probeAabb = Comp<MapGridComponent>(probeGrid!.Value).LocalAABB;
+                ruinRadius = probeAabb.Size.Length() * 0.5f;
+
+            Del(probeMap);
+
+            if (!probeSuccess)
+                continue;
+
+            bool placed = false;
+
+            // Try several random positions and pick the first one that doesn't overlap anything.
+            for (int attempt = 0; attempt < maxPlacementAttempts; attempt++)
+            {
+                Vector2 randomOffset = _random.NextVector2(minDistance, maxDistance);
+                Vector2 candidateCenter = center + randomOffset;
+                bool separated = true;
+
+                for (int j = 0; j < placedRuins.Count; j++)
+                {
+                    Vector2 otherCenter = placedRuins[j].Center;
+                    float otherRadius = placedRuins[j].Radius;
+
+                    float minAllowed = otherRadius + ruinRadius + minSeparation;
+
+                    float dx = candidateCenter.X - otherCenter.X;
+                    float dy = candidateCenter.Y - otherCenter.Y;
+                    float distSquared = dx * dx + dy * dy;
+
+                    if (distSquared < minAllowed * minAllowed)
+                        separated = false;
+                        break;
+                }
+
+                if (!separated)
+                    continue;
+
+                bool loadSuccess = _mapLoader.TryLoadGrid(mapId, ruinPath, out _, offset: candidateCenter);
+
+                if (!loadSuccess)
+                    continue;
+
+                placedRuins.Add((candidateCenter, ruinRadius));
+                placed = true;
+                break;
+            }
+
+            // TO-DO: add error logging for ruins that could not be placed
+            _ = placed;
         }
     }
 }

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -101,6 +101,44 @@ public sealed class PlanetSystem : EntitySystem
         if (RuinSpawningCount == 0)
             return;
 
-        List<ResPath> SelectedRuins = new List<ResPath>();
+        List<ResPath> selectedRuins = new List<ResPath>();
+
+        // Guaranteed rare ruins come first in selection!
+        int guaranteedRare = Math.Clamp(planet.GuaranteedRareRuinCount, 0, Math.Min(selectedRuins, rareRuins.Count));
+
+        for (int i = 0; i < guaranteedRare; i++)
+        {
+            if (rareRuins.Count == 0)
+                break;
+
+            ResPath ruin = rareRuins[rareRuins.Count - 1];
+            rareRuins.RemoveAt(rareRuins.Count -1)
+            selectedRuins.Add(ruin);
+        }
+        // Chance to select ruin from rare pool when filling up the slots.
+        int rareChance = Math.Clamp(planet.RareRuinChance, 0, 100);
+
+        while (selectedRuins.Count < RuinSpawningCount && (Ruins.Count > 0 || rareRuins.Count > 0))
+        {
+            bool pickRare = false;
+
+            if (rareRuin.Count > 0)
+            {
+                if (Ruins.Count == 0)
+                    pickRare = true;
+                else if (_random.Next(100) < rareChance)
+                    pickRare = true;
+            }
+
+            List<ResPath> pool = pickRare ? rareRuins : Ruins
+
+            if (pool.Count > 0)
+                continue;
+
+            ResPath ruin = pool[pool.Count - 1];
+            pool.RemoveAt(pool.Count - 1);
+            selectedRuins.Add(ruin);
+        }
     }
 }
+

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -161,12 +161,13 @@ public sealed class PlanetSystem : EntitySystem
             // load the ruin onto a temp map first to calculate its bounding box for separation.
             EntityUid probeMap = _map.CreateMap(out MapId probeMapId, runMapInit: false);
             float ruinRadius = 0f;
+            Box2 probeAabb = Box2.UnitCentered;
 
             bool probeSuccess = _mapLoader.TryLoadGrid(probeMapId, ruinPath, out var probeGrid, offset: Vector2.Zero);
 
             if (probeSuccess)
             {
-                Box2 probeAabb = Comp<MapGridComponent>(probeGrid!.Value).LocalAABB;
+                probeAabb = Comp<MapGridComponent>(probeGrid!.Value).LocalAABB;
                 ruinRadius = probeAabb.Size.Length() * 0.5f;
             }
 
@@ -209,6 +210,11 @@ public sealed class PlanetSystem : EntitySystem
 
                 if (!loadSuccess)
                     continue;
+
+                // Reserve one tile around the ruin so biome stuff does not spawn right against it.
+                _setTiles.Clear();
+                Box2 ruinReserveBox = probeAabb.Translated(candidateCenter).Enlarged(1f);
+                _biome.ReserveTiles(mapUid, ruinReserveBox, _setTiles);
 
                 placedRuins.Add((candidateCenter, ruinRadius));
                 placed = true;

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -24,7 +24,6 @@ public sealed class PlanetSystem : EntitySystem
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
-
     private readonly List<(Vector2i, Tile)> _setTiles = new();
 
     /// <summary>
@@ -87,18 +86,15 @@ public sealed class PlanetSystem : EntitySystem
         if (planet.RuinMaxCount <= 0)
             return;
 
-        if (planet.RuinPaths.Count == 0 && planet.RareRuinPaths.Count == 0)
-            return;
-
         List<ResPath> ruins = new List<ResPath>(planet.RuinPaths);
         List<ResPath> rareRuins = new List<ResPath>(planet.RareRuinPaths);
+
+        _random.Shuffle(ruins);
+        _random.Shuffle(rareRuins);
 
         int totalRuinAvailable = ruins.Count + rareRuins.Count;
         if (totalRuinAvailable == 0)
             return;
-
-        _random.Shuffle(ruins);
-        _random.Shuffle(rareRuins);
 
         int minCount = Math.Clamp(planet.RuinMinCount, 0, totalRuinAvailable);
         int maxCount = Math.Clamp(planet.RuinMaxCount, minCount, totalRuinAvailable);
@@ -115,9 +111,6 @@ public sealed class PlanetSystem : EntitySystem
 
         for (int i = 0; i < guaranteedRare; i++)
         {
-            if (rareRuins.Count == 0)
-                break;
-
             ResPath ruin = rareRuins[rareRuins.Count - 1];
             rareRuins.RemoveAt(rareRuins.Count -1);
             selectedRuins.Add(ruin);
@@ -139,9 +132,6 @@ public sealed class PlanetSystem : EntitySystem
 
             List<ResPath> pool = pickRare ? rareRuins : ruins;
 
-            if (pool.Count == 0)
-                continue;
-
             ResPath ruin = pool[pool.Count - 1];
             pool.RemoveAt(pool.Count - 1);
             selectedRuins.Add(ruin);
@@ -149,16 +139,16 @@ public sealed class PlanetSystem : EntitySystem
 
         // Ruin placement prediction, keeps track of the ruins that will be placed to ensure no overlap or ruins that generate too closely.
         List<(Vector2 Center, float Radius)> placedRuins = new List<(Vector2 Center, float Radius)>();
-        float minDistance = planet.RuinMinDistance;
-        float maxDistance = planet.RuinMaxDistance;
-        float minSeparation = planet.RuinMinSeparation;
-        int maxPlacementAttempts = planet.RuinPlacementAttempts;
+        float minDistance = MathF.Max(0f, planet.RuinMinDistance);
+        float maxDistance = MathF.Max(minDistance, planet.RuinMaxDistance);
+        float minSeparation = MathF.Max(0f, planet.RuinMinSeparation);
+        int maxPlacementAttempts = Math.Max(1, planet.RuinPlacementAttempts);
 
         for (int i = 0; i < selectedRuins.Count; i++)
         {
             ResPath ruinPath = selectedRuins[i];
 
-            // load the ruin onto a temp map first to calculate its bounding box for separation.
+            // load the ruin onto a temp map first to calculate its bounding box for separation. TO-DO: Log error for being unable to calc radius
             EntityUid probeMap = _map.CreateMap(out MapId probeMapId, runMapInit: false);
             float ruinRadius = 0f;
             Box2 probeAabb = Box2.UnitCentered;
@@ -176,9 +166,7 @@ public sealed class PlanetSystem : EntitySystem
             if (!probeSuccess)
                 continue;
 
-            bool placed = false;
-
-            // Try several random positions and pick the first one that doesn't overlap anything.
+            // Try several random positions and pick the first one that doesn't overlap anything.  TO-DO: Log error for being unable to load
             for (int attempt = 0; attempt < maxPlacementAttempts; attempt++)
             {
                 Vector2 randomOffset = _random.NextVector2(minDistance, maxDistance);
@@ -217,12 +205,8 @@ public sealed class PlanetSystem : EntitySystem
                 _biome.ReserveTiles(mapUid, ruinReserveBox, _setTiles);
 
                 placedRuins.Add((candidateCenter, ruinRadius));
-                placed = true;
                 break;
             }
-
-            // TO-DO: add error logging for ruins that could not be placed
-            _ = placed;
         }
     }
 }

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -8,7 +8,7 @@ using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using Robust.Shared.Random;
-
+using Robust.Shared.Maths;
 namespace Content.Server._DV.Planet;
 
 public sealed class PlanetSystem : EntitySystem
@@ -19,6 +19,8 @@ public sealed class PlanetSystem : EntitySystem
     [Dependency] private readonly MapLoaderSystem _mapLoader = default!;
     [Dependency] private readonly MetaDataSystem _meta = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
 
     private readonly List<(Vector2i, Tile)> _setTiles = new();
 
@@ -87,5 +89,18 @@ public sealed class PlanetSystem : EntitySystem
         int totalRuinAvailable = Ruins.Count + rareRuins.Count;
         if (totalRuinAvailable == 0)
             return;
+
+        _random.Shuffle(Ruins);
+        _random.Shuffle(rareRuins);
+
+        int minCount = Math.Clamp(planet.RuinMinCount, 0, totalRuinAvailable);
+        int maxCount = Math.Clamp(planet.RuinMaxCount, minCount, totalRuinAvailable);
+
+        int RuinSpawningCount = _random.Next(minCount, maxCount + 1);
+
+        if (RuinSpawningCount == 0)
+            return;
+
+        List<ResPath> SelectedRuins = new List<ResPath>();
     }
 }

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -10,6 +10,7 @@ using Robust.Shared.Utility;
 using Robust.Shared.Random;
 using Robust.Shared.Maths;
 using System;
+using System.Numerics;
 
 namespace Content.Server._DV.Planet;
 

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -148,7 +148,7 @@ public sealed class PlanetSystem : EntitySystem
         {
             ResPath ruinPath = selectedRuins[i];
 
-            // load the ruin onto a temp map first to calculate its bounding box for separation. TO-DO: Log error for being unable to calc radius
+            // Load the ruin onto a temp map first to calculate its bounding box for separation.
             EntityUid probeMap = _map.CreateMap(out MapId probeMapId, runMapInit: false);
             float ruinRadius = 0f;
             Box2 probeAabb = Box2.UnitCentered;
@@ -164,9 +164,13 @@ public sealed class PlanetSystem : EntitySystem
             Del(probeMap);
 
             if (!probeSuccess)
+            {
+                Log.Error($"Failed to load ruin grid {ruinPath} while calculating placement bounds.");
                 continue;
+            }
 
-            // Try several random positions and pick the first one that doesn't overlap anything.  TO-DO: Log error for being unable to load
+            // Try several random positions and pick the first one that doesn't overlap anything.
+            var placed = false;
             for (int attempt = 0; attempt < maxPlacementAttempts; attempt++)
             {
                 Vector2 randomOffset = _random.NextVector2(minDistance, maxDistance);
@@ -205,7 +209,13 @@ public sealed class PlanetSystem : EntitySystem
                 _biome.ReserveTiles(mapUid, ruinReserveBox, _setTiles);
 
                 placedRuins.Add((candidateCenter, ruinRadius));
+                placed = true;
                 break;
+            }
+
+            if (!placed)
+            {
+                Log.Warning($"Failed to place ruin grid {ruinPath} after {maxPlacementAttempts} attempts.");
             }
         }
     }

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -146,14 +146,8 @@ public sealed class PlanetSystem : EntitySystem
             selectedRuins.Add(ruin);
         }
 
-        // Ruin placement prediction, keeps track of here ruins will be place to ensure no overlap or ruins that generate too closely.
+        // Ruin placement prediction, keeps track of the ruins that will be placed to ensure no overlap or ruins that generate too closely.
         List<(Vector2 Center, float Radius)> placedRuins = new List<(Vector2 Center, float Radius)>();
-
-        // TO-DO: Move these to PlanetPrototype fields
-        float minDistance = 80f;
-        float maxDistance = 450f;
-        float minSeparation = 50f;
-        int maxPlacementAttempts = 10;
 
         for (int i = 0; i < selectedRuins.Count; i++)
         {

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
+using Robust.Shared.Random;
 
 namespace Content.Server._DV.Planet;
 
@@ -70,5 +71,21 @@ public sealed class PlanetSystem : EntitySystem
 
         _map.InitializeMap(map);
         return map;
+
+    // Ruin generation for planet maps.
+    private void TrySpawningRuins(EntityUid mapUid, MapId mapId, PlanetPrototype planet)
+    {
+        if (planet.RuinMaxCount <= 0)
+            return;
+
+        if (planet.RuinPaths.Count == 0 && planet.RareRuinPaths.Count == 0)
+            return;
+
+        List<ResPath> Ruins = new List<ResPath>(planet.RuinPaths);
+        List<ResPath> rareRuins = new List<ResPath>(planet.RareRuinPaths);
+
+        int totalRuinAvailable = Ruins.Count + rareRuins.Count;
+        if (totalRuinAvailable == 0)
+            return;
     }
 }

--- a/Content.Server/_DV/Planet/PlanetSystem.cs
+++ b/Content.Server/_DV/Planet/PlanetSystem.cs
@@ -59,6 +59,7 @@ public sealed class PlanetSystem : EntitySystem
     /// </summary>
     public EntityUid? LoadPlanet(ProtoId<PlanetPrototype> id, ResPath path)
     {
+        PlanetPrototype planet = _proto.Index(id);
         var map = SpawnPlanet(id, runMapInit: false);
         var mapId = Comp<MapComponent>(map).MapId;
         if (!_mapLoader.TryLoadGrid(mapId, path, out var grid))
@@ -73,11 +74,14 @@ public sealed class PlanetSystem : EntitySystem
         var aabb = Comp<MapGridComponent>(grid.Value).LocalAABB;
         _biome.ReserveTiles(map, aabb.Enlarged(0.2f), _setTiles);
 
+        TrySpawningRuins(map, mapId, planet, aabb.Center);
+
         _map.InitializeMap(map);
         return map;
+    }
 
     // Ruin generation for planet maps.
-    private void TrySpawningRuins(EntityUid mapUid, MapId mapId, PlanetPrototype planet)
+    private void TrySpawningRuins(EntityUid mapUid, MapId mapId, PlanetPrototype planet, Vector2 center)
     {
         if (planet.RuinMaxCount <= 0)
             return;
@@ -85,28 +89,28 @@ public sealed class PlanetSystem : EntitySystem
         if (planet.RuinPaths.Count == 0 && planet.RareRuinPaths.Count == 0)
             return;
 
-        List<ResPath> Ruins = new List<ResPath>(planet.RuinPaths);
+        List<ResPath> ruins = new List<ResPath>(planet.RuinPaths);
         List<ResPath> rareRuins = new List<ResPath>(planet.RareRuinPaths);
 
-        int totalRuinAvailable = Ruins.Count + rareRuins.Count;
+        int totalRuinAvailable = ruins.Count + rareRuins.Count;
         if (totalRuinAvailable == 0)
             return;
 
-        _random.Shuffle(Ruins);
+        _random.Shuffle(ruins);
         _random.Shuffle(rareRuins);
 
         int minCount = Math.Clamp(planet.RuinMinCount, 0, totalRuinAvailable);
         int maxCount = Math.Clamp(planet.RuinMaxCount, minCount, totalRuinAvailable);
 
-        int RuinSpawningCount = _random.Next(minCount, maxCount + 1);
+        int ruinSpawningCount = _random.Next(minCount, maxCount + 1);
 
-        if (RuinSpawningCount == 0)
+        if (ruinSpawningCount == 0)
             return;
 
         List<ResPath> selectedRuins = new List<ResPath>();
 
         // Guaranteed rare ruins come first in selection!
-        int guaranteedRare = Math.Clamp(planet.GuaranteedRareRuinCount, 0, Math.Min(selectedRuins, rareRuins.Count));
+        int guaranteedRare = Math.Clamp(planet.GuaranteedRareRuins, 0, rareRuins.Count);
 
         for (int i = 0; i < guaranteedRare; i++)
         {
@@ -118,23 +122,23 @@ public sealed class PlanetSystem : EntitySystem
             selectedRuins.Add(ruin);
         }
         // Chance to select ruin from rare pool when filling up the slots.
-        int rareChance = Math.Clamp(planet.RareRuinChance, 0, 100);
+        int rareChance = Math.Clamp(planet.RuinRareChance, 0, 100);
 
-        while (selectedRuins.Count < RuinSpawningCount && (Ruins.Count > 0 || rareRuins.Count > 0))
+        while (selectedRuins.Count < ruinSpawningCount && (ruins.Count > 0 || rareRuins.Count > 0))
         {
             bool pickRare = false;
 
-            if (rareRuin.Count > 0)
+            if (rareRuins.Count > 0)
             {
-                if (Ruins.Count == 0)
+                if (ruins.Count == 0)
                     pickRare = true;
                 else if (_random.Next(100) < rareChance)
                     pickRare = true;
             }
 
-            List<ResPath> pool = pickRare ? rareRuins : Ruins;
+            List<ResPath> pool = pickRare ? rareRuins : ruins;
 
-            if (pool.Count > 0)
+            if (pool.Count == 0)
                 continue;
 
             ResPath ruin = pool[pool.Count - 1];
@@ -155,7 +159,7 @@ public sealed class PlanetSystem : EntitySystem
         {
             ResPath ruinPath = selectedRuins[i];
 
-            // load the ruin onto a temp map first to calculate its bounding box for sepeartion.
+            // load the ruin onto a temp map first to calculate its bounding box for separation.
             EntityUid probeMap = _map.CreateMap(out MapId probeMapId, runMapInit: false);
             float ruinRadius = 0f;
 
@@ -165,6 +169,7 @@ public sealed class PlanetSystem : EntitySystem
             {
                 Box2 probeAabb = Comp<MapGridComponent>(probeGrid!.Value).LocalAABB;
                 ruinRadius = probeAabb.Size.Length() * 0.5f;
+            }
 
             Del(probeMap);
 
@@ -192,8 +197,10 @@ public sealed class PlanetSystem : EntitySystem
                     float distSquared = dx * dx + dy * dy;
 
                     if (distSquared < minAllowed * minAllowed)
+                    {
                         separated = false;
                         break;
+                    }
                 }
 
                 if (!separated)

--- a/Content.Shared/_DV/Planet/PlanetPrototype.cs
+++ b/Content.Shared/_DV/Planet/PlanetPrototype.cs
@@ -2,6 +2,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Parallax.Biomes;
 using Content.Shared.Parallax.Biomes.Markers;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._DV.Planet;
 

--- a/Content.Shared/_DV/Planet/PlanetPrototype.cs
+++ b/Content.Shared/_DV/Planet/PlanetPrototype.cs
@@ -46,4 +46,40 @@ public sealed partial class PlanetPrototype : IPrototype
     /// </summary>
     [DataField]
     public List<ProtoId<BiomeMarkerLayerPrototype>> BiomeMarkerLayers = new();
+
+    /// <summary>
+    /// Ruin map paths for the ruin pool.
+    /// </summary>
+    [DataField]
+    public List<ResPath> RuinPaths = new();
+
+    /// <summary>
+    /// Minimum number of ruins to spawn at round start.
+    /// </summary>
+    [DataField]
+    public int RuinMinCount = 0;
+
+    /// <summary>
+    /// Maximum number of ruins to spawn at round start.
+    /// </summary>
+    [DataField]
+    public int RuinMaxCount = 0;
+
+    /// <summary>
+    /// Optional rare ruin map paths that should be selected less often.
+    /// </summary>
+    [DataField]
+    public List<ResPath> RareRuinPaths = new();
+
+    /// <summary>
+    /// Number of rare ruins guaranteed.
+    /// </summary>
+    [DataField]
+    public int GuaranteedRareRuins = 0;
+
+    /// <summary>
+    /// Percent chance that each additional ruin selected is rare.
+    /// </summary>
+    [DataField]
+    public int RuinRareChance = 0;
 }

--- a/Content.Shared/_DV/Planet/PlanetPrototype.cs
+++ b/Content.Shared/_DV/Planet/PlanetPrototype.cs
@@ -83,4 +83,28 @@ public sealed partial class PlanetPrototype : IPrototype
     /// </summary>
     [DataField]
     public int RuinRareChance = 0;
+
+    /// <summary>
+    /// Minimum distance from the base grid edge for ruin placement.
+    /// </summary>
+    [DataField]
+    public float RuinMinDistance = 80f;
+
+    /// <summary>
+    /// Maximum distance from the base grid edge for ruin placement.
+    /// </summary>
+    [DataField]
+    public float RuinMaxDistance = 450f;
+
+    /// <summary>
+    /// Minimum spacing between spawned ruin bounds.
+    /// </summary>
+    [DataField]
+    public float RuinMinSeparation = 60f;
+
+    /// <summary>
+    /// Placement attempts per ruin before giving up.
+    /// </summary>
+    [DataField]
+    public int RuinPlacementAttempts = 10;
 }

--- a/Resources/Prototypes/_DV/planets.yml
+++ b/Resources/Prototypes/_DV/planets.yml
@@ -50,44 +50,44 @@
   #- /Maps/Lavaland/bait.yml # TO-DO: Free RPG.
   #- /Maps/Lavaland/basalt_ruin.yml # TO-DO: Make a grid.
   #- /Maps/Lavaland/bridge.yml # TO-DO: Massive lava river with a single bridge
-  - /Maps/Lavaland/broken_cargo.yml
-  - /Maps/Lavaland/catwalk_crossroad.yml
-  - /Maps/Lavaland/cave_murder.yml
-  - /Maps/Lavaland/commieoutpost.yml
+  - /Maps/Lavaland/broken_cargo.yml # Checked
+  - /Maps/Lavaland/catwalk_crossroad.yml # Checked
+  - /Maps/Lavaland/cave_murder.yml # Checked
+  - /Maps/Lavaland/commieoutpost.yml # Questionable but Checked
   #- /Maps/Lavaland/crashed_pod_trail.yml # TO-DO: Trail too long.
-  - /Maps/Lavaland/crasheddropship.yml
-  - /Maps/Lavaland/crashedinstigator.yml
+  - /Maps/Lavaland/crasheddropship.yml # Checked
+  - /Maps/Lavaland/crashedinstigator.yml # Checked
   - /Maps/Lavaland/crashedsloop.yml
   #- /Maps/Lavaland/crashedsyndiepod.yml # TO-DO: Make a grid.
-  - /Maps/Lavaland/Envy.yml
+  - /Maps/Lavaland/Envy.yml # Checked, I don't hate it...but
   - /Maps/Lavaland/escape_pod_crash.yml
   - /Maps/Lavaland/front_desk.yml
   - /Maps/Lavaland/generator_scrapyard.yml
-  - /Maps/Lavaland/Gluttony.yml
-  - /Maps/Lavaland/Greed.yml
+  - /Maps/Lavaland/Gluttony.yml # Checked, I don't hate it...but
+  - /Maps/Lavaland/Greed.yml # Checked, I don't hate it...but
   - /Maps/Lavaland/hermit_base.yml
   - /Maps/Lavaland/lava_farm.yml
   - /Maps/Lavaland/miming_drill.yml
   #- /Maps/Lavaland/minefield.yml # TO-DO: Probably remove the AKM?
-  - /Maps/Lavaland/miner_tomb.yml
+  - /Maps/Lavaland/miner_tomb.yml # Checked
   - /Maps/Lavaland/mug_factory.yml
   - /Maps/Lavaland/penalcolony.yml
-  - /Maps/Lavaland/pizza_party.yml
+  - /Maps/Lavaland/pizza_party.yml # Checked
   # - /Maps/Lavaland/Pride.yml # TO-DO: Just a room filled with mirrors.
-  - /Maps/Lavaland/ripley.yml
+  - /Maps/Lavaland/ripley.yml # Checked
   - /Maps/Lavaland/roundel.yml
-  - /Maps/Lavaland/shinobi_graveyard.yml
+  - /Maps/Lavaland/shinobi_graveyard.yml # Checked
   - /Maps/Lavaland/sloth.yml
   - /Maps/Lavaland/solemn_lament.yml
-  - /Maps/Lavaland/temple.yml
+  - /Maps/Lavaland/temple.yml # Checked
   #- /Maps/Lavaland/wrecked_outpost.yml # TO-DO: Make a grid.
   #- /Maps/Lavaland/Wrath.yml # TO-DO: Probably remove the AKM?
-#  rareRuinPaths: for later
-  - /Maps/Lavaland/labour_camp.yml
-  - /Maps/Lavaland/fleshlab.yml
-  - /Maps/Lavaland/mineshaft.yml
-#  guaranteedRareRuins: 1
-#  ruinRareChance: 20
+  rareRuinPaths:
+  - /Maps/Lavaland/labour_camp.yml # Checked
+  - /Maps/Lavaland/fleshlab.yml # Checked
+  - /Maps/Lavaland/mineshaft.yml # Checked
+  guaranteedRareRuins: 1
+  ruinRareChance: 20
   ruinMinCount: 5
   ruinMaxCount: 8
 

--- a/Resources/Prototypes/_DV/planets.yml
+++ b/Resources/Prototypes/_DV/planets.yml
@@ -46,6 +46,50 @@
   - OreBluespace
   - OreArtifactFragment
   - LavalandGibtonite
+  ruinPaths:
+  #- /Maps/Lavaland/bait.yml # TO-DO: Free RPG.
+  #- /Maps/Lavaland/basalt_ruin.yml # TO-DO: Make a grid.
+  #- /Maps/Lavaland/bridge.yml # TO-DO: Massive lava river with a single bridge
+  - /Maps/Lavaland/broken_cargo.yml
+  - /Maps/Lavaland/catwalk_crossroad.yml
+  - /Maps/Lavaland/cave_murder.yml
+  - /Maps/Lavaland/commieoutpost.yml
+  #- /Maps/Lavaland/crashed_pod_trail.yml # TO-DO: Trail too long.
+  - /Maps/Lavaland/crasheddropship.yml
+  - /Maps/Lavaland/crashedinstigator.yml
+  - /Maps/Lavaland/crashedsloop.yml
+  #- /Maps/Lavaland/crashedsyndiepod.yml # TO-DO: Make a grid.
+  - /Maps/Lavaland/Envy.yml
+  - /Maps/Lavaland/escape_pod_crash.yml
+  - /Maps/Lavaland/front_desk.yml
+  - /Maps/Lavaland/generator_scrapyard.yml
+  - /Maps/Lavaland/Gluttony.yml
+  - /Maps/Lavaland/Greed.yml
+  - /Maps/Lavaland/hermit_base.yml
+  - /Maps/Lavaland/lava_farm.yml
+  - /Maps/Lavaland/miming_drill.yml
+  #- /Maps/Lavaland/minefield.yml # TO-DO: Probably remove the AKM?
+  - /Maps/Lavaland/miner_tomb.yml
+  - /Maps/Lavaland/mug_factory.yml
+  - /Maps/Lavaland/penalcolony.yml
+  - /Maps/Lavaland/pizza_party.yml
+  # - /Maps/Lavaland/Pride.yml # TO-DO: Just a room filled with mirrors.
+  - /Maps/Lavaland/ripley.yml
+  - /Maps/Lavaland/roundel.yml
+  - /Maps/Lavaland/shinobi_graveyard.yml
+  - /Maps/Lavaland/sloth.yml
+  - /Maps/Lavaland/solemn_lament.yml
+  - /Maps/Lavaland/temple.yml
+  #- /Maps/Lavaland/wrecked_outpost.yml # TO-DO: Make a grid.
+  #- /Maps/Lavaland/Wrath.yml # TO-DO: Probably remove the AKM?
+#  rareRuinPaths: for later
+  - /Maps/Lavaland/labour_camp.yml
+  - /Maps/Lavaland/fleshlab.yml
+  - /Maps/Lavaland/mineshaft.yml
+#  guaranteedRareRuins: 1
+#  ruinRareChance: 20
+  ruinMinCount: 5
+  ruinMaxCount: 8
 
 - type: planet
   id: GlacierSurface


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->


<!-- What did you change? -->
### THIS IS A DRAFT: There are still a lot of tweaks and testing I need to do. 

#### TO-DO
-Error log for when a grid fails to load.
-Mass scanners showing grids as "grids" or showing them at all.
-Fixing ruins that are maps instead of grids which prevent them from spawning.
-Updating/removing ruins from the pool that are not up to standards.
-More generation and placement testing.
## About the PR
Ruin generation for planet maps are now real which mean Lavaland and Surface 
Glacier (or any other planet we add in the future) are able to spawn round-start with randomized ruins! There will be 30+ ruins included for Lavaland, some being rare.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Lavaland was intended to spawn with ruins for salvagers. Currently, our Lavaland is very bare bones compare to other servers with ruin generation. (This was also a request.)
## Technical details
<!-- Summary of code changes for easier review. -->

This might be the fourth time that I tried to implement ruin generation without going insane, and I still can't promise that this is stable and not shitcoded. Instead of trying to add a new system to handle ruin generation the same way dungeons are generated for salvage expedition, I opted to have the ruin grids load in before the planet map is initialized. 

**The process is separated into three parts:**
**Ruin Selection:** 
-`_random.Shuffle` the grids pools so ruins are randomized.
-Select how many ruins to spawn base on `ruinSpawningCount`.
-`GuaranteedRareRuins` are pull and added to `selectedRuins` for priority placement.
-`pickRare` ruins (if there are any rare ruins) are calculated during the looping of ruin selection base on a set integer percentage. 
**Ruin Placement Prediction:**
-Grids are loaded onto a temporary map and their `localAABB` is measured and converted to radius. 
-Data is stored for placement and map is deleted.
**Ruin Placement:**
-`_random.NextVector2(minDistance, maxDistance)` create a random point around the base (mining station) between set min/max distance.
-`minAllowed` check to see if ruins are far enough from one another with each attempt until it is and it gets loaded.

This was largely base off of other forks, specifically how GoobStation14 handled the ruin placement before the Goidamerge.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Not yet...
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Ruin Generation: Lavaland can now generate with a couple of ruins at round-start from a pool of 30+ ruins.