### PR TITLE
Add Colorful Chairs

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -175,156 +175,156 @@
 # Delta V - Begin additions
         - to: chairComfyBlack
           steps:
-            - material: FloorCarpetBlack
-              amount: 1
+          - material: FloorCarpetBlack
+            amount: 1
 
         - to: chairComfyBlue
           steps:
-            - material: FloorCarpetBlue
-              amount: 1
+          - material: FloorCarpetBlue
+            amount: 1
 
         - to: chairComfySkyBlue
           steps:
-            - material: FloorCarpetSkyBlue
-              amount: 1
+          - material: FloorCarpetSkyBlue
+            amount: 1
 
         - to: chairComfyCyan
           steps:
-            - material: FloorCarpetCyan
-              amount: 1
+          - material: FloorCarpetCyan
+            amount: 1
 
         - to: chairComfyGreen
           steps:
-            - material: FloorCarpetGreen
-              amount: 1
+          - material: FloorCarpetGreen
+            amount: 1
 
         - to: chairComfyOrange
           steps:
-            - material: FloorCarpetOrange
-              amount: 1
+          - material: FloorCarpetOrange
+            amount: 1
 
         - to: chairComfyPurple
           steps:
-            - material: FloorCarpetPurple
-              amount: 1
+          - material: FloorCarpetPurple
+            amount: 1
 
         - to: chairComfyPink
           steps:
-            - material: FloorCarpetPink
-              amount: 1
+          - material: FloorCarpetPink
+            amount: 1
 
         - to: chairComfyRed
           steps:
-            - material: FloorCarpetRed
-              amount: 1
+          - material: FloorCarpetRed
+            amount: 1
 
     - node: chairComfyBlack
       entity: ComfyChairBlack
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemBlack
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemBlack
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfyBlue
       entity: ComfyChairBlue
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemBlue
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemBlue
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfySkyBlue
       entity: ComfyChairSkyBlue
       edges:
-        - to: chairComfy
-          completed:
-          - !type:SpawnPrototype
-            prototype: FloorCarpetItemSkyBlue
-            amount: 1
-          steps:
-          - tool: Slicing
-            doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemSkyBlue
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfyCyan
       entity: ComfyChairCyan
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemCyan
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemCyan
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfyGreen
       entity: ComfyChairGreen
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemGreen
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemGreen
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfyOrange
       entity: ComfyChairOrange
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemOrange
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemOrange
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfyPurple
       entity: ComfyChairPurple
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemPurple
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemPurple
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfyPink
       entity: ComfyChairPink
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemPink
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemPink
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 
     - node: chairComfyRed
       entity: ComfyChairRed
       edges:
-        - to: chairComfy
-          completed:
-            - !type:SpawnPrototype
-              prototype: FloorCarpetItemRed
-              amount: 1
-          steps:
-            - tool: Slicing
-              doAfter: 1
+      - to: chairComfy
+        completed:
+        - !type:SpawnPrototype
+          prototype: FloorCarpetItemRed
+          amount: 1
+        steps:
+        - tool: Slicing
+          doAfter: 1
 # Delta V - End additions
 
     - node: chairPilotSeat

--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/seats.yml
@@ -172,6 +172,160 @@
           steps:
             - tool: Screwing
               doAfter: 1
+# Delta V - Begin additions
+        - to: chairComfyBlack
+          steps:
+            - material: FloorCarpetBlack
+              amount: 1
+
+        - to: chairComfyBlue
+          steps:
+            - material: FloorCarpetBlue
+              amount: 1
+
+        - to: chairComfySkyBlue
+          steps:
+            - material: FloorCarpetSkyBlue
+              amount: 1
+
+        - to: chairComfyCyan
+          steps:
+            - material: FloorCarpetCyan
+              amount: 1
+
+        - to: chairComfyGreen
+          steps:
+            - material: FloorCarpetGreen
+              amount: 1
+
+        - to: chairComfyOrange
+          steps:
+            - material: FloorCarpetOrange
+              amount: 1
+
+        - to: chairComfyPurple
+          steps:
+            - material: FloorCarpetPurple
+              amount: 1
+
+        - to: chairComfyPink
+          steps:
+            - material: FloorCarpetPink
+              amount: 1
+
+        - to: chairComfyRed
+          steps:
+            - material: FloorCarpetRed
+              amount: 1
+
+    - node: chairComfyBlack
+      entity: ComfyChairBlack
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemBlack
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+
+    - node: chairComfyBlue
+      entity: ComfyChairBlue
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemBlue
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+
+    - node: chairComfySkyBlue
+      entity: ComfyChairSkyBlue
+      edges:
+        - to: chairComfy
+          completed:
+          - !type:SpawnPrototype
+            prototype: FloorCarpetItemSkyBlue
+            amount: 1
+          steps:
+          - tool: Slicing
+            doAfter: 1
+
+    - node: chairComfyCyan
+      entity: ComfyChairCyan
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemCyan
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+
+    - node: chairComfyGreen
+      entity: ComfyChairGreen
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemGreen
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+
+    - node: chairComfyOrange
+      entity: ComfyChairOrange
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemOrange
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+
+    - node: chairComfyPurple
+      entity: ComfyChairPurple
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemPurple
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+
+    - node: chairComfyPink
+      entity: ComfyChairPink
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemPink
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+
+    - node: chairComfyRed
+      entity: ComfyChairRed
+      edges:
+        - to: chairComfy
+          completed:
+            - !type:SpawnPrototype
+              prototype: FloorCarpetItemRed
+              amount: 1
+          steps:
+            - tool: Slicing
+              doAfter: 1
+# Delta V - End additions
 
     - node: chairPilotSeat
       entity: ChairPilotSeat

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/chairs.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/chairs.yml
@@ -1,0 +1,26 @@
+- type: entity
+  name: random comfy chair spawner
+  id: RandomComfyChairSpawner
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: red
+      - sprite: Structures/Furniture/chairs.rsi
+        state: comfy
+        color: "#82C36E"
+  - type: EntityTableSpawner
+    offset: 0
+    table: !type:GroupSelector
+      children:
+      - id: ComfyChair
+      - id: ComfyChairGreen
+      - id: ComfyChairYellow
+      - id: ComfyChairRed
+      - id: ComfyChairBlue
+      - id: ComfyChairBlack
+      - id: ComfyChairPink
+      - id: ComfyChairOrange
+      - id: ComfyChairSkyBlue
+      - id: ComfyChairCyan
+      - id: ComfyChairPurple

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/chairs.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/chairs.yml
@@ -15,7 +15,6 @@
       children:
       - id: ComfyChair
       - id: ComfyChairGreen
-      - id: ComfyChairYellow
       - id: ComfyChairRed
       - id: ComfyChairBlue
       - id: ComfyChairBlack

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/chairs.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/chairs.yml
@@ -1,7 +1,7 @@
 - type: entity
-  name: random comfy chair spawner
-  id: RandomComfyChairSpawner
   parent: MarkerBase
+  id: RandomComfyChairSpawner
+  name: random comfy chair spawner
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/chairs.yml
@@ -2,8 +2,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairGreen
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -16,8 +14,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairRed
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -30,8 +26,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairBlue
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -44,8 +38,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairBlack
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -58,8 +50,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairPink
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -72,8 +62,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairOrange
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -86,8 +74,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairSkyBlue
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -100,8 +86,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairCyan
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy
@@ -114,8 +98,6 @@
 - type: entity
   parent: ComfyChair
   id: ComfyChairPurple
-  name: comfy chair
-  description: It looks comfy.
   components:
   - type: Sprite
     state: comfy

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/chairs.yml
@@ -12,20 +12,6 @@
     graph: Seat
     node: chairComfyGreen
 
-#Yellow
-- type: entity
-  parent: ComfyChair
-  id: ComfyChairYellow
-  name: comfy chair
-  description: It looks comfy.
-  components:
-  - type: Sprite
-    state: comfy
-    color: "#CCCC00"
-  - type: Construction
-    graph: Seat
-    node: chairComfyYellow
-
 #Red
 - type: entity
   parent: ComfyChair

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/chairs.yml
@@ -1,0 +1,139 @@
+#Green
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairGreen
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#82C36E"
+  - type: Construction
+    graph: Seat
+    node: chairComfyGreen
+
+#Yellow
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairYellow
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#CCCC00"
+  - type: Construction
+    graph: Seat
+    node: chairComfyYellow
+
+#Red
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairRed
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#FF3333"
+  - type: Construction
+    graph: Seat
+    node: chairComfyRed
+
+#Blue
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairBlue
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#004C99"
+  - type: Construction
+    graph: Seat
+    node: chairComfyBlue
+
+#Black
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairBlack
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#606060"
+  - type: Construction
+    graph: Seat
+    node: chairComfyBlack
+
+#Pink
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairPink
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#FF66FF"
+  - type: Construction
+    graph: Seat
+    node: chairComfyPink
+
+#Orange
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairOrange
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#FF8000"
+  - type: Construction
+    graph: Seat
+    node: chairComfyOrange
+
+#Sky Blue
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairSkyBlue
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#66B2FF"
+  - type: Construction
+    graph: Seat
+    node: chairComfySkyBlue
+
+#Cyan
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairCyan
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#00CCCC"
+  - type: Construction
+    graph: Seat
+    node: chairComfyCyan
+
+#Purple
+- type: entity
+  parent: ComfyChair
+  id: ComfyChairPurple
+  name: comfy chair
+  description: It looks comfy.
+  components:
+  - type: Sprite
+    state: comfy
+    color: "#B266FF"
+  - type: Construction
+    graph: Seat
+    node: chairComfyPurple

--- a/Resources/Prototypes/_DV/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/furniture.yml
@@ -744,18 +744,6 @@
     - !type:TileNotBlocked
 
 - type: construction
-  id: ComfyChairYellow
-  graph: Seat
-  startNode: start
-  targetNode: chairComfyYellow
-  category: construction-category-furniture
-  objectType: Structure
-  placementMode: SnapgridCenter
-  canBuildInImpassable: false
-  conditions:
-    - !type:TileNotBlocked
-
-- type: construction
   id: ComfyChairRed
   graph: Seat
   startNode: start

--- a/Resources/Prototypes/_DV/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/furniture.yml
@@ -729,3 +729,124 @@
   conditions:
     - !type:TileNotBlocked
   hide: false
+
+#Colored Comfy Chairs
+- type: construction
+  id: ComfyChairGreen
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyGreen
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairYellow
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyYellow
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairRed
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyRed
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairBlue
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyBlue
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairBlack
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyBlack
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairPink
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyPink
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairOrange
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyOrange
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairSkyBlue
+  graph: Seat
+  startNode: start
+  targetNode: chairComfySkyBlue
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairCyan
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyCyan
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked
+
+- type: construction
+  id: ComfyChairPurple
+  graph: Seat
+  startNode: start
+  targetNode: chairComfyPurple
+  category: construction-category-furniture
+  objectType: Structure
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  conditions:
+    - !type:TileNotBlocked

--- a/Resources/Prototypes/_DV/Recipes/Construction/furniture.yml
+++ b/Resources/Prototypes/_DV/Recipes/Construction/furniture.yml
@@ -813,7 +813,7 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked
 
 - type: construction
   id: ComfyChairCyan
@@ -825,7 +825,7 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked
 
 - type: construction
   id: ComfyChairPurple
@@ -837,4 +837,4 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   conditions:
-    - !type:TileNotBlocked
+  - !type:TileNotBlocked


### PR DESCRIPTION
## About the PR
- Adds several new shades of colorful chairs
- Construction graphs
- Random spawner for mapping

## Why / Balance
Pretty 

## Technical details
Ignore the yellow one. We don't have a yellow carpet for material.

## Media
<img width="576" height="195" alt="image" src="https://github.com/user-attachments/assets/0491d606-46d7-423d-9d3e-b468d7495a0a" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) 

**Changelog**
:cl: Velcroboy
- add: Players can now find and construct colorful comfy chairs!
