### PR TITLE
Secret Weights Maintenance

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -212,7 +212,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 4 # DeltaV - was 6.5
+    weight: 2.5 # DeltaV - was 6.5
     earliestStart: 60 # DeltaV - was 40
     reoccurrenceDelay: 20
     minimumPlayers: 45 # DeltaV - was 20

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -111,7 +111,7 @@
     startAudio:
       path: /Audio/Announcements/announce.ogg
     weight: 12 # DeltaV - was 8
-    duration: 35
+    duration: 20 #DeltaV was 35
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-anomaly-spawn-result-message
   - type: AnomalySpawnRule
@@ -152,7 +152,7 @@
   parent: BaseGameRule
   components:
   - type: StationEvent
-    weight: 10
+    weight: 4 #DeltaV was 10
     duration: 1
     minimumPlayers: 15
   - type: PrecognitionResult # DeltaV - Precogniton
@@ -212,7 +212,7 @@
   id: DragonSpawn
   components:
   - type: StationEvent
-    weight: 2.5 # DeltaV - was 6.5
+    weight: 4 # DeltaV - was 6.5
     earliestStart: 60 # DeltaV - was 40
     reoccurrenceDelay: 20
     minimumPlayers: 45 # DeltaV - was 20
@@ -347,7 +347,7 @@
   id: RevenantSpawn
   components:
   - type: StationEvent
-    weight: 2 # DeltaV - was 7.5, lowered because of GlimmerRevenantSpawn event
+    weight: 4 # DeltaV - was 7.5, lowered because of GlimmerRevenantSpawn event
     duration: 1
     earliestStart: 45
     minimumPlayers: 20
@@ -457,7 +457,7 @@
   id: SolarFlare
   components:
   - type: StationEvent
-    weight: 10
+    weight: 7 #DeltaV was 10
     startAnnouncement: station-event-solar-flare-start-announcement
     endAnnouncement: station-event-solar-flare-end-announcement
     startAudio:
@@ -510,7 +510,7 @@
       path: /Audio/_DV/Announcements/attention.ogg # DeltaV - custom announcer
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 6 #DeltaV was 5
     duration: 30 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-slimes-spawn-result-message
@@ -531,7 +531,7 @@
       path: /Audio/_DV/Announcements/attention.ogg # DeltaV - custom announcer
     earliestStart: 20
     minimumPlayers: 15
-    weight: 5
+    weight: 6 #DeltaV was 5
     duration: 30 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-snake-spawn-result-message
@@ -570,7 +570,7 @@
       path: /Audio/_DV/Announcements/attention.ogg # DeltaV - custom announcer
     earliestStart: 45 # DeltaV - was 20
     minimumPlayers: 30 # DeltaV - was 20
-    weight: 1 # DeltaV - was 1.5
+    weight: 1.5
     duration: 30 # DeltaV: was 60, used as a delay now
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-spider-clown-spawn-result-message
@@ -595,7 +595,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ InitialInfected ]
-      max: 4 # DeltaV - was 3
+      max: 5 # DeltaV - was 3
       playerRatio: 10
       blacklist:
         components:
@@ -667,7 +667,7 @@
   components:
   - type: StationEvent
     earliestStart: 30
-    weight: 5 # DeltaV - Was 8 now 5
+    weight: 4 # DeltaV - Was 8 now 4
     minimumPlayers: 15
     maxOccurrences: 1 # can only happen once per round
     startAnnouncement: station-event-communication-interception
@@ -714,8 +714,8 @@
   id: IonStorm
   components:
   - type: StationEvent
-    weight: 10
-    reoccurrenceDelay: 30 # DeltaV - Was 20 #20 mins feels too short, and can scramble borgs way too much
+    weight: 14 #DeltaV was 10
+    reoccurrenceDelay: 20
     duration: 1
   - type: PrecognitionResult # DeltaV - Precogniton
     message: psionic-power-precognition-ion-storm-result-message
@@ -740,7 +740,7 @@
   - type: StationEvent
     startAudio:
       path: /Audio/_DV/Announcements/attention.ogg # DeltaV - custom announcer
-    weight: 5
+    weight: 8 #DeltaV was 5
     minimumPlayers: 25
     reoccurrenceDelay: 20
   - type: GreytideVirusRule

--- a/Resources/Prototypes/_DV/CosmicCult/events.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/events.yml
@@ -3,10 +3,10 @@
   id: ColossusSpawn
   components:
   - type: StationEvent
-    weight: 4.5
+    weight: 3 # DeltaV was 4.5
     earliestStart: 45
     reoccurrenceDelay: 20
-    minimumPlayers: 25
+    minimumPlayers: 30 # DeltaV was 25
     duration: null
   - type: PrecognitionResult
     message: psionic-power-precognition-colossus-spawn-result-message

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -24,8 +24,8 @@
   id: MeteorSwarm
   components:
   - type: StationEvent
-    earliestStart: 30
-    weight: 7.5
+    earliestStart: 15 #DeltaV was 30
+    weight: 6 #DeltaV was 7.5
     minimumPlayers: 10 #Enough to hopefully have at least one engineering guy
     startAnnouncement: station-event-meteor-swarm-start-announcement
     endAnnouncement: station-event-meteor-swarm-end-announcement
@@ -48,7 +48,7 @@
       path: /Audio/_DV/Announcements/aliens.ogg
     earliestStart: 25
     minimumPlayers: 30
-    weight: 2
+    weight: 3 #DeltaV was 2
     duration: 30
   - type: PrecognitionResult
     message: psionic-power-precognition-xeno-vents-result-message
@@ -95,7 +95,7 @@
   id: ListeningPost
   components:
   - type: StationEvent
-    earliestStart: 30
+    earliestStart: 45 #DeltaV was 30
     weight: 4
     minimumPlayers: 25
     maxOccurrences: 1
@@ -143,8 +143,8 @@
   id: MalignRiftSpawn
   components:
   - type: StationEvent
-    earliestStart: 15
-    weight: 6
+    earliestStart: 30 #DeltaV was 15
+    weight: 4 #DeltaV was 6
   - type: PrecognitionResult
     message: psionic-power-precognition-rift-spawn-result-message
   - type: RandomMultipleSpawnRule

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -25,7 +25,7 @@
   components:
   - type: StationEvent
     earliestStart: 15 #DeltaV was 30
-    weight: 6 #DeltaV was 7.5
+    weight: 7.5
     minimumPlayers: 10 #Enough to hopefully have at least one engineering guy
     startAnnouncement: station-event-meteor-swarm-start-announcement
     endAnnouncement: station-event-meteor-swarm-end-announcement

--- a/Resources/Prototypes/_DV/secret_weights.yml
+++ b/Resources/Prototypes/_DV/secret_weights.yml
@@ -1,10 +1,9 @@
 - type: weightedRandom
   id: SecretDeltaV
   weights:
-    Survival: 0.30
-    Extended: 0.06 # Requested for more "RP Centric" rounds
-    Nukeops: 0.12
-    Zombie: 0.10
+    Survival: 0.34
+    Nukeops: 0.20
+    Zombie: 0.08
     Traitor: 0.30
-    CosmicCult: 0.12 # my cult so cosmic!
+    CosmicCult: 0.08 # my cult so cosmic!
     #Pirates: 0.15 #ahoy me bucko

--- a/Resources/Prototypes/_DV/secret_weights.yml
+++ b/Resources/Prototypes/_DV/secret_weights.yml
@@ -2,8 +2,9 @@
   id: SecretDeltaV
   weights:
     Survival: 0.30
-    Nukeops: 0.15
+    Extended: 0.06 # Requested for more "RP Centric" rounds
+    Nukeops: 0.12
     Zombie: 0.10
-    Traitor: 0.35
-    CosmicCult: 0.10 # my cult so cosmic!
+    Traitor: 0.30
+    CosmicCult: 0.12 # my cult so cosmic!
     #Pirates: 0.15 #ahoy me bucko


### PR DESCRIPTION
## About the PR
Changed levels in Secret Weights and multiple Event.yml files 

## Why / Balance
Most rounds end currently with 5-6 round ending antagonists on station, and a mass casualty of some sort. This balance is intended to encourage more RP, and lessen the "MASS CASUALTIES" that the scheduler faces.
## Technical details
Changed A LOT of files. These changes were made while in the Project Management Meeting, I can post changes later.
## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
not needed, YML changes for scheduler

**Changelog**
:cl:
- tweak: The weights have been adjusted for antagonists and Round ending "Disasters"
