### PR TITLE
CE AI Upload Access

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1653,7 +1653,7 @@
   - type: Computer
     board: StationAiUploadCircuitboard
   - type: AccessReader
-    access: [ [ "ResearchDirector" ] ]
+    access: [ [ "ResearchDirector" ], ["ChiefEngineer" ] # DeltaV - added chief engineer
   - type: Lock
     unlockOnClick: false
   - type: SiliconLawUpdater

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1653,7 +1653,7 @@
   - type: Computer
     board: StationAiUploadCircuitboard
   - type: AccessReader
-    access: [ [ "ResearchDirector" ], ["ChiefEngineer" ] # DeltaV - added chief engineer
+    access: [ [ "ResearchDirector" ], ["ChiefEngineer" ] ] # DeltaV - added chief engineer
   - type: Lock
     unlockOnClick: false
   - type: SiliconLawUpdater


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In server rules CE, MG, captain are authorized to change the AI laws but CE doesn't have access. It also just makes sense. It also kind of sucks if there's no MG captain HAS to be the one to deal with the AI. Engineering is also way more equipped to deal with ai than epistemics. I think engineering does a lot more for the ai than epistemics does and AI should have a RP relationship with the chief engineer. Dealing with the AI is often a chore that MG will not have time for or just fail to prioritize. When this is the case it really sucks to be chud engineer who could fix it in 20 seconds but you don't have access, even though you logically should.
Also giving a locker with ai access but no intellicard might make it easier to subvert the AI, but it is still an "inferior" locker to steal. CE locker is generally kind of more useless than any other command locker for antags since CEbelt is no longer an obj its just the magboots.
## Technical details
<!-- Summary of code changes for easier review. -->
Add ChiefEngineer access to access checkeer on ai upload computer
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Chief Engineers are now able to access the AI Upload Console to properly assist in debugging.
