### PR TITLE
Make Psionic Eruption less dangerous

### DIFF
--- a/Content.Server/_DV/Psionics/Systems/PsionicPowers/PsionicEruptionPowerSystem.cs
+++ b/Content.Server/_DV/Psionics/Systems/PsionicPowers/PsionicEruptionPowerSystem.cs
@@ -181,12 +181,12 @@ public sealed class PsionicEruptionSystem : BasePsionicPowerSystem<PsionicErupti
 
         int boom = _glimmer.GetGlimmerTier(_glimmer.Glimmer) switch
         {
-            GlimmerTier.Minimal => 4,
-            GlimmerTier.Low => 8,
-            GlimmerTier.Moderate => 12,
-            GlimmerTier.High => 16,
-            GlimmerTier.Dangerous => 32,
-            GlimmerTier.Critical => 64,
+            GlimmerTier.Minimal => 2,
+            GlimmerTier.Low => 3,
+            GlimmerTier.Moderate => 4,
+            GlimmerTier.High => 8,
+            GlimmerTier.Dangerous => 16,
+            GlimmerTier.Critical => 32,
             _ => 0
         };
         _explosion.QueueExplosion(pos, ExplosionSystem.DefaultExplosionPrototypeId, boom, 1, 5, psionic, maxTileBreak: 0);

--- a/Content.Server/_DV/Psionics/Systems/PsionicPowers/PsionicEruptionPowerSystem.cs
+++ b/Content.Server/_DV/Psionics/Systems/PsionicPowers/PsionicEruptionPowerSystem.cs
@@ -185,7 +185,7 @@ public sealed class PsionicEruptionSystem : BasePsionicPowerSystem<PsionicErupti
             GlimmerTier.Low => 3,
             GlimmerTier.Moderate => 4,
             GlimmerTier.High => 8,
-            GlimmerTier.Dangerous => 16,
+            GlimmerTier.Dangerous => 12,
             GlimmerTier.Critical => 32,
             _ => 0
         };

--- a/Resources/Locale/en-US/_DV/abilities/psionic.ftl
+++ b/Resources/Locale/en-US/_DV/abilities/psionic.ftl
@@ -115,9 +115,8 @@ eruption-warning-window-title = Your Brain isn't Ready!
 eruption-warning-window-prompt-text-part = You feel a strong pressure building up in your mind
                                             and you need to release it before it overwhelms you.
                                             When you are ready, you can unleash a psionic eruption.
-                                            Doing so will cause a massive psionic discharge,
-                                            which will destroy yourself and the station around you.
-                                            THIS ALONE DOES NOT MAKE YOU AN ANTAGONIST.
+                                            Doing so will cause a massive psionic discharge, obliterating you entirely.
+                                            You should probably try to find a fix to that...
                                             Do not detonately randomly, ensure proper buildup.
                                             Do you understand?
 eruption-warning-window-acknowledge-button = I Understand


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Psionic Eruption's explosion is now vastly less damaging to its environment. The UI popup has been reworded to focus more on the fact that this power will simply just kill you.

## Why / Balance
Psionic Eruption is one of the most unique powers currently in the game, and it would be an absolute shame to lose it. There is a ton of occasionally-tapped storytelling potential there, just because you didn't see all of it yourself doesn't mean it didn't happen.
Honestly, if I was evil I'd make the power *actually* make you blow up after a period of time, but I feel like that would be an entire argument among CR so I'll avoid that one.
Few people in the thread said it would be ideal to just lower the destructive potential, so that's what this does.

## Technical details
All explosion intensities lowered by anywhere between 50% to 75% across the board.
<img width="497" height="290" alt="image" src="https://github.com/user-attachments/assets/4c47505a-f38b-43bd-b53b-5b159ccace73" />

Every explosion size below 900 glimmer is a full 3x3 or cross 3x3 of varying intensity. Deals about 37.5 damage in the epicenter at most.
<img width="318" height="297" alt="image" src="https://github.com/user-attachments/assets/553a5a4c-4f54-46b7-88ed-83fe493e5d45" />

Past 900 glimmer, becomes a rough 5x5. 52 damage at epicenter.
<img width="396" height="439" alt="image" src="https://github.com/user-attachments/assets/46903d51-f5a3-4a38-b6b0-3999cc36c588" />

If I'm using explosionui right, at least.

## Media
reworded ui
<img width="625" height="350" alt="image" src="https://github.com/user-attachments/assets/47c63b27-b930-473a-be06-ae11abbec0d5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Psionic Eruption has had its destructive potential substantially reduced.
