### PR TITLE
Tweak decal spawners

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/dirt.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/dirt.yml
@@ -74,7 +74,7 @@
     - FloorGrassLightIndoors
     - FloorMowedAstroSnowDug
     - FloorSteelBurnt
-    # Delata V - End Additions
+    # Delta V - End Additions
     # N14 - Begin Additions
     # Add N14 tiles after they are resprited.
     # N14 - End Additions
@@ -168,7 +168,7 @@
     - FloorGrassLightIndoors
     - FloorMowedAstroSnowDug
     - FloorSteelBurnt
-    # Delata V - End Additions
+    # Delta V - End Additions
     # N14 - Begin Additions
     # Add N14 tiles after they are resprited.
     # N14 - End Additions

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/dirt.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/dirt.yml
@@ -8,27 +8,31 @@
     - DirtLight
     - DirtMedium
     - DirtHeavy
-    maxDecalsPerTile: 1
+    maxDecalsPerTile: 4 # Delta V - Was 1
     snapPosition: true
     zIndex: 5
     prob: 0.8
     color: '#FFFFFF7F'
     cleanable: true
     tileBlacklist: # Everything here just looks bad if it gets regular dirt on it
-    - FloorSteelMono
-    - FloorSteelDiagonal
-    - FloorSteelOffset
-    - FloorSteelDiagonalMini
+    # Delta V - Begin edits
+    #- FloorSteelMono
+    #- FloorSteelDiagonal
+    #- FloorSteelOffset
+    #- FloorSteelDiagonalMini
+    # Delta V - End edits
     - FloorWood
     - FloorWoodLarge
-    - FloorWhiteMono
-    - FloorWhiteDiagonal
-    - FloorWhiteOffset
-    - FloorWhiteDiagonalMini
-    - FloorDarkMono
-    - FloorDarkDiagonal
-    - FloorDarkOffset
-    - FloorDarkDiagonalMini
+    # Delta V - Begin edits
+    #- FloorWhiteMono
+    #- FloorWhiteDiagonal
+    #- FloorWhiteOffset
+    #- FloorWhiteDiagonalMini
+    #- FloorDarkMono
+    #- FloorDarkDiagonal
+    #- FloorDarkOffset
+    #- FloorDarkDiagonalMini
+    # Delta V - End edits
     - FloorArcadeBlue
     - FloorArcadeBlue2
     - FloorArcadeRed
@@ -37,16 +41,15 @@
     - FloorCarpetOffice
     - FloorBoxing
     - FloorGym
-    - FloorGlass
-    - FloorRGlass
+    # Delta V - Begin edits
+    #- FloorGlass
+    #- FloorRGlass
+    # Delta V - End edits
     - FloorAstroGrass
     - FloorMowedAstroGrass
     - FloorJungleAstroGrass
     - FloorAstroIce
     - FloorAstroSnow
-    - FloorMowedAstroSnow # DeltaV
-    - FloorAstroSnowDug # DeltaV
-    - FloorMowedAstroSnow # DeltaV
     - FloorAstroAsteroidSand
     - FloorFlesh
     - FloorAsteroidSandUnvariantized
@@ -64,6 +67,17 @@
     - FloorAsphalt
     - FloorReinforced
     - FloorLino
+    # Delta V - Begin Additions
+    - FloorMowedAstroSnow
+    - FloorAstroSnowDug
+    - FloorGrassDarkIndoors
+    - FloorGrassLightIndoors
+    - FloorMowedAstroSnowDug
+    - FloorSteelBurnt
+    # Delata V - End Additions
+    # N14 - Begin Additions
+    # Add N14 tiles after they are resprited.
+    # N14 - End Additions
     deleteSpawnerAfterSpawn: true
 
 - type: entity
@@ -107,15 +121,17 @@
     - Dirt
     - DirtHeavyMonotile
     tileBlacklist:
-    - FloorSteelDiagonal
-    - FloorSteelOffset
-    - FloorSteelDiagonalMini
-    - FloorWhiteDiagonal
-    - FloorWhiteOffset
-    - FloorWhiteDiagonalMini
-    - FloorDarkDiagonal
-    - FloorDarkOffset
-    - FloorDarkDiagonalMini
+    # Delta V - Begin edits
+    #- FloorSteelDiagonal
+    #- FloorSteelOffset
+    #- FloorSteelDiagonalMini
+    #- FloorWhiteDiagonal
+    #- FloorWhiteOffset
+    #- FloorWhiteDiagonalMini
+    #- FloorDarkDiagonal
+    #- FloorDarkOffset
+    #- FloorDarkDiagonalMini
+    # Delta V - End edits
     - FloorArcadeBlue
     - FloorArcadeBlue2
     - FloorArcadeRed
@@ -145,6 +161,17 @@
     - FloorGrass
     - FloorAsphalt
     - FloorReinforced
+    # Delta V - Begin Additions
+    - FloorMowedAstroSnow
+    - FloorAstroSnowDug
+    - FloorGrassDarkIndoors
+    - FloorGrassLightIndoors
+    - FloorMowedAstroSnowDug
+    - FloorSteelBurnt
+    # Delata V - End Additions
+    # N14 - Begin Additions
+    # Add N14 tiles after they are resprited.
+    # N14 - End Additions
 
 - type: entity
   parent: DecalSpawnerDirtMonospace

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/flora.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/flora.yml
@@ -35,7 +35,7 @@
     - FloorGrassDarkIndoors
     - FloorGrassLightIndoors
     - FloorMowedAstroSnowDug
-    # Delata V - End Additions
+    # Delta V - End Additions
 
 - type: entity
   parent: DecalSpawnerFloraBase

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/flora.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/flora.yml
@@ -4,7 +4,7 @@
   abstract: true
   components:
   - type: RandomDecalSpawner
-    radius: d3
+    radius: 0.3
     zIndex: 5
     deleteSpawnerAfterSpawn: true
     tileWhitelist:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/flora.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Decals/flora.yml
@@ -4,7 +4,7 @@
   abstract: true
   components:
   - type: RandomDecalSpawner
-    radius: 0.3
+    radius: d3
     zIndex: 5
     deleteSpawnerAfterSpawn: true
     tileWhitelist:
@@ -16,7 +16,6 @@
     - FloorDesertAstroSand
     - FloorAstroIce
     - FloorAstroSnow
-    - FloorMowedAstroSnow # DeltaV
     - FloorAstroAsteroidSand
     - FloorAsteroidSandUnvariantized
     - FloorAsteroidIronsandUnvariantized
@@ -30,6 +29,13 @@
     - FloorGrassDark
     - FloorGrassJungle
     - FloorGrass
+    # Delta V - Begin Additions
+    - FloorMowedAstroSnow
+    - FloorAstroSnowDug
+    - FloorGrassDarkIndoors
+    - FloorGrassLightIndoors
+    - FloorMowedAstroSnowDug
+    # Delata V - End Additions
 
 - type: entity
   parent: DecalSpawnerFloraBase


### PR DESCRIPTION
## About the PR
- Expands the set of tiles that can spawn dirt
- Adds missing DV prototypes
- Tweaks the amount of dirt that can spawn per tile 1->4

## Why / Balance
A little more accessible to mappers

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) 

**Changelog**
n/a
