### PR TITLE
Withdraw 30 sheets at a time from fabs

### DIFF
--- a/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
+++ b/Content.Client/Materials/UI/MaterialDisplay.xaml.cs
@@ -71,7 +71,7 @@ public sealed partial class MaterialDisplay : PanelContainer
         if (!_canEject)
             return;
 
-        int[] sheetsToEjectArray = { 1, 5, 10 };
+        int[] sheetsToEjectArray = { 1, 5, 10, 30 }; // DeltaV - added 30 to array
 
         for (var i = 0; i < sheetsToEjectArray.Length; i++)
         {
@@ -88,7 +88,7 @@ public sealed partial class MaterialDisplay : PanelContainer
                 Name = $"{sheetsToEject}",
                 Access = AccessLevel.Public,
                 Text = Loc.GetString($"{sheetsToEject}"),
-                MinWidth = 45,
+                MinWidth = 35, // DeltaV - reduced from 45 to accomodate extra button
                 StyleClasses = { styleClass }
             };
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Adds a button to withdraw 30 sheets at a time from fabs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously, you could only withdraw in increments of 1, 5, or 10. Material stacks max out at 30, so it's good to be able to print a full stack in one click.

## Technical details
<!-- Summary of code changes for easier review. -->
Changes two lines in Client\Materials\UI\MaterialDisplay.xaml.cs:
- adds 30 to sheetsToEjectArray
- reduces MinWidth for created buttons from 45 to 35 to accommodate an extra button 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="770" height="527" alt="image" src="https://github.com/user-attachments/assets/d714e12e-cb10-4dbe-9818-1395a92c56ac" />
<img width="316" height="274" alt="image" src="https://github.com/user-attachments/assets/c9910f35-01cf-45d0-a4d8-1ce55c950464" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

🆑 
- tweak: Added a button to withdraw 30 material sheets from any machine that uses the materials system. Techfabs, imprinters, etc..