### PR TITLE
Bugfix - Correct AI Ion laws to be socially acceptable

### DIFF
--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -71,6 +71,7 @@
   - INTELLIGENT
   - INVISIBLE
   - LARGE
+  # LIGHT - DeltaV - Prevents the AI from gaining "LIGHT CREW" laws
   - LOUD
   - MASKED
   - MEAN

--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -71,7 +71,6 @@
   - INTELLIGENT
   - INVISIBLE
   - LARGE
-  - LIGHT
   - LOUD
   - MASKED
   - MEAN


### PR DESCRIPTION
## Removes AI Adjective called Light

Prevents AI from getting the law "ONLY LIGHT PEOPLE ARE PART OF THE CREW"

## Requirements
- [] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
(no logical way to test rolling the AI lawset, I do not have 10 BILLION FAFILLION GAJILLION SHAB-AB-DOOD-ILLION years to test it)

## Licensing
Licensing not needed, as this removes an item / Change. Keep it DV license

  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->


**Changelog**

:cl: tweak: AI Ion laws are no longer allowed to mention "LIGHT PEOPLE", as this was a bug

