### PR TITLE
Raise initial Cargo cut from sales to 98%

### DIFF
--- a/Content.Shared/Cargo/Components/StationBankAccountComponent.cs
+++ b/Content.Shared/Cargo/Components/StationBankAccountComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class StationBankAccountComponent : Component
     /// When giving funds to a particular account, the proportion of funds they should receive compared to remaining accounts.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public double PrimaryCut = 0.50;
+    public double PrimaryCut = 0.98; //DeltaV - was 0.50
 
     /// <summary>
     /// When giving funds to a particular account from an override sell, the proportion of funds they should receive compared to remaining accounts.


### PR DESCRIPTION

## About the PR
Changes cargo cut from 50% to 98%

## Why / Balance
Nobody uses departmental economy. 
#5515 MYSTERIOUSLY vanished. probably taken by dark forces. who knows.

## Requirements
- [x] I have not tested any added content and changes.
- [x] I have not added media to this PR even if it does require an in-game showcase.

## Licensing
i own the rights to the number 98. its mine. you cant have it.

**Changelog**
:cl:
- fix: Cargo inital sales cut raised from 50% to 98%

