### PR TITLE
Buff glasses vision correction

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -82,6 +82,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/glasses.rsi
   - type: VisionCorrection
+    correctionPower: 8 # Delta-V (was default value, 2)
   - type: Tag
     tags:
     - HamsterWearable
@@ -112,6 +113,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/jamjar.rsi
   - type: VisionCorrection
+    correctionPower: 8 # Delta-V (was default value, 2)
   - type: Tag
     tags:
     - HamsterWearable
@@ -128,6 +130,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/outlawglasses.rsi
   - type: VisionCorrection
+    correctionPower: 8 # Delta-V (was default value, 2)
   - type: IdentityBlocker
   - type: StaticPrice
     price: 500

--- a/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
@@ -52,7 +52,7 @@
   - type: EyeProtection
     protectionTime: 5
   - type: VisionCorrection
-    correctionPower: 1.50 # Being flash proof comes at the cost of less range of vision
+    correctionPower: 2 # Being flash proof comes at the cost of less range of vision
   - type: IdentityBlocker
     coverage: EYES
 

--- a/Resources/Prototypes/_DV/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Eyes/hud.yml
@@ -12,7 +12,7 @@
     graph: PrescriptionMedHud
     node: prescmedhud
   - type: VisionCorrection
-    correctionPower: 1.75 # The hud part decreases efficiency
+    correctionPower: 2.5 # The hud part decreases efficiency
 
 - type: entity
   parent: ClothingEyesHudSecurity
@@ -28,7 +28,7 @@
     graph: PrescriptionSecHud
     node: prescsechud
   - type: VisionCorrection
-    correctionPower: 1.75 # The hud part decreases efficiency
+    correctionPower: 2.5 # The hud part decreases efficiency
 
 - type: entity
   parent: ClothingEyesHudDiagnostic
@@ -59,7 +59,7 @@
     graph: PrescriptionDiagHud
     node: prescdiaghud
   - type: VisionCorrection
-    correctionPower: 1.75 # The hud part decreases efficiency
+    correctionPower: 2.5 # The hud part decreases efficiency
 
 # ERT
 

--- a/Resources/Prototypes/_DV/Entities/Clothing/Psionic/psionic_clothing.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Psionic/psionic_clothing.yml
@@ -21,6 +21,7 @@
   - type: Clothing
     sprite: Clothing/Eyes/Glasses/glasses.rsi
   - type: VisionCorrection
+    correctionPower: 8 # Delta-V (was default value, 2)
   - type: TelegnosisPower
 
 - type: entity

--- a/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Eyes/glasses.yml
@@ -10,3 +10,4 @@
     sprite: _NF/Clothing/Eyes/Glasses/pilot.rsi
   - type: HandheldGPS
   - type: VisionCorrection
+    correctionPower: 8 # Delta-V (was default value, 2)


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
NT stopped cheapening out on glasses and they are now all around much better at correcting your vision.

## Why / Balance
So, as someone that played a short-sighted character a few times.
The shader effect for it is cool and works well at blocking your vision far away. You can counter it with glasses, but that has the inherent disadvantage of losing the ability to use flash/welding protection, night vision, thermals, etc. And prescription HUDs are a compromise to get at least basic job info. Alright. The idea is neat.

But... the blur stays there even with glasses, just weaker to the point it becomes just annoying. You can still see just fine up to the edges of the screen, it's all just got this white-ish filter that ends up kinda being headache inducing after you stare at it for up to 2 hours. It doesn't make you *worse* at much, with only the Prescription Sec HUD still having a limited range, it just ends up annoying.

So we're buffing them all.
The downside of being nearsighted seems like it should be the danger of *losing the glasses* or being unable to use better eye gear without losing your ability to see properly, rather than having to deal with a slightly blurry filter the entire shift.
Insert a Velma "MY GLASSES" gif here (one day i'll figure out how to make you drop them when you slip too)

## Technical details
YAML ops.
Glasses (plain ones and other variants like jamjars) vision correction strength: 2 -> 8
Prescription HUD vision correction strength: 1.75 -> 2.5
Prescription Sec Glasses vision correction strength: 1.5 -> 2

## Media
<img width="2716" height="1991" alt="OLD" src="https://github.com/user-attachments/assets/bc509123-caf9-4663-ab53-259b946d1b7f" />

<img width="2715" height="1991" alt="NEW" src="https://github.com/user-attachments/assets/695f9a15-b6c6-49cd-9336-b9e5668c5df8" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Prescription glasses and HUDs are better at correcting bad vision.
-->
