### PR TITLE
Revert APC max load to 20kW

### DIFF
--- a/Content.Server/Power/Components/ApcComponent.cs
+++ b/Content.Server/Power/Components/ApcComponent.cs
@@ -39,7 +39,7 @@ public sealed partial class ApcComponent : BaseApcNetComponent
     /// timer, which after enough overloading causes the APC to "trip" off.
     /// </summary>
     [DataField]
-    public float MaxLoad = 40e3f; // DeltaV - Was 20e3f, upping to allow for maps to catch up ; THIS WILL BE REVERTED TO 20kW BY MARCH 2026
+    public float MaxLoad = 20e3f;
 
     /// <summary>
     /// Time that the APC can be continuously overloaded before tripping off.


### PR DESCRIPTION
## About the PR
Revert APCs to upstream value of 20kW

## Why / Balance
They were temporarily increased to 40kW to give time for map makers to adjust

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- tweak: APC breaker limit reduced from 40kW to 20kW
