### PR TITLE
Prevent Code Orange from being selected manually

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -49,6 +49,7 @@
       selectable: true
       sound:
         path: /Audio/_Starlight/misc/orange.ogg
+      disableSelection: true # DeltaV - Don't allow the station to set it manually
       color: "#ff8119"
       emergencyLightColor: "#ff8119"
       forceEnableEmergencyLights: true

--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -46,10 +46,9 @@
   # Begin Starlight Additions
     orange:
       announcement: alert-level-orange-announcement
-      selectable: true
+      selectable: false # DeltaV - Don't allow the station to set it manually
       sound:
         path: /Audio/_Starlight/misc/orange.ogg
-      disableSelection: true # DeltaV - Don't allow the station to set it manually
       color: "#ff8119"
       emergencyLightColor: "#ff8119"
       forceEnableEmergencyLights: true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I made code orange unavailable in the communications console. It can now only be set by Central Command or by the meltdown of a nuclear reactor. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People are deliberately calling Code Orange to scare the station and CC. Self antags and actual antags are calling it for... the funny I guess? I assume their goal is to jumpscare the station with a scary alert. Because it automatically triggers on a nuclear reactor going critical, people instantly assume that code orange means the reactor is about to explode. No other manual alert level really has this effect except for (maybe) code white. And because of the "Mayday protocols are activated" line, it's the _only_ manual alert level that unambiguously gets the attention of Central Command. 

On a more subjective note, I feel like code orange is too intense for something that is able to be set manually. The loud alarm/klaxon thing is extremely cool, but it feels a bit overdramatic with how it's currently used. All of the other alert levels that do something similar (delta, gamma, octarine, epsilon) are either automatic or CC only. Overuse of it will probably lead to people caring less about it, which I think would be a bit of a shame. 

Personally, I also don't see the point in the station having both code Yellow and Orange. I feel like there's too much overlap between the two. Code Yellow was _already_ functionally an "abandon ship" alert in my experience. People are currently using code Orange as functionally a replacement for Yellow too, even for problems that haven't caused evauation. Orange seems a bit too much like "make CC mad" bait at the moment. 

The relevant community feedback thread can be seen [here](https://discord.com/channels/968983104247185448/1505704989949952050), though it's only a handful of messages. 

## Technical details
<!-- Summary of code changes for easier review. -->
one (1) (i) line of yaml.


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="297" height="295" alt="Screenshot 2026-05-17 201653" src="https://github.com/user-attachments/assets/0f2a70f2-1078-4bd8-a660-b278edb5f9d9" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- remove: Command is no longer able to set the station's alert level to Code Orange