### PR TITLE
corps locker tweaks

### DIFF
--- a/Resources/Locale/en-US/_DV/chemistry/bottles.ftl
+++ b/Resources/Locale/en-US/_DV/chemistry/bottles.ftl
@@ -1,1 +1,2 @@
 chemistry-bottle-firebugs-friend = Firebug's Friend
+chemistry-bottle-revivopine = Revivopine

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -131,7 +131,7 @@
     - id: TrackingImplanter
       amount: 2
     #- id: ClothingOuterHardsuitCombatCorpsman # DeltaV - ClothingOuterHardsuitBrigmedic replaced in favour of corpsman's combat hardsuit; removing from standard filled locker to place in hardsuit filled locker.
-    # - id: BoxSterileMask # DeltaV - remove clutter
+    #- id: BoxSterileMask # DeltaV - remove clutter
     # - id: ClothingHeadHatBeretCorpsman # DeltaV - ClothingHeadHatBeretBrigmedic replaced in favour of corpsman beret. # DeltaV - added corpsman uniform to secdrobe
     - id: ClothingHeadsetBrigmedic # DeltaV - add spare headset.
 #   - id: ClothingOuterCoatAMG # DeltaV - removed until I can resprite it or replace it.
@@ -146,6 +146,7 @@
     - id: EmergencyRollerBedSpawnFolded
     - id: MedkitCombatFilled
     - id: Portafib
+    - id: ChemistryBottleRevivopine # DeltaV - add revivopine bottle
     # End DeltaV additions
     - id: MedkitFilled
     - !type:GroupSelector

--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -131,7 +131,7 @@
     - id: TrackingImplanter
       amount: 2
     #- id: ClothingOuterHardsuitCombatCorpsman # DeltaV - ClothingOuterHardsuitBrigmedic replaced in favour of corpsman's combat hardsuit; removing from standard filled locker to place in hardsuit filled locker.
-    - id: BoxSterileMask
+    # - id: BoxSterileMask # DeltaV - remove clutter
     # - id: ClothingHeadHatBeretCorpsman # DeltaV - ClothingHeadHatBeretBrigmedic replaced in favour of corpsman beret. # DeltaV - added corpsman uniform to secdrobe
     - id: ClothingHeadsetBrigmedic # DeltaV - add spare headset.
 #   - id: ClothingOuterCoatAMG # DeltaV - removed until I can resprite it or replace it.
@@ -151,8 +151,8 @@
     - !type:GroupSelector
       prob: 0.7
       children:
-      - id: MedkitCombatFilled
-        weight: 1.6
+      #- id: MedkitCombatFilled - DeltaV - doesn't need 2 or 3 of these
+      #  weight: 1.6
       - id: MedkitAdvancedFilled
       - id: MedkitOxygenFilled
         weight: 0.8
@@ -166,18 +166,6 @@
     #  prob: 0.15
     - id: LunchboxSecurityFilledRandom # Delta-v Lunchboxes!
       prob: 0.3
-
-# DeltaV - adding corpsman locker w/ hardsuit
-- type: entityTable
-  id: FillLockerBrigmedicHarduit
-  table: !type:AllSelector
-    children:
-    - id: ClothingOuterHardsuitCombatCorpsman # DeltaV - ClothingOuterHardsuitWarden replaced in favour of warden's riot combat hardsuit.
-    - id: ClothingShoesBootsSecurityMagboots # DeltaV - Added security magboots.
-    - id: OxygenTankFilled
-    - id: NitrogenTankFilled
-    - id: ClothingMaskBreath
-# END DeltaV - adding corpsman locker w/ hardsuit
 
 - type: entity
   id: LockerDetectiveFilled

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/security.yml
@@ -163,16 +163,7 @@
         - !type:NestedSelector
           tableId: FillLockerBrigmedic
         - !type:NestedSelector
-          tableId: LockerFillBrigmedicHardsuit
-
-- type: entityTable
-  id: LockerFillBrigmedicHardsuit
-  table: !type:AllSelector
-    children:
-    - id: ClothingOuterHardsuitCombatCorpsman
-    - id: ClothingShoesBootsSecurityMagboots
-    - id: OxygenTankFilled
-    - id: ClothingMaskBreath
+          tableId: FillSuitStorageCorpsman
 
 - type: entity
   parent: SecurityGunSafeNonlethalDV

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/suit_storage.yml
@@ -69,6 +69,7 @@
     - id: ClothingOuterHardsuitCombatCorpsman
     - id: ClothingMaskBreath
     - id: ClothingShoesBootsSecurityMagboots #Added security magboots.
+    - id: JetpackSecurityFilled #Sec hardsuits get jetpacks
 
 - type: entity
   parent: SuitStorageBase

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/chemistry-bottles.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/chemistry-bottles.yml
@@ -44,3 +44,18 @@
           Quantity: 28
         - ReagentId: Phlogiston
           Quantity: 2
+
+- type: entity
+  parent: BaseChemistryBottleFilled
+  id: ChemistryBottleRevivopine
+  suffix: revivopine
+  components:
+  - type: Label
+    currentLabel: chemistry-bottle-revivopine
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Revivopine
+          Quantity: 30


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
add jetpack to corps locker, remove box of masks, remove second combat kit
Edit: add revivopine bottle and add it to corps locker
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We had a massive discussion thread on corps having pens and shit that never got implemented
Corps doesn't need two combat kits, sometimes there are even THREE because of mapping
corps can have round start 60 mesh / suture? what? You would actually struggle to use all of that even in warops. They can still have a bunch of other random kits including advanced topical kits.
I expect 90 days in the opinion mines for this one
## Technical details
<!-- Summary of code changes for easier review. -->
remove both BrigmedicHardsuit fill tables and replace hardsuitlocker fill entry with CorpsmanHardsuit fill
comment out combat kit and sterile mask on upstream table
add jetpack to hardsuit storage fill
add bottle of revivopine prototype
add bottle to corps locker
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d2e9ea54-9b90-4330-9886-e6cd6aef4276" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Corps hardsuit lockers now have jetpacks and a bottle of revivopine. They also no longer have a second combat medkit or sterile mask boxes.
