### PR TITLE
Map Edits: Jug Hotfix

### DIFF
--- a/Resources/Maps/_DV/Events/ArenaMedieval.yml
+++ b/Resources/Maps/_DV/Events/ArenaMedieval.yml
@@ -127942,7 +127942,7 @@ entities:
       parent: 6747
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200

--- a/Resources/Maps/_DV/Salvage/DV-asteroid-mining-chemlab.yml
+++ b/Resources/Maps/_DV/Salvage/DV-asteroid-mining-chemlab.yml
@@ -2194,7 +2194,7 @@ entities:
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -2210,7 +2210,7 @@ entities:
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -2226,7 +2226,7 @@ entities:
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -2242,7 +2242,7 @@ entities:
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 75

--- a/Resources/Maps/_DV/Salvage/DV-laundromat-chunk.yml
+++ b/Resources/Maps/_DV/Salvage/DV-laundromat-chunk.yml
@@ -3462,14 +3462,12 @@ entities:
   entities:
   - uid: 264
     components:
-    - type: MetaData
-      name: jug (Bleach)
     - type: Transform
       pos: -0.5863483,10.646547
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -3482,14 +3480,12 @@ entities:
       currentLabel: Bleach
   - uid: 265
     components:
-    - type: MetaData
-      name: jug (Ammonia)
     - type: Transform
       pos: -0.3519733,10.599672
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -3502,14 +3498,12 @@ entities:
       currentLabel: Ammonia
   - uid: 267
     components:
-    - type: MetaData
-      name: jug (Super Suds)
     - type: Transform
       pos: 7.45502,5.636329
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -3522,14 +3516,12 @@ entities:
       currentLabel: Super Suds
   - uid: 338
     components:
-    - type: MetaData
-      name: jug (Detergent)
     - type: Transform
       pos: -0.6285926,5.559648
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200

--- a/Resources/Maps/_DV/Shuttles/Centcomm/ntcc_marquess_jani.yml
+++ b/Resources/Maps/_DV/Shuttles/Centcomm/ntcc_marquess_jani.yml
@@ -2140,18 +2140,14 @@ entities:
   entities:
   - uid: 254
     components:
-    - type: MetaData
-      name: jug (bleach)
     - type: Transform
       pos: 3.7016594,3.828351
       parent: 1
     - type: Label
       currentLabel: bleach
-    - type: NameModifier
-      baseName: jug
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -2162,18 +2158,14 @@ entities:
             Quantity: 200
   - uid: 384
     components:
-    - type: MetaData
-      name: jug (bleach)
     - type: Transform
       pos: 3.7016594,3.484601
       parent: 1
     - type: Label
       currentLabel: bleach
-    - type: NameModifier
-      baseName: jug
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200

--- a/Resources/Maps/arena.yml
+++ b/Resources/Maps/arena.yml
@@ -133851,7 +133851,7 @@ entities:
       parent: 6747
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200
@@ -133868,7 +133868,7 @@ entities:
       parent: 6747
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200

--- a/Resources/Maps/hammurabi.yml
+++ b/Resources/Maps/hammurabi.yml
@@ -196450,7 +196450,7 @@ entities:
       parent: 1
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200

--- a/Resources/Maps/tortuga.yml
+++ b/Resources/Maps/tortuga.yml
@@ -151125,14 +151125,12 @@ entities:
   entities:
   - uid: 30685
     components:
-    - type: MetaData
-      name: jug (Ammonia)
     - type: Transform
       pos: 7.3784237,58.221817
       parent: 33
     - type: SolutionContainerManager
       solutions:
-        beaker:
+        drink:
           temperature: 293.15
           canReact: True
           maxVol: 200


### PR DESCRIPTION
## About the PR
Solution container of jugs was changed, borking all the instances of edited jugs on maps. This changes to the correct container.

## Why / Balance
Bork is no longer borken

## Technical details
n/a

## Media
n/a

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [ ] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) 

**Changelog**
:cl: Velcroboy
:MAPS:
- fix: Fixed broken jugs across various maps 