### PR TITLE
Reduce WT550 SMG fire-rate

### DIFF
--- a/Resources/Locale/en-US/_DV/weapons/ammuntion/smg.ftl
+++ b/Resources/Locale/en-US/_DV/weapons/ammuntion/smg.ftl
@@ -1,0 +1,2 @@
+ent-MagazinePistolSubMachineGunTopMounted =
+    .desc = Unconventional 20-round top feeding magazine for the WT550 SMG. Intended to hold general-purpose kinetic ammunition.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -115,6 +115,7 @@
     whitelist:
       tags:
       - CartridgePistol
+    capacity: 20
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag_top_mounted.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -115,7 +115,7 @@
     whitelist:
       tags:
       - CartridgePistol
-    capacity: 20
+    capacity: 20 # DeltaV
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/Pistol/smg_mag_top_mounted.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -246,7 +246,7 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
-    fireRate: 5.5
+    fireRate: 3.5
     minAngle: 1
     maxAngle: 6
     angleIncrease: 1.5
@@ -254,7 +254,7 @@
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2
-    burstFireRate: 7
+    burstFireRate: 5.5
     availableModes:
     - Burst
     - FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -246,7 +246,7 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
-    fireRate: 3.5
+    fireRate: 3.5 # DeltaV - Was 5.5
     minAngle: 1
     maxAngle: 6
     angleIncrease: 1.5
@@ -254,7 +254,7 @@
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2
-    burstFireRate: 5.5
+    burstFireRate: 5.5 # DeltaV - Was 7
     availableModes:
     - Burst
     - FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -246,15 +246,15 @@
   - type: ChamberMagazineAmmoProvider
     boltClosed: null
   - type: Gun
-    fireRate: 3.5 # DeltaV - Was 5.5
-    minAngle: 1
-    maxAngle: 6
+    fireRate: 5 # DeltaV - Was 5.5
+    minAngle: 2 # DeltaV - Was 1
+    maxAngle: 16 # DeltaV - Was 6
     angleIncrease: 1.5
     angleDecay: 6
     selectedMode: FullAuto
     shotsPerBurst: 5
     burstCooldown: 0.2
-    burstFireRate: 5.5 # DeltaV - Was 7
+    burstFireRate: 7
     availableModes:
     - Burst
     - FullAuto


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Full auto fire rate for WT550 5.5-3.5
Burst fire rate 7->5.5
## Why / Balance
The WT550 has for a long time been the pinnacle of weaponry that security can acquire. It's compact, has great mag size, has great accuracy, and has a very good fire rate. Not to mention it is very cheap to the point where a crate of them can be ordered about 15 minutes into any given round. It's been due for a nerf for a long while now, and while what I've initially changed may not be what CR decides on it's something to get the conversation started.

This, in essence, removes 34 DPS from the gun in full auto mode and somewhere around the same in burst mode.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**

:cl:
- tweak: WT550 fire rate has been reduced by 0.5
- tweak: WT550 Magazine size has been reduced 30->20
- tweak: WT550 is slightly less accurate