### PR TITLE
Increased firerate of vulcan from 3.5 to 4.0

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -19,7 +19,7 @@
     maxAngle: 32
     angleIncrease: 6
     angleDecay: 24
-    fireRate: 3.5
+    fireRate: 4.0 # Increased from 3.5 to 4.0
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -19,7 +19,7 @@
     maxAngle: 32
     angleIncrease: 6
     angleDecay: 24
-    fireRate: 4.0 # Increased from 3.5 to 4.0
+    fireRate: 4.0
     selectedMode: SemiAuto
     availableModes:
     - SemiAuto


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

I increased the firerate of the vulcan from 3.5 to 4.0

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

When I originally reworked the vulcan [here](https://github.com/DeltaV-Station/Delta-v/pull/4672#issue-3630242024), I think I kind of dialed the dps of the vulcan back a little too far. I was worried it would be too strong if I made it accurate considering it fires .30 rifle. Looking back though, although I've seen the vulcan used more, I don't know if it's as gamer as I intended for it to be. It's DPS sits at 66.5, which is still pretty sub par, even ignoring the fact that it's semi-auto only. Now it's DPS is 76, which is still pretty modest.

For comparison, the Lecter's DPS is 85, and the Drozd's is 96. That's a difference of 11 DPS between their two tiers of gun (longarm vs SMG). With this in mind, it's safe to say that increasing/decreasing a gun's DPS by ~10 points suffices for balancing when making a new tier of gun (The vulcan is a DMR)

## Technical details
<!-- Summary of code changes for easier review. -->

Single line yaml change

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- tweak: Vulcan firerate increased from 3.5 to 4.0
