### PR TITLE
Tweak: Remove Time Requirements on Specific Clothing

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
@@ -10,6 +10,7 @@
     ClothingUniformJumpskirtAtmosCasual: 3 # DeltaV
     ClothingShoesColorWhite: 3
     ClothingHeadsetEngineering: 2
+    ClothingHeadHatBeretAtmospherics: 3 # DeltaV - Remove Specific Role Timers
     ClothingHeadHelmetFire: 2
     ClothingOuterSuitFire: 2
     ClothingOuterWinterAtmos: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/engidrobe.yml
@@ -10,6 +10,7 @@
     ClothingShoesColorBlack: 3
     ClothingOuterVestHazard: 3
     ClothingShoesBootsWork: 3
+    ClothingHeadHatBeretEngineering: 3 # DeltaV - Remove Specific Role Timers
     ClothingHeadHatHardhatYellow: 3
     ClothingHeadHatHardhatOrange: 3
     ClothingHeadsetEngineering: 3

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
@@ -15,6 +15,7 @@
     ClothingMaskGas: 3
     ClothingOuterWinterSci: 2
     ClothingNeckScarfStripedPurple: 3
+    ClothingHeadHatBeretRND: 3 # DeltaV - Remove Specific Role Timers
     ClothingHeadTinfoil: 2 # Nyanotrasen - Tinfoil hats for Epistemics
     ClothingShoesBootsWinterSci: 2
     ClothingOuterExplorerCoat: 3 # DeltaV

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -41,11 +41,11 @@
     head: ClothingHeadHatHardhatRed
 
 - type: loadout
-  id: SeniorEngineerBeret
+  id: EngineerBeret # DeltaV - Was SeniorEngineerBeret
   startingGear: EngineeringBeret
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorEngineering
+#  effects: # DeltaV - Remove Specific Role Timers
+#  - !type:GroupLoadoutEffect
+#    proto: SeniorEngineering
 
 # Jumpsuit
 - type: loadout

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -41,7 +41,7 @@
     head: ClothingHeadHatHardhatRed
 
 - type: loadout
-  id: EngineerBeret # DeltaV - Was SeniorEngineerBeret
+  id: SeniorEngineerBeret
   startingGear: EngineeringBeret
 #  effects: # DeltaV - Remove Specific Role Timers
 #  - !type:GroupLoadoutEffect

--- a/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Science/scientist.yml
@@ -18,9 +18,9 @@
 - type: loadout
   id: ScientificBeret
   startingGear: ScientificBeret
-  effects:
-  - !type:GroupLoadoutEffect
-    proto: SeniorResearcher
+#  effects: # DeltaV - Remove Specific Role Timers
+#  - !type:GroupLoadoutEffect
+#    proto: SeniorResearcher
 
 - type: loadout
   id: RoboticistCap

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1122,7 +1122,7 @@
   - StationEngineerHardhatYellow
   - StationEngineerHardhatOrange
   - StationEngineerHardhatRed
-  - SeniorEngineerBeret
+  - EngineerBeret # DeltaV - Was SeniorEngineerBeret
 
 - type: loadoutGroup
   id: StationEngineerJumpsuit

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1122,7 +1122,7 @@
   - StationEngineerHardhatYellow
   - StationEngineerHardhatOrange
   - StationEngineerHardhatRed
-  - EngineerBeret # DeltaV - Was SeniorEngineerBeret
+  - SeniorEngineerBeret
 
 - type: loadoutGroup
   id: StationEngineerJumpsuit

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/dressers.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/dressers.yml
@@ -187,6 +187,7 @@
         # Cloak
         - id: ClothingNeckCloakHos
         - id: ClothingNeckMantleHOS
+        - id: ClothingNeckHosRobe
         # Outerwear
         - id: ClothingOuterCoatStasecHoS
         - id: ClothingOuterCoatHoSTrench

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Cargo/salvage_specialist.yml
@@ -44,6 +44,6 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobSalvageSpecialist
-      time: 432000 # 120hr
+      time: 216000 # 60hr
   equipment:
     neck: ClothingNeckMantleSalvage

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Engineering/atmospheric_technician.yml
@@ -22,12 +22,6 @@
 
 - type: loadout
   id: AtmosBeret
-  effects:
-  - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobAtmosphericTechnician
-      time: 216000 # 60hr
   equipment:
     head: ClothingHeadHatBeretAtmospherics
 

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/head_of_security.yml
@@ -54,11 +54,5 @@
 # Neck
 - type: loadout
   id: HeadOfSecurityRobe
-  effects:
-   - !type:JobRequirementLoadoutEffect
-    requirement:
-      !type:RoleTimeRequirement
-      role: JobHeadOfSecurity
-      time: 180000
   equipment:
     neck: ClothingNeckHosRobe


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Title sums it up! I talked with the PR author for the Salvage mantle, and they gave me the approval to at least lower the mantle hours down to 60 hours (from 120 hours).
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
After a discussion within a CR thread, it seems like CR is uninterested with locking certain clothing behind hours.
These are my reasonings:
-Command roles especially are unhealthy to grind hours for.
-We shouldn't encourage people to grind hours for items that hold no senior/mentor (aka RP) status. 
-You already have status playing command/whitelisted role, no need to prove yourself more...
-Berets should be for everyone, I don't like locking a whole clothing type behind hours. If you want a senior beret or clothing, then don't just make it a department recolor. 
## Technical details
<!-- Summary of code changes for easier review. -->
Yaml
-Commented time requirements out.
-Move items to respective vendors and dresser. 
-`SeniorEngineerBeret` to `EngineerBeret` for clarity.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- remove: Remove Time Requirements on Certain Berets and HoS Robe.