### PR TITLE
Minor indentation change on pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ This just saves them the trouble. Note that AGPL or MIT licensing is only applic
 - [ ] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
   - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
   - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
-    <!-- Feel free to add more licenses as you see fit -->
+<!-- Feel free to add more licenses as you see fit -->
 
 **Changelog**
 <!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.


### PR DESCRIPTION
## About the PR
This PR removes the indentation in the comment just below licensing on the pull request template

## Why / Balance
It's the only seemingly-pointlessly indented comment in the entire file, plus it's kind of inconvenient to delete. Invisible comments do not really need indentation

I tend to delete comments as I fill out PRs and it's annoying working around this one specific line. I've been caught in a loop several times now of accidentally deleting that line entirely only to add a new one and have it autoindented `(because it's trying to add to a list)` so I have to backspace again

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
It feels very strange having licensing for this PR considering this is not for the game itself
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
