### PR TITLE
stealthsuit tweaks

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -21,11 +21,13 @@
         Slash: 0.95
         Piercing: 0.95
         Heat: 0.95
-  - type: ClothingGrantComponent
-    component:
-    - type: Stealth
+  # DeltaV start
+  # - type: ClothingGrantComponent
+  #   component:
+  #   - type: Stealth
     # Harmony start
-    - type: StealthOnMove
-      passiveVisibilityRate: -0.5
-      movementVisibilityRate: 0.45 # DeltaV - was 0.6
+  #   - type: StealthOnMove
+  #     passiveVisibilityRate: -0.5
+  #     movementVisibilityRate: 0.6
     # Harmony end
+  # DeltaV end

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -3,7 +3,7 @@
   id: ClothingOuterHardsuitCybersunStealth
   # suffix: stealth - Harmony change
   name: cybersun stealth hardsuit
-  description: A hardsuit with stealth plating for operations, the shielding doesn't work while you're moving though! Needs the helmet on to finish the stealth field.
+  description: A hardsuit with stealth plating for operations, the shielding doesn't work while you're moving though! # DeltaV- remove mention needing helmet
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/cybersunstealth.rsi
@@ -14,22 +14,24 @@
   - type: PressureProtection
     highPressureMultiplier: 0.05
     lowPressureMultiplier: 1000
+  # DeltaV changes begin
   - type: ExplosionResistance
-    damageCoefficient: 0.8 # DeltaV - was 0.65
+    damageCoefficient: 0.8 #  was 0.65
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.7 # DeltaV - was 0.65
-        Slash: 0.7 # DeltaV - was 0.65
-        Piercing: 0.6 
-        Heat: 0.8 # DeltaV - was 0.6
-        Radiation: 0.8 # DeltaV - was 0.55
-        #Caustic: 0.7 # DeltaV
-  - type: StaminaResistance # DeltaV
+        Blunt: 0.7 # was 0.65
+        Slash: 0.7 # was 0.65
+        Piercing: 0.6 # unchanged
+        Heat: 0.8 # was 0.6
+        Radiation: 0.8 # was 0.55
+        #Caustic: 0.7 
+  - type: StaminaResistance 
     damageCoefficient: 0.7
+  # DeltaV changes end
   - type: ClothingSpeedModifier
-    walkModifier: 1.0 # DeltaV - was 0.8
-    sprintModifier: 1.0 # DeltaV - was 0.85
+    walkModifier: 0.8
+    sprintModifier: 0.9 # DeltaV - was 0.85
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitCybersunStealth
@@ -37,10 +39,12 @@
     tags:
     - Hardsuit
     - WhitelistChameleon
-  # Harmony start
-  # - type: ClothingGrantComponent
-  #   component:
-  #   - type: StealthOnMove
-  #     passiveVisibilityRate: -0.5
-  #     movementVisibilityRate: 0.6
-  # Harmony end
+  # DeltaV start - removed Harmony block comment disabling stealth without helmet
+  - type: ClothingGrantComponent
+    component:
+    - type: Stealth
+      minVisibility: 0.05 # better than ninja, but will always have a wiggle
+    - type: StealthOnMove
+      passiveVisibilityRate: -0.5
+      movementVisibilityRate: 0.6
+  # DeltaV end


### PR DESCRIPTION

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
has 0.9 speed (had no slowdown before)
minimum visibility 0.5 (was previously perfect)
helmet does not need to be up for stealth (so they can use psionic nullifier helmet)
I was going to make it run on batteries but toggling systems fucked. and batteries are too complicated for my simple time. also if it just wiggles all the time it doesn't need batteries.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Stealth was previously perfect which made wormops + sit in corner too easy. It is still possible, but if your cover is blown people will actually possibly maybe be able to see you, or punish mistakes
when this was ported 20% slowdown was removed probably to compensate for removing 5% armor values (mistake), and the stealthonmove value was reduced to such a value making it so you could actually regenerate stealth while still moving ? to compensate for higher base movement speed maybe?
It could probably be healthy eating 10% less armor (current values are 30% everything 40% pierce) 

I tested making the minimum cloaking the same as ninja, but honestly the ninja is pretty visible but has the benefit of higher movement speed, so I let it be slightly better. 

## Technical details
<!-- Summary of code changes for easier review. -->
change stealth suit helmet to no longer have clothinggrant comp
give clothinggrant to hardsuit
make comment block instead of a zillion lines in the armor values
stealthonmove increased back to 0.6
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Go my unembedded youtube link
[url](https://youtu.be/RcNkeckpt5c)
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Cybersun stealth suits are slightly slower, and no longer have perfect cloaking after a Spider Clan attack on production facilities.
