### PR TITLE
Add filled(H20/nutrients) soil beds

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Structures/soil.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/soil.yml
@@ -1,0 +1,11 @@
+- type: entity
+  parent: hydroponicsSoil
+  id: FungalSoilFilled
+  name: fungal soil
+  description: A mix of organic matter and fungal root creating a soil to grow your plant in space. Seems to be dry.
+  suffix: Filled
+  components:
+  - type: Sprite
+    sprite: Structures/Hydroponics/misc.rsi
+    state: fungal_soil
+    noRot: true


### PR DESCRIPTION
## About the PR
- Adds a filled soil bed for mapping purposes.

## Why / Balance
Needed for mapping

## Technical details
n/a

## Media
<img width="537" height="243" alt="image" src="https://github.com/user-attachments/assets/70d9b763-01fc-4187-b584-0c89491706e5" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) 

**Changelog**
n/a
