### PR TITLE
Tweak Durathread

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/armor.yml
@@ -42,14 +42,16 @@
   - type: Armor # Good against stabs and knocks, offers minimal protection from gunshots and lasfire.
     modifiers:
       coefficients:
-        Blunt: 0.60
-        Slash: 0.60
-        Piercing: 0.90
-        Heat: 0.90
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.8
+        Heat: 0.8
   - type: StaminaResistance
     damageCoefficient: 0.9
   - type: ExplosionResistance # Better than nothing against a blast or shockwave.
     damageCoefficient: 0.90
+  - type: ClothingSpeedModifier
+    sprintModifier: 0.90
   - type: AllowSuitStorage
   - type: Tag
     tags:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I tweaked Durathread values to be the opposite of the Plate carrier with a few exceptions.
Blunt/Slash/Pierce/Heat Resistance raised by 10% from 40/40/10/10 to 50/50/20/20.
**Running** movementspeed penalty increased by 10% from 0% to 10%.
Walking movementspeed is the same.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was already hard to justify taking the Durathread over the plate carrier, because in many situations, the plate carrier was just better. Especially in regards to melee mobs, where most deal partly pierce damage. Even against Energy swords, Plate Carriers had more heat resistance.
The only clean exception would be the ninja katana.

This has been exarcerbated by the introduction of the slim armor vest. It's hard to justify 20% less pierce, 10% less heat resistance for 10% more blunt/slash.

Regarding the Durathread as a melee armor, I've opted to not make it slow down walking speed, as sometimes, you'd want to walk over slippery surfaces in melee. Explosion resistance has not been increased because you don't encounter shrimps with exploding claws that often.
## Technical details
<!-- Summary of code changes for easier review. -->
Pure YML changes.
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="493" height="443" alt="grafik" src="https://github.com/user-attachments/assets/a5e58ef9-bfa1-4504-a7dd-a579abdd4b7e" />
<img width="429" height="330" alt="grafik" src="https://github.com/user-attachments/assets/946a2a54-55e4-4d7b-98a3-942fc96f8e60" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Tweaked the Durathread to have 10% slower running speed for 10% more Brute/Heat resistances across the board!

