### PR TITLE
[TESTMERGE] Quadratic armour

### DIFF
--- a/Content.Server/Armor/ArmorSystem.cs
+++ b/Content.Server/Armor/ArmorSystem.cs
@@ -30,5 +30,13 @@ public sealed class ArmorSystem : SharedArmorSystem
             var damageType = _protoManager.Index<DamageTypePrototype>(modifier.Key);
             args.Price += component.PriceMultiplier * damageType.ArmorPriceFlat * modifier.Value;
         }
+
+        // Begin DeltaV Additions
+        foreach (var modifier in component.Modifiers.Armor)
+        {
+            var damageType = _protoManager.Index<DamageTypePrototype>(modifier.Key);
+            args.Price += component.PriceMultiplier * damageType.ArmorPrice * modifier.Value;
+        }
+        // End DeltaV Additions
     }
 }

--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -218,13 +218,25 @@ namespace Content.Server.Zombies
             RaiseLocalEvent(uid, armorEv);
             foreach (var resistanceEffectiveness in zombieComponent.ResistanceEffectiveness.DamageDict)
             {
-                if (armorEv.DamageModifiers.Coefficients.TryGetValue(resistanceEffectiveness.Key, out var coefficient))
+                // Begin DeltaV changes - we have armour and need to bridge the gap to this
+                foreach (var modifier in armorEv.DamageModifiers)
                 {
+                    if (!modifier.Coefficients.TryGetValue(resistanceEffectiveness.Key, out var coefficient) &&
+                        modifier.Armor.TryGetValue(resistanceEffectiveness.Key, out var armor))
+                    {
+                        coefficient = 1f - Math.Clamp(0.1f * armor, 0f, 1f); // shitty approximation
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
                     // Scale the coefficient by the resistance effectiveness, very descriptive I know
                     // For example. With 30% slash resist (0.7 coeff), but only a 60% resistance effectiveness for slash,
                     // you'll end up with 1 - (0.3 * 0.6) = 0.82 coefficient, or a 18% resistance
                     var adjustedCoefficient = 1 - ((1 - coefficient) * resistanceEffectiveness.Value.Float());
                     chance *= adjustedCoefficient;
+                    // End DeltaV changes - we have armour and need to bridge the gap to this
                 }
             }
 

--- a/Content.Shared/Armor/ArmorComponent.cs
+++ b/Content.Shared/Armor/ArmorComponent.cs
@@ -37,7 +37,12 @@ public sealed partial class ArmorComponent : Component
     [DataField("staminaMeleeDamageCoefficient")]
     private float? _staminaMeleeDamageCoefficient;
 
-    public float StaminaMeleeDamageCoefficient => _staminaMeleeDamageCoefficient ?? Modifiers.Coefficients.GetValueOrDefault("Blunt", 1.0f);
+    public float StaminaMeleeDamageCoefficient => _staminaMeleeDamageCoefficient ??
+                                                  (Modifiers.Coefficients.TryGetValue("Blunt", out var coefficient)
+                                                      ? coefficient
+                                                      : Modifiers.Armor.TryGetValue("Blunt", out var armor)
+                                                          ? 1f - Math.Clamp(0.01f * armor, 0f, 1f)
+                                                          : 1f);
     // End DeltaV - Give armor melee stamina resistance
 }
 
@@ -61,7 +66,7 @@ public sealed class CoefficientQueryEvent : EntityEventArgs, IInventoryRelayEven
     /// <summary>
     /// The Total of all Coefficients.
     /// </summary>
-    public DamageModifierSet DamageModifiers { get; set; } = new DamageModifierSet();
+    public List<DamageModifierSet> DamageModifiers = new(); // DeltaV - stack modifiers instead of doing weird math
 
     public CoefficientQueryEvent(SlotFlags slots)
     {

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -37,10 +37,7 @@ public abstract class SharedArmorSystem : EntitySystem
         if (TryComp<MaskComponent>(ent, out var mask) && mask.IsToggled)
             return;
 
-        foreach (var armorCoefficient in ent.Comp.Modifiers.Coefficients)
-        {
-            args.Args.DamageModifiers.Coefficients[armorCoefficient.Key] = args.Args.DamageModifiers.Coefficients.TryGetValue(armorCoefficient.Key, out var coefficient) ? coefficient * armorCoefficient.Value : armorCoefficient.Value;
-        }
+        args.Args.DamageModifiers.Add(ent.Comp.Modifiers); // DeltaV - new armour stacking
     }
 
     private void OnDamageModify(EntityUid uid, ArmorComponent component, InventoryRelayedEvent<DamageModifyEvent> args)
@@ -102,6 +99,19 @@ public abstract class SharedArmorSystem : EntitySystem
                 ("value", flatArmor.Value)
             ));
         }
+
+        // Begin DeltaV Additions
+        foreach (var factor in component.Modifiers.Armor)
+        {
+            msg.PushNewline();
+
+            var armorType = Loc.GetString("armor-damage-type-" + factor.Key.Id.ToLower());
+            msg.AddMarkupOrThrow(Loc.GetString("armor-armor-value",
+                ("type", armorType),
+                ("value", MathF.Round(factor.Value))
+            ));
+        }
+        // End DeltaV Additions
 
         // Begin DeltaV Additions - Add melee stamina resistance information if it has any
         if (!MathHelper.CloseTo(component.StaminaMeleeDamageCoefficient, 1.0f))

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -108,7 +108,7 @@ public abstract class SharedArmorSystem : EntitySystem
             var armorType = Loc.GetString("armor-damage-type-" + factor.Key.Id.ToLower());
             msg.AddMarkupOrThrow(Loc.GetString("armor-armor-value",
                 ("type", armorType),
-                ("value", MathF.Round(factor.Value))
+                ("value", MathF.Round(factor.Value * 2f))
             ));
         }
         // End DeltaV Additions

--- a/Content.Shared/Blocking/BlockingSystem.User.cs
+++ b/Content.Shared/Blocking/BlockingSystem.User.cs
@@ -62,11 +62,13 @@ public sealed partial class BlockingSystem
         blockFraction = Math.Clamp(blockFraction, 0, 1);
         _damageable.TryChangeDamage((item, dmgComp), blockFraction * args.OriginalDamage);
 
-        var modify = new DamageModifierSet();
-        foreach (var key in dmgComp.Damage.DamageDict.Keys)
-        {
-            modify.Coefficients.TryAdd(key, 1 - blockFraction);
-        }
+        var modify = blocking.IsBlocking ? blocking.ActiveBlockDamageModifier : blocking.PassiveBlockDamageModifer; new DamageModifierSet();
+        // Begin DV Removals
+        // foreach (var key in dmgComp.Damage.DamageDict.Keys)
+        // {
+        //    modify.Coefficients.TryAdd(key, 1 - blockFraction);
+        // }
+        // End DV Removals
 
         args.Damage = DamageSpecifier.ApplyModifierSet(args.Damage, modify);
 

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -336,9 +336,9 @@ public sealed partial class BlockingSystem : EntitySystem
         foreach (var armor in modifiers.Armor)
         {
             msg.PushNewline();
-            msg.AddMarkupOrThrow(Robust.Shared.Localization.Loc.GetString("blocking-coefficient-value",
+            msg.AddMarkupOrThrow(Robust.Shared.Localization.Loc.GetString("blocking-armor-value",
                 ("type", armor.Key),
-                ("value", MathF.Round(armor.Value))
+                ("value", MathF.Round(armor.Value * 2f))
             ));
         }
         // End DeltaV Additions

--- a/Content.Shared/Blocking/BlockingSystem.cs
+++ b/Content.Shared/Blocking/BlockingSystem.cs
@@ -331,5 +331,16 @@ public sealed partial class BlockingSystem : EntitySystem
                 ("value", flat.Value)
             ));
         }
+
+        // Begin DeltaV Additions
+        foreach (var armor in modifiers.Armor)
+        {
+            msg.PushNewline();
+            msg.AddMarkupOrThrow(Robust.Shared.Localization.Loc.GetString("blocking-coefficient-value",
+                ("type", armor.Key),
+                ("value", MathF.Round(armor.Value))
+            ));
+        }
+        // End DeltaV Additions
     }
 }

--- a/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
+++ b/Content.Shared/Changeling/Systems/ChangelingDevourSystem.cs
@@ -108,13 +108,15 @@ public sealed class ChangelingDevourSystem : EntitySystem
 
         RaiseLocalEvent(target, ev);
 
-        foreach (var compProtectiveDamageType in ent.Comp.ProtectiveDamageTypes)
-        {
-            if (!ev.DamageModifiers.Coefficients.TryGetValue(compProtectiveDamageType, out var coefficient))
-                continue;
-            if (coefficient < 1f - ent.Comp.DevourPreventionPercentageThreshold)
-                return true;
-        }
+        // Begin DV Removals
+        // foreach (var compProtectiveDamageType in ent.Comp.ProtectiveDamageTypes)
+        // {
+        //    if (!ev.DamageModifiers.Coefficients.TryGetValue(compProtectiveDamageType, out var coefficient))
+        //        continue;
+        //    if (coefficient < 1f - ent.Comp.DevourPreventionPercentageThreshold)
+        //        return true;
+        // }
+        // End DV Removals
 
         return false;
     }

--- a/Content.Shared/Damage/DamageModifierSet.cs
+++ b/Content.Shared/Damage/DamageModifierSet.cs
@@ -1,7 +1,9 @@
+using Content.Shared._DV.Damage; // DeltaV
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+using Robust.Shared.Prototypes; // DeltaV
 
 namespace Content.Shared.Damage
 {
@@ -24,5 +26,8 @@ namespace Content.Shared.Damage
 
         [DataField("flatReductions", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, DamageTypePrototype>))]
         public Dictionary<string, float> FlatReduction = new();
+
+        [DataField(customTypeSerializer: typeof(DVDamageValueDictionarySerializer<ProtoId<DamageTypePrototype>>))]
+        public Dictionary<ProtoId<DamageTypePrototype>, float> Armor = new();
     }
 }

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -164,6 +164,14 @@ namespace Content.Shared.Damage
                 if (modifierSet.Coefficients.TryGetValue(key, out var coefficient))
                     newValue *= coefficient; // coefficients can heal you, e.g. cauterizing bleeding
 
+                // Begin DeltaV Additions
+                if (modifierSet.Armor.TryGetValue(key, out var armor) && 2 * armor > value)
+                {
+                    var blocked = Math.Max(0f, 1f - Math.Min(newValue / (2f * armor), 1f));
+                    newValue = (1f - blocked) * newValue;
+                }
+                // End DeltaV Additions
+
                 if (newValue != 0)
                     newDamage.DamageDict[key] = FixedPoint2.New(newValue);
             }

--- a/Content.Shared/Damage/DamageSpecifier.cs
+++ b/Content.Shared/Damage/DamageSpecifier.cs
@@ -130,6 +130,8 @@ namespace Content.Shared.Damage
         }
         #endregion constructors
 
+        private static readonly ProtoId<DamageTypePrototype> Penetration = "Penetration"; // DeltaV - penetration
+
         /// <summary>
         ///     Reduce (or increase) damages by applying a damage modifier set.
         /// </summary>
@@ -144,6 +146,8 @@ namespace Content.Shared.Damage
             // more cause they're just bloody stumps.
             DamageSpecifier newDamage = new();
             newDamage.DamageDict.EnsureCapacity(damageSpec.DamageDict.Count);
+
+            var penetration = damageSpec.DamageDict.GetValueOrDefault(Penetration).Float(); // DeltaV - penetration
 
             foreach (var (key, value) in damageSpec.DamageDict)
             {
@@ -165,9 +169,10 @@ namespace Content.Shared.Damage
                     newValue *= coefficient; // coefficients can heal you, e.g. cauterizing bleeding
 
                 // Begin DeltaV Additions
-                if (modifierSet.Armor.TryGetValue(key, out var armor) && 2 * armor > value)
+                if (modifierSet.Armor.TryGetValue(key, out var armor) && 2 * Math.Max(armor - penetration, 0f) > newValue)
                 {
-                    var blocked = Math.Max(0f, 1f - Math.Min(newValue / (2f * armor), 1f));
+                    var reducedArmor = Math.Max(armor - penetration, 0f);
+                    var blocked = Math.Max(0f, 1f - Math.Min(newValue / (2f * reducedArmor), 1f));
                     newValue = (1f - blocked) * newValue;
                 }
                 // End DeltaV Additions

--- a/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
+++ b/Content.Shared/Damage/Prototypes/DamageTypePrototype.cs
@@ -28,5 +28,11 @@ namespace Content.Shared.Damage.Prototypes
         /// </summary>
         [DataField("armorFlatPrice")]
         public double ArmorPriceFlat { get; set; }
+
+        /// <summary>
+        /// DeltaV - the price for each armor point
+        /// </summary>
+        [DataField]
+        public double ArmorPrice;
     }
 }

--- a/Content.Shared/Damage/Systems/DamageExamineSystem.cs
+++ b/Content.Shared/Damage/Systems/DamageExamineSystem.cs
@@ -48,6 +48,8 @@ public sealed class DamageExamineSystem : EntitySystem
         message.AddMessage(markup);
     }
 
+    private static readonly ProtoId<DamageTypePrototype> Penetration = "Penetration"; // DeltaV - penetration
+
     /// <summary>
     /// Retrieves the damage examine values.
     /// </summary>
@@ -66,12 +68,20 @@ public sealed class DamageExamineSystem : EntitySystem
 
         foreach (var damage in damageSpecifier.DamageDict)
         {
-            if (damage.Value != FixedPoint2.Zero)
+            if (damage.Value != FixedPoint2.Zero && damage.Key != Penetration) // DeltaV - penetration
             {
                 msg.PushNewline();
                 msg.AddMarkupOrThrow(Loc.GetString("damage-value", ("type", _prototype.Index<DamageTypePrototype>(damage.Key).LocalizedName), ("amount", damage.Value)));
             }
         }
+
+        // Begin DeltaV - i know this is a hack but i am NOT rewriting all of damageable to wire in an extra number
+        if (damageSpecifier.DamageDict.TryGetValue(Penetration, out var penetration))
+        {
+            msg.PushNewline();
+            msg.AddMarkupOrThrow(Loc.GetString("damage-examine-penetration", ("amount", MathF.Round(penetration * 2f))));
+        }
+        // End DeltaV
 
         return msg;
     }

--- a/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
+++ b/Content.Shared/_DV/Armor/Components/HandHeldArmorComponent.cs
@@ -40,7 +40,11 @@ public sealed partial class HandHeldArmorComponent : Component
     /// DeltaV - Gets the effective stamina melee damage coefficient, based on the armor's blunt protection.
     /// </summary>
     [ViewVariables]
-    public float StaminaMeleeDamageCoefficient => Modifiers.Coefficients.GetValueOrDefault("Blunt", 1.0f);
+    public float StaminaMeleeDamageCoefficient => Modifiers.Coefficients.TryGetValue("Blunt", out var coefficient)
+                                                      ? coefficient
+                                                      : Modifiers.Armor.TryGetValue("Blunt", out var armor)
+                                                          ? 1f - Math.Clamp(0.01f * armor, 0f, 1f)
+                                                          : 1f;
 
     /// <summary>
     /// The required components for the held armor to be active while held.

--- a/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
+++ b/Content.Shared/_DV/Armor/Systems/HandHeldArmorSystem.cs
@@ -41,13 +41,7 @@ public sealed class HandHeldArmorSystem : EntitySystem
             || _whitelist.IsWhitelistPass(armor.Comp.Blacklist, armor.Comp.Holder.Value))
             return;
 
-        foreach (var armorCoefficient in armor.Comp.Modifiers.Coefficients)
-        {
-            args.Args.DamageModifiers.Coefficients[armorCoefficient.Key] =
-                args.Args.DamageModifiers.Coefficients.TryGetValue(armorCoefficient.Key, out var coefficient)
-                ? coefficient * armorCoefficient.Value
-                : armorCoefficient.Value;
-        }
+        args.Args.DamageModifiers.Add(armor.Comp.Modifiers);
     }
 
     private void OnDamageModify(Entity<HandHeldArmorComponent> armor, ref HeldRelayedEvent<DamageModifyEvent> args)
@@ -110,6 +104,15 @@ public sealed class HandHeldArmorSystem : EntitySystem
             msg.AddMarkupOrThrow(Loc.GetString("armor-reduction-value",
                 ("type", armorType),
                 ("value", flatArmor.Value)
+            ));
+        }
+
+        foreach (var factor in armor.Modifiers.Armor)
+        {
+            var armorType = Loc.GetString("armor-damage-type-" + factor.Key.Id.ToLower());
+            msg.AddMarkupOrThrow(Loc.GetString("armor-coefficient-value",
+                ("type", armorType),
+                ("value", MathF.Round(factor.Value))
             ));
         }
 

--- a/Content.Shared/_DV/Damage/DVDamageConstantPrototype.cs
+++ b/Content.Shared/_DV/Damage/DVDamageConstantPrototype.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._DV.Damage;
+
+/// <summary>
+/// A constant value to reference in <see cref="DVDamageValueDictionarySerializer" />
+/// </summary>
+[Prototype("dvDamageConstant", 10)]
+public sealed partial class DVDamageConstantPrototype : IPrototype
+{
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    [DataField]
+    public float Value;
+}

--- a/Content.Shared/_DV/Damage/DVDamageValueDictionarySerializer.cs
+++ b/Content.Shared/_DV/Damage/DVDamageValueDictionarySerializer.cs
@@ -1,0 +1,79 @@
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Mapping;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Content.Shared._DV.Damage;
+
+/// <summary>
+/// Reads a float dictionary with support for named <see cref="DVDamageConstantPrototype" /> constants
+/// </summary>
+[UsedImplicitly]
+public sealed class DVDamageValueDictionarySerializer<TKey> : ITypeReader<Dictionary<TKey, float>, MappingDataNode> where TKey : notnull
+{
+    public Dictionary<TKey, float> Read(ISerializationManager serializationManager,
+        MappingDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context,
+        ISerializationManager.InstantiationDelegate<Dictionary<TKey, float>>? instanceProvider)
+    {
+        var dict = instanceProvider != null ? instanceProvider() : new Dictionary<TKey, float>();
+        var proto = dependencies.Resolve<IPrototypeManager>();
+
+        var keyNode = new ValueDataNode();
+        foreach (var (key, value) in node.Children)
+        {
+            keyNode.Value = key;
+            var tKey = serializationManager.Read<TKey>(keyNode, hookCtx, context);
+
+            if (value is not ValueDataNode nValue)
+            {
+                throw new Exception($"{value} is not a scalar");
+            }
+
+            if (float.TryParse(nValue.Value, out var num))
+            {
+                dict[tKey] = num;
+                continue;
+            }
+
+            dict[tKey] = proto.Index<DVDamageConstantPrototype>(nValue.Value).Value;
+        }
+
+        return dict;
+    }
+
+    public ValidationNode Validate(ISerializationManager serializationManager,
+        MappingDataNode node,
+        IDependencyCollection dependencies,
+        ISerializationContext? context = null)
+    {
+        var mapping = new Dictionary<ValidationNode, ValidationNode>();
+        var proto = dependencies.Resolve<IPrototypeManager>();
+
+        foreach (var (key, value) in node.Children)
+        {
+            var keyNode = new ValueDataNode(key);
+            ValidationNode valueNode;
+
+            if (value is not ValueDataNode nValue)
+            {
+                valueNode = new ErrorNode(value, "Node is not a scalar");
+            }
+            else if (float.TryParse(nValue.Value, out _) || proto.HasIndex<DVDamageConstantPrototype>(nValue.Value))
+            {
+                valueNode = new ValidatedValueNode(nValue);
+            }
+            else
+            {
+                valueNode = new ErrorNode(value, $"{nValue.Value} is neither a damage constant or a literal value");
+            }
+
+            mapping.Add(serializationManager.ValidateNode<TKey>(keyNode, context), valueNode);
+        }
+
+        return new ValidatedMappingNode(mapping);
+    }
+}

--- a/Resources/Locale/en-US/_DV/damage/armor-examine.ftl
+++ b/Resources/Locale/en-US/_DV/damage/armor-examine.ftl
@@ -1,0 +1,1 @@
+armor-armor-value = - Armor value of [color=lightblue]{$value}[/color] for [color=yellow]{$type}[/color].

--- a/Resources/Locale/en-US/_DV/damage/armor-examine.ftl
+++ b/Resources/Locale/en-US/_DV/damage/armor-examine.ftl
@@ -1,1 +1,1 @@
-armor-armor-value = - Armor value of [color=lightblue]{$value}[/color] for [color=yellow]{$type}[/color].
+armor-armor-value = - [color=yellow]{$type}[/color] armor up to [color=lightblue]{$value}[/color] damage.

--- a/Resources/Locale/en-US/_DV/damage/blocking-examine.ftl
+++ b/Resources/Locale/en-US/_DV/damage/blocking-examine.ftl
@@ -1,0 +1,1 @@
+blocking-armor-value = - It has an armor value of [color=lightblue]{$value}[/color] against [color=yellow]{$type}[/color] damage.

--- a/Resources/Locale/en-US/_DV/damage/blocking-examine.ftl
+++ b/Resources/Locale/en-US/_DV/damage/blocking-examine.ftl
@@ -1,1 +1,1 @@
-blocking-armor-value = - It has an armor value of [color=lightblue]{$value}[/color] against [color=yellow]{$type}[/color] damage.
+blocking-armor-value = - It provides [color=yellow]{$type}[/color] armor up to [color=lightblue]{$value}[/color] damage.

--- a/Resources/Locale/en-US/_DV/damage/damage-examine.ftl
+++ b/Resources/Locale/en-US/_DV/damage/damage-examine.ftl
@@ -1,0 +1,1 @@
+damage-examine-penetration = It penetrates armor with with a factor of [color=yellow]{$amount}[/color].

--- a/Resources/Locale/en-US/_DV/damage/damage-types.ftl
+++ b/Resources/Locale/en-US/_DV/damage/damage-types.ftl
@@ -1,2 +1,3 @@
 damage-type-ion = Ion
 damage-type-shadow = Shadow
+damage-type-penetration = Penetration

--- a/Resources/Prototypes/Damage/types.yml
+++ b/Resources/Prototypes/Damage/types.yml
@@ -6,6 +6,7 @@
   name: damage-type-asphyxiation
   armorCoefficientPrice: 5
   armorFlatPrice: 50
+  armorPrice: 25 # DeltaV
 
 
 # Damage representing not having enough blood.
@@ -15,6 +16,7 @@
   name: damage-type-bloodloss
   armorCoefficientPrice: 5
   armorFlatPrice: 50
+  armorPrice: 25 # DeltaV
 
 - type: damageType
   id: Blunt
@@ -27,30 +29,35 @@
   name: damage-type-cellular
   armorCoefficientPrice: 5
   armorFlatPrice: 30
+  armorPrice: 15 # DeltaV
 
 - type: damageType
   id: Caustic
   name: damage-type-caustic
   armorCoefficientPrice: 5
   armorFlatPrice: 30
+  armorPrice: 15 # DeltaV
 
 - type: damageType
   id: Cold
   name: damage-type-cold
   armorCoefficientPrice: 2.5
   armorFlatPrice: 20
+  armorPrice: 10 # DeltaV
 
 - type: damageType
   id: Heat
   name: damage-type-heat
   armorCoefficientPrice: 2.5
   armorFlatPrice: 20
+  armorPrice: 10 # DeltaV
 
 - type: damageType
   id: Piercing
   name: damage-type-piercing
   armorCoefficientPrice: 2
   armorFlatPrice: 10
+  armorPrice: 5 # DeltaV
 
 # Poison damage. Generally caused by various reagents being metabolised.
 - type: damageType
@@ -58,24 +65,28 @@
   name: damage-type-poison
   armorCoefficientPrice: 10
   armorFlatPrice: 60
+  armorPrice: 30 # DeltaV
 
 - type: damageType
   id: Radiation
   name: damage-type-radiation
   armorCoefficientPrice: 2.5
   armorFlatPrice: 16
+  armorPrice: 8 # DeltaV
 
 - type: damageType
   id: Shock
   name: damage-type-shock
   armorCoefficientPrice: 2.5
   armorFlatPrice: 20
+  armorPrice: 10 # DeltaV
 
 - type: damageType
   id: Slash
   name: damage-type-slash
   armorCoefficientPrice: 2
   armorFlatPrice: 10
+  armorPrice: 5 # DeltaV
 
 # Damage represent structures internal integrity.
 # Exclusive for structures such as walls, airlocks and others.
@@ -84,6 +95,7 @@
   name: damage-type-structural
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+  armorPrice: 1 # DeltaV
 
 # Metaphysical damage. Damage represents supernatural injuries that emphasize the fantasy elements in the game
 - type: damageType
@@ -91,4 +103,5 @@
   name: damage-type-holy
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+  armorPrice: 1 # DeltaV
 

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -124,8 +124,10 @@
     fiberColor: fibers-black
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
+      # Begin DeltaV
+      armor:
+        Slash: DamageUnarmed
+      # End DeltaV
   - type: FingerprintMask
 
 #### Medical

--- a/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/base_clothinghead.yml
@@ -171,12 +171,14 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.90
-        Radiation: 0.25
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+        Radiation: DamageRifle
+      # End DeltaV
   - type: GroupExamine
   - type: IngestionBlocker
   - type: Tag
@@ -269,7 +271,7 @@
     zombificationResistanceCoefficient: 0.90
   - type: Armor # so zombification resistance shows up
     modifiers:
-      coefficients: { }
+      armor: { } # DeltaV
   - type: GroupExamine
   - type: HideLayerClothing
     slots:

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -116,9 +116,11 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.90
-        Radiation: 0.75
+      # Begin DeltaV
+      armor:
+        Heat: DamageUnarmed
+        Radiation: DamageTider
+      # End DeltaV
   - type: PointLight
     radius: 5
     energy: 2

--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -14,9 +14,9 @@
     equippedPrefix: off
   - type: Armor #Delta V - Personal protective equipment is now protective!
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.95
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
   - type: PointLight
     enabled: false
     mask: /Textures/Effects/LightMasks/cone.png
@@ -150,8 +150,10 @@
     sprite: Clothing/Head/Hardhats/armored.rsi
   - type: Armor #Copied from the sec helmet, as it's hard to give these sane values without locational damage existing.
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
+      # End DeltaV

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -342,11 +342,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #Security Hardsuit
 - type: entity
@@ -366,11 +368,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag
     tags:
     - CorgiWearable
@@ -391,13 +395,15 @@
     color: "#00FFFF"
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
-        Radiation: 0.90
-        Caustic: 0.90
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+        Radiation: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV
   - type: PressureProtection
     highPressureMultiplier: 0.6
     lowPressureMultiplier: 1000
@@ -420,11 +426,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #Captain's Hardsuit
 - type: entity
@@ -594,11 +602,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #Luxury Mining Hardsuit
 - type: entity
@@ -638,11 +648,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag
     tags:
     - CorgiWearable
@@ -666,11 +678,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #Syndicate Elite Hardsuit
 - type: entity
@@ -695,11 +709,13 @@
     reduction: 0.2
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95 # DeltaV - was 0.9
-        Slash: 0.95 # DeltaV - was 0.9
-        Piercing: 0.95 # DeltaV - was 0.9
-        Heat: 0.85 # DeltaV - was 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag
     tags:
     - CorgiWearable
@@ -723,11 +739,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag
     tags:
     - CorgiWearable
@@ -751,11 +769,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag
     tags:
     - CorgiWearable
@@ -779,11 +799,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag
     tags:
     - CorgiWearable
@@ -865,11 +887,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #CENTCOMM / ERT HARDSUITS
 #ERT Leader Hardsuit
@@ -887,11 +911,13 @@
     color: "#addbff"
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #ERT Chaplain Hardsuit
 - type: entity
@@ -933,11 +959,13 @@
     reduction: 0.2
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #ERT Medical Hardsuit
 - type: entity
@@ -968,11 +996,13 @@
     color: "#ffadc6"
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #ERT Janitor Hardsuit
 - type: entity
@@ -1029,11 +1059,13 @@
     coolingCoefficient: 0.005
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.75
 
@@ -1056,13 +1088,15 @@
     reduction: 0.2
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.80
-        Heat: 0.80
-        Radiation: 0.80
-        Caustic: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
+        Radiation: DamageTider
+        Caustic: DamageUnarmed
+      # End DeltaV
   - type: Tag # DeltaV - Deathsquad isn't real, it can't hurt you.
     tags: []
 

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -162,11 +162,11 @@
   # Begin DeltaV additions
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
   # End DeltaV additions
 
 - type: entity
@@ -433,11 +433,11 @@
   # Begin DeltaV additions
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
   # End DeltaV additions
 
 - type: entity
@@ -1069,8 +1069,10 @@
     sprite: Clothing/Head/Hats/melon.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: ClothingHeadBase
@@ -1084,8 +1086,10 @@
     sprite: Clothing/Head/Hats/holyhatmelon.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.95
+      # Begin DeltaV
+      armor:
+        Caustic: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: [ClothingHeadBase, BaseSyndicateContraband]

--- a/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/helmets.yml
@@ -21,11 +21,13 @@
   components:
   - type: Armor #Values seem to let the user survive one extra hit if attacked consistently.
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 #Basic Helmet (Security Helmet)
 - type: entity
@@ -74,13 +76,15 @@
     sprite: Clothing/Head/Helmets/swat.rsi
   - type: Armor #This is intentionally not spaceproof, when the time comes to port the values from SS13 this should be buffed from what it was.
     modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.80
-        Heat: 0.80
-        Radiation: 0.80
-        Caustic: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
+        Radiation: DamageTider
+        Caustic: DamageUnarmed
+      # End DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.75
   - type: HideLayerClothing
@@ -117,10 +121,12 @@
   - type: IngestionBlocker
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageUnarmed
+      # Begin DeltaV
   - type: HideLayerClothing
     layers:
       Hair: HEAD
@@ -141,10 +147,12 @@
     damageCoefficient: 0.9
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+      # Begin DeltaV
   - type: HideLayerClothing
     layers:
       Hair: HEAD
@@ -180,11 +188,13 @@
   - type: IngestionBlocker
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageTider
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # Begin DeltaV
   - type: HideLayerClothing
     layers:
       Hair: HEAD
@@ -335,11 +345,13 @@
     sprite: Clothing/Head/Helmets/linghelmet.rsi
   - type: Armor #admeme item so it should be fine being overpowered while helmets are still intentionally kneecapped.
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageSniper
+        Slash: DamageSniper
+        Piercing: DamageSniper
+        Heat: DamageTider
+      # End DeltaV
   - type: HideLayerClothing
     layers:
       Hair: HEAD
@@ -432,11 +444,13 @@
     sprite: Clothing/Head/Helmets/syndie-raid.rsi
   - type: Armor
     modifiers: #There's gotta be SOME reason to use this over other helmets.
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.85
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
+      # End DeltaV
   - type: HideLayerClothing
     layers:
       Hair: HEAD
@@ -585,8 +599,10 @@
   - type: IngestionBlocker
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+      # End DeltaV
   - type: Construction
     graph: cardHelmet
     node: cardhelmet

--- a/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hoods.yml
@@ -161,9 +161,11 @@
     sprite: Clothing/Head/Hoods/rad.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.95
-        Radiation: 0.65
+      # Begin DeltaV
+      armor:
+        Heat: DamageUnarmed
+        Radiation: DamageRifle
+      # End DeltaV
   - type: IdentityBlocker
   - type: BreathMask
   - type: HideLayerClothing

--- a/Resources/Prototypes/Entities/Clothing/Head/scraphelmet.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/scraphelmet.yml
@@ -69,11 +69,13 @@
   - type: IngestionBlocker
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: HideLayerClothing
     slots:
     - Hair

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -34,11 +34,13 @@
     sprite: Clothing/Mask/gassecurity.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: [ClothingMaskGas, BaseSyndicateContraband]
@@ -54,11 +56,13 @@
   - type: EyeProtection
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: ClothingMaskGas
@@ -72,8 +76,10 @@
     sprite: Clothing/Mask/gasatmos.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.80
+      # Begin DeltaV
+      armor:
+        Heat: DamageTider
+      # End DeltaV
 
 - type: entity
   parent: [ClothingMaskGasAtmos, BaseCommandContraband]
@@ -113,11 +119,13 @@
     sprite: Clothing/Mask/gasexplorer.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: ClothingMaskPullableBase
@@ -158,11 +166,13 @@
     sprite: Clothing/Mask/medicalsecurity.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: ClothingMaskPullableBase
@@ -272,11 +282,13 @@
     sprite: Clothing/Mask/clown_security.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag
     tags:
     - ClownMask
@@ -424,11 +436,13 @@
     hideOnToggle: true
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: [ ClothingMaskGas, BaseSecurityCargoContraband ]
@@ -442,11 +456,13 @@
     sprite: Clothing/Mask/merc.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: [ ClothingMaskGas, BaseCentcommContraband ]
@@ -470,11 +486,13 @@
   - type: EyeProtection
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: ClothingMaskGasERT
@@ -493,11 +511,13 @@
     - HeadSide
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.90
-        Heat: 0.90
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: Tag # DeltaV - Deathsquad isn't real, it can't hurt you.
     tags: []
 
@@ -719,11 +739,13 @@
     sprite: Clothing/Mask/mime_security.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: ClothingMaskBase

--- a/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/specific.yml
@@ -72,10 +72,12 @@
   - type: SelfEquipOnly
   - type: CursedMask
     despairDamageModifier:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageSniper
+      # End DeltaV
   - type: HideLayerClothing
     slots:
     - Snout

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -16,11 +16,13 @@
     sprite: Clothing/OuterClothing/Armor/security.rsi
   - type: Armor #Based on /tg/ but slightly compensated to fit the fact that armor stacks in SS14.
     modifiers:
-      coefficients:
-        Blunt: 0.70
-        Slash: 0.70
-        Piercing: 0.70 #Can save you, but bullets will still hurt. Will take about 10 shots from a Viper before critting, as opposed to 7 while unarmored and 16~ with a bulletproof vest.
-        Heat: 0.80
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamageTider
+      # End DeltaV
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.75 # Decent at stopping disablers
   - type: ExplosionResistance
@@ -61,11 +63,13 @@
     sprite: Clothing/OuterClothing/Armor/bulletproof.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.4
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageSniper
+        Heat: DamageUnarmed
+      # Begin DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.80
 
@@ -81,11 +85,13 @@
     sprite: Clothing/OuterClothing/Armor/armor_reflec.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.75 # DeltaV - changed from 60% resistant to 25%
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamagePistol # DeltaV - changed from 60% resistant to 25%
+      # End DeltaV
   - type: Reflect
     reflectProb: 0.75 # DeltaV - changed from 100% reflect to 75%
     reflects:
@@ -111,12 +117,14 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.6
-        Heat: 0.5
-        Caustic: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
+        Caustic: DamageUnarmed
+      # End DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.65
   - type: ClothingSpeedModifier
@@ -166,11 +174,13 @@
     sprite: Clothing/OuterClothing/Vests/webvest.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.6 #ballistic plates = better protection
-        Slash: 0.6
-        Piercing: 0.3
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamageSniper
+        Heat: DamageUnarmed
+      # End DeltaV
     staminaMeleeDamageCoefficient: 0.9 # DeltaV - Reduce Melee Stamina
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.6
@@ -195,13 +205,15 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.7
-        Heat: 0.3
-        Radiation: 0.5
-        Caustic: 0.5
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamageTider
+        Heat: DamageSniper
+        Radiation: DamagePistol
+        Caustic: DamagePistol
+      # End DeltaV
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.6 # twice as good as web vest
   - type: ExplosionResistance
@@ -224,11 +236,13 @@
     sprite: Clothing/OuterClothing/Vests/mercwebvest.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7 #slightly better overall protection but slightly worse than bulletproof armor against bullets seems sensible
-        Slash: 0.7
-        Piercing: 0.5
-        Heat: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamageRifle
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -251,12 +265,14 @@
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.35
-        Slash: 0.35
-        Piercing: 0.35
-        Heat: 0.35
-        Caustic: 0.5
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageRifle
+        Caustic: DamagePistol
+      # End DeltaV
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.35
   - type: ExplosionResistance
@@ -327,12 +343,14 @@
     sprite: Clothing/OuterClothing/Armor/riot.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.7
-        Heat: 0.9
-        Caustic: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamagePistol
+        Heat: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: GroupExamine
@@ -349,11 +367,13 @@
     sprite: Clothing/OuterClothing/Armor/cult_armour.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageRifle
+      # End DeltaV
   - type: GroupExamine
 
 - type: entity
@@ -368,13 +388,15 @@
     sprite: Clothing/OuterClothing/Armor/heavy.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.2
-        Slash: 0.2
-        Piercing: 0.2
-        Heat: 0.5
-        Radiation: 0
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Blunt: DamageSniper
+        Slash: DamageSniper
+        Piercing: DamageSniper
+        Heat: DamageRifle
+        Radiation: DamageSuper
+        Caustic: DamagePistol
+      # End DeltaV
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.1
   - type: GroupExamine
@@ -437,12 +459,14 @@
     sprite: Clothing/OuterClothing/Armor/lingarmor.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.9
-        Radiation: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageTider
+        Radiation: DamageTider
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.65
     sprintModifier: 0.65
@@ -465,10 +489,12 @@
     sprite: Clothing/OuterClothing/Armor/bone_armor.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.8
-        Piercing: 0.4
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamageTider
+        Piercing: DamageRifle
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -494,11 +520,13 @@
     sprite: Clothing/OuterClothing/Armor/podwars_armor.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.6
-        Heat: 0.5
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageRifle
+      # End DeltaV
   - type: GroupExamine
   - type: ProtectedFromStepTriggers
     slots: WITHOUT_POCKET
@@ -515,8 +543,10 @@
     sprite: Clothing/OuterClothing/Armor/card_armour.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+      # End DeltaV
   - type: Construction
     graph: cardArmour
     node: cardarmour

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -127,12 +127,14 @@
     size: Ginormous
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.90
-        Radiation: 0.25
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+        Radiation: DamageSniper
+      # End DeltaV
   - type: ToggleableClothing
     slot: head
   - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/bio.yml
@@ -14,8 +14,10 @@
     - Tail
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Caustic: DamagePistol
+      # End DeltaV
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.35
   - type: GroupExamine
@@ -48,8 +50,10 @@
     sprite: Clothing/OuterClothing/Bio/janitor.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.4
+      # Begin DeltaV
+      armor:
+        Caustic: DamageRifle
+      # End DeltaV
 
 - type: entity
   parent: ClothingOuterBioGeneral
@@ -76,10 +80,12 @@
     sprite: Clothing/OuterClothing/Bio/security.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.8
-        Slash: 0.6
-        Piercing: 0.8
+      # Begin DeltaV
+      armor:
+        Caustic: DamageTider
+        Slash: DamagePistol
+        Piercing: DamageTider
+      # Begin DeltaV
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.4
   - type: GroupExamine

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/coats.yml
@@ -69,12 +69,14 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.7
-        Caustic: 0.75 # not the full 90% from ss13 because of the head
+      # Begin DeltaV - Armor
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageRifle
+        Caustic: DamageRifle
+      # End DeltaV - Armor
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -85,13 +87,13 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-#Begin DeltaV modifications
-        Blunt: 0.70 # Was 0.65
-        Slash: 0.70 # Was 0.65
-        Piercing: 0.70 # Was 0.7
-        Heat: 0.80 # Was 0.7
-#End DeltaV modifications
+      # Begin DeltaV - Armor
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageRifle
+      # End DeltaV - Armor
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -145,8 +147,10 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
+      # Begin DeltaV
+      armor:
+        Slash: DamageUnarmed
+      # End DeltaV
   - type: Edible
     requiresSpecialDigestion: true
   - type: SolutionContainerManager
@@ -169,8 +173,10 @@
     sprite: Clothing/OuterClothing/Coats/labcoat.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Slash: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLab]
@@ -189,8 +195,10 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_chem.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Slash: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabChem]
@@ -209,8 +217,10 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_viro.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Slash: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabViro]
@@ -229,8 +239,10 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_gene.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Slash: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabGene]
@@ -249,10 +261,12 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_cmo.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.95
-        Caustic: 0.65
+      # Begin DeltaV
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabCmo]
@@ -271,8 +285,10 @@
     sprite: _DV/Clothing/OuterClothing/Coats/epicoat.rsi # DeltaV - Epistemic lab coat
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Caustic: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatRnd]
@@ -291,8 +307,10 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_robo.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Caustic: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatRobo]
@@ -311,9 +329,11 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_rd.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
-        Radiation: 0.9
+      # Begin DeltaV
+      armor:
+        Caustic: DamagePistol
+        Radiation: DamageUnarmed
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatRD]
@@ -376,10 +396,12 @@
     sprite: Clothing/OuterClothing/Coats/dogi.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.65
-        Piercing: 0.85
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageRifle
+        Piercing: DamageTider
+      # End DeltaV
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -426,12 +448,14 @@
     sprite: Clothing/OuterClothing/Coats/brigmedic.rsi
   - type: Armor # DeltaV - tweak for Velta armour
     modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.75
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamagePistol
+        Caustic: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: ClothingOuterStorageFoldableBase
@@ -445,8 +469,10 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_senior_researcher.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Caustic: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabSeniorResearcher]
@@ -465,8 +491,10 @@
     sprite: Clothing/OuterClothing/Coats/labcoat_senior_physician.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Caustic: DamagePistol
+      # End DeltaV
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabSeniorPhysician]

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -36,12 +36,14 @@
     damageCoefficient: 0.5
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.8
-        Radiation: 0.5
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+        Radiation: DamageRifle
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
@@ -85,13 +87,15 @@
     damageCoefficient: 0.5
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Shock: 0.8
-        Caustic: 0.5
-        Radiation: 0.2
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageRifle
+        Radiation: DamageSniper
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
@@ -133,12 +137,14 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Radiation: 0.3 #salv is supposed to have radiation hazards in the future
-        Caustic: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Radiation: DamageRifle
+        Caustic: DamageTider
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -183,13 +189,15 @@
     damageCoefficient: 0.7
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.6
-        Piercing: 0.7
-        Heat: 0.7
-        Radiation: 0.3
-        Caustic: 0.7
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
+        Radiation: DamageRifle
+        Caustic: DamagePistol
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.75
     sprintModifier: 0.75
@@ -233,13 +241,15 @@
     damageCoefficient: 0.3
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.5
-        Heat: 0.7 #Goliath hide gets grilled instead of you
-        Radiation: 0.3
-        Caustic: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamageRifle
+        Heat: DamagePistol #Goliath hide gets grilled instead of you
+        Radiation: DamageSniper
+        Caustic: DamageTider
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -280,12 +290,14 @@
     sprintModifier: 1.0
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.5
-        Heat: 0.3
-        Radiation: 0.1
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageSniper
+        Radiation: DamageSuper
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -317,12 +329,14 @@
     damageCoefficient: 0.4
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
-        Heat: 0.8
-        Caustic: 0.7
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamagePistol
+        Caustic: DamagePistol
+      # End DeltaV
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.3
   - type: ClothingSpeedModifier
@@ -353,10 +367,12 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.7
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+      # End DeltaV
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.3
   - type: ClothingSpeedModifier
@@ -384,12 +400,14 @@
     damageCoefficient: 0.4
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.4
-        Slash: 0.5
-        Piercing: 0.6
-        Heat: 0.8
-        Caustic: 0.7
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamagePistol
+        Heat: DamageTider
+        Caustic: DamageTider
+      # End DeltaV
   - type: StaminaResistance # DeltaV
     damageCoefficient: 0.3
   - type: ClothingSpeedModifier
@@ -429,13 +447,15 @@
     damageCoefficient: 0.5
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.6
-        Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.6
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamagePistol
+        Heat: DamagePistol
+        Radiation: DamagePistol
+        Caustic: DamagePistol
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -488,13 +508,15 @@
     damageCoefficient: 0.2
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.4
-        Radiation: 0.0
-        Caustic: 0.7
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageSniper
+        Radiation: DamageSuper
+        Caustic: DamagePistol
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -538,8 +560,10 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.1
+      # Begin DeltaV
+      armor:
+        Caustic: DamageSuper
+      # End DeltaV
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.4
   - type: ClothingSpeedModifier
@@ -571,15 +595,17 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.3
-        Radiation: 0.1
-        Caustic: 0.2
-        Holy: 0.7 # DeltaV
-        Shadow: 0.7 # DeltaV
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageTider
+        Piercing: DamageUnarmed
+        Heat: DamageSniper
+        Radiation: DamageSuper
+        Caustic: DamageSuper
+        Holy: DamagePistol
+        Shadow: DamagePistol
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -627,13 +653,15 @@
     damageCoefficient: 0.5
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.8
-        Radiation: 0.5
-        Caustic: 0.6
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamagePistol
+        Radiation: DamageRifle
+        Caustic: DamageRifle
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -679,13 +707,15 @@
     damageCoefficient: 0.9
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.9
-        Radiation: 0.5
-        Caustic: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageTider
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+        Radiation: DamageSniper
+        Caustic: DamagePistol
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -735,14 +765,16 @@
     damageCoefficient: 0.2 # DeltaV - was 0.75
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.5
-        Cold: 0.8 # DeltaV - Cold res
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageRifle
+        Radiation: DamageRifle
+        Caustic: DamageRifle
+        Cold: DamagePistol
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -841,14 +873,16 @@
     damageCoefficient: 0.3 # DeltaV - was 0.6
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8 # DeltaV - was 0.6
-        Slash: 0.8 # DeltaV - was 0.6
-        Piercing: 0.6
-        Heat: 0.2
-        Radiation: 0.01
-        Caustic: 0.5
-        Cold: 0.4 # DeltaV - Cold res
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageRifle
+        Heat: DamageSniper
+        Radiation: DamageSuper
+        Caustic: DamageRifle
+        Cold: DamageRifle
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -901,14 +935,16 @@
     damageCoefficient: 0.2 # DeltaV - was 0.6
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.3
-        Heat: 0.5
-        Radiation: 0.25
-        Caustic: 0.4
-        Cold: 0.8 # DeltaV - Cold res
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageSniper
+        Heat: DamageRifle
+        Radiation: DamageSniper
+        Caustic: DamageRifle
+        Cold: DamagePistol
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -963,14 +999,16 @@
     damageCoefficient: 0.5
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.2
-        Slash: 0.2
-        Piercing: 0.2
-        Heat: 0.2
-        Radiation: 0.2
-        Caustic: 0.2
-        Cold: 0.6 # DeltaV - Cold res
+      # Begin DeltaV
+      armor:
+        Blunt: DamageSniper
+        Slash: DamageSniper
+        Piercing: DamageSniper
+        Heat: DamageSniper
+        Radiation: DamageSniper
+        Caustic: DamageSniper
+        Cold: DamageRifle
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -1018,13 +1056,15 @@
     damageCoefficient: 0.5
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.4
-        Heat: 0.25
-        Radiation: 0.25
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageSniper
+        Radiation: DamageSniper
+        Caustic: DamagePistol
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -1063,11 +1103,12 @@
     damageCoefficient: 0.2
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 1
-        Heat: 0.5
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Heat: DamageRifle
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -1099,12 +1140,14 @@
     damageCoefficient: 0.7
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.9
-        Heat: 0.4
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageRifle
+        Caustic: DamagePistol
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.6
     sprintModifier: 0.6
@@ -1137,12 +1180,14 @@
     damageCoefficient: 0.6
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.8
-        Piercing: 0.85
-        Heat: 0.4
-        Caustic: 0.75
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageRifle
+        Caustic: DamagePistol
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -1290,13 +1335,15 @@
     damageCoefficient: 0.15 # Needs 21 hits with a disabler to stun :godo:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.1 #best armor in the game
-        Slash: 0.1
-        Piercing: 0.1
-        Heat: 0.1
-        Radiation: 0.1
-        Caustic: 0.1
+      # Begin DeltaV
+      armor:
+        Blunt: DamageSuper
+        Slash: DamageSuper
+        Piercing: DamageSuper
+        Heat: DamageSuper
+        Radiation: DamageSuper
+        Caustic: DamageSuper
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -1344,15 +1391,17 @@
     damageCoefficient: 0.7
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.6
-        Heat: 0.1
-        Cold: 0.1
-        Shock: 0.1
-        Radiation: 0.1
-        Caustic: 0.1
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamageSuper
+        Cold: DamageSuper
+        Shock: DamageSuper
+        Radiation: DamageSuper
+        Caustic: DamageSuper
+      # End DeltaV
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -1464,11 +1513,13 @@
     damageCoefficient: 0.85
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.9
-        Piercing: 0.85
-        Caustic: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Caustic: DamageTider
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/scraparmor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/scraparmor.yml
@@ -68,12 +68,14 @@
     unequipDelay: 5 #Its insane more armor/hardsuits don't have equip times tbh?
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5 #Some nukie tier physical protection...
-        Heat: 0.8
-        Radiation: 0.8 #Hey, it's a bunch of solid steel.
+      # Begin DeltaV - Armor
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle #Some nukie tier physical protection...
+        Heat: DamageTider
+        Radiation: DamageTider #Hey, it's a bunch of solid steel.
+      # End DeltaV - Armor
   - type: ExplosionResistance
     damageCoefficient: 0.80
   - type: ClothingSpeedModifier #But that protection comes at a price.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -207,10 +207,12 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.90
-        Radiation: 0.75
-        Caustic: 0.5
+      # Begin DeltaV
+      armor:
+        Heat: DamageTider
+        Radiation: DamagePistol
+        Caustic: DamageSniper
+      # End DeltaV
   - type: GroupExamine
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitVoidParamed

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/specific.yml
@@ -19,7 +19,9 @@
       coolingCoefficient: 0.1
     - type: Armor
       modifiers:
-        coefficients:
-          Slash: 0.95
-          Heat: 0.90
+        # Begin DeltaV
+        armor:
+          Slash: DamageUnarmed
+          Heat: DamageUnarmed
+        # End DeltaV
       showArmorOnExamine: false

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/suits.yml
@@ -25,11 +25,13 @@
     sprintModifier: 0.75 # DeltaV - slower for insulation, originally 0.8
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.75
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageTider
+      # End DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.10 # DeltaV - made more resistant, originally 0.15
   - type: GroupExamine
@@ -88,10 +90,12 @@
     reduction: 0.65 # doesnt have a full seal so not as good
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.9
-        Heat: 0.8
-        Cold: 0.8
+      # Begin DeltaV
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageTider
+        Cold: DamageTider
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
@@ -138,10 +142,12 @@
     reduction: 0.8 # atmos firesuit offers best protection, hardsuits are a little vulnerable
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.9
-        Heat: 0.8
-        Cold: 0.8
+      # Begin DeltaV
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageTider
+        Cold: DamageTider
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -169,9 +175,11 @@
     sprite: Clothing/OuterClothing/Suits/rad.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.90
-        Radiation: 0.01
+      # Begin DeltaV
+      armor:
+        Heat: DamageUnarmed
+        Radiation: DamageSuper
+      # End DeltaV
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/rad.rsi
     clothingVisuals: # Delta V - Need this for harpies
@@ -222,12 +230,14 @@
     coolingCoefficient: 0.01
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.8
-        Ion: 0 # DeltaV - I love self gibbing as ninja IPC!!
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
+        Ion: DamageSuper
+      # End DeltaV
   # phase cloak
   - type: ToggleClothing
     action: ActionTogglePhaseCloak

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -15,9 +15,11 @@
     size: Normal
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageTider
+      # End DeltaV - Armor
     priceMultiplier: 0
   - type: ZombificationResistance
     zombificationResistanceCoefficient: 0.55
@@ -124,11 +126,11 @@
     clothingPrototype: ClothingHeadHatHoodWinterCaptain
   - type: Armor # DeltaV - adds resists to coat, same as HoS coat. Still better than nothing, but nowhere as good as a carapace
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -243,10 +245,12 @@
       - state: CHEM-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.75
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageTider
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterChem
@@ -273,10 +277,12 @@
 #      - state: CMO-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.75
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageTider
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterCMO
@@ -336,10 +342,12 @@
       - state: GENE-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.9
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSci
@@ -408,11 +416,13 @@
     clothingPrototype: ClothingHeadHatHoodWinterHOS
   - type: Armor # DeltaV - adds resists to coat. As good as Cap's, but I don't know why you'd wear this over a trench coat
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
+      # Begin DeltaV - armor
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
+      # End DeltaV - armor
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -459,10 +469,12 @@
       - state: JANI-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.9
-        Caustic: 0.9
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterJani
@@ -489,10 +501,12 @@
 #      - state: MED-equipped-OUTERCLOTHING 
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.9
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterMed
@@ -565,10 +579,12 @@
       - state: PARA-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.75
-        Caustic: 0.9
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageTider
+        Caustic: DamageUnarmed
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterPara
@@ -619,10 +635,12 @@
       - state: RD-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.9
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterRD
@@ -673,10 +691,12 @@
       - state: SCI-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.9
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSci
@@ -705,11 +725,13 @@
     clothingPrototype: ClothingHeadHatHoodWinterSec
   - type: Armor # DeltaV - adds resists to coat. Make sure to update ClothingLongcoatSecurity if these values change.
     modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85 # DeltaV - not as resistant as pre-rebase, but still better than nothing
-        Heat: 0.75
+      # Begin DeltaV - Armor
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamagePistol
+      # End DeltaV - Armor
 
 - type: entity
   parent: ClothingOuterWinterCoatToggleable
@@ -733,10 +755,12 @@
       - state: VIRO-equipped-OUTERCLOTHING
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.9
+      # Begin DeltaV - Armor
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamageUnarmed
+      # End DeltaV - Armor
     priceMultiplier: 0.15
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatHoodWinterSci

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -231,8 +231,10 @@
     node: jumpsuit
   - type: Armor
     modifiers:
-      coefficients:
-        Radiation: 0.8
+      # Begin DeltaV
+      armor:
+        Radiation: DamageTider
+      # End DeltaV
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -14,23 +14,20 @@
       size: Ginormous
       #heldPrefix: riot #Harmony Change: Removed due to being redundant
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.9
-          Slash: 0.9
-          Piercing: 0.9
-          Heat: 0.9
+        armor:
+          Blunt: DamageUnarmed
+          Slash: DamageUnarmed
+          Piercing: DamageUnarmed
+          Heat: DamageUnarmed
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.8
-          Slash: 0.8
-          Piercing: 0.8
-          Heat: 0.8
-        flatReductions:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
-          Heat: 1
+        armor:
+          Blunt: DamageTider
+          Slash: DamageTider
+          Piercing: DamageTider
+          Heat: DamageTider
+      # End DeltaV
     - type: Damageable
       damageContainer: Shield
     - type: ExaminableDamage
@@ -114,17 +111,16 @@
     - type: StaticPrice
       price: 90
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.7
-          Slash: 0.7
+        armor:
+          Blunt: DamagePistol
+          Slash: DamagePistol
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.5
-          Slash: 0.5
-        flatReductions:
-          Blunt: 1
-          Slash: 1
+        armor:
+          Blunt: DamageRifle
+          Slash: DamageRifle
+      # End DeltaV
 
 - type: entity
   name: laser shield
@@ -148,14 +144,14 @@
       - suitStorage
 # End of Harmony Change
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Heat: 0.7
+        armor:
+          Heat: DamagePistol
       activeBlockModifier:
-        coefficients:
-          Heat: 0.5
-        flatReductions:
-          Heat: 1
+        armor:
+          Heat: DamageRifle
+      # End DeltaV
 
 - type: entity
   name: ballistic shield
@@ -179,14 +175,14 @@
       - suitStorage
 # End of Harmony Change
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Piercing: 0.7
+        armor:
+          Piercing: DamagePistol
       activeBlockModifier:
-        coefficients:
-          Piercing: 0.5
-        flatReductions:
-          Piercing: 1
+        armor:
+          Piercing: DamageRifle
+      # End DeltaV
 
 #Craftable shields
 
@@ -212,22 +208,18 @@
       - suitStorage
 # End of Harmony Change
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.95
-          Slash: 0.95
-          Piercing: 0.95
-          Heat: 2
+        armor:
+          Blunt: DamageUnarmed
+          Slash: DamageUnarmed
+          Piercing: DamageUnarmed
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.85
-          Slash: 0.85
-          Piercing: 0.85
-          Heat: 2
-        flatReductions:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
+        armor:
+          Blunt: DamageTider
+          Slash: DamageTider
+          Piercing: DamageTider
+      # End DeltaV
     - type: Construction
       graph: WoodenBuckler
       node: woodenBuckler
@@ -267,20 +259,18 @@
     - type: Item
       heldPrefix: cardshield
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 1
-          Slash: 2
-          Piercing: 0.6
-          Heat: 3
+        armor:
+          Blunt: DamageUnarmed
+          Slash: DamageUnarmed
+          Piercing: DamageUnarmed
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.9
-          Slash: 1.8
-          Piercing: 0.5
-          Heat: 2.5
-        flatReductions:
-          Blunt: 0.5
+        armor:
+          Blunt: DamageTider
+          Slash: DamageTider
+          Piercing: DamageTider
+      # End DeltaV
     - type: Construction
       graph: CardShield
       node: cardShield
@@ -330,23 +320,18 @@
       - suitStorage
   # End of Harmony Change
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.95
-          Slash: 0.95
-          Piercing: 0.95
-          Heat: 0.9
+        armor:
+          Blunt: DamageUnarmed
+          Slash: DamageUnarmed
+          Piercing: DamageUnarmed
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.85
-          Slash: 0.85
-          Piercing: 0.85
-          Heat: 0.8
-        flatReductions:
-          Blunt: 0.5
-          Slash: 0.5
-          Piercing: 0.5
-          Heat: 1
+        armor:
+          Blunt: DamageTider
+          Slash: DamageTider
+          Piercing: DamageTider
+      # End DeltaV
     - type: Construction
       graph: MakeshiftShield
       node: makeshiftShield
@@ -388,20 +373,18 @@
       sprite: Objects/Weapons/Melee/web-shield.rsi
       heldPrefix: icon
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.95
-          Slash: 0.95
-          Piercing: 0.95
+        armor:
+          Blunt: DamageUnarmed
+          Slash: DamageUnarmed
+          Piercing: DamageUnarmed
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.85
-          Slash: 0.85
-          Piercing: 0.85
-        flatReductions:
-          Blunt: 0.5
-          Slash: 0.5
-          Piercing: 0.5
+        armor:
+          Blunt: DamageTider
+          Slash: DamageTider
+          Piercing: DamageTider
+      # End DeltaV
     - type: Construction
       graph: WebObjects
       node: shield
@@ -441,23 +424,18 @@
     - type: Item
       heldPrefix: ratvarian
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.8
-          Slash: 0.8
-          Piercing: 0.8
-          Heat: 1.5
+        armor:
+          Blunt: DamageTider
+          Slash: DamageTider
+          Piercing: DamageTider
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.7
-          Slash: 0.7
-          Piercing: 0.7
-          Heat: 1.5
-        flatReductions:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
-      #Have it break into brass when clock cult is in
+        armor:
+          Blunt: DamagePistol
+          Slash: DamagePistol
+          Piercing: DamagePistol
+      # End DeltaV
 
 - type: entity
   name: mirror shield
@@ -474,20 +452,14 @@
       reflects:
         - Energy
     - type: Blocking #Mirror shield reflects heat/laser, but is relatively weak to everything else.
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 1.2
-          Slash: 1.2
-          Piercing: 1.2
-          Heat: .7
+        armor:
+          Heat: DamagePistol
       activeBlockModifier:
-        coefficients:
-          Blunt: 1.2
-          Slash: 1.2
-          Piercing: 1.2
-          Heat: .6
-        flatReductions:
-          Heat: 1
+        armor:
+          Heat: DamageRifle
+      # End DeltaV
       blockSound: !type:SoundPathSpecifier
         path: /Audio/Effects/glass_step.ogg
     - type: Destructible
@@ -563,21 +535,18 @@
       reflects:
         - Energy
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 1.0
-          Slash: 0.9
-          Piercing: 0.7 # DeltaV - Was 0.85
-          Heat: 0.5 # DeltaV - Was 0.6
+        armor:
+          Slash: DamageTider
+          Piercing: DamagePistol
+          Heat: DamageRifle
       activeBlockModifier:
-        coefficients:
-          Blunt: 1.2
-          Slash: 0.85
-          Piercing: 0.5
-          Heat: 0.4
-        flatReductions:
-          Heat: 1
-          Piercing: 1
+        armor:
+          Slash: DamagePistol
+          Piercing: DamageRifle
+          Heat: DamageSniper
+      # End DeltaV
     - type: Appearance
     - type: Damageable
       damageContainer: Shield

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -63,11 +63,11 @@
     enabled: false
   - type: HandHeldArmor # Holding the Bible protects you
     modifiers:
-      coefficients:
-        Cold: 0.7
-        Asphyxiation: 0.7
-        Holy: 0.3
-        Shadow: 0.3
+      armor:
+        Cold: DamagePistol
+        Asphyxiation: DamagePistol
+        Holy: DamageSniper
+        Shadow: DamageSniper
     whitelist:
       components:
         - BibleUser # Only if you're the Chaplain or Mystagogue

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -111,9 +111,11 @@
     size: Normal
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
+      # Begin DeltaV - Armor
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+      # End DeltaV - Armor
   - type: PhysicalComposition
     materialComposition:
       Plastic: 50

--- a/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Research/anomaly.yml
@@ -215,8 +215,10 @@
       core_slot: !type:ContainerSlot
   - type: DamageOnAttackedProtection
     damageProtection:
-      flatReductions:
-        Heat: 100
-        Cold: 100
-        Radiation: 100
+      # Begin DeltaV Changes - armor
+      armor:
+        Heat: DamageSuper
+        Cold: DamageSuper
+        Radiation: DamageSuper
+      # End DeltaV Changes - armor
     slots: NONE

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -8,6 +8,7 @@
     damage:
       types:
         Piercing: 17
+        Penetration: 10 # DeltaV
 
 - type: entity
   parent: BaseBulletPractice
@@ -31,6 +32,7 @@
       types:
         Piercing: 12
         Heat: 5
+        Penetration: 10 # DeltaV
 
 - type: entity
   parent: BaseBulletUranium
@@ -43,4 +45,5 @@
       types:
         Radiation: 7
         Piercing: 8
+        Penetration: 10 # DeltaV
         

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -42,6 +42,7 @@
       types:
         Piercing: 10
         Structural: 15
+        Penetration: 5 # DeltaV
 
 - type: entity
   parent: PelletShotgun
@@ -64,6 +65,7 @@
       types:
         Piercing: 7
         Heat: 3
+        Penetration: 5 # DeltaV
   - type: IgnitionSource
     ignited: true
 

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hats.yml
@@ -59,8 +59,8 @@
     canBeFried: true
   - type: Armor
     modifiers:
-      coefficients:
-        Radiation: 0.95
+      armor:
+        Radiation: DamageUnarmed
   - type: Construction
     graph: TinfoilHat
     node: tinfoilhat
@@ -116,11 +116,11 @@
   - type: PsionicallyInsulative
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.95
-        Radiation: 0.95
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageUnarmed
+        Radiation: DamageUnarmed
 
 - type: entity
   parent: ClothingHeadBase
@@ -156,10 +156,10 @@
     sprite: Nyanotrasen/Clothing/Head/Helmets/men.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.95
-        Piercing: 0.95
+      armor:
+        Blunt: DamageTider
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
 
 - type: entity
   parent: ClothingHeadBase

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/helmets.yml
@@ -10,8 +10,8 @@
     sprite: Nyanotrasen/Clothing/Head/Helmets/kabuto.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.80
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
         

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/armor.yml
@@ -10,10 +10,10 @@
     sprite: Nyanotrasen/Clothing/OuterClothing/Armor/gladiator.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.8
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
 
 - type: entity
   parent: ClothingOuterBase
@@ -27,9 +27,9 @@
     sprite: Nyanotrasen/Clothing/OuterClothing/Armor/bogu.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.9
+      armor:
+        Blunt: DamageTider
+        Slash: DamageUnarmed
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.85
@@ -46,8 +46,8 @@
     sprite: Nyanotrasen/Clothing/OuterClothing/Armor/touseigusoku.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.60
-        Piercing: 0.85
+      armor:
+        Blunt: DamageTider
+        Slash: DamagePistol
+        Piercing: DamageTider
         

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/coats.yml
@@ -10,11 +10,11 @@
     sprite: Nyanotrasen/Clothing/OuterClothing/Coats/mantis_jacket.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.8
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
   - type: TemperatureProtection
     coolingCoefficient: 0.3
 
@@ -30,5 +30,5 @@
     sprite: _DV/Clothing/OuterClothing/Coats/mystacoat.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      armor:
+        Caustic: DamagePistol

--- a/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
@@ -22,12 +22,12 @@
     damageCoefficient: 0.6
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.7
-        Piercing: 0.5
-        Heat: 0.5
-        Caustic: 0.7
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageRifle
+        Heat: DamageRifle
+        Caustic: DamagePistol
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
@@ -102,11 +102,11 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.90
-        Heat: 0.90
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
   - type: FlashImmunity
   - type: TypingIndicatorClothing
     proto: CosmicTyping

--- a/Resources/Prototypes/_DV/CosmicCult/damage_modifier_sets.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/damage_modifier_sets.yml
@@ -1,7 +1,7 @@
 - type: damageModifierSet
   id: EntropicColossus
-  coefficients:
-    Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.5
-    Heat: 0.65
+  armor:
+    Blunt: DamageRifle
+    Slash: DamageRifle
+    Piercing: DamageRifle
+    Heat: DamageRifle

--- a/Resources/Prototypes/_DV/Damage/constants.yml
+++ b/Resources/Prototypes/_DV/Damage/constants.yml
@@ -1,0 +1,23 @@
+- type: dvDamageConstant
+  id: DamageUnarmed
+  value: 5
+
+- type: dvDamageConstant
+  id: DamageTider
+  value: 10
+
+- type: dvDamageConstant
+  id: DamagePistol
+  value: 15
+
+- type: dvDamageConstant
+  id: DamageRifle
+  value: 25
+
+- type: dvDamageConstant
+  id: DamageSniper
+  value: 50
+
+- type: dvDamageConstant
+  id: DamageSuper
+  value: 100

--- a/Resources/Prototypes/_DV/Damage/constants.yml
+++ b/Resources/Prototypes/_DV/Damage/constants.yml
@@ -16,7 +16,7 @@
 
 - type: dvDamageConstant
   id: DamageSniper
-  value: 50
+  value: 30
 
 - type: dvDamageConstant
   id: DamageSuper

--- a/Resources/Prototypes/_DV/Damage/types.yml
+++ b/Resources/Prototypes/_DV/Damage/types.yml
@@ -3,9 +3,18 @@
   name: damage-type-ion
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+  armorPrice: 1
 
 - type: damageType
   id: Shadow
   name: damage-type-shadow
   armorCoefficientPrice: 1
   armorFlatPrice: 1
+  armorPrice: 1
+
+- type: damageType
+  id: Penetration # not a real damage type but i am NOT rewriting all of damageable for this
+  name: damage-type-penetration
+  armorCoefficientPrice: 1
+  armorFlatPrice: 1
+  armorPrice: 1

--- a/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Eyes/glasses.yml
@@ -10,8 +10,8 @@
     sprite: _DV/Clothing/Eyes/Glasses/safetyglasses.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.85
+      armor:
+        Caustic: DamageTider
 
 - type: entity
   parent: [ClothingEyesBase, ShowMedicalIcons, BaseSecurityContraband]

--- a/Resources/Prototypes/_DV/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Hands/gloves.yml
@@ -46,8 +46,8 @@
     fiberColor: fibers-black
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.95
+      armor:
+        Caustic: DamageUnarmed
 
 - type: entity
   parent: [ClothingHandsBase, BaseCentcommContraband]

--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/eva-helmets.yml
@@ -10,8 +10,8 @@
     sprite: _DV/Clothing/Head/Helmets/eva_epistemics.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Radiation: 0.9
+      armor:
+        Radiation: DamageUnarmed
   - type: ExplosionResistance
     damageCoefficient: 0.95
   - type: Tag

--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -16,11 +16,11 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.90
-        Heat: 0.90
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitCombatStandard
@@ -50,11 +50,11 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitCombatMedical
@@ -84,11 +84,11 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.85
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
 
 - type: entity
   parent: ClothingHeadHelmetHardsuitCombatRiot
@@ -118,11 +118,11 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.85
-        Piercing: 0.85
-        Heat: 0.85
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
   - type: FlashImmunity # Counterpoint: the HoS can't see
   - type: EyeProtection # They're blind as hell
 
@@ -184,11 +184,11 @@
     color: "#addbff"
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
 
 #ERT Chaplain Hardsuit
 - type: entity
@@ -226,11 +226,11 @@
     color: "#f4ffad"
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
 
 #ERT Medical Hardsuit
 - type: entity
@@ -261,11 +261,11 @@
     color: "#ffadc6"
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
 
 #ERT Janitor Hardsuit
 - type: entity
@@ -296,8 +296,8 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Radiation: 0.95
+      armor:
+        Radiation: DamageUnarmed
   - type: Sprite
     sprite: _DV/Clothing/Head/Helmets/engineering-light.rsi
     layers:

--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/hoods.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/hoods.yml
@@ -40,13 +40,13 @@
     sprite: _DV/Clothing/Head/Hoods/harbingerhood.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Heat: 0.9
-        Holy: 0.9
-        Shadow: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+        Holy: DamageUnarmed
+        Shadow: DamageUnarmed
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/_DV/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Masks/masks.yml
@@ -23,8 +23,8 @@
     sprite: _DV/Clothing/Mask/gassecurityDV.rsi
   - type: Armor #Below values can be buffed or nerfed as needed.
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.90
-        Piercing: 0.95
-        Heat: 0.95
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed

--- a/Resources/Prototypes/_DV/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Neck/misc.yml
@@ -28,8 +28,8 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.90
+      armor:
+        Heat: DamageUnarmed
 
 - type: entity
   parent: ClothingNeckCWPSec
@@ -54,11 +54,11 @@
     sprite: _DV/Clothing/Neck/Misc/cwpgorlex.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.80
-        Cold: 0.40
-        Heat: 0.90
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageTider
+        Cold: DamageRifle
+        Heat: DamageUnarmed
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 0.95

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/Longcoats/command.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/Longcoats/command.yml
@@ -46,10 +46,10 @@
     sprite: _Floof/Clothing/OuterClothing/Longcoats/chief-medical-officer.rsi
   - type: Armor # Same as ClothingOuterWinterCMO, can't just parent because of ClothingOuterWinterCoatToggleable
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.90
-        Caustic: 0.75
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamagePistol
 
 - type: entity
   parent: [ClothingOuterWinterCoat, BaseCommandContraband]
@@ -85,12 +85,12 @@
     sprite: _Floof/Clothing/OuterClothing/Longcoats/head-of-security.rsi
   - type: Armor # Same as ClothingOuterWinterHoS, can't use as parent because ClothingOuterArmoredWinterCoatToggleable
     modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.6
-        Heat: 0.7
-        Caustic: 0.75
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamageTider
+        Caustic: DamageTider
 
 - type: entity
   parent: [ClothingOuterArmorBaseCarapace, ClothingOuterWinterCoat, BaseCentcommContraband]

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/armor.yml
@@ -11,11 +11,11 @@
     sprite: _DV/Clothing/OuterClothing/Armor/platecarrier.rsi
   - type: Armor # Good against gunshots, decent against everything else. Balanced by reduced movement speed.
     modifiers:
-      coefficients:
-        Blunt: 0.80
-        Slash: 0.80
-        Piercing: 0.50
-        Heat: 0.80
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageRifle
+        Heat: DamageTider
   - type: StaminaResistance
     damageCoefficient: 0.6 # Decent at stopping disablers
   - type: ClothingSpeedModifier
@@ -41,11 +41,11 @@
     sprite: _DV/Clothing/OuterClothing/Armor/duravest.rsi
   - type: Armor # Good against stabs and knocks, offers minimal protection from gunshots and lasfire.
     modifiers:
-      coefficients:
-        Blunt: 0.60
-        Slash: 0.60
-        Piercing: 0.90
-        Heat: 0.90
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
   - type: StaminaResistance
     damageCoefficient: 0.9
   - type: ExplosionResistance # Better than nothing against a blast or shockwave.
@@ -67,11 +67,11 @@
     sprite: _DV/Clothing/OuterClothing/Armor/riot.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.40
-        Slash: 0.40
-        Piercing: 0.70
-        Heat: 0.70
+      armor:
+        Blunt: DamageSniper
+        Slash: DamageSniper
+        Piercing: DamageRifle
+        Heat: DamageRifle
   - type: StaminaResistance
     damageCoefficient: 0.5
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/coats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/coats.yml
@@ -11,11 +11,11 @@
     sprite: _DV/Clothing/OuterClothing/Coats/ryuzocoat.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.8
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -29,11 +29,11 @@
     sprite: _DV/Clothing/OuterClothing/Coats/hop.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.8
-        Heat: 0.8
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
   - type: AllowSuitStorage
 
 - type: entity
@@ -50,9 +50,9 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.9
-        Heat: 0.75
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageTider
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -68,9 +68,9 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.9
-        Heat: 0.75
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageTider
 
 - type: entity
   parent: ClothingOuterStorageBase
@@ -86,11 +86,11 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.75
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageTider
   - type: AllowSuitStorage #Syndicate Windbreaker, so gun.
 
 - type: entity
@@ -149,11 +149,11 @@
     sprite: _DV/Clothing/OuterClothing/Coats/detectivearmouredcoat.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
   - type: AllowSuitStorage
   - type: TemperatureProtection
     coolingCoefficient: 0.1
@@ -171,13 +171,13 @@
     sprite: _DV/Clothing/OuterClothing/Coats/harbingercoat.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
-        Holy: 0.60
-        Shadow: 0.60
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
+        Holy: DamagePistol
+        Shadow: DamagePistol
   - type: AllowSuitStorage
   - type: TemperatureProtection
     coolingCoefficient: 0.1
@@ -211,8 +211,8 @@
     coolingCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Heat: 0.9
+      armor:
+        Heat: DamageUnarmed
 
 # Medical
 ## Lab coats
@@ -229,8 +229,8 @@
     sprite: _DV/Clothing/OuterClothing/Coats/medical_lab.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      armor:
+        Caustic: DamageTider
 
 - type: entity
   parent: ClothingOuterStorageFoldableBase
@@ -244,8 +244,8 @@
     sprite: _DV/Clothing/OuterClothing/Coats/chemistry_senior_lab.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      armor:
+        Caustic: DamageTider
 
 - type: entity
   parent: ClothingOuterStorageFoldableBase
@@ -259,8 +259,8 @@
     sprite: _DV/Clothing/OuterClothing/Coats/cybersun_lab.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      armor:
+        Caustic: DamageTider
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabCybersun]
@@ -281,8 +281,8 @@
     sprite: _DV/Clothing/OuterClothing/Coats/long_lab.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      armor:
+        Caustic: DamageTider
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabLong]
@@ -301,8 +301,8 @@
     sprite: _DV/Clothing/OuterClothing/Coats/medical_long_lab.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      armor:
+        Caustic: DamageTider
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabLongMedical]
@@ -321,8 +321,8 @@
     sprite: _DV/Clothing/OuterClothing/Coats/chemistry_long_lab.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.75
+      armor:
+        Caustic: DamageTider
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabLongChemist]
@@ -341,10 +341,10 @@
     sprite: _DV/Clothing/OuterClothing/Coats/cmo_long_lab.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Slash: 0.95
-        Heat: 0.95
-        Caustic: 0.65
+      armor:
+        Slash: DamageUnarmed
+        Heat: DamageUnarmed
+        Caustic: DamagePistol
 
 - type: entity
   parent: [ClothingOuterStorageFoldableBaseOpened, ClothingOuterCoatLabLongCMO]

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -16,15 +16,15 @@
     damageCoefficient: 0.50
   - type: Armor # Good armour resistance across the board, comparable to the standard security hardsuit.
     modifiers:
-      coefficients:
-        Blunt: 0.60
-        Slash: 0.60
-        Piercing: 0.60
-        Radiation: 0.75
-        Caustic: 0.75
-        Heat: 0.75
-        Holy: 0.85
-        Shadow: 0.85
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Radiation: DamagePistol
+        Caustic: DamagePistol
+        Heat: DamagePistol
+        Holy: DamageTider
+        Shadow: DamageTider
   - type: StaminaResistance
     damageCoefficient: 0.3 # It's a hardsuit, duh
   - type: ClothingSpeedModifier
@@ -70,15 +70,15 @@
     damageCoefficient: 0.60
   - type: Armor # Slightly less armour than the standard hardsuit, but far higher mobility.
     modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.65
-        Radiation: 0.80
-        Caustic: 0.80
-        Heat: 0.80
-        Holy: 0.85
-        Shadow: 0.85
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Radiation: DamageTider
+        Caustic: DamageTider
+        Heat: DamageTider
+        Holy: DamageTider
+        Shadow: DamageTider
   - type: ClothingSpeedModifier
     walkModifier: 0.85
     sprintModifier: 0.85
@@ -116,15 +116,15 @@
     damageCoefficient: 0.40
   - type: Armor # More protective than a standard security hardsuit, but far slower.
     modifiers:
-      coefficients:
-        Blunt: 0.50
-        Slash: 0.50
-        Piercing: 0.40
-        Radiation: 0.70
-        Caustic: 0.70
-        Heat: 0.40
-        Holy: 0.80
-        Shadow: 0.80
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Radiation: DamageRifle
+        Caustic: DamageRifle
+        Heat: DamageRifle
+        Holy: DamageTider
+        Shadow: DamageTider
   - type: StaminaResistance
     damageCoefficient: 0.2
   - type: ClothingSpeedModifier
@@ -164,15 +164,15 @@
     damageCoefficient: 0.40
   - type: Armor # About as protective as a riot hardsuit but with far less movement penalty.
     modifiers:
-      coefficients:
-        Blunt: 0.50
-        Slash: 0.50
-        Piercing: 0.50
-        Radiation: 0.75
-        Caustic: 0.75
-        Heat: 0.75
-        Holy: 0.75
-        Shadow: 0.75
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Radiation: DamagePistol
+        Caustic: DamagePistol
+        Heat: DamagePistol
+        Holy: DamagePistol
+        Shadow: DamagePistol
   - type: StaminaResistance
     damageCoefficient: 0.2
   - type: ClothingSpeedModifier
@@ -210,15 +210,15 @@
     damageCoefficient: 0.50
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.60
-        Slash: 0.60
-        Piercing: 0.60
-        Radiation: 0.0
-        Caustic: 0.4
-        Heat: 0.70
-        Holy: 0.60
-        Shadow: 0.60
+      armor:
+        Blunt: DamageSniper
+        Slash: DamageSniper
+        Piercing: DamageSniper
+        Radiation: DamageSuper
+        Caustic: DamageSniper
+        Heat: DamageRifle
+        Holy: DamageRifle
+        Shadow: DamageRifle
   - type: StaminaResistance
     damageCoefficient: 0.3
   - type: ClothingSpeedModifier
@@ -387,15 +387,15 @@
     damageCoefficient: 0.50
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.50
-        Heat: 0.6
-        Radiation: 0
-        Caustic: 0.35
-        Holy: 0.50
-        Shadow: 0.50
+      armor:
+        Blunt: DamageSniper
+        Slash: DamageSniper
+        Piercing: DamageSniper
+        Heat: DamageSniper
+        Radiation: DamageSuper
+        Caustic: DamageSniper
+        Holy: DamageSniper
+        Shadow: DamageSniper
   - type: StaminaResistance
     damageCoefficient: 0.2
   - type: ClothingSpeedModifier
@@ -502,13 +502,13 @@
     sprite: _DV/Clothing/OuterClothing/Hardsuits/rhinosuit.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.5
-        Piercing: 0.7
-        Heat: 0.6
-        Radiation: 0.3
-        Caustic: 0.7
+      armor:
+        Blunt: DamagePistol
+        Slash: DamageRifle
+        Piercing: DamagePistol
+        Heat: DamageRifle
+        Radiation: DamageSniper
+        Caustic: DamagePistol
   - type: ClothingSpeedModifier
     walkModifier: 0.7
     sprintModifier: 0.7
@@ -548,14 +548,14 @@
     damageCoefficient: 0.2
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5
-        Slash: 0.5
-        Piercing: 0.5
-        Heat: 0.5
-        Radiation: 0.5
-        Caustic: 0.5
-        Cold: 0.8
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Heat: DamageRifle
+        Radiation: DamageRifle
+        Caustic: DamageRifle
+        Cold: DamagePistol
   - type: DamageOnShootProtection
     slots: OUTERCLOTHING
     damageProtection:
@@ -594,14 +594,14 @@
     damageCoefficient: 0.1
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.2
-        Slash: 0.2
-        Piercing: 0.2
-        Heat: 0.2
-        Radiation: 0.2
-        Caustic: 0.2
-        Cold: 0.6
+      armor:
+        Blunt: DamageSniper
+        Slash: DamageSniper
+        Piercing: DamageSniper
+        Heat: DamageSniper
+        Radiation: DamageSniper
+        Caustic: DamageSniper
+        Cold: DamageRifle
   - type: DamageOnShootProtection
     slots: OUTERCLOTHING
     damageProtection:

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/k9.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/k9.yml
@@ -25,13 +25,13 @@
     damageCoefficient: 0.50
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.60
-        Slash: 0.60
-        Piercing: 0.60
-        Radiation: 0.75
-        Caustic: 0.75
-        Heat: 0.75
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Radiation: DamagePistol
+        Caustic: DamagePistol
+        Heat: DamagePistol
   - type: StaminaResistance
     damageCoefficient: 0.3
   - type: ClothingSpeedModifier
@@ -71,13 +71,13 @@
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/k9_riot.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.65
-        Slash: 0.65
-        Piercing: 0.65
-        Radiation: 0.80
-        Caustic: 0.80
-        Heat: 0.80
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageRifle
+        Piercing: DamageRifle
+        Radiation: DamageTider
+        Caustic: DamageTider
+        Heat: DamageTider
   - type: ToggleableClothing
     clothingPrototype: ClothingOuterHardsuitCombatRiotK9Helmet
 

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/misc.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/misc.yml
@@ -11,8 +11,8 @@
     sprite: _DV/Clothing/OuterClothing/Misc/chemapron.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.25
+      armor:
+        Caustic: DamageSniper
 
 - type: entity
   parent: ClothingOuterBaseToggleable
@@ -26,8 +26,8 @@
     sprite: _DV/Clothing/OuterClothing/Misc/interdynechemsuit.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.40
+      armor:
+        Caustic: DamageRifle
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHatInterdyneChemistryHood
 

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/softsuits.yml
@@ -17,9 +17,9 @@
       toggleable-under-clothing: !type:ContainerSlot {}
   - type: Armor
     modifiers:
-      coefficients:
-        Radiation: 0.2 # Little easier to steal the core when you have a rad suit
-        Heat: 0.75 # Take an extra shot or two
+      armor:
+        Radiation: DamageSniper # Little easier to steal the core when you have a rad suit
+        Heat: DamagePistol # Take an extra shot or two
   - type: ClothingSpeedModifier # Make em a bit more nimble so they can hide/Run
     walkModifier: 1
     sprintModifier: 1
@@ -37,9 +37,9 @@
     sprite: _DV/Clothing/OuterClothing/Suits/eva_epistemics.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Radiation: 0.6
-        Caustic: 0.8 # Wouldn't want John Scientist getting obliterated by the funny caustic chem artifact.
+      armor:
+        Radiation: DamagePistol
+        Caustic: DamagePistol # Wouldn't want John Scientist getting obliterated by the funny caustic chem artifact.
   - type: ExplosionResistance
     damageCoefficient: 0.7 # Practically a budget bombsuit, so it absorbs a lot of explosion damage.
   - type: ClothingSpeedModifier
@@ -87,9 +87,9 @@
         shader: unshaded
   - type: Armor
     modifiers:
-      coefficients:
-        Radiation: 0.5
-        Heat: 0.95
+      armor:
+        Radiation: DamageRifle
+        Heat: DamageUnarmed
   - type: ExplosionResistance
     damageCoefficient: 0.85
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/vests.yml
@@ -10,11 +10,11 @@
     sprite: _DV/Clothing/OuterClothing/Vests/flak.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.75
-        Heat: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageTider
+        Heat: DamageUnarmed
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -30,11 +30,11 @@
     sprite: _DV/Clothing/OuterClothing/Vests/flakpress.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.75
-        Heat: 0.9
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageTider
+        Heat: DamageUnarmed
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -61,12 +61,12 @@
     sprite: _DV/Clothing/OuterClothing/Vests/advcarrier.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.4
-        Shock: 0.8
-        Heat: 0.7
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamageRifle
+        Shock: DamagePistol
+        Heat: DamagePistol
   - type: StaminaResistance
     damageCoefficient: 0.6
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -5,11 +5,11 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.75
-        Heat: 0.75
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
 
 - type: entity
   abstract: true
@@ -38,11 +38,11 @@
     sprite: _DV/Clothing/OuterClothing/WinterCoats/cc_warden_winter_coat.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7
-        Slash: 0.7
-        Piercing: 0.4 #Stronger than the warden's armored jacket, because shenanigans and CC spends alot of money.
-        Heat: 0.75
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamageSniper #Stronger than the warden's armored jacket, because shenanigans and CC spends alot of money.
+        Heat: DamagePistol
 
 - type: entity
   parent: ClothingOuterWinterCoat

--- a/Resources/Prototypes/_DV/Entities/Clothing/Shoes/specific.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Shoes/specific.yml
@@ -10,8 +10,8 @@
     sprite: _DV/Clothing/Shoes/Specific/enclosedshoes.rsi
   - type: Armor
     modifiers:
-      coefficients:
-        Caustic: 0.95
+      armor:
+        Caustic: DamageUnarmed
 
 - type: entity
   parent: ClothingShoesClownBase

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -63,6 +63,7 @@
     damage:
       types:
         Heat: 2
+        Penetration: 25
 
 - type: entity
   parent: BasicHitscan

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -16,11 +16,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.95
-        Piercing: 0.95
-        Heat: 0.95
+      # Begin DeltaV - Armor
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV - Armor
   # DeltaV start
   # - type: ClothingGrantComponent
   #   component:

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -19,13 +19,12 @@
     damageCoefficient: 0.8 #  was 0.65
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.7 # was 0.65
-        Slash: 0.7 # was 0.65
-        Piercing: 0.6 # unchanged
-        Heat: 0.8 # was 0.6
-        Radiation: 0.8 # was 0.55
-        #Caustic: 0.7 
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamageTider
+        Radiation: DamageTider
   - type: StaminaResistance 
     damageCoefficient: 0.7
   # DeltaV changes end

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -11,8 +11,10 @@
   - type: CrematoriumImmune
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.75
-        Piercing: 0.70
-        Heat: 0.75
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamagePistol
+      # End DeltaV

--- a/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/Head/Hardsuits/asakim.yml
@@ -21,11 +21,13 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.8
-        Slash: 0.8
-        Piercing: 0.85
-        Heat: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Heat: DamageTider
+      # End DeltaV
   - type: FlashImmunity
   - type: EyeProtection
     protectionTime: 15

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
@@ -37,15 +37,17 @@
     price: 50000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.5 # DeltaV - was 0.35
-        Slash: 0.85
-        Piercing: 0.4 # DeltaV - was 0.3
-        Heat: 0.6 # DeltaV - was 0.4
-        Radiation: 0
-        Shock: 0.8
-        Poison: 0.4
-        Caustic: 0.4
+      # Begin DeltaV - Armor
+      armor:
+        Blunt: DamageRifle
+        Slash: DamageTider
+        Piercing: DamageRifle
+        Heat: DamagePistol
+        Radiation: DamageSuper
+        Shock: DamageTider
+        Poison: DamageSniper
+        Caustic: DamageSniper
+      # End DeltaV - Armor
   - type: ClothingSpeedModifier
     walkModifier: 1
     sprintModifier: 1

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -14,12 +14,14 @@
     lowPressureMultiplier: 1000
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.9
-        Radiation: 0.3
-        Caustic: 0.8
+      # Begin DeltaV
+      armor:
+        Blunt: DamageTider
+        Slash: DamageTider
+        Piercing: DamageTider
+        Radiation: DamageSniper
+        Caustic: DamageTider
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.8

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Head/helmets.yml
@@ -6,11 +6,13 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.97
-        Slash: 0.96
-        Piercing: 0.97
-        Heat: 0.98
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # Begin DeltaV
   - type: Sprite
     sprite: _Starlight/Clothing/Head/Helmets/makeshift.rsi
   - type: Clothing
@@ -27,11 +29,13 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.95
-        Slash: 0.93
-        Piercing: 0.95
-        Heat: 0.96
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # Begin DeltaV
   - type: Sprite
     sprite: _Starlight/Clothing/Head/Helmets/improvised.rsi
   - type: Clothing
@@ -45,11 +49,13 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.92
-        Slash: 0.90
-        Piercing: 0.92
-        Heat: 0.94
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # Begin DeltaV
   - type: Sprite
     sprite: _Starlight/Clothing/Head/Helmets/forged.rsi
   - type: Clothing
@@ -63,11 +69,13 @@
   components:
   - type: Armor
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.88
-        Piercing: 0.90
-        Heat: 0.92
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageUnarmed
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # Begin DeltaV
   - type: Sprite
     sprite: _Starlight/Clothing/Head/Helmets/paladin.rsi
   - type: Clothing

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/armor.yml
@@ -10,11 +10,13 @@
     sprite: _Starlight/Clothing/OuterClothing/Armor/makeshift.rsi
   - type: Armor 
     modifiers:
-      coefficients:
-        Blunt: 0.90
-        Slash: 0.80
-        Piercing: 0.90
-        Heat: 0.95
+      # Begin DeltaV
+      armor:
+        Blunt: DamageUnarmed
+        Slash: DamageTider
+        Piercing: DamageUnarmed
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
@@ -36,11 +38,13 @@
     sprite: _Starlight/Clothing/OuterClothing/Armor/improvised.rsi
   - type: Armor 
     modifiers:
-      coefficients:
-        Blunt: 0.85
-        Slash: 0.70
-        Piercing: 0.85
-        Heat: 0.90
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamageTider
+        Heat: DamageUnarmed
+      # End DeltaV
   - type: ClothingSpeedModifier
     walkModifier: 0.95
     sprintModifier: 0.95
@@ -59,11 +63,13 @@
     sprite: _Starlight/Clothing/OuterClothing/Armor/forged.rsi
   - type: Armor 
     modifiers:
-      coefficients:
-        Blunt: 0.75
-        Slash: 0.65
-        Piercing: 0.70
-        Heat: 0.85
+      # Begin DeltaV
+      armor:
+        Blunt: DamagePistol
+        Slash: DamagePistol
+        Piercing: DamagePistol
+        Heat: DamageTider
+      # End DeltaV
   - type: ExplosionResistance
     damageCoefficient: 0.90
 

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
@@ -17,23 +17,20 @@
       - Back
       - suitStorage
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.7
-          Slash: 0.5 #Encourages long swordfights, which I really, really want to see.
-          Piercing: 0.8
-          Heat: 0.85
+        armor:
+          Blunt: DamageTider
+          Slash: DamagePistol
+          Piercing: DamageTider
+          Heat: DamageTider
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.5
-          Slash: 0.3
-          Piercing: 0.7
-          Heat: 0.75
-        flatReductions:
-          Blunt: 1
-          Slash: 1
-          Piercing: 1
-          Heat: 1
+        armor:
+          Blunt: DamagePistol
+          Slash: DamageRifle
+          Piercing: DamagePistol
+          Heat: DamagePistol
+      # End DeltaV
     - type: MeleeWeapon
       damage:
         types:
@@ -82,18 +79,20 @@
     - type: Clothing
       sprite: _Starlight/Objects/Weapons/Melee/paladin_greatshield.rsi
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.7
-          Slash: 0.7
-          Piercing: 0.7
-          Heat: 0.85
+        armor:
+          Blunt: DamagePistol
+          Slash: DamagePistol
+          Piercing: DamagePistol
+          Heat: DamagePistol
       activeBlockModifier:
-        coefficients: #Insanely high resist because normal shields suck when raising. This is a WALL.
-          Blunt: 0.1
-          Slash: 0.1
-          Piercing: 0.1
-          Heat: 0.75 # Achilles Heel
+        armor: #Insanely high resist because normal shields suck when raising. This is a WALL.
+          Blunt: DamageSniper
+          Slash: DamageSniper
+          Piercing: DamageSniper
+          Heat: DamagePistol # Achilles Heel
+      # End DeltaV
     - type: MeleeWeapon
       attackRate: 0.50 # Large and heavy but god help you if someone hits you with this thing.
       damage:
@@ -148,18 +147,20 @@
     - type: Clothing
       sprite: _Starlight/Objects/Weapons/Melee/forged_buckler_shield.rsi
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.7
-          Slash: 0.6
-          Piercing: 0.7
-          Heat: 0.9
+        armor:
+          Blunt: DamagePistol
+          Slash: DamagePistol
+          Piercing: DamagePistol
+          Heat: DamageUnarmed
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.6
-          Slash: 0.5
-          Piercing: 0.6
-          Heat: 0.8
+        armor:
+          Blunt: DamageRifle
+          Slash: DamageRifle
+          Piercing: DamageRifle
+          Heat: DamageTider
+      # End DeltaV
     - type: MeleeWeapon
       damage:
         types:
@@ -259,18 +260,20 @@
     - type: Clothing
       sprite: _Starlight/Objects/Weapons/Melee/improvised_shield.rsi
     - type: Blocking
+      # Begin DeltaV
       passiveBlockModifier:
-        coefficients:
-          Blunt: 0.8
-          Slash: 0.7
-          Piercing: 0.9
-          Heat: 0.95
+        armor:
+          Blunt: DamageTider
+          Slash: DamageTider
+          Piercing: DamageUnarmed
+          Heat: DamageUnarmed
       activeBlockModifier:
-        coefficients:
-          Blunt: 0.7
-          Slash: 0.6
-          Piercing: 0.8
-          Heat: 0.85
+        armor:
+          Blunt: DamagePistol
+          Slash: DamagePistol
+          Piercing: DamageTider
+          Heat: DamageTider
+      # End DeltaV
     - type: MeleeWeapon
       damage:
         types:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Armour values are now on a quadratic curve, rather than a linear coefficient as before.

## The Theory
### What makes a good armour system?
Variations between armour values should feel meaningful, even between 5 to 10. (or 5% to 10%).
Damage below some point should be and _feel_ negligible compared to the armour, and damage above some point should make the armour itself feel negligible.
Armour values should also compose in a manner that feels legible, but not be so overwhelmingly strong as to make stacking up a bunch of weak armours equivalent to one good armour.

### Linear Armour
<img width="1099" height="619" alt="Bildschirmfoto 2026-05-14 um 11 06 13 PM" src="https://github.com/user-attachments/assets/0038b7ab-16e6-4b19-be6d-a516016877f2" />

Our current system of armour is mostly based on a linear model.
The incoming damage is multiplied by some coefficient to determine the end damage.
Right off the bat, this model fails at making distinct armour values feel meaningful, except in the large percentage increments we see in the game currently.
The model also fails at making very small and very high damage amounts feel the way they should.
It lacks the granularity for something like "this armour should protect you pretty much completely against tider punches, but it shouldn't make you immune from a Death Squad member."
The same 20% that brings 5 damage down to 1 damage is the same 20% that brings 50 damage down to 10 damage.

<img width="1103" height="618" alt="Bildschirmfoto 2026-05-14 um 11 13 39 PM" src="https://github.com/user-attachments/assets/530c826c-7bd8-49a6-9607-7c1f96110e07" />
The composition behaviour is also fairly strong, being straight multiplication of the coefficient.
Two 50% armours behave as a single 25% armour.

### Flat Reduction
<img width="1117" height="638" alt="Bildschirmfoto 2026-05-14 um 11 16 33 PM" src="https://github.com/user-attachments/assets/17f0deae-e5e7-45c1-9e8c-46229a9d233d" />
The other armour model we currently have in the game is flat reduction.
In terms of granularity, this definitely takes the cake.
Armour values directly correlate with damage as seen on weapons, so you can easily specify an armour that protects fully against a wrench but basically not at all against a Death Squad agent.

For situations where there's just one (1) value, this is an excellent choice for game feel.
However, where it falls flat is composition.
Combining multiple Flat Reduction armours results in, well, the consequences of combining multiple flat reduction armours.
<img width="1116" height="631" alt="Bildschirmfoto 2026-05-14 um 11 19 34 PM" src="https://github.com/user-attachments/assets/7f46a399-e894-45a9-8e4d-5a97878794e9" />

This effectively expands their "zero damage at all range" by a _large_ margin, and substantially tanks incoming damage above that as well.

### Logistic Reduction
<img width="1036" height="539" alt="Bildschirmfoto 2026-05-14 um 11 20 30 PM" src="https://github.com/user-attachments/assets/55719e04-090c-4b4f-bf75-0140b96c4d00" />

This one is mostly a joke.
It quite literally optimises for the criteria of "damages below a point should feel negligible, and damages above a point should feel strong."
At least, until you pan the chart to the right.

<img width="1046" height="602" alt="Bildschirmfoto 2026-05-14 um 11 21 39 PM" src="https://github.com/user-attachments/assets/5a5db207-6798-44eb-a281-519d637aa0c4" />
This causes a maximum cap on the damage you can take at once, and it doesn't bode well to splicing some other function in for a better behaviour.

<img width="1112" height="619" alt="Bildschirmfoto 2026-05-14 um 11 22 52 PM" src="https://github.com/user-attachments/assets/28f5c3ca-f9ad-4d58-aaef-9eac1a1e5f70" />
Composition also effectively just squashes the chart down, making it about as strong as linear reduction in this regard, if not moreso.

### Quadratic Reduction
So far, the best model we've seen for the gamefeel of very weak and very strong attacks against armour is the Flat Reduction.
However, in a game as complex as Delta-V, the composition is an Achilles' heel and makes armour stacking inordinately strong.
The complete cessation of all damage below the threshold also acts as a hardblock, and completely kills attrition.
While the amount of attrition in the linear model felt eeeeh, it's still important to have attrition so that e.g. nuclear operatives tearing through crew have to worry about the possibility of being worn down over time.

It'd be nice if we had something with good feel for very weak and very strong attacks, while preserving attrition, while having good composition behaviour.
Presenting: quadratic reduction.

<img width="617" height="620" alt="Bildschirmfoto 2026-05-14 um 11 34 26 PM" src="https://github.com/user-attachments/assets/8813f8d9-7b61-4e3f-bf12-a04a0d8df7c2" />
This simple curve (plus or minus a linear graph stitched on) is deceptively good at fulfilling all of the criteria above.
For damage below the armour value of the curve, it is substantially weaker making very weak attacks feel effectively so, while not being zero and completely killing attrition.
For damage above twice the armour value of the curve, the effect of the armour is effectively null.
This armour can protect effectively against trivial weapons, _and_ fall nicely to a death squad member.

Differences between armour values are also substantial, with their granularity scaling nicely with the size of the armour value.
Differences between small armour values are pronounced, like the flat model, while being able to express strong armours, that nonetheless, aren't completely invincible.

The armour value in this model effectively serves as a "range" where the armour is effective.
Damage on the low end of the efficacy range is blocked more strongly, while damage on the high end of the efficacy range is blocked more weakly, before effectively not being blocked at all.

This "range" property preserves, even in composition.
<img width="549" height="532" alt="Bildschirmfoto 2026-05-14 um 11 38 08 PM" src="https://github.com/user-attachments/assets/10ac60b7-105f-4cc0-82d9-d46368ef7bd8" />
Stacking armour in this model effectively only increases the efficacy of the armour in the range, while leaving values outside of it unaffected.
So, no matter how many weak armours you can scrounge together, you'll get steamrolled by Death Squad all the same.

This model is the one that I believe can lead to an _amazing_ game feel if executed correctly, and I use it in this pull request consequently.
My focus is on broad strokes game-feel, not the devil in the details of balancing minute differences in armour.

## Technical details
Add support to DamageModifierSet/DamageSpecifier
Add DVDamageValueDictionarySerializer/DVDamageConstantPrototype so we can have named constants.
The YAML mines go insane.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Damage reduction in armour has been fully overhauled!

<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
