### PR TITLE
Send PDA ringer sound to the StationAI player directly

### DIFF
--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Mind;
 using Content.Shared.PDA.Ringer;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
+using Content.Shared.Silicons.StationAi; // DeltaV - StationAI: Send PDA ringer sound to the player directly
 using Content.Shared.Store;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
@@ -55,6 +56,22 @@ public abstract class SharedRingerSystem : EntitySystem
             if (curTime < ringer.NextNoteTime.Value)
                 continue;
 
+            // DeltaV Start - StationAI: Send PDA ringer sound to the player directly
+            // Check if a StationAI owns this ringer. If so, the sound needs to play so that it is audible for the StationAI (not from the PDA's location)
+            if (HasComp<StationAiHeldComponent>(uid))
+            {
+                if (_net.IsServer)
+                {
+                    _audio.PlayGlobal(
+                        GetSound(ringer.Ringtone[ringer.NoteCount]),
+                        Filter.Entities(uid),
+                        true,
+                        AudioParams.Default.WithVolume(ringer.Volume)
+                    );
+                }
+            }
+            else
+            // DeltaV End - StationAI: Send PDA ringer sound to the player directly
             // Play the note
             // We only do this on the server because otherwise the sound either dupes or blends into a mess
             // There's no easy way to figure out which player started it, so that we can exclude them from the list

--- a/Content.Shared/PDA/SharedRingerSystem.cs
+++ b/Content.Shared/PDA/SharedRingerSystem.cs
@@ -2,7 +2,6 @@ using Content.Shared.Mind;
 using Content.Shared.PDA.Ringer;
 using Content.Shared.Popups;
 using Content.Shared.Roles;
-using Content.Shared.Silicons.StationAi; // DeltaV - StationAI: Send PDA ringer sound to the player directly
 using Content.Shared.Store;
 using JetBrains.Annotations;
 using Robust.Shared.Audio;
@@ -56,9 +55,9 @@ public abstract class SharedRingerSystem : EntitySystem
             if (curTime < ringer.NextNoteTime.Value)
                 continue;
 
-            // DeltaV Start - StationAI: Send PDA ringer sound to the player directly
-            // Check if a StationAI owns this ringer. If so, the sound needs to play so that it is audible for the StationAI (not from the PDA's location)
-            if (HasComp<StationAiHeldComponent>(uid))
+            // DeltaV Start - Silicons: Send PDA ringer sound to the player directly
+            // Check if this ringer is also a player. If so, the sound needs to play to the player itself.
+            if (HasComp<ActorComponent>(uid))
             {
                 if (_net.IsServer)
                 {
@@ -71,7 +70,7 @@ public abstract class SharedRingerSystem : EntitySystem
                 }
             }
             else
-            // DeltaV End - StationAI: Send PDA ringer sound to the player directly
+            // DeltaV End - Silicons: Send PDA ringer sound to the player directly
             // Play the note
             // We only do this on the server because otherwise the sound either dupes or blends into a mess
             // There's no easy way to figure out which player started it, so that we can exclude them from the list


### PR DESCRIPTION


<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Prevents the sound from appearing at the StationAI core's location and instead plays the sound globally for the StationAI player.

## Why / Balance
This allows for better roleplay as it reduces the chance of a NanoChat message sent to the StationAI being lost in the chat due to the missing audio cue.

## Technical details
If uid of Ringer-having entity has StationAiHeldComponent, play ringer globally with a filter to the specific entity that has received it.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Station AI can now hear the PDAs ringer for NanoChat/News
