### PR TITLE
fix: Admin QOL Patches

### DIFF
--- a/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListLawsCommand.cs
@@ -26,11 +26,11 @@ public sealed class ListLawsCommand : LocalizedEntityCommands
         switch (args.Length)
         {
             case 0:
-                foreach (var (ent, lawProvider) in _entityManager.AllEntities<SiliconLawProviderComponent>())
+                var query = _entityManager.EntityQueryEnumerator<SiliconLawProviderComponent, SiliconLawBoundComponent>();
+                while (query.MoveNext(out var ent, out var lawProvider, out _))
                 {
                     WriteLawReport(shell, ent, lawProvider);
                 }
-
                 break;
             case 1:
                 if (!_player.TryGetSessionByUsername(args[0], out var session) ||

--- a/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
@@ -26,7 +26,7 @@ public sealed class ListWatchlistedCommand : LocalizedEntityCommands
         foreach (var (playerId, records) in _notes.ConnectedPlayerWatchlists)
         {
             if (!_player.TryGetSessionById(playerId, out var sessionData))
-                return;
+                continue;
 
             shell.WriteMarkup($"\n[bold]{sessionData.Name}[/bold]");
             foreach (var record in records)

--- a/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
+++ b/Content.Server/_DV/Administration/Commands/ListWatchlistedCommand.cs
@@ -28,7 +28,7 @@ public sealed class ListWatchlistedCommand : LocalizedEntityCommands
             if (!_player.TryGetSessionById(playerId, out var sessionData))
                 return;
 
-            shell.WriteMarkup($"\n[bold]{sessionData.Name}[/bold]\n");
+            shell.WriteMarkup($"\n[bold]{sessionData.Name}[/bold]");
             foreach (var record in records)
             {
                 shell.WriteLine("");

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -242,7 +242,7 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
                 ent);
 
             // var logSeverity = HasComp<HumanoidAppearanceComponent>(args.Target) ? LogImpact.Extreme : LogImpact.High; // DeltaV - replaced below
-            var (logSeverity, hasMind) = DetermineSeverityHasMind(args.Target.Value); // DeltaV
+            var (logSeverity, hasMind) = LogValuesForTarget(args.Target.Value); // DeltaV
 
             _logger.Add(LogType.Action,
                 logSeverity,
@@ -330,7 +330,7 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
             // END DeltaV
 
             // var logSeverity = HasComp<HumanoidAppearanceComponent>(args.Target) ? LogImpact.Extreme : LogImpact.High; // DeltaV - replaced below
-            var (logSeverity, hasMind) = DetermineSeverityHasMind(args.Target.Value); // DeltaV
+            var (logSeverity, hasMind) = LogValuesForTarget(args.Target.Value); // DeltaV
 
             _logger.Add(LogType.Gib,
                 logSeverity,
@@ -361,7 +361,7 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
     }
 
     // DeltaV - Added method START
-    private (LogImpact, bool) DetermineSeverityHasMind(EntityUid? butcherTarget)
+    private (LogImpact, bool) LogValuesForTarget(EntityUid? butcherTarget)
     {
         var logSeverity = LogImpact.Medium; // Never alert by default
 

--- a/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
+++ b/Content.Shared/Kitchen/SharedKitchenSpikeSystem.cs
@@ -241,26 +241,8 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
                 args.Target.Value,
                 ent);
 
-            // DeltaV - Replace logSeverity START
-            var logSeverity = LogImpact.Medium;
-
-            // Extreme impact if SSD indicator comp is present on target (as of writing only regular player characters have it), always alerting
-            if (HasComp<SSDIndicatorComponent>(args.Target.Value))
-            {
-                logSeverity = LogImpact.Extreme;
-            }
-
-            var hasMind = false;
-            // Extreme impact if a mind is attached to the target, always alerting
-            if (TryComp<MindContainerComponent>(args.Target.Value, out var mindContainer))
-            {
-                if (mindContainer.HasMind)
-                {
-                    hasMind = true;
-                    logSeverity = LogImpact.Extreme;
-                }
-            }
-            // DeltaV - Replace logSeverity END
+            // var logSeverity = HasComp<HumanoidAppearanceComponent>(args.Target) ? LogImpact.Extreme : LogImpact.High; // DeltaV - replaced below
+            var (logSeverity, hasMind) = DetermineSeverityHasMind(args.Target.Value); // DeltaV
 
             _logger.Add(LogType.Action,
                 logSeverity,
@@ -347,11 +329,12 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
             }
             // END DeltaV
 
-            var logSeverity = HasComp<HumanoidAppearanceComponent>(args.Target) ? LogImpact.Extreme : LogImpact.High;
+            // var logSeverity = HasComp<HumanoidAppearanceComponent>(args.Target) ? LogImpact.Extreme : LogImpact.High; // DeltaV - replaced below
+            var (logSeverity, hasMind) = DetermineSeverityHasMind(args.Target.Value); // DeltaV
 
             _logger.Add(LogType.Gib,
                 logSeverity,
-                $"{ToPrettyString(args.User):user} finished butchering {ToPrettyString(args.Target):target} on the {ToPrettyString(ent):spike}");
+                $"{ToPrettyString(args.User):user} finished butchering {ToPrettyString(args.Target):target}{(hasMind ? " (MIND ATTACHED)" : "")} on the {ToPrettyString(ent):spike}"); // DeltaV - Add hasMind indicator
         }
         else
         {
@@ -376,6 +359,28 @@ public sealed class SharedKitchenSpikeSystem : EntitySystem
 
         args.Handled = true;
     }
+
+    // DeltaV - Added method START
+    private (LogImpact, bool) DetermineSeverityHasMind(EntityUid? butcherTarget)
+    {
+        var logSeverity = LogImpact.Medium; // Never alert by default
+
+        // Extreme impact if SSD indicator comp is present on target (as of writing only regular player characters have it), always alerting
+        if (HasComp<SSDIndicatorComponent>(butcherTarget))
+        {
+            logSeverity = LogImpact.Extreme;
+        }
+
+        var hasMind = TryComp<MindContainerComponent>(butcherTarget, out var mindContainer) && mindContainer.HasMind;
+        // Extreme impact if a mind is attached to the target, always alerting
+        if (hasMind)
+        {
+            logSeverity = LogImpact.Extreme;
+        }
+
+        return (logSeverity, hasMind);
+    }
+    // DeltaV - Added method END
 
     private void OnSpikeExamined(Entity<KitchenSpikeComponent> ent, ref ExaminedEvent args)
     {

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -15,8 +15,8 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Mindshield.Components; // DeltaV - Admin QOL
-using Content.Shared.Mobs;
-using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs; // DeltaV - Admin QOL
+using Content.Shared.Mobs.Components; // DeltaV - Admin QOL
 using Content.Shared.Popups;
 using Content.Shared.SSDIndicator; // DeltaV - Admin QOL
 using Content.Shared.Strip.Components;

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -639,10 +639,13 @@ public abstract class SharedStrippableSystem : EntitySystem
             {
                 logImpact = LogImpact.High;
             }
-            // ... and living, and the user is not mindshielded, always alert.
+            // TODO: ... and living, and the user is not mindshielded, alert on recent SSD
+            // Previously this was setting it to Extreme always if not shielded, but that's going to lead to a lot of false positives.
+            // Set it to extreme again once SSD Recency is merged and it happened in the first stage.
             else if (!isUserShielded)
             {
-                logImpact = LogImpact.Extreme;
+                // logImpact = LogImpact.Extreme;
+                logImpact = LogImpact.High;
             }
         }
 

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -340,6 +340,18 @@ public abstract class SharedStrippableSystem : EntitySystem
         _doAfterSystem.TryStartDoAfter(doAfterArgs);
     }
 
+    // DeltaV - Add utility function START
+    private (bool isTargetSsd, bool isTargetDead, bool isUserShielded) LogValuesForStripAction(EntityUid user, EntityUid target)
+    {
+        var isTargetSsd = TryComp<SSDIndicatorComponent>(target, out var ssdIndicator) && ssdIndicator.IsSSD;
+        var isTargetDead = TryComp<MobThresholdsComponent>(target, out var thresholds) &&
+                           thresholds.CurrentThresholdState == MobState.Dead;
+        var isUserShielded = HasComp<MindShieldComponent>(user);
+
+        return (isTargetSsd, isTargetDead, isUserShielded);
+    }
+    // DeltaV - Add utility function END
+
     /// <summary>
     ///     Removes the item from the target's inventory and inserts it in the user's active hand.
     /// </summary>
@@ -362,11 +374,7 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         // DeltaV - LogImpact Additions START
         // Previously High by default. Stop chat spam from searches in Sec. Somebody with bad intentions is likely to strip from the specified slots.
-        var isTargetSsd = TryComp<SSDIndicatorComponent>(target, out var ssdIndicator) && ssdIndicator.IsSSD;
-        var isTargetDead = TryComp<MobThresholdsComponent>(target, out var thresholds) &&
-                           thresholds.CurrentThresholdState == MobState.Dead;
-        var isUserShielded = HasComp<MindShieldComponent>(user);
-
+        var (isTargetSsd, isTargetDead, isUserShielded) = LogValuesForStripAction(user, target);
         var logImpact = LogImpact.Medium;
 
         // If someone strips a key item from a living SSD, always alert. If not SSD or SSD and dead, alert on new player.
@@ -609,12 +617,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         _handsSystem.TryDrop(target, item, checkActionBlocker: false);
         _handsSystem.PickupOrDrop(user, item, animateUser: stealth, animate: !stealth, handsComp: user.Comp);
 
-        // DeltaV - Additions START
-        var isTargetSsd = TryComp<SSDIndicatorComponent>(target, out var ssdIndicator) && ssdIndicator.IsSSD;
-        var isTargetDead = TryComp<MobThresholdsComponent>(target, out var thresholds) &&
-                     thresholds.CurrentThresholdState == MobState.Dead;
-        var isUserShielded = HasComp<MindShieldComponent>(user);
-        // DeltaV - Additions END
+        var (isTargetSsd, isTargetDead, isUserShielded) = LogValuesForStripAction(user, target); // DeltaV
 
         _adminLogger.Add(LogType.Stripping, !isUserShielded && isTargetSsd && !isTargetDead ? LogImpact.Extreme : LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Add conditional LogImpact. If not SSD Lower LogImpact to Medium, if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice. If living SSD, always alert.
         // Hand update will trigger strippable update.

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -42,8 +42,8 @@ public abstract class SharedStrippableSystem : EntitySystem
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
     private readonly string[] _keyItemSlots = ["id", "belt", "back"]; // DeltaV - high impact on player, key items
-    private readonly string[] _badStripSlots = ["jumpsuit"]; // DeltaV - people shouldn't be stripping each others clothes off
-    private readonly string[] _badSsdStripSlots = ["pocket1", "pocket2"]; // DeltaV - rummaging through pockets of ssd people is not nice
+    private readonly string[] _extremeStripSlots = ["jumpsuit"]; // DeltaV - people shouldn't be stripping each others clothes off
+    private readonly string[] _highSsdStripSlots = ["pocket1", "pocket2"]; // DeltaV - rummaging through pockets of ssd people is not nice
 
     public override void Initialize()
     {
@@ -385,10 +385,10 @@ public abstract class SharedStrippableSystem : EntitySystem
             logImpact = isTargetSsd && !isTargetDead ? LogImpact.Extreme : LogImpact.High;
         }
 
-        // In any case, alert if a player is trying to strip certain additional slots from a living SSD
-        if (_badSsdStripSlots.Contains(slot.ToLower()) && isTargetSsd && !isTargetDead)
+        // In any case, alert if a new player is trying to strip certain additional slots from a living SSD
+        if (_highSsdStripSlots.Contains(slot.ToLower()) && isTargetSsd && !isTargetDead)
         {
-            logImpact = LogImpact.Extreme;
+            logImpact = LogImpact.High;
         }
 
         // ... unless the user is mindshielded. Security searches people who might disconnect.
@@ -398,7 +398,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         }
 
         // If someone strips a jumpsuit from a dead player, they're probably trying to perform surgery, alert on new player. Otherwise, always alert, even if shielded.
-        if (_badStripSlots.Contains(slot.ToLower()))
+        if (_extremeStripSlots.Contains(slot.ToLower()))
         {
             logImpact = isTargetDead ? LogImpact.High : LogImpact.Extreme;
         }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -619,7 +619,7 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         var (isTargetSsd, isTargetDead, isUserShielded) = LogValuesForStripAction(user, target); // DeltaV
 
-        _adminLogger.Add(LogType.Stripping, !isUserShielded && isTargetSsd && !isTargetDead ? LogImpact.Extreme : LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Add conditional LogImpact. If not SSD Lower LogImpact to Medium, if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice. If living SSD, always alert.
+        _adminLogger.Add(LogType.Stripping, !isUserShielded && isTargetSsd && !isTargetDead ? LogImpact.High : LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Add conditional LogImpact. If not SSD Lower LogImpact to Medium; if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice. If living SSD, alert on new players.
         // Hand update will trigger strippable update.
     }
 

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -404,7 +404,7 @@ public abstract class SharedStrippableSystem : EntitySystem
         }
 
         // ... unless the user is an (admin) observer, admins setting up ghost roles in ATAG shouldn't trigger alerts
-        if (isUserShielded)
+        if (isUserGhost)
         {
             logImpact = LogImpact.Medium;
         }

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Cuffs.Components;
 using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
+using Content.Shared.Ghost; // DeltaV - Admin QOL
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.IdentityManagement;
@@ -341,14 +342,15 @@ public abstract class SharedStrippableSystem : EntitySystem
     }
 
     // DeltaV - Add utility function START
-    private (bool isTargetSsd, bool isTargetDead, bool isUserShielded) LogValuesForStripAction(EntityUid user, EntityUid target)
+    private (bool isTargetSsd, bool isTargetDead, bool isUserShielded, bool isUserGhost) LogValuesForStripAction(EntityUid user, EntityUid target)
     {
         var isTargetSsd = TryComp<SSDIndicatorComponent>(target, out var ssdIndicator) && ssdIndicator.IsSSD;
         var isTargetDead = TryComp<MobThresholdsComponent>(target, out var thresholds) &&
                            thresholds.CurrentThresholdState == MobState.Dead;
         var isUserShielded = HasComp<MindShieldComponent>(user);
+        var isUserGhost = HasComp<GhostComponent>(user);
 
-        return (isTargetSsd, isTargetDead, isUserShielded);
+        return (isTargetSsd, isTargetDead, isUserShielded, isUserGhost);
     }
     // DeltaV - Add utility function END
 
@@ -374,7 +376,7 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         // DeltaV - LogImpact Additions START
         // Previously High by default. Stop chat spam from searches in Sec. Somebody with bad intentions is likely to strip from the specified slots.
-        var (isTargetSsd, isTargetDead, isUserShielded) = LogValuesForStripAction(user, target);
+        var (isTargetSsd, isTargetDead, isUserShielded, isUserGhost) = LogValuesForStripAction(user, target);
         var logImpact = LogImpact.Medium;
 
         // If someone strips a key item from a living SSD, always alert. If not SSD or SSD and dead, alert on new player.
@@ -389,16 +391,22 @@ public abstract class SharedStrippableSystem : EntitySystem
             logImpact = LogImpact.Extreme;
         }
 
-        // ... unless the user is mindshielded. Cadets search people who might disconnect.
+        // ... unless the user is mindshielded. Security searches people who might disconnect.
         if (isUserShielded)
         {
             logImpact = LogImpact.Medium;
         }
 
-        // If someone strips a jumpsuit from a dead player, they're probably trying to perform surgery, alert on new player. Otherwise, always alert.
+        // If someone strips a jumpsuit from a dead player, they're probably trying to perform surgery, alert on new player. Otherwise, always alert, even if shielded.
         if (_badStripSlots.Contains(slot.ToLower()))
         {
             logImpact = isTargetDead ? LogImpact.High : LogImpact.Extreme;
+        }
+
+        // ... unless the user is an (admin) observer, admins setting up ghost roles in ATAG shouldn't trigger alerts
+        if (isUserShielded)
+        {
+            logImpact = LogImpact.Medium;
         }
         // DeltaV - LogImpact Additions END
 
@@ -617,9 +625,35 @@ public abstract class SharedStrippableSystem : EntitySystem
         _handsSystem.TryDrop(target, item, checkActionBlocker: false);
         _handsSystem.PickupOrDrop(user, item, animateUser: stealth, animate: !stealth, handsComp: user.Comp);
 
-        var (isTargetSsd, isTargetDead, isUserShielded) = LogValuesForStripAction(user, target); // DeltaV
+        var (isTargetSsd, isTargetDead, isUserShielded, isUserGhost) = LogValuesForStripAction(user, target); // DeltaV
 
-        _adminLogger.Add(LogType.Stripping, !isUserShielded && isTargetSsd && !isTargetDead ? LogImpact.High : LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Add conditional LogImpact. If not SSD Lower LogImpact to Medium; if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice. If living SSD, alert on new players.
+        // DeltaV - Add conditional logImpact START
+        // Lower default to Medium - the target is much more likely to notice, the item was probably being offered.
+        var logImpact = LogImpact.Medium;
+
+        // If they are SSD
+        if (isTargetSsd)
+        {
+            // ... and dead, alert on new player.
+            if (isTargetDead)
+            {
+                logImpact = LogImpact.High;
+            }
+            // ... and living, and the user is not mindshielded, always alert.
+            else if (!isUserShielded)
+            {
+                logImpact = LogImpact.Extreme;
+            }
+        }
+
+        // If the user is an (admin) observer, don't alert.
+        if (isUserGhost)
+        {
+            logImpact = LogImpact.Medium;
+        }
+        // DeltaV - Add conditional logImpact END
+
+        _adminLogger.Add(LogType.Stripping, logImpact, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {(isTargetSsd ? "[SSD] " : "")}{(isTargetDead ? "[DEAD] " : "")}{ToPrettyString(target):target}'s hands"); // DeltaV - replace logImpact, previously High. add SSD and DEAD indicators.
         // Hand update will trigger strippable update.
     }
 

--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -14,6 +14,9 @@ using Content.Shared.Interaction.Components;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.VirtualItem;
+using Content.Shared.Mindshield.Components; // DeltaV - Admin QOL
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Popups;
 using Content.Shared.SSDIndicator; // DeltaV - Admin QOL
 using Content.Shared.Strip.Components;
@@ -37,8 +40,9 @@ public abstract class SharedStrippableSystem : EntitySystem
 
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
 
-    private readonly string[] _highImpactOnStrip = ["id", "belt", "back"]; // DeltaV - high impact on player, key items
-    private readonly string[] _extremeImpactOnStrip = ["jumpsuit"]; // DeltaV - people shouldn't be stripping each others clothes off
+    private readonly string[] _keyItemSlots = ["id", "belt", "back"]; // DeltaV - high impact on player, key items
+    private readonly string[] _badStripSlots = ["jumpsuit"]; // DeltaV - people shouldn't be stripping each others clothes off
+    private readonly string[] _badSsdStripSlots = ["pocket1", "pocket2"]; // DeltaV - rummaging through pockets of ssd people is not nice
 
     public override void Initialize()
     {
@@ -358,26 +362,39 @@ public abstract class SharedStrippableSystem : EntitySystem
 
         // DeltaV - LogImpact Additions START
         // Previously High by default. Stop chat spam from searches in Sec. Somebody with bad intentions is likely to strip from the specified slots.
+        var isTargetSsd = TryComp<SSDIndicatorComponent>(target, out var ssdIndicator) && ssdIndicator.IsSSD;
+        var isTargetDead = TryComp<MobThresholdsComponent>(target, out var thresholds) &&
+                           thresholds.CurrentThresholdState == MobState.Dead;
+        var isUserShielded = HasComp<MindShieldComponent>(user);
+
         var logImpact = LogImpact.Medium;
-        if (_highImpactOnStrip.Contains(slot.ToLower()))
+
+        // If someone strips a key item from a living SSD, always alert. If not SSD or SSD and dead, alert on new player.
+        if (_keyItemSlots.Contains(slot.ToLower()))
         {
-            logImpact = LogImpact.High;
+            logImpact = isTargetSsd && !isTargetDead ? LogImpact.Extreme : LogImpact.High;
         }
 
-        if (_extremeImpactOnStrip.Contains(slot.ToLower()))
+        // In any case, alert if a player is trying to strip certain additional slots from a living SSD
+        if (_badSsdStripSlots.Contains(slot.ToLower()) && isTargetSsd && !isTargetDead)
         {
             logImpact = LogImpact.Extreme;
         }
 
-        var isSsd = false;
-        if (TryComp<SSDIndicatorComponent>(target, out var ssdIndicator) && ssdIndicator.IsSSD)
+        // ... unless the user is mindshielded. Cadets search people who might disconnect.
+        if (isUserShielded)
         {
-            isSsd = true;
-            logImpact = LogImpact.Extreme;
+            logImpact = LogImpact.Medium;
+        }
+
+        // If someone strips a jumpsuit from a dead player, they're probably trying to perform surgery, alert on new player. Otherwise, always alert.
+        if (_badStripSlots.Contains(slot.ToLower()))
+        {
+            logImpact = isTargetDead ? LogImpact.High : LogImpact.Extreme;
         }
         // DeltaV - LogImpact Additions END
 
-        _adminLogger.Add(LogType.Stripping, logImpact, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {(isSsd ? "[SSD] " : "")}{ToPrettyString(target):target}'s {slot} slot"); // DeltaV - replace default LogImpact, insert SSD indicator
+        _adminLogger.Add(LogType.Stripping, logImpact, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {(isTargetSsd ? "[SSD] " : "")}{(isTargetDead ? "[DEAD] " : "")}{ToPrettyString(target):target}'s {slot} slot"); // DeltaV - replace default LogImpact, insert SSD and DEAD indicators
     }
 
     /// <summary>
@@ -592,7 +609,14 @@ public abstract class SharedStrippableSystem : EntitySystem
         _handsSystem.TryDrop(target, item, checkActionBlocker: false);
         _handsSystem.PickupOrDrop(user, item, animateUser: stealth, animate: !stealth, handsComp: user.Comp);
 
-        _adminLogger.Add(LogType.Stripping, LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Lower LogImpact to Medium, if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice.
+        // DeltaV - Additions START
+        var isTargetSsd = TryComp<SSDIndicatorComponent>(target, out var ssdIndicator) && ssdIndicator.IsSSD;
+        var isTargetDead = TryComp<MobThresholdsComponent>(target, out var thresholds) &&
+                     thresholds.CurrentThresholdState == MobState.Dead;
+        var isUserShielded = HasComp<MindShieldComponent>(user);
+        // DeltaV - Additions END
+
+        _adminLogger.Add(LogType.Stripping, !isUserShielded && isTargetSsd && !isTargetDead ? LogImpact.Extreme : LogImpact.Medium, $"{ToPrettyString(user):actor} has stripped the item {ToPrettyString(item):item} from {ToPrettyString(target):target}'s hands"); // DeltaV - Add conditional LogImpact. If not SSD Lower LogImpact to Medium, if someone is stripping from hands, the item was probably being offered to them. If not, the target is much more likely to notice. If living SSD, always alert.
         // Hand update will trigger strippable update.
     }
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Patches for some issues I noticed with the commands and alerts added/changed by #5436:
- `lslaws` no longer lists law board entities
- *finishing* to butcher monkeys/kobolds no longer causes an alert either
- avoid spamming ssd stripping alerts by checking if the target is dead or the user is mindshielded
- also alert if unmindshielded new player stripping from living ssd player's hands
- made lswatchlisted output a little more compact
- fixed lswatchlisted aborting completely when encountering a record for a player without a session
 
## Why / Balance
Dealing with the consequences of my actions

## Technical details
really simple c# changes. added some conditions to stripping alerts and broke out the checked values for both stripping alerts and butcher alerts into separate functions for reuse.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
DeltaVAdmin:
- fix: SSD Stripping alerts are now less spammy
- fix: /lslaws no longer lists law board entities
- tweak: finishing to butcher monkeys/kobolds no longer alerts either
- fix: /lslwatchlisted now works properly. It will no longer display a partial/empty list.

