### PR TITLE
Makes surgical caps optional for Surgeon loadout

### DIFF
--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -601,6 +601,7 @@
 - type: loadoutGroup
   id: SurgeonHead
   name: loadout-group-surgeon-head
+  minLimit: 0
   loadouts:
   - BlueSurgeryCap
   - GreenSurgeryCap


### PR DESCRIPTION
## About the PR
Makes surgical caps optional for Surgeon loadout

## Why / Balance
I can't think of any other jobs\* that force a cosmetic hat onto you in loadout. (I believe Zookeeper is an exception, but I never see Zookeeper and the role is overdue for loadout changes to bring it in line with every other job)

Being able to identify the surgeon based on the cap is something worth considering, but the cap can be removed roundstart anyway by anyone who cares. Some of the hats and scrubs are available to doctors anyway

Surgical caps kind of block hair, don't go with every look, and are kind of awkward to work around when designing a loadout for a surgeon character. This is hopefully a nice QOL change for that

## Media
<img width="960" height="685" alt="image" src="https://github.com/user-attachments/assets/92849c6d-3eab-4632-901b-be956dee502d" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl: Minerva
- tweak: Surgeons are no longer required by loadout to have a surgical cap.