### PR TITLE
Add more rewards to the ancient books

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/bookrewards.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/bookrewards.yml
@@ -1,0 +1,49 @@
+- type: entity
+  parent: MarkerBase
+  id: BookRewardSpawner
+  name: Book reward spawner
+  suffix: 50
+  components:
+    - type: Sprite
+      layers:
+        - state: red
+        - sprite: Objects/Consumable/Food/snacks.rsi
+          state: pistachio-trash
+    - type: EntityTableSpawner
+      offset: 0.2
+      table: !type:NestedSelector
+        tableId: BookRewardItems
+        prob: 0.5
+  placement:
+    mode: AlignTileAny
+
+- type: entityTable
+  id: BookRewardItems
+  table: !type:GroupSelector
+    children:
+    - !type:GroupSelector
+      weight: 80
+      children:
+      - id: MaterialBluespace1
+      - id: CrystalNormality
+    - !type:GroupSelector
+      weight: 15
+      children:
+      - id: MaterialBluespace
+      - id: CrystalNormality5
+    - !type:GroupSelector
+      weight: 4
+      children:
+      - id: ClothingHandsGlovesColorYellowUnsulated
+      - id: ClothingHandsDispelGloves
+      - id: ClothingEyesTelegnosisSpectables
+    - !type:GroupSelector
+      weight: .7
+      children:
+      - id: BlinkBook
+      - id: ForceWallSpellbook
+    - !type:GroupSelector
+      weight: .3
+      children:
+      - id: KnockSpellbook
+      - id: SpawnSpellbook

--- a/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/bookrewards.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/Spawners/Random/bookrewards.yml
@@ -36,7 +36,7 @@
       children:
       - id: ClothingHandsGlovesColorYellowUnsulated
       - id: ClothingHandsDispelGloves
-      - id: ClothingEyesTelegnosisSpectables
+      - id: ClothingEyesTelegnosisSpectacles
     - !type:GroupSelector
       weight: .7
       children:

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/ancient_books.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/ancient_books.yml
@@ -78,6 +78,7 @@
   - type: SpawnItemsOnUse
     items:
       - id: ResearchDisk
+      - id: BookRewardSpawner
       - id: AncientBookCommon1
         orGroup: AncientBookCommonPool
       - id: AncientBookCommon2
@@ -133,6 +134,7 @@
   - type: SpawnItemsOnUse
     items:
       - id: ResearchDisk10000
+      - id: BookRewardSpawner
       - id: AncientBookRare1
         orGroup: AncientBookRarePool
       - id: AncientBookRare2

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/ancient_books.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/ancient_books.yml
@@ -105,6 +105,7 @@
   - type: SpawnItemsOnUse
     items:
       - id: ResearchDisk5000
+      - id: BookRewardSpawner
       - id: AncientBookUncommon1
         orGroup: AncientBookUncommonPool
       - id: AncientBookUncommon2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This is a small buff to Archivists. Ancient books now come with the possibility of having an extra reward included. This can be bluespace or normality crystals, psionic items, or even rare spellbooks. Goal with this is to hopefully see archivists be more proactive in opening books, and in turn salvage more willing to grab them when they see them.

## Why / Balance
As it stands, while I don't want archivist to be a necessarily role I do want to see people engage with it's mechanics. By giving the chance to get something more then just a disk, I hope people will be more willing to consistently engage with the books even past research being finished.

On the balance side of things, every book that is opened has a 50% chance of dropping _something._ If you roll the 50% chance to get something, you have an 80% chance of getting *1* bluespace _or_ *1* normality crystal. You have a 15% chance of getting 5 bluespace or normality crystals, a 4% chance of getting Unsulated gloves, dispel gloves, or telegnosis spectacles. there is a .7% chance to get a Blink Spellbook or a Forcewall spellbook, and a .3% chance to get a Knock spellbook or Spawn spellbook.

## Technical details
yaml changes mostly.

## Media
<img width="579" height="591" alt="image" src="https://github.com/user-attachments/assets/d8b7fafa-901a-4a8c-a5d0-2aa53fb037c8" />

the things I got after opening 90 books

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Ancient books are being found with extra rewards inside them. Give it a try and see what you can find!

