### PR TITLE
Syndicate dual swords balance patch

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/Uplink/weaponry.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/weaponry.yml
@@ -83,9 +83,9 @@
   icon: { sprite: /Textures/_DV/Objects/Weapons/Melee/dualswords.rsi, state: icon }
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 5
+    Telecrystal: 4
   productEntity: DualSwords
   cost:
-    Telecrystal: 7
+    Telecrystal: 6
   categories:
   - UplinkWeaponry

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/swords.yml
@@ -81,15 +81,17 @@
         Slash: 2
     soundHit:
         path: /Audio/Weapons/bladeslice.ogg
+  - type: Reflect
+    reflectProb: .25
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Slash: 3
+        Slash: 4.5
   - type: Item
     sprite: _DV/Objects/Weapons/Melee/dualswords.rsi
   - type: JumpAbility
-    jumpDistance: 2
+    jumpDistance: 2.5
     jumpSound: /Audio/Effects/stealthoff.ogg
   - type: ActionGrant
     actions:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
After observing the usage of the dual swords over the past few days and taking feedback from people who both used and faced them, I have adjusted some of the numbers. The most oft-seen complaints are that while the swords are fun to use, the damage and TTK are lackluster, and that the cost is pretty high for the lack of utility compared to the esword, even considering the jump. suggestions included raising the damage, raising the swing speed, adding other damage types like poison, adding a reflect chance, and other forms of utility. for now i've decided to just go with a damage increase, adding a reflect chance, and upping the jump distance by .5

## Why / Balance
Raises wielded damage from 5 to 6.5 for a total 45.5 DPS, adds a 25% reflect chance. I tried the reflect at 10% and 15%, but both those numbers felt like they barely added anything so decided to raise it a bit more. i'm hesitant to raise it past 25% for now though, we'll need to see how it goes. Jump distance was increased by .5, so about 25% increase so hopefully people use it more now. While the idea of making them deal poison damage is neat, I worry about giving the swords an AP damage while they swing so fast. The swing speed could be lowered to allow for it, but then that's compromising the vision and identity of the swords as F A S T so I'd really rather not do that. Cost has been reduced to 6, with the ability to be discounted to 4.

## Technical details
small yaml changes, see balance

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
none right now it's very minor
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Better materials have been acquired for the production of the syndicate dual swords, allowing their cuts to bite a bit deeper and even for bullets to be reflected. Try them out if you get the chance.

