### PR TITLE
Corps locker tweaks

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -131,7 +131,7 @@
     - id: TrackingImplanter
       amount: 2
     #- id: ClothingOuterHardsuitCombatCorpsman # DeltaV - ClothingOuterHardsuitBrigmedic replaced in favour of corpsman's combat hardsuit; removing from standard filled locker to place in hardsuit filled locker.
-    - id: BoxSterileMask
+    # - id: BoxSterileMask # DeltaV - removed, locker is very cluttered and these are not useful
     # - id: ClothingHeadHatBeretCorpsman # DeltaV - ClothingHeadHatBeretBrigmedic replaced in favour of corpsman beret. # DeltaV - added corpsman uniform to secdrobe
     - id: ClothingHeadsetBrigmedic # DeltaV - add spare headset.
 #   - id: ClothingOuterCoatAMG # DeltaV - removed until I can resprite it or replace it.
@@ -151,8 +151,8 @@
     - !type:GroupSelector
       prob: 0.7
       children:
-      - id: MedkitCombatFilled
-        weight: 1.6
+      #- id: MedkitCombatFilled #DeltaV - corps doesn't need 2+ combat kits, often more are mapped
+      #  weight: 1.6
       - id: MedkitAdvancedFilled
       - id: MedkitOxygenFilled
         weight: 0.8
@@ -172,11 +172,12 @@
   id: FillLockerBrigmedicHarduit
   table: !type:AllSelector
     children:
-    - id: ClothingOuterHardsuitCombatCorpsman # DeltaV - ClothingOuterHardsuitWarden replaced in favour of warden's riot combat hardsuit.
+    - id: ClothingOuterHardsuitCombatCorpsman 
     - id: ClothingShoesBootsSecurityMagboots # DeltaV - Added security magboots.
     - id: OxygenTankFilled
     - id: NitrogenTankFilled
     - id: ClothingMaskBreath
+    - id: JetpackSecurityFilled # DeltaV - Security jetpacks
 # END DeltaV - adding corpsman locker w/ hardsuit
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healing.yml
@@ -851,12 +851,12 @@
           amount: *Range1to6
         - id: PillCharcoal
           amount: *Range1to6
-        - id: PillAmbuzol
-          weight: 0.75
-          amount: *Range1to6
-        - id: PillAmbuzolPlus
-          weight: 0.75
-          amount: *Range1to6
+        #- id: PillAmbuzol # DeltaV - remove random ambuzol
+        #  weight: 0.75
+        #  amount: *Range1to6
+        #- id: PillAmbuzolPlus
+        #  weight: 0.75
+        #  amount: *Range1to6
         - id: PillSpaceDrugs
           weight: 0.75
           amount: *Range1to6

--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -954,7 +954,7 @@
     - Salbutamol # Funkychem - dex+ -> salbutamol
     - Epinephrine
     - Leporazine
-    - Ambuzol
+    #- Ambuzol # Deltav - remove random ambuzol
     - Tricordrazine
     - Artifexium
     - Ethylredoxrazine

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
@@ -69,6 +69,9 @@
     - id: ClothingOuterHardsuitCombatCorpsman
     - id: ClothingMaskBreath
     - id: ClothingShoesBootsSecurityMagboots #Added security magboots.
+    - id: JetpackSecurityFilled
+    - id: HandheldGPSBasic
+
 
 - type: entity
   parent: SuitStorageBase

--- a/Resources/Prototypes/_Impstation/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Structures/Specific/Anomaly/anomaly_injections.yml
@@ -42,7 +42,7 @@
     - DexalinPlus
     - Epinephrine
     - Leporazine
-    - Ambuzol
+    #- Ambuzol # DeltaV - remove random ambuzol
     - Tricordrazine
     - Artifexium
     - Ethylredoxrazine


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
added jetpack to hardsuit storage and locker (it doesn't seem to want to spawn in the hardsuit locker)
add gps to hardsuit locker
remove sterile mask box
remove chance of combat medkit on medkit roll table
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
jetpack missing is annoying, corps is very often EVA
Corps has 1 guarenteed combat medkit, 2 + already having advanced topicals in rig is excessive. Then there is often a third mapped somewhere. Corps is absolutely spoiled rotten with advanced topicals they can just give it away, or HOS/ ward can loot the locker and not really ever need a corps. Genuinely 30 sutures + 30 regen meshes you're going to struggle to even use all of even on warops
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Changed locker fills
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Corps hardsuit lockers now come with jetpacks and gps, and only one combat medkit.