### PR TITLE
Map Edits: Remove Fun

### DIFF
--- a/Resources/Maps/asterisk.yml
+++ b/Resources/Maps/asterisk.yml
@@ -69510,7 +69510,7 @@ entities:
     - type: Transform
       pos: -41.5,14.5
       parent: 2
-- proto: SuperweaponSafeSpawner
+- proto: GunSafeAdvancedLaser
   entities:
   - uid: 12209
     components:

--- a/Resources/Maps/byoin.yml
+++ b/Resources/Maps/byoin.yml
@@ -90071,7 +90071,7 @@ entities:
     - type: Transform
       pos: 18.5,10.5
       parent: 2
-- proto: GunSafeRocketLauncher
+- proto: GunSafeAdvancedLaser
   entities:
   - uid: 8200
     components:

--- a/Resources/Maps/chibi.yml
+++ b/Resources/Maps/chibi.yml
@@ -28221,7 +28221,7 @@ entities:
     - type: Transform
       pos: 31.5,6.5
       parent: 2
-- proto: SuperweaponSafeSpawner
+- proto: GunSafeAdvancedLaser
   entities:
   - uid: 1408
     components:

--- a/Resources/Maps/edge.yml
+++ b/Resources/Maps/edge.yml
@@ -109163,7 +109163,7 @@ entities:
     - type: Transform
       pos: -24.5,-15.5
       parent: 2
-- proto: SuperweaponSafeSpawner
+- proto: GunSafeAdvancedLaser
   entities:
   - uid: 10894
     components:

--- a/Resources/Maps/glacier.yml
+++ b/Resources/Maps/glacier.yml
@@ -116432,7 +116432,7 @@ entities:
     - type: Transform
       pos: -15.5,24.5
       parent: 2
-- proto: SuperweaponSafeSpawner
+- proto: GunSafeAdvancedLaser
   entities:
   - uid: 18502
     components:

--- a/Resources/Maps/tortuga.yml
+++ b/Resources/Maps/tortuga.yml
@@ -195381,7 +195381,7 @@ entities:
     - type: Transform
       pos: -3.5,72.5
       parent: 33
-- proto: SuperweaponSafeSpawner
+- proto: GunSafeAdvancedLaser
   entities:
   - uid: 26015
     components:


### PR DESCRIPTION
## About the PR
Super weapons have been removed from
- Asterisk
- Byoin
- Chibi
- Edge
- Glacier
- Tortuga

## Why / Balance
The overlords demand it

## Technical details
Will communicate this to mappers in Discord

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [ ] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl: Velcroboy
:MAPS:
- remove: Asterisk: Removed superweapon
- remove: Byoin: Removed superweapon
- remove: Chibi: Removed superweapon
- remove: Edge: Removed superweapon
- remove: Glacier: Removed superweapon
- remove: Tortuga: Removed superweapon