### PR TITLE
Customizable sec belt/webbing inventory

### DIFF
--- a/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
+++ b/Resources/Locale/en-US/_DV/preferences/loadout-groups.ftl
@@ -140,6 +140,7 @@ loadout-group-all-gun = Security Sidearm
 loadout-group-security-gun-ammo = Ammunition
 loadout-group-revolver-ammo = Ammunition
 loadout-group-all-ammo = Ammunition
+security-utility = Utility
 
 # Justice
 loadout-group-chiefjustice-head = Chief Justice head

--- a/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Security/security_officer.yml
@@ -86,12 +86,12 @@
 - type: loadout
   id: SecurityBelt
   equipment:
-    belt: ClothingBeltSecurityFilled
+    belt: ClothingBeltSecurityBeltCustom # DeltaV - loadouts
 
 - type: loadout
   id: SecurityWebbing
   equipment:
-    belt: ClothingBeltSecurityWebbingFilled
+    belt: ClothingBeltSecurityWebbingCustom # DeltaV - loadouts
 
 # Outerclothing
 - type: loadout

--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -413,6 +413,7 @@
   - GroupSpeciesBreathToolSecurity
   - SecurityAllFirearm # DeltaV - loadouts
   - SecurityAllAmmo # DeltaV - loadouts
+  - SecurityUtility # DeltaV - loadouts
 
 - type: roleLoadout
   id: JobWarden
@@ -432,6 +433,7 @@
   - GroupSpeciesBreathToolSecurity
   - SecurityAllFirearm # DeltaV - loadouts
   - SecurityAllAmmo # DeltaV - loadouts
+  - SecurityUtility # DeltaV - loadouts
 
 - type: roleLoadout
   id: JobSecurityOfficer
@@ -452,6 +454,7 @@
   - GroupSpeciesBreathToolSecurity
   - SecurityFirearm # DeltaV - loadouts
   - SecurityFirearmAmmo # DeltaV - loadouts
+  - SecurityUtility # DeltaV - loadouts
 
 - type: roleLoadout
   id: JobDetective

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -44,6 +44,7 @@
   - GroupSpeciesBreathToolSecurity
   - SecurityFirearm # DeltaV - loadouts
   - SecurityFirearmAmmo # DeltaV - loadouts
+  - SecurityUtility
 
 # Wildcards
 - type: roleLoadout

--- a/Resources/Prototypes/_DV/Catalog/Fills/Items/Belts/belts.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Items/Belts/belts.yml
@@ -26,6 +26,30 @@
         - id: EmergencyMedipen
 
 - type: entity
+  id: ClothingBeltSecurityBeltCustom
+  parent: ClothingBeltSecurity
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: Stunbaton
+        - id: Handcuffs
+
+- type: entity
+  id: ClothingBeltSecurityWebbingCustom
+  parent: ClothingBeltSecurityWebbing
+  suffix: Filled
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: Stunbaton
+        - id: Handcuffs
+
+- type: entity
   id: ClothingBeltFoamSheathFilled
   parent: ClothingBeltFoamSheath
   suffix: Filled

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
@@ -145,3 +145,41 @@
   id: SecurityClothingHandsGlovesFingerless
   equipment:
     gloves: ClothingHandsGlovesFingerless
+
+# SecBelt utility
+
+- type: loadout
+  id: FlashBangLoadout
+  storage:
+    belt:
+    - GrenadeFlashBang
+
+- type: loadout
+  id: TearGasLoadout
+  storage:
+    belt:
+    - TearGasGrenade
+
+- type: loadout
+  id: SecHoloProjectorLoadout
+  storage:
+    belt:
+    - HoloprojectorSecurity
+
+- type: loadout
+  id: StingerGrenadeLoadout
+  storage:
+    belt:
+    - GrenadeStinger
+
+- type: loadout
+  id: RadioHandheldSecurityLoadout
+  storage:
+    belt:
+    - RadioHandheldSecurity
+
+- type: loadout
+  id: HandcuffsLoadout
+  storage:
+    belt:
+    - Handcuffs

--- a/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Jobs/Security/security_officer.yml
@@ -183,3 +183,9 @@
   storage:
     belt:
     - Handcuffs
+
+- type: loadout
+  id: SecLiteLoadout
+  storage:
+    belt:
+    - FlashlightSeclite

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -417,7 +417,7 @@
 ## Security utility
 - type: loadoutGroup
   id: SecurityUtility
-  name: Utility
+  name: security-utility
   minLimit: 0
   maxLimit: 4
   loadouts:

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -414,6 +414,20 @@
   - SecurityFirearmSpeedLoaderSpecialRubber
   - SecurityFirearmSpeedLoaderSpecial
 
+## Security utility
+- type: loadoutGroup
+  id: SecurityUtility
+  name: security-utility
+  minLimit: 0
+  maxLimit: 4
+  loadouts:
+  - FlashBangLoadout
+  - TearGasLoadout
+  - StingerGrenadeLoadout
+  - RadioHandheldSecurityLoadout
+  - SecHoloProjectorLoadout
+  - HandcuffsLoadout
+
 ## Security Gloves
 - type: loadoutGroup
   id: SecurityGloves

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -417,7 +417,7 @@
 ## Security utility
 - type: loadoutGroup
   id: SecurityUtility
-  name: security-utility
+  name: Utility
   minLimit: 0
   maxLimit: 4
   loadouts:
@@ -427,6 +427,7 @@
   - RadioHandheldSecurityLoadout
   - SecHoloProjectorLoadout
   - HandcuffsLoadout
+  - SecLiteLoadout
 
 ## Security Gloves
 - type: loadoutGroup


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
In loadouts, you can now customize what you want to have in your secbelt, besides the essentials.

## Why / Balance
Security by default now starts with a stunbaton and one single handcuff in their belt. However, in loadouts, they can now choose what goes into their belt with 4 items (due to webbing having smaller inventory, secbelt will still have one free slot in your belt), which range from:
- additional handcuff
- flashbang
- stinger
- teargas
- holobarrier
- handheld sec radio
- seclight

This would generally give more on how you wanna customize your secoff, instead of having to throw out that dang teargas and head to secvend to grab yer tools.
This only affects the Warden, HOS, prison guard and secoffs. Cadets come with a normal filled secbelt (tear gas, flashbang, baton, 2 handcuffs) because I figure they should generally know their basics.

**CM can debate if loadout groupings of secbelts should go to cadets too. And if "utility" is a good name for the secbelt stuff**

Also also, some GUY told me I SHOULDN'T remove TEARGAS from SECBELTS, but WHO CARES.

## Technical details
I've made a "ClothingBeltSecurityBeltCustom" (and web version) and applied to round start sec roles. This is to not affect visiting sec ghost roles and other ghost roles that rely on secfilled belt. 

## Media
<img width="588" height="428" alt="image" src="https://github.com/user-attachments/assets/5e5685e5-e31e-4980-990d-636a922e5d59" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- add: In an effort to save money on tear gas grenade production, Security can now choose up to 4 items for their secbelt in the character loadout under the “Utility” section! Remember to actually choose what you want, unless you want to go in with just a baton and cuffs.