### PR TITLE
Remove duplicate towels

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -64,9 +64,9 @@
   - TowelColorMaroon
   - TowelColorMime
   - TowelColorSilver
-  - TowelColorGold
   #- TowelColorWhite # DeltaV - Removed due because of being a duplicate
   #- TowelColorYellow # DeltaV - Removed due because of being a duplicate
+  - TowelColorGold
   # Begin DeltaV Additions
   - AACTablet
   - GoldRing

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -64,7 +64,6 @@
   - TowelColorMaroon
   - TowelColorMime
   - TowelColorSilver
-  - TowelColorWhite
   - TowelColorGold
   # Begin DeltaV Additions
   - AACTablet

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -65,6 +65,8 @@
   - TowelColorMime
   - TowelColorSilver
   - TowelColorGold
+  #- TowelColorWhite # DeltaV - Removed due because of being a duplicate
+  #- TowelColorYellow # DeltaV - Removed due because of being a duplicate
   # Begin DeltaV Additions
   - AACTablet
   - GoldRing

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -65,7 +65,6 @@
   - TowelColorMime
   - TowelColorSilver
   - TowelColorWhite
-  - TowelColorYellow
   - TowelColorGold
   # Begin DeltaV Additions
   - AACTablet


### PR DESCRIPTION
## About the PR
Me when we have two yellow/white towels in loadout.

## Why / Balance
Don't ask me why we had it twice, upstream moment ig?

## Technical details
We love -2 yml ops.

## Media
Before
<img width="515" height="1241" alt="image" src="https://github.com/user-attachments/assets/40cda6b3-28bf-4564-980d-f991c4f27406" />
After (bottom duplicates gone)
<img width="455" height="1101" alt="image" src="https://github.com/user-attachments/assets/9b330af7-f16f-402a-a5b3-db309a2f58e8" />



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- fix: Removes duplicates of yellow and white towels in loadout.
