### PR TITLE
Ambuzol requires stellibinin

### DIFF
--- a/Resources/Locale/en-US/_DV/paper/paper-misc.ftl
+++ b/Resources/Locale/en-US/_DV/paper/paper-misc.ftl
@@ -53,6 +53,7 @@ paper-viral-care-package-manual = [color=#134975]░░██░░ [head=2]Vira
 
       ​[head=2][color=#134975]How to mix Ambuzol:[/color][/head]
       ​[bullet] Pour [bold]15u Hydrogen[/bold] and [bold]5u Nitrogen[/bold] into a bottle to mix [color=#77b58e][bold]Ammonia[/bold][/color].
+      [bullet] Grind the Galaxythistle bulbs in a reagent grinder to extract [bold][color=#2b2f77]Stellibinin[/color][/bold].
       ​[bullet] Mix [bold][color=#77b58e]5u Ammonia[/color][/bold] and [bold][color=#2b2f77]5u Stellibinin[/color][/bold] with [bold][color=#2b0700]10u Zombie Blood[/color][/bold] to synthesize [bold][color=#86caf7]40u Ambuzol[/color][/bold].
 
       ​[head=2][color=#134975]How to use Ambuzol:[/color][/head]

--- a/Resources/Locale/en-US/_DV/paper/paper-misc.ftl
+++ b/Resources/Locale/en-US/_DV/paper/paper-misc.ftl
@@ -53,8 +53,7 @@ paper-viral-care-package-manual = [color=#134975]░░██░░ [head=2]Vira
 
       ​[head=2][color=#134975]How to mix Ambuzol:[/color][/head]
       ​[bullet] Pour [bold]15u Hydrogen[/bold] and [bold]5u Nitrogen[/bold] into a bottle to mix [color=#77b58e][bold]Ammonia[/bold][/color].
-      ​[bullet] Pour [bold]5u Silicon[/bold], [bold]5u Potassium[/bold] and [bold]5u Nitrogen[/bold] into a different bottle to mix [color=#3a1d8a][bold]Dylovene[/bold][/color].
-      ​[bullet] Mix [bold][color=#77b58e]5u Ammonia[/color][/bold] and [bold][color=#3a1d8a]5u Dylovene[/color][/bold] with [bold][color=#2b0700]10u Zombie Blood[/color][/bold] to synthesize [bold][color=#86caf7]40u Ambuzol[/color][/bold].
+      ​[bullet] Mix [bold][color=#77b58e]5u Ammonia[/color][/bold] and [bold][color=#2b2f77]5u Stellibinin[/color][/bold] with [bold][color=#2b0700]10u Zombie Blood[/color][/bold] to synthesize [bold][color=#86caf7]40u Ambuzol[/color][/bold].
 
       ​[head=2][color=#134975]How to use Ambuzol:[/color][/head]
       It is [bold]imperative[/bold] to [bold]not drink[/bold] it! Neither use Hyposprays!

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -210,7 +210,7 @@
 - type: reaction
   id: Ambuzol
   reactants:
-    Dylovene:
+    Stellibinin:
       amount: 1
     Ammonia:
       amount: 1

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/medical.yml
@@ -32,10 +32,10 @@
     containers:
       entity_storage: !type:AllSelector
         children:
-        - id: JugPotassium
+        - id: FoodGalaxythistle
+          amount: 4
         - id: JugNitrogen
         - id: JugHydrogen
-        - id: JugSilicon
         - id: Skimmer
         - id: BoxBottle
         - id: BoxSyringe


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
title
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Zeds can be shut down by 1 robust chemist in <1 minute necessitating bombing medbay / chemistry, and some maps have 3 chem machines so its just not possible for chems to be sabotaged unless the chemist is II.
This requires medical to work with botany. Botany should be growing galaxythistle anyways.
One UNROBUSTED, DEFAULT harvest of galaxythistle yields 40u of ambuzol.
Dumping a bottle of robust into a tray (wasteful) gets you 160u of ambuzol. 
It is still very easy to make, but opens up more avenues of sabotaging cure production and means it can't be done without power (grinding the plants takes electricity, it needs to be carried from botany to med)
## Technical details
<!-- Summary of code changes for easier review. -->
changed the recipe, changed the recipe written on a note, changed emergency virus crate to have galaxythistle in it instead of dylo ingredients
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The zombie virus has mutated, and effective ambuzol needs stellibinin to create.
