### PR TITLE
Tobacco Rework

### DIFF
--- a/Resources/Locale/en-US/_DV/smokeables/vape.ftl
+++ b/Resources/Locale/en-US/_DV/smokeables/vape.ftl
@@ -1,2 +1,2 @@
-﻿ent-Vape=
+ent-Vape=
     .desc = For those that enjoy clouds. WARNING: Pour only water into the vape.

--- a/Resources/Locale/en-US/_DV/smokeables/vape.ftl
+++ b/Resources/Locale/en-US/_DV/smokeables/vape.ftl
@@ -1,0 +1,2 @@
+﻿ent-Vape=
+    .desc = For those that enjoy clouds. WARNING: Pour only water into the vape.

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cigs.yml
@@ -10,13 +10,13 @@
     CigPackMixed: 2
     CigarCase: 1
     SmokingPipeFilledTobacco: 1
-    # Vape: 1 # DeltaV - Disable the Vape
+    Vape: 1
     Matchbox: 5
     PackPaperRollingFilters: 3
     CheapLighter: 4
     Lighter: 2
     FlippoLighter: 2
+    GroundTobacco: 6 #DeltaV - Moved this from contraband
   contrabandInventory:
-    GroundTobacco: 3
     CigarGold: 2
     Igniter: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -41,7 +41,7 @@
     TowercapSeeds: 5
     WheatSeeds: 5
     WatermelonSeeds: 5
-    TobaccoSeeds: 2 #DeltaV - remove from contriband, moved here
+    TobaccoSeeds: 2 #DeltaV - Moved this from contraband
   contrabandInventory:
     FoodSnackSemki: 2
     FlyAmanitaSeeds: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/seeds.yml
@@ -41,7 +41,7 @@
     TowercapSeeds: 5
     WheatSeeds: 5
     WatermelonSeeds: 5
+    TobaccoSeeds: 2 #DeltaV - remove from contriband, moved here
   contrabandInventory:
-    TobaccoSeeds: 2
     FoodSnackSemki: 2
     FlyAmanitaSeeds: 1

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
@@ -1,9 +1,8 @@
 - type: entity
   id: Vape
-  categories: [ HideSpawnMenu ] # DeltaV - Disable the Vape
   parent: BaseVape
   name: vape
-  description: "Like a cigar, but for tough teens. (WARNING:Pour only water into the vape)"
+  description: "for those that enjoy clouds. WARNING:Pour only water into the vape."
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Vapes/vape-standard.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
@@ -2,7 +2,7 @@
   id: Vape
   parent: BaseVape
   name: vape
-  description: "For those that enjoy clouds. WARNING: Pour only water into the vape."
+  description: "Like a cigar, but for tough teens. (WARNING:Pour only water into the vape)"
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Vapes/vape-standard.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Vapes/vape.yml
@@ -2,7 +2,7 @@
   id: Vape
   parent: BaseVape
   name: vape
-  description: "for those that enjoy clouds. WARNING:Pour only water into the vape."
+  description: "For those that enjoy clouds. WARNING: Pour only water into the vape."
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Vapes/vape-standard.rsi


### PR DESCRIPTION
## About the PR
Moves tobacco and crushed tobacco from the contriband section of both vends (Shadycigs and Seed vend) into the usable section

Re-enables the vape for shadycigs vend, also changes the description to something more appropriate

## Why / Balance
Tobacco pipe (Which is obtainable in a normal vend) requires crushed tobacco to use. Crushed tobacco has no "Syndicate" feasibility, and is generally not a traitor item, doesnt make sense for it to be traitor locked.


## Requirements

- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.


## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so: (Rewrote Vape information)
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
**Changelog**

:cl: tweak: Seedvends and Shadycigs vends have new items
