### PR TITLE
Tape recorder voice changing in secret stashes

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/tape_recorder.yml
@@ -16,6 +16,10 @@
   - type: TapeRecorder
   - type: ActiveListener
     range: 4
+  - type: ChangeVoiceInContainer
+    whitelist:
+      components:
+      - SecretStash
   - type: UseDelay
     delay: 1
   - type: Speech


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR adds the `ChangeVoiceInContainer` component (the same one pAIs and MMIs have) to tape recorders. This changes their voice to the voice of the container it's in *but only things with SecretStash, like...*
- Toilets (crowbar cistern. check for contents before inserting a tape recorder or it'll literally be deleted)
- Plushies (cut them open with a knife)
- Plants
- Cakes, somehow? A knife didn't work. Maybe it tries slicing it before opening the stash

(To use the tape recorder in the stash, you are expected to use signals, but timing the tape also works)

## Why / Balance
This PR makes anonymizing names more generally accessible `(even to non-antagonists)` as well as adding a fun extra functionality to tape recorders. Tape recorders can already be used to anonymize voice `(damage the tape and repair it)`, but that comes at the cost of being nigh incomprehensible because it messes with the text

For antagonists on a budget/non-traitors, this could be used as a terrible anonymize-only voice mask with the tradeoffs of being more annoying to use, needing pre-recording and maybe some tape juggling, as well as only having names from the list above
- Getting caught with the tape recorder/thing being used to hold the tape recorder is still *very bad* because they've literally recorded themselves saying that incriminating thing
- I'm not that sure about *antagonist stuff* in general but I think a some of the non-traitor antagonists would benefit from this. Security has to decide whether that threat that was called in via potted plant `(I imagine this as just hiding it in the dirt)` is credible. Being able to do foreboding antagonist threat roleplay via comms *without* being a traitor *or* making the text almost incomprehensible *without* instantly starting a security hunt—because you used your undisguised voice—preventing you from even acting on those threats. Security will be suspicious someone said something bad, but the credibility of that is questionable until *something actually happens*

For engineers/bored people, they could set up a plushie outside their department to make it seem like the plushie is greeting people `(I've seen this be done before, but having the plushie seem to be the one speaking would be cute)`. Or make a potted plant yell at people in the halls. Or a talking toilet
Someone could use this to become some sort of whistleblower using a plushie. I'm not quite sure what other fun silly gimmicks could be done using this

I do have some concerns about making this PR, largely because pAIs or MMIs have their messages very much linked to them because they're players. But an admin *should* be capable of tracking people down if they misuse this? I think? Toolshed for example is something that could very easily be used to find the tape recorder responsible and then probably the person who set it up. I don't know because I'm not an admin
My worries are from the fact it's an item that isn't directly linked to a player speaking clearly. It might make misuse of tape recorders harder to find. I don't know. Keep in mind anonymizing voices using tape recorders is already possible, but it's terrible. Maybe I'm overestimating the average griefer
Someone *could* set this up to scream into an intercom infinitely and not get caught easily, but regular tape recorders before this PR can do this. Damaging the tapes anonymizes the name too

I have no clue what I'm talking about. I have no clue if I've elaborated enough

## Media
Yes, I recreated the meme before realizing OBS doesn't work...
<img width="320" height="266" alt="image" src="https://github.com/user-attachments/assets/c10ac082-a6eb-4c72-81c3-56066d8849fd" />

.

<img width="243" height="209" alt="image" src="https://github.com/user-attachments/assets/30dd7fb6-d01d-4538-8027-345a4103a53e" />

<img width="216" height="176" alt="image" src="https://github.com/user-attachments/assets/80b0821a-e1eb-4cd0-9e9f-b0e86e32dd3a" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl: Minerva
- tweak: Tape recorders now change their voice when hidden in plushies, toilets, or plants.