### PR TITLE
Adds DV-specific scrubs to Medical Doctor loadout

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1718,6 +1718,13 @@
   - BlueSurgeryCap
   - GreenSurgeryCap
   - PurpleSurgeryCap
+  # Begin DeltaV Additions
+  - BlackSurgeryCap
+  - CyanSurgeryCap
+  - PinkSurgeryCap
+  - WhiteSurgeryCap
+  - RainbowSurgeryCap
+  # End DeltaV Additions
   - NurseHat
 
 - type: loadoutGroup
@@ -1731,6 +1738,13 @@
   - MedicalBlueScrubs
   - MedicalGreenScrubs
   - MedicalPurpleScrubs
+  # Begin DeltaV Additions
+  - MedicalBlackScrubs
+  - MedicalCyanScrubs
+  - MedicalPinkScrubs
+  - MedicalWhiteScrubs
+  - MedicalRainbowScrubs
+  # End DeltaV Additions
   # Begin DeltaV Additions - Medical Clothing Overhaul
   - MedicalApronJumpsuit
   - MedicalApronJumpskirt


### PR DESCRIPTION
## About the PR
Adds DV-specific scrubs to Medical Doctor loadout. Also adds the matching surgical caps to the loadout to match

https://github.com/DeltaV-Station/Delta-v/pull/5613 is my PR to add DV-specific scrubs to the MediDrobe. I use some of the same points here

## Why / Balance
It's medical clothing anyway
The upstream scrubs were there already, so why not DV-specific ones?

This does make the selection a bit more crowded, but that issue is solved with loadout grouping. I will likely follow this PR up with another to group scrubs and surgical caps

## Media
<img width="920" height="721" alt="image" src="https://github.com/user-attachments/assets/65e27ae2-01a4-4745-a059-7381af087265" />

<img width="921" height="722" alt="image" src="https://github.com/user-attachments/assets/aa6e8b16-e485-49e2-b1cb-1c39bbb74fc3" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl: Minerva
- tweak: Medical Doctors may now select DV-specific scrubs in loadout.