### PR TITLE
Make the nukie medicine bundle contain salbu instead of dex+

### DIFF
--- a/Resources/Locale/en-US/_DV/store/nukie-delivery.ftl
+++ b/Resources/Locale/en-US/_DV/store/nukie-delivery.ftl
@@ -1,0 +1,2 @@
+nukie-delivery-medicine-bundle-desc-deltav = Contains jugs of basic medicine that are essential for any Nuclear Operation:
+  Bicaridine, Puncturase, Dermaline, Dylovene, Hyronalin, Saline, Salbutamol, and Tranexamic Acid.

--- a/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/duffelbag.yml
@@ -48,7 +48,8 @@
         - id: JugDylovene
         - id: JugHyronalin
         - id: JugSaline
-        - id: JugDexalinPlus
+        #- id: JugDexalinPlus # DeltaV - removed Dex+ Jug (it didn't spawn anyways)
+        - id: JugSalbutamol # DeltaV - Add salbu jug
         - id: JugTranexamicAcid
 
 - type: entity

--- a/Resources/Prototypes/Catalog/nukie_delivery_catalog.yml
+++ b/Resources/Prototypes/Catalog/nukie_delivery_catalog.yml
@@ -9,7 +9,7 @@
 - type: listing
   id: NukieDeliveryMedicineBundle
   name: nukie-delivery-medicine-bundle-name
-  description: nukie-delivery-medicine-bundle-desc
+  description: nukie-delivery-medicine-bundle-desc-deltav # DeltaV - modified description to remove dex+
   productEntity: ClothingBackpackDuffelSyndicateFilledMedicine
   categories:
   - NukieDelivery

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: Jug
-  suffix: salbutamol
   id: JugSalbutamol
   categories: [ HideSpawnMenu ]
+  suffix: salbutamol
   components:
   - type: Label
     currentLabel: reagent-name-salbutamol

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
@@ -1,0 +1,14 @@
+- type: entity
+  parent: Jug
+  suffix: salbutamol
+  id: JugSalbutamol
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Label
+    currentLabel: reagent-name-salbutamol
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        reagents:
+        - ReagentId: Salbutamol
+          Quantity: 200


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I added a salbu jug to the nukie medicine (not medical) bundle. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The medicine bundle is intended to carry the basic chems that a nukie team needs if they wait 20 minutes.  Dex+ was removed and replaced with salbutamol in most places. This bundle was missed, whenever it was added. 

## Technical details
<!-- Summary of code changes for easier review. -->
It's just yaml. I created a salbutamol jug entity, added it to the medicine bundle, commented out the dex jug, and modified the bundle's description. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="316" height="107" alt="Screenshot 2026-05-23 221955" src="https://github.com/user-attachments/assets/6530886b-3152-480b-b2a5-cb5d37b986e1" />
<img width="242" height="123" alt="Screenshot 2026-05-23 222026" src="https://github.com/user-attachments/assets/f717a4aa-3337-4c55-b8ec-bd43535e56f4" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The nukie medicine bundle now contains a jug of salbutamol, instead of dexalin plus. 