### PR TITLE
Ghost buffers

### DIFF
--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -57,7 +57,7 @@ public sealed partial class RevenantComponent : Component
     /// through harvesting player souls.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("maxEssence")]
-    public FixedPoint2 EssenceRegenCap = 75;
+    public FixedPoint2 EssenceRegenCap = 100; // DeltaV changed from 75 to 100
 
     /// <summary>
     /// The coefficient of damage taken to actual health lost.
@@ -69,7 +69,7 @@ public sealed partial class RevenantComponent : Component
     /// The amount of essence passively generated per second.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("essencePerSecond")]
-    public FixedPoint2 EssencePerSecond = 0.5f;
+    public FixedPoint2 EssencePerSecond = 1.0f; // DeltaV increased from 0.5 to 1
 
     [ViewVariables]
     public float Accumulator = 0;
@@ -110,7 +110,7 @@ public sealed partial class RevenantComponent : Component
     public Vector2 HauntDebuffs = new(3, 8);
 
     [DataField("hauntStolenEssencePerWitness"), ViewVariables(VVAccess.ReadWrite)]
-    public FixedPoint2 HauntStolenEssencePerWitness = 2.5;
+    public FixedPoint2 HauntStolenEssencePerWitness = 5; // DeltaV changed from 2.5 to 5
 
     [DataField("hauntEssenceRegenPerWitness"), ViewVariables(VVAccess.ReadWrite)]
     public FixedPoint2 HauntEssenceRegenPerWitness = 0.5;
@@ -134,7 +134,7 @@ public sealed partial class RevenantComponent : Component
     /// The amount of essence that is needed to use the ability.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("defileCost")]
-    public FixedPoint2 DefileCost = 30;
+    public FixedPoint2 DefileCost = 20; // DeltaV - reduced cost from 30 to 20
 
     /// <summary>
     /// The status effects applied after the ability
@@ -148,7 +148,7 @@ public sealed partial class RevenantComponent : Component
     /// The radius around the user that this ability affects
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("defileRadius")]
-    public float DefileRadius = 3.5f;
+    public float DefileRadius = 4f; //DeltaV - increased from 3.5 to 4
 
     /// <summary>
     /// The amount of tiles that are uprooted by the ability
@@ -161,7 +161,7 @@ public sealed partial class RevenantComponent : Component
     /// happen to it.
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField("defileEffectChance")]
-    public float DefileEffectChance = 0.5f;
+    public float DefileEffectChance = 0.6f; //DeltaV - increased from 0.5 to 0.6
     #endregion
 
     #region Overload Lights Ability
@@ -261,13 +261,13 @@ public sealed partial class RevenantComponent : Component
 
     #region Animate
     [ViewVariables(VVAccess.ReadWrite), DataField]
-    public FixedPoint2 AnimateCost = 50;
+    public FixedPoint2 AnimateCost = 40; //DeltaV - reduced from 50 to 40
 
     /// <summary>
     /// How long an item should be animated for
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite), DataField]
-    public TimeSpan AnimateTime = TimeSpan.FromSeconds(15);
+    public TimeSpan AnimateTime = TimeSpan.FromSeconds(10); // DeltaV - reduced from 15 to 10
 
     [ViewVariables(VVAccess.ReadWrite), DataField]
     public Vector2 AnimateDebuffs = new(3, 8);
@@ -282,7 +282,7 @@ public sealed partial class RevenantComponent : Component
     public float AnimateSprintSpeed = DefaultAnimateSprintSpeed;
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool AnimateCanBoltGuns = false;
+    public bool AnimateCanBoltGuns = true; // DeltavV - made true
     #endregion
     // End Imp Changes
 

--- a/Resources/Prototypes/Actions/revenant.yml
+++ b/Resources/Prototypes/Actions/revenant.yml
@@ -8,7 +8,7 @@
   parent: BaseAction
   id: ActionRevenantDefile
   name: Defile
-  description: Costs 30 Essence.
+  description: Costs 20 Essence. # DeltaV cost reduced to 20 from 30
   components:
   - type: Action
     itemIconStyle: NoItem # Imp

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -28,6 +28,22 @@
   - type: Damageable
     damageContainer: ManifestedSpirit
     damageModifierSet: Spirit # DeltaV: Keep revenant extreme weakness to heat and bible
+  - type: MeleeWeapon # Begin DeltaV additions
+    soundHit:
+        path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
+    angle: 90
+    animation: WeaponArcClaw
+    wideAnimation: WeaponArcClaw
+    wideAnimationRotation: -90
+    swingLeft: true
+    attackRate: 0.3
+    range: 1.0
+    altDisarm: false
+    damage:
+      types:
+        Slash: 2
+        Shadow: 2
+  - type: CombatMode # end DeltaV additions 
   - type: NoSlip
   - type: Eye
     drawFov: false

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -71,7 +71,7 @@
     malfunctionWhitelist:
       components:
       # emag lockers open
-      - EntityStorage
+      # - EntityStorage # Trolling armory is very stale
       # emag doors open
       - Airlock
       # troll medical to help get kills

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -62,7 +62,7 @@
       - StasisBed
       - EmaggableMedibot
       # borg become killer
-      - EmagSiliconLaw
+      # - EmagSiliconLaw # DeltaV - emag borg doesn't make sense
   - type: PointLight
     color: MediumPurple
     radius: 2

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -302,6 +302,8 @@
   #- type: StunVisuals # DeltaV - No stars
   - type: CanDoCPR # DeltaV - Addition of CPR
   - type: PotentialPsionic # DeltaV - organic species can all be psionic
+  - type: RevealRevenantOnCollide # DeltaV - passing through people reveal revenant
+    revealTime: 1
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/condiments.yml
@@ -76,6 +76,8 @@
       - Packet
   - type: ExaminableSolution
     exactVolume: true
+  - type: Spillable # DeltaV - spilling salt on the floor, should work for all packets
+    solution: food
 
 - type: entity
   parent: BaseFoodCondimentPacket

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -30,6 +30,7 @@
   - type: Summonable
     specialItem: SpawnPointGhostRemilia
   - type: RevealRevenantOnCollide # Imp
+    revealTime: 20 # DeltaV - from 5 to 10 seconds reveal
   - type: ReactionMixer
     mixMessage: "bible-mixing-success"
     reactionTypes:

--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -30,7 +30,7 @@
   - type: Summonable
     specialItem: SpawnPointGhostRemilia
   - type: RevealRevenantOnCollide # Imp
-    revealTime: 20 # DeltaV - from 5 to 10 seconds reveal
+    revealTime: 20 # DeltaV - from 5 to 20 seconds reveal
   - type: ReactionMixer
     mixMessage: "bible-mixing-success"
     reactionTypes:

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -123,11 +123,12 @@
   coefficients:
     Cold: 0.0
     Shock: 0.5
-    Blunt: 0.5
-    Slash: 0.5
-    Piercing: 0.5
+    Blunt: 0.0
+    Slash: 0.0
+    Piercing: 0.0
     Heat: 1.5
     Holy: 3.0
+    Shadow: 0.0
 
 - type: damageModifierSet
   id: ShockAbsorber
@@ -145,6 +146,9 @@
   coefficients:
     Cold: 0.0
     Shock: 0.2
+    Blunt: 0.0
+    Slash: 0.0
+    Piercing: 0.0
     Heat: 3.0
     Holy: 5.0
     Shadow: 0.0

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -146,9 +146,9 @@
   coefficients:
     Cold: 0.0
     Shock: 0.2
-    Blunt: 0.0
-    Slash: 0.0
-    Piercing: 0.0
+    Blunt: 0.2
+    Slash: 0.2
+    Piercing: 0.2
     Heat: 3.0
     Holy: 5.0
     Shadow: 0.0

--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -146,10 +146,10 @@
   coefficients:
     Cold: 0.0
     Shock: 0.2
-    Blunt: 0.2
-    Slash: 0.2
-    Piercing: 0.2
-    Heat: 3.0
+    Blunt: 0.4
+    Slash: 0.4
+    Piercing: 0.4
+    Heat: 2.0
     Holy: 5.0
     Shadow: 0.0
 

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -62,9 +62,9 @@
           radius: 0.35
         density: 13
         mask:
-        - Opaque
+        - SmallMobMask
         layer:
-        - MobLayer
+        - Opaque
   - type: MovementSpeedModifier
     baseSprintSpeed: 8
     baseWalkSpeed: 5

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -28,8 +28,8 @@
       0: Alive
       120: Dead
   - type: Damageable
-    damageModifierSet: CorporealSpirit
     damageContainer: BiologicalMetaphysical
+    damageModifierSet: CorporealSpirit
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -28,7 +28,7 @@
       0: Alive
       120: Dead
   - type: Damageable
-    damageModifierSet: ManifestedSpirit
+    damageModifierSet: CorporealSpirit
     damageContainer: BiologicalMetaphysical
   - type: Fixtures
     fixtures:
@@ -40,7 +40,7 @@
         mask:
         - SmallMobMask
         layer:
-        - SmallMobLayer
+        - Opaque
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.75

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -31,7 +31,7 @@
       120: Dead
   - type: Damageable
     damageContainer: BiologicalMetaphysical
-    damageModifierSet: CorporealSpirit
+    damageModifierSet: Spirit
   - type: Fixtures
     fixtures:
       fix1:
@@ -42,7 +42,7 @@
         mask:
         - SmallMobMask
         layer:
-        - Opaque
+        - SmallMobLayer
   - type: MovementSpeedModifier
     baseWalkSpeed: 2.25
     baseSprintSpeed: 3.75

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -10,6 +10,8 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: skia
+  - type: Stealth
+    lastVisibility: 0.8
   - type: DamageStateVisuals
     states:
       Alive:

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -111,6 +111,7 @@
     range: 5.0
     energyConsumption: 20000
     disableDuration: 20.0
+  - type: Jaunt
   - type: Butcherable
     spawned:
     - id: Ectoplasm

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
@@ -24,6 +24,7 @@
   - type: Tag
     tags:
       - SilverSword
+  - type: RevealRevenantOnCollide
 
 - type: entity
   parent: SilverSword
@@ -37,7 +38,6 @@
   - type: Construction
     graph: RadiantSword
     node: embeddedsword
-
 
 - type: entity
   parent: SilverSword
@@ -60,5 +60,6 @@
     graph: RadiantSword
     node: radiantsword
   - type: RevealRevenantOnCollide
+    revealTime: 10
   - type: CollisionWake
     enabled: false

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
@@ -25,9 +25,11 @@
     tags:
       - SilverSword
   - type: RevealRevenantOnCollide
+  - type: CollisionWake
+    enabled: False
 
 - type: entity
-  parent: SilverSword
+parent: SilverSword
   id: EmbeddedSword
   name: bluespace embedded sword
   description: you didn't think just adding bluespace would make this a workable weapon, did you?

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
@@ -29,7 +29,7 @@
     enabled: False
 
 - type: entity
-parent: SilverSword
+  parent: SilverSword
   id: EmbeddedSword
   name: bluespace embedded sword
   description: you didn't think just adding bluespace would make this a workable weapon, did you?

--- a/Resources/Prototypes/_DV/NPC/wisp.yml
+++ b/Resources/Prototypes/_DV/NPC/wisp.yml
@@ -11,6 +11,14 @@
     - !type:HTNCompoundTask
       task: IdleCompound
 
+  - preconditions:
+      - !type:PulledPrecondition
+        isPulled: true
+    tasks:
+      - !type:HTNPrimitiveTask
+        operator: !type:UnPullOperator
+          shutdownState: TaskFinished
+
 - type: htnCompound
   id: DrainPsionicCompound
   branches:

--- a/Resources/Prototypes/_Impstation/Actions/revenant.yml
+++ b/Resources/Prototypes/_Impstation/Actions/revenant.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: BaseAction
   id: ActionRevenantHaunt
   name: Haunt
@@ -30,7 +30,7 @@
   parent: BaseAction
   id: ActionRevenantAnimate
   name: Animate
-  description: Costs 50 Essence.
+  description: Costs 40 Essence. # DeltaV - reduced cost 50 to 40
   components:
   - type: Action
     itemIconStyle: NoItem


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
-Skia, wisp, and rev are immune to basic melee damages, and cannot be hit with bullets
-skia may now jaunt (uses wizard jaunt. I wanted to use shadow jaunt but it didn't work for whatever mysterious Action reason)
-revenants can no longer emag borgs
-revenants can now claw targets at a very close range for 2 slash and 2 shadow damage
-revenants are revealed by silver swords for 5 seconds, salt puddles for 5 seconds, radiant swords for 10 seconds, and bibles for 20 seconds
-wisps will escape being pulled (when they feel like it)
-wisps collide like mice and won't sit in walls or windows
-sauce packets are now spillable, for ease of making salt puddles

NOTES / followup PRs: There are some outstanding bugs / oddities that I have discovered. Namely, revenants haunting guns will not bolt the guns (even though there is c# code checking this and attempting to bolt the gun), they will not shoot shotguns ( because there is no bolt thus the code skips it), and skia have limb damage / get a crippled torso from damage that heals over time but does not actually contribute to their damage total (I believe this has to do with their damageContainer but since skia regenerates in light I didn't want to fuck up how that all works). Also wisps are not very proactive in running away, I would also like to make them shoot the person who grabs them but HTN is a mystery to me at this point. Also I would like ghosts to be revealed while passing over containers with salt in them and not just puddles, but IDK how to make that only occur when salt is for sure inside it.

EDIT CR changes: skia is back to its original layer and can still be shot, but has highly increased resistances
rev can also be revealed by organic player species walking through them (for just one second)
EDIT EDIT: skia and rev .6 resistance to brutes, 3x heat damage -> 2x heat damage

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ghosts overall being able to be killed by whacking them has always annoyed me and made them extremely lame nothingburgers. Having them be smack immune means your neurons will have to activate and you will have to engage with some mechanic. Acts as a validhunting shield as well (slightly). 

Skia are highly mobile, but breaking lightbulb simulator isn't amazing content. You can actually get cornered by engiborg or janiborg replacing lights or just a couple flares. Jaunt lets you reposition and actually regenerate, or avoid dying from an unfortunate spawn position. I guess you could also jaunt into a bright area and shrivel up and die too. Ideally it would work like shadekin and have fancy animations and custom sprites but I don't have da skillz for that.

Wisps being draggable has always annoyed me and just is very LRP / immersion breaking (literally dragging the ghost and it doesn't care) Ideally i would make it so touching it makes it aggro and kill you but idk how so this is the best I can do for now.

As for revs, they really get to do nothing most of the time and are extremely annoying. giving them a VERY WEAK melee at least gives them a nudge towards getting essence on their own, makes them a more real threat instead of "theres a ghost that might haunt a paper that will annoy me".  If theres a ghost you should be scared not annoyed. Right now they just make a loud noise and run away as fast as they can and say a funny joke when they haunt to get essence. Counterplay items like salt and bibles are never ever ever ever ever used, so I have buffed them so you can actually try and defend yourself more easily. Silver swords are printable at seclathe so if a rev is really annoying you can arm up with those or raid perma kitchen for salt packets.

## Technical details
<!-- Summary of code changes for easier review. -->
- skia.yml: add jaunt component, make fixture layer to opaque, damageModifier to Spirit from manifestedSpirit, changed the order of items in damageable component to match elsewhere
- rev.yml: remove borg and locker emagging, add melee weapon and combatmode component,
- rev actions reduced prices and cooldowns, increased base essence pool and doubled passive essence rate + doubled essence yield from haunt from 2.5 to 5
- glimmer_creatures.yml: Changed wisp fixture to act like move like mouse but not be hit by bullets 
- modifiersets: make corporealspirit immune to blunt slash pierce and shadow damage, spirit have .8 resistance instead to brutes
- condiments: make sauce packets spillable via right click or throwing
- HTN: wisp will try to move away when being pulled
- swords: add reveal component to base silver sword, make radiant sword have 10 seconds
-base: add revealrevenantoncollide 1 second to basemobspeciesorganic
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
go my youtube link [https://youtu.be/pNoVcePW2Ok](url)
CR Changes: [https://youtu.be/rTGK6R9ddQo](url)
NOTE: both videos are not accurate of damage values in current state

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Glimmer wisps are now immune to physical and shadow damage.
- tweak: Skias and revenants are now highly resistant to brute damages. Try using holy or heat damage instead!
- tweak: Silver swords, radiant swords, and bibles are all more effective at revealing revenants! Salt works in a pinch, or... your own soul passing through them. 
- tweak: Skia may now jaunt. The shadows are its domain!
- tweak: Revenants are unable to emag borgs or lockers.
- tweak: The veil thins, and revenants are now able to claw their targets. Call the priest!
- tweak: Other small changes.

