### PR TITLE
Adds more Felinid and Vulpkanin customizations to Kitsune

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/felinid.yml
@@ -44,7 +44,7 @@
   id: FurredLeftArm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_arm
@@ -53,7 +53,7 @@
   id: FurredRightArm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_arm
@@ -62,7 +62,7 @@
   id: FurredLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_leg
@@ -71,7 +71,7 @@
   id: FurredRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_leg
@@ -80,7 +80,7 @@
   id: FurredLeftFoot
   bodyPart: LFoot
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_foot
@@ -89,7 +89,7 @@
   id: FurredRightFoot
   bodyPart: RFoot
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_foot
@@ -98,7 +98,7 @@
   id: FurredLeftHand
   bodyPart: LHand
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_hand
@@ -107,7 +107,7 @@
   id: FurredRightHand
   bodyPart: RHand
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Kitsune]
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_hand

--- a/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/vulpkanin.yml
@@ -5,7 +5,7 @@
   id: VulpEar
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -16,7 +16,7 @@
   id: VulpEarFade
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -27,7 +27,7 @@
   id: VulpEarSharp
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: vulp
@@ -38,7 +38,7 @@
   id: VulpEarJackal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: jackal
@@ -49,7 +49,7 @@
   id: VulpEarTerrier
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: terrier
@@ -60,7 +60,7 @@
   id: VulpEarWolf
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: wolf
@@ -115,7 +115,7 @@
   id: VulpEarShock
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: shock
@@ -133,7 +133,7 @@
   id: VulpEarDalmatian
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/ear_markings.rsi
       state: dalmatian
@@ -318,7 +318,7 @@
   id: VulpTailAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -329,7 +329,7 @@
   id: VulpTailAltTip
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: vulp_alt
@@ -340,7 +340,7 @@
   id: VulpTailLong
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: long
@@ -413,7 +413,7 @@
   id: VulpTailCoyote
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: coyote
@@ -422,7 +422,7 @@
   id: VulpTailCoyoteWag
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: coyote_wag
@@ -440,7 +440,7 @@
   id: VulpTailHusky
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky-inner
@@ -451,7 +451,7 @@
   id: VulpTailHuskyAlt
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: husky
@@ -489,7 +489,7 @@
   id: VulpTailOtie
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: otie
@@ -498,7 +498,7 @@
   id: VulpTailFluffy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Vulpkanin, Felinid]
+  speciesRestriction: [Vulpkanin, Felinid, Kitsune]
   sprites:
     - sprite: _DV/Mobs/Customization/Vulpkanin/tail_markings.rsi
       state: fluffy


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds more Felinid and Vulpkanin customizations to Kitsune. This includes:
- All the Vulpkanin ears/tails that Felinid has access to. If Vulpkanin and Felinid have it, I also added Kitsune. They're foxes
- Felinid furred limbs 

## Why / Balance
Kitsune don't really have much in terms of customization, especially not when compared to Felinid. This PR helps that

There *is* probably the problem of being able to tell species apart `(which can also be done far more reliably, in under a second, by shift-clicking)`, but Kitsune and Felinid already visually similar (humanoids with a tail and ears) and already share certain Vulpkanin markings allowing them to look completely identical

## Media
<img width="221" height="319" alt="image" src="https://github.com/user-attachments/assets/25f74027-3395-4f5d-bdc9-8fdb4cc4218d" />

.

<img width="256" height="249" alt="image" src="https://github.com/user-attachments/assets/27e9fc21-2703-46f0-86fa-e8f4c55d52ae" />
Kitsunes and felinids can already be made to be identical. Sizes are slightly different but I was too lazy to iterate to perfectly guess size. No I don't know which is which I already forgot

.
<img width="339" height="254" alt="image" src="https://github.com/user-attachments/assets/283685b4-7e55-4f64-ab4a-0e8f09565827" />
Only four ear options... Tails are better, but are still missing some of the good-looking things Vulpkanin have


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl: Minerva
- tweak: Kitsune now shares more markings with Felinid and Vulpkanin.