### PR TITLE
Fix: Chronic Pain Popup Visible to All

### DIFF
--- a/Content.Shared/_DV/ChronicPain/EntitySystems/SharedChronicPainSystem.cs
+++ b/Content.Shared/_DV/ChronicPain/EntitySystems/SharedChronicPainSystem.cs
@@ -94,7 +94,7 @@ public abstract partial class SharedChronicPainSystem : EntitySystem
             return;
 
         var effect = RobustRandom.Pick(effects);
-        Popup.PopupPredicted(Loc.GetString(effect), entity, entity);
+        Popup.PopupClient(Loc.GetString(effect), entity, entity);
 
         // Set next popup time
         var delay = RobustRandom.Next(entity.Comp.MinimumPopupDelay, entity.Comp.MaximumPopupDelay);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixed a bug that causes the popups from the Chronic Pain trait to be visible to everyone nearby. It is now only visible to the client with the trait.
Fixes #5743

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These popups are clearly only intended for the player with the trait to see. They have to express their discomfort the usual way now.
## Technical details
<!-- Summary of code changes for easier review. -->
Replaced PopupPredicted in SharedChronicPainSystem.cs with PopupClient
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1116" height="589" alt="Screenshot 2026-04-27 204655" src="https://github.com/user-attachments/assets/04b92ce8-736f-493e-88dd-74553f37111b" />
The player on the left is the one with the trait while the player on the right does not have the trait. The popup is only visible to the player with the trait now.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Sugarcane
- fix: Fixed the chronic pain trait popups being visible to every player nearby.

