### PR TITLE
Salvage Access Only on Salvage Magnet

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -41,7 +41,7 @@
   - type: SalvageMagnet
   - type: ActivatableUIRequiresAccess
   - type: AccessReader
-    access: [["Salvage"]]
+    access: [["Salvage"]] #Delta V: made the salvage magnet only open it's UI if you have Salvage access on your ID card
   - type: ApcPowerReceiver
     powerLoad: 2500 # TODO change this to a HV power draw that really hits the grid hard WHEN active
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -39,9 +39,9 @@
     channels:
     - Supply
   - type: SalvageMagnet
-  - type: ActivatableUIRequiresAccess
-  - type: AccessReader
-    access: [["Salvage"]] #Delta V: made the salvage magnet only open it's UI if you have Salvage access on your ID card
+  - type: ActivatableUIRequiresAccess # DeltaV - Limit access
+  - type: AccessReader # DeltaV - Limit access
+    access: [["Salvage"]]
   - type: ApcPowerReceiver
     powerLoad: 2500 # TODO change this to a HV power draw that really hits the grid hard WHEN active
   - type: Machine

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -39,6 +39,9 @@
     channels:
     - Supply
   - type: SalvageMagnet
+  - type: ActivatableUIRequiresAccess
+  - type: AccessReader
+    access: [["Salvage"]]
   - type: ApcPowerReceiver
     powerLoad: 2500 # TODO change this to a HV power draw that really hits the grid hard WHEN active
   - type: Machine


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Made the Salvage Magnet only open it's UI if you have Salvage access on your ID card
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
it feels like every single round has like 1-3 assistants breaking out into space to tide using the salvage magnet. It's just kind of straight up annoying when salvage can't do their job because the infamous space tider is spamming their magnet, jumping out to loot the debris, then jumping back with no approval from salvage. This does still allow it to be emagged to be changed to AA, so if an antag really for some reason wants to space tide using the magnet they still can.
## Technical details
<!-- Summary of code changes for easier review. -->
like three YML lines
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
No media because it just says "Access denied." if you click the magnet with no Salvage access on your ID card
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- tweak: Salvage magnet now requires salvage access to use, or an EMAG.