### PR TITLE
Captains Weapons buff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -738,10 +738,10 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/laser_cannon.ogg
   - type: BatteryAmmoProvider
-    proto: RedMediumLaser
+    proto: AntiquePistol #DeltaV Was (RedMediumLaser)
     fireCost: 100
   - type: BatterySelfRecharger
-    autoRechargeRate: 40
+    autoRechargeRate: 60 #DeltaV was (40)
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -83,11 +83,11 @@
     attackRate: 1.5
     damage:
       types:
-        Slash: 17 #cmon, it has to be at least BETTER than the rest.
+        Slash: 20 #DeltaV Was (17) Old Note (#cmon, it has to be at least BETTER than the rest.)
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
   - type: Reflect
-    reflectProb: .1
+    reflectProb: .25 #DeltaV Was (.1)
     spread: 90
   - type: Item
     storedSprite:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -103,3 +103,13 @@
         Heat: 100
         Radiation: 20
         Structural: 100
+
+- type: entity
+  parent: BasicHitscan
+  id: AntiquePistol
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: HitscanBasicDamage
+    damage:
+      types:
+        Heat: 20


### PR DESCRIPTION
## About the PR
This pr is to buff the Captains only two weapons they have and can have 

## Why / Balance
At this time captains weapons have felt weak in comparison to the events the captain has to face some being slimes, spiders, and even nukies where caps gun can do vary little with how it is same with the sword this also ties into sec tech t3 which gives sec a gun that's just like caps in every way. The captain can also not get a new weapon/upgrade there's unless it is war ops since it would be power gaming to do so this would also make it so losing caps gun or sword is a real issue to deal with.

## Technical details
- Buffs caps gun and sword from 17 to 20 damage 
- Buffs caps gun recharge from 40 to 60
- Buffs caps saber reflect chance from 10% to 25%

**Captains** **gun** **pre** **buff**
- Total damage until it runs out of battery is 200 damage
- Damage a second is 33 damage 
- When battery runs out its 17 damage every 2-3 seconds

**Bloodred** **suit**
- Total damage  until it runs out of battery is 91 damage
- Damage a second is 15 damage
- When battery runs out its 7.64 damage every 2-3 seconds

**Captains** **saber** **pre** **buff**
- 6 hits to crit 
- 50 damage every two seconds
- Reflect chance min: 1-3 hits  max: 30-48 hits 

**Bloodred** **suit**
- 14 hits to crit
- 22 damage every two seconds

**Captains** **gun** **buff**
- Total damage until it runs out of battery is 280 damage
- Damage a second is 40 damage
- When battery runs out its 20 damage every 1-2 seconds

**Bloodred** **suit**
- Total damage until it runs out of battery is 125.93
- Damage a second is 17.93 damage 
- When battery runs out its 9 damage every 1-2 seconds

**Captains** **saber** **buff**
- 5 hits to crit
- 60 damage every two seconds
- Reflect chance min: 1-2 hits max: 9 hits

**Bloodred** **suit**
- 12 hits to crit
- 26.96 damage every two seconds

**Note:** of course all the numbers here where done at point blank and will change a lot since it depends on the player to hit the shots and other factors like armor types and shields but the info above was done on a no armor target and a bloodred suit target missing no shots. The reflect chance was done with both the energy turrets and ballistic turrets 


## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl:
- tweak: Captains saber and gun now do 20 damage
- tweak: Captains laser gun now has a recharge of 60
- tweak: Captains saber now has a reflect chance of 25% 
-->
