### PR TITLE
Uplink rework part 1

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -169,7 +169,7 @@
   discountDownTo:
     Telecrystal: 3
   cost:
-    Telecrystal: 6
+    Telecrystal: 5 # DeltaV - was 6
   categories:
   - UplinkWeaponry
   conditions:
@@ -249,7 +249,7 @@
   discountDownTo:
     Telecrystal: 11
   cost:
-    Telecrystal: 18
+    Telecrystal: 15 # DeltaV - was 18
   categories:
   - UplinkWeaponry
 
@@ -378,7 +378,7 @@
   discountDownTo:
     Telecrystal: 3
   cost:
-    Telecrystal: 6 # DeltaV - was 5
+    Telecrystal: 4 # DeltaV - was 5
   categories:
     - UplinkExplosives
   conditions:
@@ -409,7 +409,7 @@
   discountDownTo:
     Telecrystal: 6
   cost:
-    Telecrystal: 12
+    Telecrystal: 10 # DeltaV - was 12
   categories:
   - UplinkExplosives
   conditions:
@@ -452,9 +452,9 @@
   productEntity: PenExplodingBox
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 2
+    Telecrystal: 4 # DeltaV - was 2
   cost:
-    Telecrystal: 3 # DeltaV - was 4
+    Telecrystal: 6 # DeltaV - was 4
   categories:
   - UplinkExplosives
 
@@ -464,7 +464,7 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 14 # DeltaV - was 11, Syndicate bomb was way too powerful for the 11 TC cost
+    Telecrystal: 10 # DeltaV - was 11
   categories:
     - UplinkExplosives
   restockTime: 1800
@@ -480,7 +480,7 @@
   description: uplink-exploding-syndicate-bomb-desc
   productEntity: SyndicateBomb
   cost:
-    Telecrystal: 10 # DeltaV - was 11, lets go bombing
+    Telecrystal: 8 # DeltaV - was 11, lets go bombing
   categories:
     - UplinkExplosives
   conditions:
@@ -511,7 +511,7 @@
   discountDownTo:
     Telecrystal: 2
   cost:
-    Telecrystal: 3 # DeltaV - was 4
+    Telecrystal: 5 # DeltaV - was 4
   categories:
   - UplinkExplosives
 

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -17,8 +17,8 @@
 - type: listing
   id: UplinkRevolverPython
   name: uplink-revolver-python-name
-  description: deltav-uplink-revolver-python-desc # DeltaV - Description changed to indicate it isn't loaded with AP by default
-  productEntity: WeaponRevolverPython # DeltaV - No longer loaded with AP by default
+  description: uplink-revolver-python-desc
+  productEntity: WeaponRevolverPythonAP
   discountCategory: rareDiscounts
   discountDownTo:
     Telecrystal: 2
@@ -154,9 +154,9 @@
   productEntity: ClothingHandsKnuckleDustersSyndicate
   discountCategory: veryRareDiscounts
   discountDownTo:
-    Telecrystal: 3
+    Telecrystal: 1 # DeltaV - was 2
   cost:
-    Telecrystal: 6
+    Telecrystal: 4 # DeltaV - was 6
   categories:
   - UplinkWeaponry
 

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -559,7 +559,8 @@
     damage:
       types:
         Blunt: 8
-        Piercing: 8
+        Piercing: 4 # DeltaV - changed from 8 to 4
+    bluntStaminaDamageFactor: 2.0 # DeltaV - added stamina damage
     soundHit:
       collection: Punch
     animation: WeaponArcFist

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/energy_crossbow.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/energy_crossbow.yml
@@ -33,7 +33,9 @@
     proto: EnergyCrossbowBolt
     capacity: 1
     count: 1
-
+  - type: TimedDespawn # DeltaV changes - limit range to match taser
+  lifetime: 0.170 # Very short range
+  
 - type: entity
   parent: [WeaponEnergyCrossbowBase, BaseSyndicateContraband]
   id: WeaponEnergyCrossbow

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -80,8 +80,9 @@
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
   - type: Gun
-    availableModes: # DeltaV - force semi for balance
+    availableModes:
     - SemiAuto
+    - FullAuto
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -239,12 +239,13 @@
       path: /Audio/Weapons/Guns/Gunshots/estocshot.ogg
     minAngle: 30
     maxAngle: 43
-    shotsPerBurst: 3
+    shotsPerBurst: 2 # DeltaV - add two-tap
     selectedMode: Burst
     availableModes:
     - Burst
     - SemiAuto
-    burstFireRate: 14
+    burstFireRate: 30 # DeltaV - add two-tap
+    burstCooldown: .5 # DeltaV - add two-tap
   - type: GunWieldBonus
     minAngle: -28
     maxAngle: -25

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Turrets/turrets_ballistic.yml
@@ -32,7 +32,7 @@
         acts: [ "Destruction" ]
       - !type:TriggerBehavior
   - type: Gun
-    fireRate: 2
+    fireRate: 3 # DeltaV - was 2
     selectedMode: FullAuto
     availableModes:
     - FullAuto

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -197,6 +197,12 @@
       malus: 0.4
     - type: Execution
       doAfterDuration: 4.0
+      # DeltaV changes
+    - type: Reflect
+      reflectProb: .1
+      reflects:
+      - Energy
+      # DeltaV changes end
     - type: Contraband
       severity: Syndicate
   - type: Sprite
@@ -419,6 +425,8 @@
     reflects:
     - Energy
     - NonEnergy
+  - type: DisarmMalus
+    malus: 0.8
     # DeltaV changes end
 # Borgs
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -381,6 +381,23 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+  # DeltaV additions begin - add dipping chemicals
+  - type: SolutionContainerManager
+    solutions:
+      melee:
+        maxVol: 2
+  - type: MeleeChemicalInjector
+    solution: melee
+  - type: RefillableSolution
+    solution: melee
+  - type: InjectableSolution
+    solution: melee
+  - type: SolutionInjectOnEmbed
+    transferAmount: 2
+    solution: melee
+  - type: SolutionTransfer
+    maxTransferAmount: 2
+  # DeltaV additions end
 
 - type: entity
   name: utility knife


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
-AP python returns
-Viper full auto returns
-Syndicate Knuckledusters have 16 stun, slightly reduced damage
-mini ecrossbow projectiles now match taser range
-estoc burst fire now shoots two simultaneous shots
-hyperblades are now very unlikely to be disarmed
-epens only reflect 10%
-throwing knives may be dipped in chemicals
-toolbox turrets have a slightly (33%) increased rate of fire
-some price changes

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fun whimsy etc
generally syndie rounds are considered boring as hell currently and are pretty quiet, I'd like to up the volume a little bit but in interesting ways not just dps and booms (viper is dps though)

## Technical details
<!-- Summary of code changes for easier review. -->
It's not that deep 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/b8a1948d-c053-4bf1-b6f8-c9e66df0154d
https://github.com/user-attachments/assets/6a7707f6-00a3-4733-be93-c6415b763b00
https://github.com/user-attachments/assets/f26ae3c8-0988-43f8-be53-26082908af7e

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: rebe83, einknusprigestoast
- tweak: AP python returns!
- tweak: Viper full auto returns! Yes, it does have a switch.
- tweak: Syndicate Knuckledusters have 16 stun, slightly reduced damage
- tweak: mini ecrossbow projectiles now match taser range
- tweak: estoc burst fire now shoots two simultaneous shots
- tweak: hyperblades are now very unlikely to be disarmed
- tweak: epens only reflect 10%
- add: throwing knives may be dipped in chemicals like spears!
- tweak: toolbox turrets have a slightly increased rate of fire
- tweak: various price adjustments

