### PR TITLE
Disable borer spawns until properly removable

### DIFF
--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -42,8 +42,8 @@
       - id: MobWhimperlet # DeltaV - added Whimperlet
         weight: 0.03
       #- id: MobMouseCancer # DeltaV - no
-      - id: MobCorticalBorer # DeltaV - ported Borer
-        weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
+      #- id: MobCorticalBorer # DeltaV - ported Borer
+      #  weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
 # Events always spawn a critter regardless of Probability https://github.com/space-wizards/space-station-14/issues/28480 I added the Rat King to their own event with a player cap.
 
 - type: entity
@@ -100,8 +100,8 @@
         weight: 0.05
       - id: MobWhimperlet # DeltaV - Added Whimperlet and its weight
         weight: 0.02
-      - id: MobCorticalBorer # DeltaV - ported Borer
-        weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
+      #- id: MobCorticalBorer # DeltaV - ported Borer
+      #  weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
 
 - type: entity
   id: SnailMigrationLowPop
@@ -150,5 +150,5 @@
       - id: MobSnailMoth
         weight: 0.07 # DeltaV - was 0.08
       #- id: MobSnailInstantDeath # DeltaV - no
-      - id: MobCorticalBorer # DeltaV - ported Borer
-        weight: 0.02 # DeltaV - 2% chance on snails
+      #- id: MobCorticalBorer # DeltaV - ported Borer
+      #  weight: 0.02 # DeltaV - 2% chance on snails


### PR DESCRIPTION
## About the PR
Borers temporarily removed from the Pests table. RIP `raw carp filet`, you will be missed.

## Why / Balance
The removal of Shitmed means there's no longer a proper way to remove these guys. Pretty sure these were supposed to be disabled in the Shitmed removal PR but it got missed. Until a proper way of dealing with borers without surgery is added, they shouldn't be in the rotation.

## Technical details
yamlop

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Borers have been temporarily disabled, due to their primary method of removal no longer existing now that surgery is gone.
