### PR TITLE
buff breaching hammer

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
@@ -8,9 +8,9 @@
     sprite: Nyanotrasen/Objects/Weapons/Melee/breaching_hammer.rsi
     state: icon
   - type: Item
-    size: Huge
+    size: Ginormous
   - type: MeleeWeapon
-    attackRate: 0.4
+    attackRate: 0.6
     range: 1.70
     wideAnimationRotation: -135
     damage:
@@ -20,21 +20,24 @@
         Structural: 10
     soundHit:
       path: /Audio/Nyanotrasen/Weapons/club.ogg
-    bluntStaminaDamageFactor: 1.50 # 15 stamina damage
-#  - type: MeleeStaminaCost
-#    swing: 10
-#    wieldCoefficient: 0.5 #if wielded you will only consume 5
+    bluntStaminaDamageFactor: 1.6 # 40 stamina damage wielded
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 20
+        Blunt: 25
         Piercing: 2
-        Structural: 20
+        Structural: 30
+  - type: ThrowingAngle
+    angle: 225
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Blunt: 10
   - type: Tool
     qualities:
       - Prying
-    speedModifier: 0.8
+    speedModifier: 1.5
   - type: Prying
     pryPowered: !type:Bool
       true

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Weapons/Melee/breaching_hammer.yml
@@ -37,8 +37,8 @@
   - type: Tool
     qualities:
       - Prying
-    speedModifier: 1.5
   - type: Prying
+    speedModifier: 1.5
     pryPowered: !type:Bool
       true
     force: !type:Bool


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
- changed size from Huge to ginormous (in line with spear)
- Increase attack rate from 0.4 to 0.6
- Increase bluntstaminafactor from 1.5 to 1.6
- increase wielded blunt to 35 from 30
- increase structural from 30 to 40
- increased prying speedmodifier from 0.8 to 1.5 in line with emergency jaws of life (15 seconds for unbolted, 40 seconds for bolted)
- added throwingangle + damageonhit 10 blunt so it does damage when thrown
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a huge tool not worth occupying both of your hands and is worse than a breaching charge which is a 1x2 inventory commitment, I have tried to buff it to be in line with the truncheons and do enough structural to be an almost relevant breaching tool (it still takes 40 seconds to break a single reinforced wall)
## Technical details
<!-- Summary of code changes for easier review. -->
modified values as stated above also removed the no longer existing (?) MeleeStaminaCost component that was commented out
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
[video](https://youtu.be/MBOk7O4_20g) 
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: NT Armory has researched a better breaching hammer. It pries faster and bonks harder! Permas beware.
