### PR TITLE
Display evacuation vote counts

### DIFF
--- a/Content.Server/_DV/RoundEnd/RoundEndSystem.cs
+++ b/Content.Server/_DV/RoundEnd/RoundEndSystem.cs
@@ -12,7 +12,6 @@ public sealed partial class RoundEndSystem : EntitySystem
     {
         var options = new VoteOptions
         {
-            DisplayVotes = false,
             Title = Loc.GetString("round-end-system-vote-title"),
             Duration = _cfg.GetCVar(DCCVars.EmergencyShuttleVoteTime),
             InitiatorText = Loc.GetString("vote-options-server-initiator-text")


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
The evacuation vote at the 2-hour mark now shows how many people voted for which option.

## Why / Balance
It feels like every two months, there's a community feedback post where someone thinks there's a secret cabal of administrators that force the shuttle to be called every time, or that votes are incorrectly counted, or that the system is bugged, or something along those lines. I don't see any downside to displaying the number of votes, and it'll help people to see how others are feeling about the current round OOC-ly.

## Technical details
one line change

## Media
<img width="562" height="141" alt="image" src="https://github.com/user-attachments/assets/0be486d5-4c21-4f4a-a0c6-869342081585" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The number of votes is now displayed during the automated evac shuttle vote.
