### PR TITLE
Random War

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -98,8 +98,9 @@
     neck: SyndicateWhistle
     pocket2: CommanderUplinkRadio45TC # DeltaV - allows them to buy commander armor
     outerClothing: ClothingOuterCoatSyndieCapArmored # DeltaV - removal of armor
-  inhand:
-  - NukeOpsDeclarationOfWar
+    back: ClothingBackpackDuffelSyndicateFilledCommander # DeltaV - add war declarator to bag
+  #inhand:
+  #- NukeOpsDeclarationOfWar # DeltaV - put war declarator in bag
 
 - type: chameleonOutfit
   id: NukeopsCommanderOutfit

--- a/Resources/Prototypes/_DV/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Backpacks/duffelbag.yml
@@ -57,3 +57,16 @@
         - id: ClothingEyesGlassesSunglasses
         - id: ClothingHeadHatCommandSoft
         - id: ClothingHeadHatBeretCommand
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelSyndicateFilledCommander
+  name: syndicate duffel bag
+  description:  A large duffel bag for holding various traitor goods.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: NukeOpsDeclarationOfWar
+          prob: 0.5


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
War declarator has a 1/2 chance to be in commander's bag

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A tree PR arrives late
There seems to be a very high tendency for any nukies to be warops because "free tc".
However warops does get very tiring, and """"stealth"""" ops are cool despite all the mald they may generate.
I think adding a measure preventing EVERY nukeop to be war ensures things don't get too stale or meta, and nukies have to be willing to adapt.
It will suck if you have a gimmick you want to do, But there is nothing stopping a """stealth""" op from using their big red announcement console. They just won't have the extra TC for TDM mode.
I will admit the "risk of staleness" is probably much less likely after the PR that is invisible (i literally can't find it on github wtf) that fixes gamemodes from repeating
## Technical details
<!-- Summary of code changes for easier review. -->
add commander bag + fill table
add commander bag to commander loadout

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4e319806-0cf9-47ac-83e4-1cd33613df16" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The TC economy is in shambles, now only 50% of nukeops have the option to declare war for extra TC.
