### PR TITLE
Revert "1984 prober lockout [mald PR]" [Mald PR]

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -14,7 +14,7 @@
     - id: GlimmerRandomSentience
     - id: GlimmerRandomAnimation
     - id: ThavenMoodUpset
-    #- id: LockProbers
+    - id: LockProbers
     - id: PsionicNosebleedEvent
     - id: MinorMassMindSwap # Delta V
     - id: GlimmerFoxfireSpawn
@@ -184,13 +184,13 @@
     glimmerBurnUpper: 70
   - type: ThavenMoodUpsetRule
 
-#- type: entity
-#  parent: BaseGlimmerEvent
-#  id: LockProbers
-#  components:
-#  - type: GlimmerEvent
-#    minimumGlimmer: 500
-#  - type: LockProbersRule
+- type: entity
+  parent: BaseGlimmerEvent
+  id: LockProbers
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 500
+  - type: LockProbersRule
 
 - type: entity
   parent: BaseGlimmerEvent


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Reverts DeltaV-Station/Delta-v#4446

(I totally didn't accidentally create a branch here instead of mine- Nope.)

## Why / Balance
EPI simply doesn't care in the slightest about glimmer anymore, make them pay in case they fuck up.
## Technical details
N/A

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The glimmer prober may power up and lock itself again past 500 glimmer.