### PR TITLE
Prevent zombies/non-humanoids/non-borgs from using jetpacks

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -26,6 +26,8 @@ using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Movement.Components; // DeltaV
+using Content.Shared._DV.Movement.Components; // DeltaV
 using Content.Shared.NameModifier.EntitySystems;
 using Content.Shared.NPC.Components; // DeltaV
 using Content.Shared.NPC.Systems;
@@ -73,6 +75,7 @@ public sealed partial class ZombieSystem
     [Dependency] private readonly TagSystem _tag = default!;
     [Dependency] private readonly ISharedPlayerManager _player = default!;
     [Dependency] private readonly PsionicSystem _psionic = default!; // DeltaV
+    [Dependency] private readonly SharedJetpackSystem _jetpack = default!; // DeltaV - Prevent Jetpacks on Zombies
 
     private static readonly ProtoId<TagPrototype> InvalidForGlobalSpawnSpellTag = "InvalidForGlobalSpawnSpell";
     private static readonly ProtoId<TagPrototype> CannotSuicideTag = "CannotSuicide";
@@ -151,6 +154,14 @@ public sealed partial class ZombieSystem
         if (HasComp<PsionicComponent>(target))
             _psionic.MindBreakEntity(target, false, true);
         // DeltaV End - Prevent Psionic Zombies
+        // DeltaV Start - Prevent Jetpacks on Zombies
+        if (TryComp<JetpackUserComponent>(target, out var jetpackUser))
+        {
+            if(TryComp<JetpackComponent>(jetpackUser.Jetpack, out var jetpack))
+                _jetpack.SetEnabled(jetpackUser.Jetpack, jetpack, false, target);
+        }
+        RemComp<AutomaticJetpackUserComponent>(target);
+        // DeltaV End - Prevent Jetpacks on Zombies
 
         //funny voice
         var accentType = "zombie";

--- a/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
+++ b/Content.Shared/_DV/Movement/Systems/SharedJetpackSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.ActionBlocker;
 using Content.Shared._DV.Movement.Components;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
@@ -7,11 +8,18 @@ namespace Content.Shared.Movement.Systems;
 public abstract partial class SharedJetpackSystem
 {
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     private void OnJetpackToggle(Entity<JetpackComponent> jetpack, ref ToggleJetpackEvent args)
     {
         if (args.Handled)
             return;
+
+        if (!_actionBlocker.CanComplexInteract(args.Performer))
+        {
+            _popup.PopupClient(Loc.GetString("jetpack-too-complex"), jetpack, args.Performer);
+            return;
+        }
 
         jetpack.Comp.AutomaticMode = !jetpack.Comp.AutomaticMode;
         jetpack.Comp.AutomaticUser = args.Performer;

--- a/Resources/Locale/en-US/_DV/movement/jetpacks.ftl
+++ b/Resources/Locale/en-US/_DV/movement/jetpacks.ftl
@@ -2,3 +2,4 @@ jetpack-activated-on-grid = The jetpack will automatically turn on when leaving 
 jetpack-activated-off-grid = The jetpack turns on.
 jetpack-activates-automatically = The jetpack automatically turns on.
 jetpack-deactivated = The jetpack will no longer turn on.
+jetpack-too-complex = The jetpack seems to be too complicated to operate.


### PR DESCRIPTION
## About the PR
Zombies and pets can no longer use jetpacks. Attempting to will result in the message:
"The jetpack seems to be too complicated to operate."

## Why / Balance
On Delta-v, pending a rework, the consensus has been that zombies are not supposed to be intelligent. Being able to correctly operate a jetpack when zombies struggle at running compared to unzombified beings is a stretch.

Quote from upstream for `ComplexInteractionComponent`:
> This is used to gate manipulation to general humanoids. If a mouse shouldn't be able to do something, then it's complex.

Upstream removes ComplexInteractionComponent from Zombies. It can safely be assumed that a mouse would not be able to operate a jetpack.

## Technical details
Introduces `CanComplexInteract` check from `ActionBlockerSystem` alongside a translation string
When Zombifying: Removes `AutomaticJetpackUserComponent`, calls `SharedJetpackSystem.SetEnable(..., false, ...)`

This technically affects every being without ComplexInteractionComponent, including pets.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="442" height="137" alt="image" src="https://github.com/user-attachments/assets/5db08e41-4443-4d3a-87aa-ad4d1c013145" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Zombies can no longer use jetpacks
- remove: Pets can no longer use jetpacks
