### PR TITLE
Cherrypick: Makes singularities respect reduced motion option (#43362)

### DIFF
--- a/Content.Client/Singularity/SingularityOverlay.cs
+++ b/Content.Client/Singularity/SingularityOverlay.cs
@@ -1,9 +1,11 @@
+using System.Numerics;
+using Content.Shared.CCVar;
 using Content.Shared.Singularity.Components;
 using Robust.Client.Graphics;
 using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Configuration;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
-using System.Numerics;
 
 namespace Content.Client.Singularity
 {
@@ -13,6 +15,7 @@ namespace Content.Client.Singularity
 
         [Dependency] private readonly IEntityManager _entMan = default!;
         [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IConfigurationManager _configManager = default!;
         private SharedTransformSystem? _xformSystem = null;
 
         /// <summary>
@@ -28,6 +31,8 @@ namespace Content.Client.Singularity
 
         private readonly ShaderInstance _shader;
 
+        private bool _reducedMotion;
+
         public SingularityOverlay()
         {
             IoCManager.InjectDependencies(this);
@@ -35,6 +40,8 @@ namespace Content.Client.Singularity
             _shader.SetParameter("maxDistance", MaxDistance * EyeManager.PixelsPerMeter);
             _entMan.EventBus.SubscribeEvent<PixelToMapEvent>(EventSource.Local, this, OnProjectFromScreenToMap);
             ZIndex = 101; // Should be drawn after the placement overlay so admins placing items near the singularity can tell where they're going.
+
+            _configManager.OnValueChanged(CCVars.ReducedMotion, (b) => { _reducedMotion = b; }, invokeImmediately: true);
         }
 
         private readonly Vector2[] _positions = new Vector2[MaxCount];
@@ -44,6 +51,8 @@ namespace Content.Client.Singularity
 
         protected override bool BeforeDraw(in OverlayDrawArgs args)
         {
+            if (_reducedMotion)
+                return false;
             if (args.Viewport.Eye == null)
                 return false;
             if (_xformSystem is null && !_entMan.TrySystem(out _xformSystem))
@@ -102,6 +111,8 @@ namespace Content.Client.Singularity
         /// </summary>
         private void OnProjectFromScreenToMap(ref PixelToMapEvent args)
         {   // Mostly copypasta from the singularity shader.
+            if (_reducedMotion)
+                return;
             if (args.Viewport.Eye == null)
                 return;
             var maxDistance = MaxDistance * EyeManager.PixelsPerMeter;


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR cherrypicks my PR from upstream at https://github.com/space-wizards/space-station-14/pull/43362

Description from my PR:
This PR makes singularities and gravity anomalies (and probably everything else that does the distortion) respect the accessibility option "Reduce motion of visual effects"


## Why / Balance
See the original PR. I use the reduced motion option and looking at the singularity causes me actual OOC discomfort

## Technical details
I have no clue what the last commits to the original PR are doing

## Media
<img width="794" height="644" alt="image" src="https://github.com/user-attachments/assets/789a7692-fac1-4471-ad96-1241d5f2e631" />
<img width="896" height="754" alt="image" src="https://github.com/user-attachments/assets/a27fdbcf-e018-41b4-b500-c7759860bfac" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
I've got no clue what to do about this section. I technically wasn't the only person to do commits for this PR

<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl: Minerva
- tweak: Singularity distortion effects now respect the reduced motion accessibility option.
