### PR TITLE
Adds DV-specific scrubs to the MediDrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medidrobe.yml
@@ -36,9 +36,23 @@
     UniformScrubsColorGreen: 4
     UniformScrubsColorBlue: 4
     UniformScrubsColorPurple: 4
+    # Begin Delta-V additions
+    UniformScrubsColorBlack: 4
+    UniformScrubsColorCyan: 4
+    UniformScrubsColorPink: 4
+    UniformScrubsColorRainbow: 4
+    UniformScrubsColorWhite: 4
+    # End Delta-v additions
     ClothingHeadHatSurgcapGreen: 4
     ClothingHeadHatSurgcapBlue: 4
     ClothingHeadHatSurgcapPurple: 4
+    # Begin Delta-V additions
+    ClothingHeadHatSurgcapBlack: 4
+    ClothingHeadHatSurgcapCyan: 4
+    ClothingHeadHatSurgcapPink: 4
+    ClothingHeadHatSurgcapRainbow: 4
+    ClothingHeadHatSurgcapWhite: 4
+    # End Delta-v additions
     ClothingShoesBootsWinterMed: 2
   contrabandInventory:
     # Begin Delta-V additions


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR adds all of the (non-Cybersun because that's already in there) DV-specific scrubs+surgical caps to the MediDrobe

I have a feeling of déjà vu. I think I've already done this but I haven't. Maybe it's the fact it's been sitting in my to-do list for so long

## Why / Balance
They are medical clothing. The MediDrobe has upstream scrubs in it, so why not DV-specific ones?

Currently, the only reliable ways to obtain these are, to my knowledge:
- Starting as a surgeon
- RNG through medical lockers
- Logistics

## Media
<img width="350" height="584" alt="image" src="https://github.com/user-attachments/assets/58c3ab9e-c733-4f7c-8a31-13b1d9c7eebf" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl: Minerva
- tweak: DV-specific medical scrubs and surgical caps can now be obtained from the MediDrobe.