### PR TITLE
More lighters in loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -77,6 +77,13 @@
   - ClothingHeadHatUshanka
   - Eyepatch
   - SuperSynthesizerInstrument #Delta-V - Ports Super Synth Trinket from Starlight
+  - LighterDonkCo
+  - LighterHonkCo
+  - LighterWaffleCo
+  - LighterDiscountDan
+  - LighterInterdyne
+  - LighterNanotrasen
+  - MatchboxGorlex
   # End DeltaV Additions
 
 - type: loadoutGroup
@@ -191,6 +198,7 @@
   minLimit: 0
   loadouts:
   - LizardPlushieCaptain
+  - LighterCentComm # DeltaV
 
 - type: loadoutGroup
   id: HoPHead

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -77,6 +77,7 @@
   - ClothingHeadHatUshanka
   - Eyepatch
   - SuperSynthesizerInstrument #Delta-V - Ports Super Synth Trinket from Starlight
+  - LighterFlippo
   - LighterDonkCo
   - LighterHonkCo
   - LighterWaffleCo

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/lighters.yml
@@ -74,74 +74,89 @@
       - ReagentId: WeldingFuel
         Quantity: 0.1
 
+
 # Loadout nerfed lighters for loadouts
 
 - type: entity
-  parent: [BaseBrandedLighter, FlippoLighter]
+  abstract: true
+  parent: BaseBrandedLighter
+  id: BaseBrandedLighterNerfed
+  suffix: Nerfed
+  components:
+  - type: SolutionContainerManager
+    solutions:
+      Welder:
+        reagents:
+        - ReagentId: WeldingFuel
+          Quantity: 12
+        maxVol: 12 # uses less fuel than a welder, so this isnt as bad as it looks
+  - type: Welder
+    fuelConsumption: 0.01
+    fuelLitCost: 0.1
+    tankSafe: true
+  - type: ItemToggleMeleeWeapon
+    activatedDamage:
+      types:
+        Heat: 1
+  - type: MeleeWeapon
+    wideAnimationRotation: 180
+    damage:
+      types:
+        Blunt: 1 # does a little bit of damage on hit when off
+  - type: PointLight
+    netsync: false # Needed to avoid an exception.
+    radius: 1.2
+
+- type: entity
+  parent: BaseBrandedLighterNerfed
   id: WaffleCoFlippoNerfed
   name: Waffle Co. flippo
   description: "A mass produced lighter. The Waffle Co. logo turns the spark wheel when pushed up, minimising risk of lighter burns for even the most inept user."
-  suffix: Nerfed
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/waffleco.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/waffleco.rsi
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 1.2
     color: brown
 
 - type: entity
-  parent: [BaseBrandedLighter, FlippoLighter]
+  parent: BaseBrandedLighterNerfed
   id: HonkCoFlippoNerfed
   name: Honk Co. flippo
-  description: "A rubbery gag lighter produced by Honk Co. hidden inside of a fake banana peel."
-  suffix: Nerfed
+  description: "A rubbery gag lighter produced by Honk Co. hidden inside of a plastic banana peel."
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/honkco.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/honkco.rsi
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 1.2
     color: yellow
 
 - type: entity
-  parent: [BaseBrandedLighter, FlippoLighter]
+  parent: BaseBrandedLighterNerfed
   id: DonkcoLighterNerfed
   name: Donk Co. flippo
   description: "A Breaded novelty lighter made by Donk Co."
-  suffix: Nerfed
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/donkco.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/donkco.rsi
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 1.2
     color: orange
 
 - type: entity
-  parent: [BaseBrandedLighter, FlippoLighter]
+  parent: BaseBrandedLighterNerfed
   id: InterdyneFlippoNerfed
-  name: Interdyne Flippo
+  name: Interdyne flippo
   description: "A deep blue, off-brand flippo lighter, decorated with the logo of Interdyne Pharmaceuticals' 'Gene Clean' clinics. Become the master of your own cigarette."
-  suffix: Nerfed
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/interdyne.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/interdyne.rsi
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 1.2
     color: cyan
 
 - type: entity
@@ -155,9 +170,6 @@
     sprite: Objects/Tools/Lighters/gorlex.rsi
   - type: Item
     sprite: Objects/Tools/Lighters/gorlex.rsi
-  - type: Storage
-    grid:
-    - 0,0,2,1
   - type: EntityTableContainerFill
     containers:
       storagebase:
@@ -166,11 +178,10 @@
   - type: Matchbox
 
 - type: entity
-  parent: [BaseBrandedLighter, FlippoLighter]
+  parent: BaseBrandedLighterNerfed
   id: CentCommFlippoNerfed
-  name: CentComm Flippo
+  name: CentComm flippo
   description: "A gaudy jade-colored flippo frame with worn gilding, containing a colored flame. The latch is secured by a miniature access reader that only responds to CentComm officials. So much for loyalty."
-  suffix: Nerfed
   components:
   - type: Sprite
     sprite: Objects/Tools/Lighters/centcomm.rsi
@@ -179,9 +190,6 @@
   - type: ItemToggleRequiresLock
     requireLocked: false
   - type: PointLight
-    enabled: false
-    netsync: false
-    radius: 1.2
     color: Gold
   - type: Lock
   - type: AccessReader

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/lighters.yml
@@ -74,7 +74,6 @@
       - ReagentId: WeldingFuel
         Quantity: 0.1
 
-
 # Loadout nerfed lighters for loadouts
 
 - type: entity
@@ -83,28 +82,18 @@
   id: BaseBrandedLighterNerfed
   suffix: Nerfed
   components:
-  - type: SolutionContainerManager
-    solutions:
-      Welder:
-        reagents:
-        - ReagentId: WeldingFuel
-          Quantity: 12
-        maxVol: 12 # uses less fuel than a welder, so this isnt as bad as it looks
   - type: Welder
     fuelConsumption: 0.01
     fuelLitCost: 0.1
     tankSafe: true
-  - type: ItemToggleMeleeWeapon
-    activatedDamage:
-      types:
-        Heat: 1
   - type: MeleeWeapon
     wideAnimationRotation: 180
     damage:
       types:
         Blunt: 1 # does a little bit of damage on hit when off
   - type: PointLight
-    netsync: false # Needed to avoid an exception.
+    enabled: false
+    netsync: false
     radius: 1.2
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Tools/lighters.yml
@@ -73,3 +73,116 @@
       reagents:
       - ReagentId: WeldingFuel
         Quantity: 0.1
+
+# Loadout nerfed lighters for loadouts
+
+- type: entity
+  parent: [BaseBrandedLighter, FlippoLighter]
+  id: WaffleCoFlippoNerfed
+  name: Waffle Co. flippo
+  description: "A mass produced lighter. The Waffle Co. logo turns the spark wheel when pushed up, minimising risk of lighter burns for even the most inept user."
+  suffix: Nerfed
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/waffleco.rsi
+  - type: Item
+    sprite: Objects/Tools/Lighters/waffleco.rsi
+  - type: PointLight
+    enabled: false
+    netsync: false
+    radius: 1.2
+    color: brown
+
+- type: entity
+  parent: [BaseBrandedLighter, FlippoLighter]
+  id: HonkCoFlippoNerfed
+  name: Honk Co. flippo
+  description: "A rubbery gag lighter produced by Honk Co. hidden inside of a fake banana peel."
+  suffix: Nerfed
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/honkco.rsi
+  - type: Item
+    sprite: Objects/Tools/Lighters/honkco.rsi
+  - type: PointLight
+    enabled: false
+    netsync: false
+    radius: 1.2
+    color: yellow
+
+- type: entity
+  parent: [BaseBrandedLighter, FlippoLighter]
+  id: DonkcoLighterNerfed
+  name: Donk Co. flippo
+  description: "A Breaded novelty lighter made by Donk Co."
+  suffix: Nerfed
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/donkco.rsi
+  - type: Item
+    sprite: Objects/Tools/Lighters/donkco.rsi
+  - type: PointLight
+    enabled: false
+    netsync: false
+    radius: 1.2
+    color: orange
+
+- type: entity
+  parent: [BaseBrandedLighter, FlippoLighter]
+  id: InterdyneFlippoNerfed
+  name: Interdyne Flippo
+  description: "A deep blue, off-brand flippo lighter, decorated with the logo of Interdyne Pharmaceuticals' 'Gene Clean' clinics. Become the master of your own cigarette."
+  suffix: Nerfed
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/interdyne.rsi
+  - type: Item
+    sprite: Objects/Tools/Lighters/interdyne.rsi
+  - type: PointLight
+    enabled: false
+    netsync: false
+    radius: 1.2
+    color: cyan
+
+- type: entity
+  parent: Matchbox
+  id: GorlexMatchboxNerfed
+  name: Gorlex match box
+  description: "A pneumatic match box styled after the Gorlex Marauders' equipment. As if those things would ever appear here."
+  suffix: Nerfed
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/gorlex.rsi
+  - type: Item
+    sprite: Objects/Tools/Lighters/gorlex.rsi
+  - type: Storage
+    grid:
+    - 0,0,2,1
+  - type: EntityTableContainerFill
+    containers:
+      storagebase:
+        id: GorlexMatchstick
+        amount: 6
+  - type: Matchbox
+
+- type: entity
+  parent: [BaseBrandedLighter, FlippoLighter]
+  id: CentCommFlippoNerfed
+  name: CentComm Flippo
+  description: "A gaudy jade-colored flippo frame with worn gilding, containing a colored flame. The latch is secured by a miniature access reader that only responds to CentComm officials. So much for loyalty."
+  suffix: Nerfed
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/Lighters/centcomm.rsi
+  - type: Item
+    sprite: Objects/Tools/Lighters/centcomm.rsi
+  - type: ItemToggleRequiresLock
+    requireLocked: false
+  - type: PointLight
+    enabled: false
+    netsync: false
+    radius: 1.2
+    color: Gold
+  - type: Lock
+  - type: AccessReader
+    access: [["CentralCommand"]]

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/jobtrinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/jobtrinkets.yml
@@ -28,7 +28,7 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
-      role: Captain
+      role: JobCaptain
       time: 72000 # 20hr
   storage:
     back:

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/jobtrinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/jobtrinkets.yml
@@ -21,3 +21,15 @@
   storage:
     back:
     - PlushieLizardJobZookeeper
+
+- type: loadout
+  id: LighterCentComm
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: Captain
+      time: 72000 # 20hr
+  storage:
+    back:
+    - CentCommFlippoNerfed

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
@@ -109,7 +109,7 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
-      role: Assistant
+      role: JobAssistant
       time: 36000 # 10hr
   storage:
     back:
@@ -122,7 +122,7 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
-      role: Chemist
+      role: JobChemist
       time: 36000 # 10hr
   storage:
     back:

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
@@ -109,7 +109,7 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
-      role: JobAssistant
+      role: JobPassenger
       time: 36000 # 10hr
   storage:
     back:

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
@@ -58,6 +58,13 @@
     - PlushieBee
 
 - type: loadout
+  id: LighterFlippo
+  storage:
+    back:
+    - FlippoLighter
+  groupBy: "smokeables"
+
+- type: loadout
   id: LighterDonkCo
   effects:
   - !type:JobRequirementLoadoutEffect

--- a/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_DV/Loadouts/Miscellaneous/trinkets.yml
@@ -56,3 +56,94 @@
   storage:
     back:
     - PlushieBee
+
+- type: loadout
+  id: LighterDonkCo
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobChef
+      time: 36000 # 10hr
+  storage:
+    back:
+    - DonkcoLighterNerfed
+  groupBy: "smokeables"
+
+- type: loadout
+  id: LighterHonkCo
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobClown
+      time: 36000 # 10hr
+  storage:
+    back:
+    - HonkCoFlippoNerfed
+  groupBy: "smokeables"
+
+- type: loadout
+  id: LighterWaffleCo
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Logistics
+      time: 36000 # 10hr
+  storage:
+    back:
+    - WaffleCoFlippoNerfed
+  groupBy: "smokeables"
+
+- type: loadout
+  id: LighterDiscountDan
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: Assistant
+      time: 36000 # 10hr
+  storage:
+    back:
+    - DiscountDanLighter
+  groupBy: "smokeables"
+
+- type: loadout
+  id: LighterInterdyne
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: Chemist
+      time: 36000 # 10hr
+  storage:
+    back:
+    - InterdyneFlippoNerfed
+  groupBy: "smokeables"
+
+- type: loadout
+  id: LighterNanotrasen
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Command
+      time: 36000 # 10hr
+  storage:
+    back:
+    - NanotrasenFlippo
+  groupBy: "smokeables"
+
+- type: loadout
+  id: MatchboxGorlex
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Security
+      time: 36000 # 10hr
+  storage:
+    back:
+    - GorlexMatchboxNerfed
+  groupBy: "smokeables"


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds more lighters into loadouts, with some questionably Company Policy fitting.

## Why / Balance
Traitors can buy these cool lighters in their uplinks, which most of them have nothing really special about them (expect a few), besides just being somewhat better lighters.

SO, seeing these cool sprites that are generally unobtainium, I've added some of these lighters into loadouts:
- **I've nerfed most of the "contraband" lighters to just be regular flippos or matchboxes**. This is just so there isn't a "better" choice of lighters, like edible omnizine donk pocket lighters.
- I've slightly changed the nerfed descriptions of these lighters, to have some indication that these are the worser ones, than the ones in uplinks. There is some concern of "teaching players that the uplink purchasble lighters are just the same as loadouts", but idk if that small thing is *really* important.
- I've added a joke lighter to Captain trinkets. They can get a worser CC branded lighter, albeit still locked behind Central access. I'm fine with removing this lighter, I just thought it would be really funny.

Most of these lighters are locked behind hour requirements, which are:
- DonkCo Lighter: 10 hours of Chef (it's a bread lighter)
- HonkCo Lighter: 10 hours of Clown (banana peel lighter, with no slipping component)
- WaffleCo Lighter: 10 hours of Logistics
- Discount Dan Lighter: 10 hours of Assistant
- Interdyne Lighter: 10 hours of Chemist
- NanoTrasen lighter: 10 hours of Command (this sorta has a larger light radius, but it's dark blue, so it's incredibly hard to see anyways.)
- CentComm Lighter: 20 hours of Captain, only for Captain role (still locked behind CC access)
- Gorlex Matchbox: 10 hours of Security (contains only 6 matches, instead of 24)

Anyways, CM can discuss if this is just Company Policy violation bait or a neat begrudging cooperation by NanoTrasen due to competition laws.


## Technical details
I've been recommended to just base off the modified lighters of the flippolighter, while just containing the sprites. I didn't want to change upstream files, since most of those lighters are for the uplink purchases with some unique quirks of it, which do not fit for loadouts.

## Media
<img width="587" height="272" alt="image" src="https://github.com/user-attachments/assets/eec703f0-0fba-4a17-8892-ee3807f2bf73" />
<img width="378" height="419" alt="image" src="https://github.com/user-attachments/assets/759dd8ae-255a-453f-8f9f-fd8be27bdc61" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- add: NanoTrasen has begrudgingly allowed crew members to carry flippo lighters, including ones from different companies. Pick out your favorite lighter in loadouts!

