### PR TITLE
Ensure shields without toggles can still block damage

### DIFF
--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -54,7 +54,7 @@ public sealed partial class BlockingSystem
             return;
 
         // Delta V - Begin Fix Toggleable Shields always blocking
-        if (!TryComp<ItemToggleComponent>(item, out var toggleComp) || !toggleComp.Activated)
+        if (TryComp<ItemToggleComponent>(item, out var toggleComp) && !toggleComp.Activated)
             return;
         // Delta V - End
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
https://github.com/DeltaV-Station/Delta-v/pull/5600 fixed deployable shields from blocking damage when they shouldn't, but inadvertently disabled shields without toggles from working.

## Why / Balance
Blockable damage should be blocked when the user has an item that could block the blockable damage for the purpose of blocking. Causing the user wielding the blocking item to take less blockable damage than they would have not blocked in the case where they were not blocking by using a blocking item.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
Bullet Shield

<img width="714" height="311" alt="image" src="https://github.com/user-attachments/assets/914dca6f-f815-4711-96ec-97e14e7f40a7" />

Energy Shield (Undeployed)

<img width="714" height="311" alt="image" src="https://github.com/user-attachments/assets/e4f254b1-0e14-4aa4-b61d-ae6cbfda8c45" />

Energy Shield (Deployed)

<img width="714" height="311" alt="image" src="https://github.com/user-attachments/assets/eba20a98-28ed-4b4d-85a3-ea0a2f362205" />

Laser Shield

<img width="714" height="311" alt="image" src="https://github.com/user-attachments/assets/86395b29-9361-4e25-a204-d411c70b09e7" />

Telescopic Shield (Undeployed)

<img width="714" height="311" alt="image" src="https://github.com/user-attachments/assets/d9c5b0c4-4945-4e3f-9699-3773db188d41" />

Telescopic Shield (Deployed)

<img width="714" height="311" alt="image" src="https://github.com/user-attachments/assets/eac3c2c7-905e-4fbb-b1d1-10faf3057c09" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Non-deployable blocking based items (shields) now block blockable damage when wielded for the purposes of blocking. (Normal shields reduce damage again)

