### PR TITLE
Avali bugfixes

### DIFF
--- a/Content.Client/_DV/Body/FeatherVisualizer.cs
+++ b/Content.Client/_DV/Body/FeatherVisualizer.cs
@@ -27,7 +27,7 @@ public sealed class FeatherVisualizer : VisualizerSystem<FeatherComponent>
             }
         }
 
-        if(!AppearanceSystem.TryGetData<Color>(uid, FeatherVisuals.BloodColor, out var bloodColor, args.Component))
+        if (!AppearanceSystem.TryGetData<Color>(uid, FeatherVisuals.BloodColor, out var bloodColor, args.Component))
             return;
 
         SpriteSystem.LayerSetColor(uid, FeatherVisualLayers.Blood, bloodColor);

--- a/Content.Client/_DV/Body/FeatherVisualizer.cs
+++ b/Content.Client/_DV/Body/FeatherVisualizer.cs
@@ -14,14 +14,10 @@ public sealed class FeatherVisualizer : VisualizerSystem<FeatherComponent>
 
     protected override void OnAppearanceChange(EntityUid uid, FeatherComponent component, ref AppearanceChangeEvent args)
     {
-        if (!AppearanceSystem.TryGetData<Color>(uid, FeatherVisuals.BloodColor, out var bloodColor, args.Component) ||
-            !AppearanceSystem.TryGetData<Color>(uid, FeatherVisuals.FeatherColor, out var featherColor, args.Component))
-        {
+        if (!AppearanceSystem.TryGetData<Color>(uid, FeatherVisuals.FeatherColor, out var featherColor, args.Component))
             return;
-        }
 
         SpriteSystem.LayerSetColor(uid, FeatherVisualLayers.Feather, featherColor);
-        SpriteSystem.LayerSetColor(uid, FeatherVisualLayers.Blood, bloodColor);
 
         if (TryComp<ClothingComponent>(uid, out var clothing))
         {
@@ -30,6 +26,11 @@ public sealed class FeatherVisualizer : VisualizerSystem<FeatherComponent>
                 _clothing.SetLayerColor(clothing, slotPair.Key, "feather", featherColor);
             }
         }
+
+        if(!AppearanceSystem.TryGetData<Color>(uid, FeatherVisuals.BloodColor, out var bloodColor, args.Component))
+            return;
+
+        SpriteSystem.LayerSetColor(uid, FeatherVisualLayers.Blood, bloodColor);
     }
 }
 

--- a/Content.Shared/_DV/Body/Systems/PreenableSystem.cs
+++ b/Content.Shared/_DV/Body/Systems/PreenableSystem.cs
@@ -54,7 +54,7 @@ public sealed class PreenableSystem : EntitySystem
 
     private void AddVerb(Entity<PreenableComponent> ent, ref GetVerbsEvent<Verb> args)
     {
-        if (!args.CanInteract)
+        if (!args.CanInteract || !args.CanAccess)
             return;
 
         // can't preen with no feathers

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
@@ -115,6 +115,11 @@
       279: 0.95
       265: 0.9
       240: 0.85
+  - type: EyeCursorOffset
+    maxOffset: 5
+    pvsIncrease: 0.5
+    enabled: false
+  - type: CursorOffsetAction
   - type: Preenable
     featherPrototype: AvaliFeather
   # End DeltaV additions


### PR DESCRIPTION
## About the PR
Feathers preened from an Avali will have their color display properly. Also, their zoom ability now exists again.

## Why / Balance
three days of them being the objective worst species with zero upside was funny, but it's time to fix it

## Technical details
shitmed removal moment + i did not squint hard enough at suggested changes. TryGetData needs to be checked independently for FeatherColor and BloodColor, because BloodColor data only exists if the feather is bloody, and the FeatherColor should be utilized regardless.

## Media
<img width="608" height="641" alt="image" src="https://github.com/user-attachments/assets/196d7f71-8fcf-4478-aefd-0de0c7c20b70" />
<img width="154" height="350" alt="image" src="https://github.com/user-attachments/assets/44032d96-f452-44bb-9deb-84a07fd7f123" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Avali feathers will now be properly colored when *not* beating said avali's skull in with a baseball bat.
- fix: Avali can now see further again.
- fix: Avali no longer have their preening verb show up at all ranges.
