### PR TITLE
Add a Client Toggle for StunVisuals

### DIFF
--- a/Content.Client/Stunnable/StunSystem.cs
+++ b/Content.Client/Stunnable/StunSystem.cs
@@ -1,10 +1,12 @@
 using System.Numerics;
+using Content.Shared._DV.CCVars; // DeltaV - Enable Stars via CVar.
 using Content.Shared.CombatMode;
 using Content.Shared.Interaction;
 using Content.Shared.Stunnable;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 using Robust.Shared.Animations;
+using Robust.Shared.Configuration; // DeltaV - Enable Stars via CVar.
 using Robust.Shared.Input;
 using Robust.Shared.Input.Binding;
 using Robust.Shared.Random;
@@ -13,6 +15,7 @@ namespace Content.Client.Stunnable;
 
 public sealed class StunSystem : SharedStunSystem
 {
+    [Dependency] private readonly IConfigurationManager _cfg = default!; // DeltaV - Enable Stars via CVar.
     [Dependency] private readonly SharedCombatModeSystem _combat = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SpriteSystem _spriteSystem = default!;
@@ -77,6 +80,9 @@ public sealed class StunSystem : SharedStunSystem
             return;
 
         var visible = Appearance.TryGetData<bool>(entity, StunVisuals.SeeingStars, out var stars) && stars;
+
+        if (visible && !_cfg.GetCVar(DCCVars.ShowStunVisuals)) // DeltaV - Enable Stars via CVar.
+            visible = false;
 
         _spriteSystem.LayerSetVisible((entity, entity.Comp), index, visible);
         _spriteSystem.LayerSetRsiState((entity, entity.Comp), index, state);

--- a/Content.Client/_DV/Options/UI/Tabs/DeltaTab.xaml
+++ b/Content.Client/_DV/Options/UI/Tabs/DeltaTab.xaml
@@ -9,6 +9,7 @@
                    StyleClasses="LabelKeyText"/>
             <CheckBox Name="DisableFiltersCheckBox" Text="{Loc 'ui-options-no-filters'}" />
             <CheckBox Name="DisableGlimmerEffectCheckBox" Text="{Loc 'ui-options-disable-glimmer-effect'}" />
+            <CheckBox Name="EnableStunVisualsCheckBox" Text="{Loc 'ui-options-enable-stun-visuals'}" />
             <Label Text="{Loc 'ui-options-delta-tips'}"
                    StyleClasses="LabelKeyText"/>
             <CheckBox Name="DisableTipsCheckBox" Text="{Loc 'ui-options-delta-disable-tips'}" />

--- a/Content.Client/_DV/Options/UI/Tabs/DeltaTab.xaml.cs
+++ b/Content.Client/_DV/Options/UI/Tabs/DeltaTab.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class DeltaTab : Control
 
         Control.AddOptionCheckBox(DCCVars.NoVisionFilters, DisableFiltersCheckBox);
         Control.AddOptionCheckBox(DCCVars.DisableGlimmerShader, DisableGlimmerEffectCheckBox);
+        Control.AddOptionCheckBox(DCCVars.ShowStunVisuals, EnableStunVisualsCheckBox);
         Control.AddOptionCheckBox(DCCVars.DisableTips, DisableTipsCheckBox);
 
         ResetTipsButton.OnPressed += _ => OnResetTipsPressed();

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -131,7 +131,7 @@ public sealed partial class DCCVars
         CVarDef.Create("species.hidden", "Motorkind", CVar.SERVER | CVar.REPLICATED);
 
     /// <summary>
-    /// What species to hide, as a comma seperated list.
+    /// Whether a stunned entity will show the stun visuals (seeing stars effect) above their head.
     /// </summary>
     public static readonly CVarDef<bool> ShowStunVisuals =
         CVarDef.Create("game.see_stun_visuals", false, CVar.CLIENTONLY | CVar.ARCHIVE);

--- a/Content.Shared/_DV/CCVars/DCCVars.cs
+++ b/Content.Shared/_DV/CCVars/DCCVars.cs
@@ -130,6 +130,12 @@ public sealed partial class DCCVars
     public static readonly CVarDef<string> HiddenSpecies =
         CVarDef.Create("species.hidden", "Motorkind", CVar.SERVER | CVar.REPLICATED);
 
+    /// <summary>
+    /// What species to hide, as a comma seperated list.
+    /// </summary>
+    public static readonly CVarDef<bool> ShowStunVisuals =
+        CVarDef.Create("game.see_stun_visuals", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
     /*
      * Traits
      */

--- a/Resources/Locale/en-US/_DV/escape-menu/options-menu.ftl
+++ b/Resources/Locale/en-US/_DV/escape-menu/options-menu.ftl
@@ -3,6 +3,7 @@ ui-options-general-forknotice = Note: These settings are fork-specific and might
 
 ui-options-no-filters = Disable species vision filters
 ui-options-disable-glimmer-effect = Disable high glimmer shader effect
+ui-options-enable-stun-visuals = Enable the 'Seeing Stars' effect on stunned entities
 
 ## DeltaV NanoChat keybinds
 ui-options-header-nano-chat = NanoChat

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -39,7 +39,7 @@
         acts: [ "Destruction" ]
   - type: ZombieImmune
   - type: ProtectedFromStepTriggers
-  #- type: StunVisuals # DeltaV - No stars
+  - type: StunVisuals
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -299,7 +299,7 @@
         Asphyxiation: -1.0
   - type: FireVisuals
     alternateState: Standing
-  #- type: StunVisuals # DeltaV - No stars
+  - type: StunVisuals
   - type: CanDoCPR # DeltaV - Addition of CPR
   - type: PotentialPsionic # DeltaV - organic species can all be psionic
 

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -39,7 +39,6 @@
   - type: RequireProjectileTarget
     active: False
   - type: AnimatedEmotes # goob edit - animated emotes
-  #- type: StunVisuals # DeltaV - No stars
 
 # The progenitor. This should only container the most basic components possible.
 # Only put things on here if every mob *must* have it. This includes ghosts.
@@ -112,7 +111,7 @@
       - !type:VomitBehavior
   - type: RadiationReceiver
   - type: Stamina
-  #- type: StunVisuals # DeltaV - No stars
+  - type: StunVisuals
   - type: MobState
   - type: MobThresholds
     thresholds:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I introduced a CVar that enables clients to show StunVisuals (Seeing Stars Effect)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The stars are a clear indication that someone is stunned, which is especially useful when using less-lethal weaponry.
I also quite like them. But since there are people that dislike them, I've made it a configuration that is turned off by default.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a CVar to the DeltaTab.
Added a check of said CVar when it comes to applying stunvisuals.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/d6485519-44e0-4da6-99e4-22701432a4eb


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added a client option to enable stunvisuals (Seeing Stars effect on stunnied entities)!
