### PR TITLE
Fix: Grav Gauntlet Sprite Error 

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/grav_gauntlet.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/grav_gauntlet.yml
@@ -44,7 +44,6 @@
   - type: UseDelay
     delay: 2
   - type: Clothing
-    sprite: _DV/Objects/Weapons/grav_gauntlet.rsi
     quickEquip: false
     slots:
     - belt


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fix RSI error when putting the gauntlet in suitStorage or belt slot due to incorrect RSI path and no sprites for those slots.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix
## Technical details
<!-- Summary of code changes for easier review. -->
Removed sprite path until someone makes sprites for the suitStorage or belt slot.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Wasn't player facing due to fallback