### PR TITLE
let me kill people

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -5,7 +5,6 @@
   playTimeTracker: JobPrisoner
   startingGear: PrisonerGear
   alwaysUseSpawner: true
-  canBeAntag: false
 #  whitelistRequired: true
   icon: "JobIconPrisoner"
   supervisors: job-supervisors-security


### PR DESCRIPTION

## About the PR
prisoners can now roll antag

## Why / Balance
i've spilled a lot of ink over this in the past so feel free to look up the whole reasoning on discord but tldr
prisoners are mechanically and by admins discouraged to be dangerous
this means we get perma daycare
letting prisoners antag roll means warden can no longer literally take a nap in perma and expect the worst crime done to them be the theft of their shoes

normal tc because prisoner antags are by far, without a doubt, the weakest role a traitor can find themselves on:
permanent tracking implanter
permanently valid outside of perma
goes to perma after 1 crime, including being out of perma
lower barrier for exfil and other RR
not allowed to own anything sec doesnt like
guard assigned to watch over them

concerns i want to preemptively address:
theyre too close to the armory: 
depending on the map, any random tider can just get 1 wall away from the armory and buy a c4 or an emag to let themselves in. at least they are allowed to carry tools while doing it. if the map really only lets you access the armory from perma, then just get permad? if starting from perma is a very necessary part of your plan, then every crew member has a way to get into perma.

its too much of a hassle for security:
it isnt? instead of 8 traitors, you have 7 traitors and one in custody.

what if permas self antag because they see another perma act as an antag:
rules b4, c2. in general i dont consider 'what if people self antag' to be worth designing around. its the same as asking, 'what if a non antag botanist sees an antag tomatoloose' idk go tell them not to self antag

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have not tested any added content or changes.
- [x] I have not added media to this PR even if it does require an in-game showcase.


**Changelog**
:cl:
- add: prisoners can now roll for traitor

