### PR TITLE
Adds long labcoats to Epistemics

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/scidrobe.yml
@@ -9,6 +9,7 @@
     ClothingUniformJumpsuitScientistFormal: 3
     ClothingUniformJumpskirtScientistFormal: 3 # DeltaV - more jumpskirts
     ClothingOuterCoatRnd: 3
+    ClothingOuterCoatLabLong: 3 # DeltaV
     ClothingShoesColorWhite: 3
     ClothingNeckTieSci: 3
     ClothingHeadsetScience: 3

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1341,6 +1341,7 @@
   minLimit: 0
   loadouts:
   - RegularLabCoat
+  - LongLabCoat # DeltaV
   - ScienceLabCoat
   - ScienceWintercoat
   - SeniorResearcherLabCoat

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -810,6 +810,7 @@
   - RoboticistLabCoat
   - RoboticistWintercoat
   - RegularLabCoat
+  - LongLabCoat
   - ScienceLabCoat
   - CardborgCostume
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR adds the (regular) long labcoats added in https://github.com/DeltaV-Station/Delta-v/pull/5485 to
- Scientist/Roboticist loadout
- SciDrobe

I did not add it to Mystagogue loadout due to the lack of a regular upstream labcoat there. It'd look weird to have only one and not both

This PR will make less sense without https://github.com/DeltaV-Station/Delta-v/pull/5622 because the description will explicitly mention the Medical department. Not gamebreaking if this gets merged before that so whatever

## Why / Balance
Scientist fashion. They already have regular labcoats, so they should also probably have the long variant

## Media
<img width="292" height="271" alt="image" src="https://github.com/user-attachments/assets/dbf665e3-92dc-4958-b596-60c631c2daaa" />

<img width="647" height="401" alt="image" src="https://github.com/user-attachments/assets/de47f0b8-6bb2-44c0-9f16-d2fe7cfee604" />

<img width="696" height="456" alt="image" src="https://github.com/user-attachments/assets/a81c04ae-5c27-4b6a-a115-6709b2bb455f" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl: Minerva
- tweak: Scientists and Roboticists can now select long labcoats in loadout. They are also now available in the SciDrobe.