### PR TITLE
Fix: Reactor Flatpack Paper Error

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
@@ -72,3 +72,41 @@
   components:
   - type: Flatpack
     entity: OperatingTable
+
+- type: entity
+  parent: BaseStructureDynamic
+  id: HeavyFlatpackBase
+  name: heavy flatpack
+  description: A large flatpack used to store a worryingly large machine.
+  categories: HideSpawnMenu
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/flatpack.rsi
+    layers:
+    - state: large
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.29"
+        density: 100
+        mask:
+        - CrateMask
+        layer:
+        - MachineLayer
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: InteractionOutline

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
@@ -74,12 +74,11 @@
     entity: OperatingTable
 
 - type: entity
+  abstract: true
   parent: BaseStructureDynamic
   id: HeavyFlatpackBase
   name: heavy flatpack
   description: A large flatpack used to store a worryingly large machine.
-  categories:
-  - HideSpawnMenu
   components:
   - type: Sprite
     sprite: Objects/Devices/flatpack.rsi

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
@@ -78,7 +78,8 @@
   id: HeavyFlatpackBase
   name: heavy flatpack
   description: A large flatpack used to store a worryingly large machine.
-  categories: HideSpawnMenu
+  categories:
+  - HideSpawnMenu
   components:
   - type: Sprite
     sprite: Objects/Devices/flatpack.rsi

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: CrateEngineering
+  parent: BaseFlatpack
   id: NuclearReactorFlatpack
   name: nuclear reactor flatpack
   description: A flatpack used for constructing a nuclear reactor. Parts sold separately.
@@ -12,7 +12,7 @@
     entity: NuclearReactorEmpty
 
 - type: entity
-  parent: CrateEngineering
+  parent: BaseFlatpack
   id: GasTurbineFlatpack
   name: gas turbine flatpack
   description: A flatpack used for constructing a gas turbine.

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
@@ -1,46 +1,5 @@
-# Begin Delta-V additions
-# A unique parent type for the unique flatpacks
 - type: entity
-  parent: BaseStructureDynamic
-  id: HeavyFlatpack
-  name: heavy flatpack
-  description: A large flatpack that behaves similarly to a crate.
-  categories: HideSpawnMenu
-  components:
-  - type: Sprite
-    sprite: Objects/Devices/flatpack.rsi
-    layers:
-    - state: large
-  - type: Fixtures
-    fixtures:
-      fix1:
-        shape:
-          !type:PhysShapeAabb
-          bounds: "-0.4,-0.4,0.4,0.29"
-        density: 100
-        mask:
-        - CrateMask
-        layer:
-        - MachineLayer
-  - type: Damageable
-    damageContainer: StructuralInorganic
-    damageModifierSet: StructuralMetallic
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTrigger
-        damage: 75
-      behaviors:
-      - !type:DoActsBehavior
-        acts: [ "Destruction" ]
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MetalBreak
-  - type: InteractionOutline
-    # End Delta-V Additions
-
-- type: entity
-  parent: HeavyFlatpack # Delta-V was CrateEngineering
+  parent: HeavyFlatpackBase # Delta-V was CrateEngineering
   id: NuclearReactorFlatpack
   name: nuclear reactor flatpack
   description: A flatpack used for constructing a nuclear reactor. Parts sold separately.
@@ -53,7 +12,7 @@
     entity: NuclearReactorEmpty
 
 - type: entity
-  parent: HeavyFlatpack # Delta-V was CrateEngineering
+  parent: HeavyFlatpackBase # Delta-V was CrateEngineering
   id: GasTurbineFlatpack
   name: gas turbine flatpack
   description: A flatpack used for constructing a gas turbine.

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
@@ -1,5 +1,46 @@
+# Begin Delta-V additions
+# A unique parent type for the unique flatpacks
 - type: entity
-  parent: BaseFlatpack
+  parent: BaseStructureDynamic
+  id: HeavyFlatpack
+  name: heavy flatpack
+  description: A large flatpack that behaves similarly to a crate.
+  categories: HideSpawnMenu
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/flatpack.rsi
+    layers:
+    - state: large
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.29"
+        density: 100
+        mask:
+        - CrateMask
+        layer:
+        - MachineLayer
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: InteractionOutline
+    # End Delta-V Additions
+
+- type: entity
+  parent: HeavyFlatpack # Delta-V was CrateEngineering
   id: NuclearReactorFlatpack
   name: nuclear reactor flatpack
   description: A flatpack used for constructing a nuclear reactor. Parts sold separately.
@@ -12,7 +53,7 @@
     entity: NuclearReactorEmpty
 
 - type: entity
-  parent: BaseFlatpack
+  parent: HeavyFlatpack # Delta-V was CrateEngineering
   id: GasTurbineFlatpack
   name: gas turbine flatpack
   description: A flatpack used for constructing a gas turbine.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Creates a new entity type called HeavyFlatpack which both NuclearReactorFlatpack and GasTurbineFlatpack use as a parent. It behaves as both a flatpack and a crate and fixes issue #5740.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The current parent was CrateEngineering which caused an error when attempting to attach a paper to it. This new parent type is custom made for these unique flatpacks instead of being a strange crate.
## Technical details
<!-- Summary of code changes for easier review. -->
Set the NuclearReactorFlatpack and GasTurbineFlatpack to use parent: HeavyFlatpack
Created entity HeavyFlatpack which has similar stats to a crate but cannot be opened, have paper attached, and can be opened with a multitool.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="175" height="168" alt="image" src="https://github.com/user-attachments/assets/0f7669cc-1678-4a2f-bb6a-60e63cdda6e5" />
Paper cannot be attached to the flatpack

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Sugarcane
- fix: Paper can no longer be attached to nuclear reactor flatpacks

