### PR TITLE
Attach GALPOL to fugitive paper + fugitive paper fixes

### DIFF
--- a/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
+++ b/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
@@ -121,11 +121,15 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         var species = PrototypeManager.Index(humanoid.Species);
 
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-morphotype", ("species", Loc.GetString(species.Name))));
+        report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-age", ("age", humanoid.Age)));
+        report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-sex", ("sex", humanoid.Sex.ToString())));
+        report.PushNewline();
 
         if (TryComp<PhysicsComponent>(uid, out var physics))
             report.AddMarkupOrThrow(Loc.GetString("fugitive-report-weight", ("weight", Math.Round(physics.FixturesMass))));
+        report.PushNewline();
 
         // add a random identifying quality that officers can use to track them down
         report.AddMarkupOrThrow(RobustRandom.Next(0, 2) switch
@@ -136,6 +140,7 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
 
         report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crimes-header"));
+        report.PushNewline();
 
         // generate some random crimes to avoid this situation
         // "officer what are my charges?"
@@ -172,6 +177,7 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         {
             var count = RobustRandom.Next(rule.MinCounts, rule.MaxCounts + 1);
             report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crime", ("crime", Loc.GetString(crime)), ("count", count)));
+            report.PushNewline();
         }
     }
 }

--- a/Resources/Locale/en-US/_DV/paper/stamp-component.ftl
+++ b/Resources/Locale/en-US/_DV/paper/stamp-component.ftl
@@ -5,3 +5,4 @@ stamp-component-stamped-name-prosec = Prosecutor
 stamp-component-stamped-name-hate-paperwork = I HATE PAPERWORK!
 stamp-component-stamped-name-nanotrasen = Nanotrasen
 stamp-component-stamped-name-NTAgent = INTERNAL AFFAIRS
+stamp-component-stamped-name-GALPOL = GALPOL

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -415,6 +415,13 @@
   id: PaperFugitiveReport
   name: fugitive report
   description: An arrest warrant for a space fugitive sent from GALPOL.
+  components:
+  - type: Paper
+    stampState: paper_stamp-centcom
+    stampedBy:
+    - stampedColor: '#3db010'
+      stampedName: GALPOL
+      stampState: "paper_stamp-centcom"
 
 - type: entity
   parent: Paper

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/paper.yml
@@ -421,7 +421,6 @@
     stampedBy:
     - stampedColor: '#3db010'
       stampedName: GALPOL
-      stampState: "paper_stamp-centcom"
 
 - type: entity
   parent: Paper

--- a/Resources/Prototypes/_DV/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Misc/rubber_stamp.yml
@@ -79,3 +79,17 @@
     stampState: "paper_stamp-cap"
   - type: Sprite
     state: stamp-cap
+
+- type: entity
+  name: GALPOL rubber stamp
+  parent: RubberStampBase
+  id: RubberStampGalpol
+  suffix: DO NOT MAP
+  description: A rubber stamp for stamping important documents. For intergalactic security affairs.
+  components:
+  - type: Stamp
+    stampedName: stamp-component-stamped-name-GALPOL
+    stampedColor: "#3db010"
+    stampState: "paper_stamp-centcom"
+  - type: Sprite
+    state: stamp-centcom


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Adds a GALPOL stamp to fugitive papers and fixes the formatting. Also adds a GALPOL stamp for eventers.

## Why / Balance
Someone complained about the lack of GALPOL stamp on fugitive papers, which sometimes was brought up as some sort of a legal defence. Now it's truly valid.

## Technical details
C# code was changed, but it's literally just couple of lines saying "add a new line". Also new stamp with yml code, using CC stamp sprite. It's probably fine to use CC stamp sprite, since it's only for eventers.

I've also noticed the console throwing warnings of
`[WARN] loc: Unknown messageId ("en-US"): "GALPOL"`
I don't know what to do with it. If there's a solution to fix it, let me know.
## Media
<img width="367" height="452" alt="image" src="https://github.com/user-attachments/assets/1cfeb90e-e445-4714-85a3-a4f496373772" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- tweak: After several complaints from NanoTrasen legal team, GALPOL now stamps their fugitive reports. 
- fix: Fixed formatting of fugitive papers. Should be more readable now.
