### PR TITLE
Fix blood amount for synths

### DIFF
--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -31,7 +31,7 @@ public sealed class SynthSystem : EntitySystem
             Dirty(uid, indicator);
         }
 
-        // Begin DeltaV - Change blood amount according to original BloodstreamCompoentn.ReferenceSolution volume
+        // Begin DeltaV - Change blood amount according to original BloodstreamCompoent.ReferenceSolution volume
         if (TryComp<BloodstreamComponent>(uid, out var bloodstream))
         {
             // Give them synth blood. Ion storm notif is handled in that system

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -1,5 +1,6 @@
 using Content.Server.Body.Systems;
 using Content.Server.Database;
+using Content.Shared.Body.Components;
 using Content.Shared.Chat.TypingIndicator;
 using Content.Shared.Chemistry.Reagent;
 using Robust.Shared.Prototypes;
@@ -30,7 +31,11 @@ public sealed class SynthSystem : EntitySystem
             Dirty(uid, indicator);
         }
 
-        // Give them synth blood. Ion storm notif is handled in that system
-        _bloodstream.ChangeBloodReagent(uid, SynthBloodReagent); // DeltaV - make strings static readonly
+        // DeltaV - Change blood amount according to 
+        if (TryComp<BloodstreamComponent>(uid, out var bloodstream))
+        {
+            // Give them synth blood. Ion storm notif is handled in that system
+            _bloodstream.ChangeBloodReagents((uid, bloodstream), new([new(SynthBloodReagent, bloodstream.BloodReferenceSolution.Volume)]));
+        }
     }
 }

--- a/Content.Server/_CD/Traits/SynthSystem.cs
+++ b/Content.Server/_CD/Traits/SynthSystem.cs
@@ -31,11 +31,12 @@ public sealed class SynthSystem : EntitySystem
             Dirty(uid, indicator);
         }
 
-        // DeltaV - Change blood amount according to 
+        // Begin DeltaV - Change blood amount according to original BloodstreamCompoentn.ReferenceSolution volume
         if (TryComp<BloodstreamComponent>(uid, out var bloodstream))
         {
             // Give them synth blood. Ion storm notif is handled in that system
             _bloodstream.ChangeBloodReagents((uid, bloodstream), new([new(SynthBloodReagent, bloodstream.BloodReferenceSolution.Volume)]));
         }
+        // End DeltaV
     }
 }


### PR DESCRIPTION
## About the PR
When setting blood quantity from the Synth trait, copy the blood volume from the original blood reference solution.

## Why / Balance
Fixes #5679
Previously the target blood volume would be set to 1, meaning it'd slowly tick down from initial 300 to 1

## Technical details
Get the original BloodReferenceSolution and set the volume of the SynthBlood accordingly.
Don't do anything if the entity doesn't have BloodstreamComponent

## Media
n/A

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- fix: Synths no longer run on a single drop of blood