### PR TITLE
Uplink pt 1 touchup

### DIFF
--- a/Resources/Locale/en-US/_DV/store/uplink/ammo.ftl
+++ b/Resources/Locale/en-US/_DV/store/uplink/ammo.ftl
@@ -8,4 +8,4 @@ uplink-caseless-pistol-tranq-name = pistol magazine (.25 caseless tranq)
 uplink-caseless-pistol-tranq-desc = A magazine with 10 rounds of tranquilizer ammunition loaded with Nocturine and Mute Toxin. Four rapid shots are needed to sedate. For use with the Cobra.
 
 uplink-caseless-pistol-poison-name = pistol magazine (.25 caseless toxin)
-uplink-caseless-pistol-poison-desc = A magazine with 10 rounds of poisonous ammunition loaded with Heartbreaker Toxin. Takes four shots and a short time to kill. For use with the Cobra.
+uplink-caseless-pistol-poison-desc = A magazine with 10 rounds of poisonous ammunition loaded with Lexorin. Takes four shots and a short time to kill. For use with the Cobra.

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -558,7 +558,7 @@
     attackRate: 1.5
     damage:
       types:
-        Blunt: 8
+        Blunt: 14 # DeltaV - 8 to 14
         Piercing: 4 # DeltaV - changed from 8 to 4
     bluntStaminaDamageFactor: 2.0 # DeltaV - added stamina damage
     soundHit:

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -559,7 +559,7 @@
     damage:
       types:
         Blunt: 14 # DeltaV - 8 to 14
-        Piercing: 4 # DeltaV - changed from 8 to 4
+        Piercing: 1 # DeltaV - changed from 8 to 1
     bluntStaminaDamageFactor: 2.0 # DeltaV - added stamina damage
     soundHit:
       collection: Punch

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -239,16 +239,16 @@
       path: /Audio/Weapons/Guns/Gunshots/estocshot.ogg
     minAngle: 30
     maxAngle: 43
-    shotsPerBurst: 2 # DeltaV - add two-tap
+    shotsPerBurst: 3 
     selectedMode: Burst
     availableModes:
     - Burst
     - SemiAuto
-    burstFireRate: 30 # DeltaV - add two-tap
-    burstCooldown: .5 # DeltaV - add two-tap
+    burstFireRate: 30 # DeltaV - add fast burst
+    burstCooldown: .5 # DeltaV - add fast burst
   - type: GunWieldBonus
     minAngle: -28
-    maxAngle: -25
+    maxAngle: -30 # DeltaV - change from -25 to -30
   - type: ItemSlots
     slots:
       gun_magazine:

--- a/Resources/Prototypes/_DV/Catalog/Uplink/ammo.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/ammo.yml
@@ -16,7 +16,7 @@
   icon: { sprite: _DV/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_pistol_mag.rsi, state: tranq }
   productEntity: MagazinePistolCaselessRifleTranquilizer
   cost:
-    Telecrystal: 4
+    Telecrystal: 3
   categories:
   - UplinkAmmo
 
@@ -27,6 +27,6 @@
   icon: { sprite: _DV/Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_pistol_mag.rsi, state: poison }
   productEntity: MagazinePistolCaselessRiflePoison
   cost:
-    Telecrystal: 5
+    Telecrystal: 4
   categories:
   - UplinkAmmo

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
@@ -61,7 +61,7 @@
     solutions:
       ammo:
         reagents:
-        - ReagentId: HeartbreakerToxin
-          Quantity: 2.5
+        - ReagentId: Lexorin
+          Quantity: 1.5
   - type: SolutionTransfer
-    maxTransferAmount: 2.5
+    maxTransferAmount: 1.5


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
increased knuckleduster blunt from 8 to 14 for 15 total damage (22.5dps) (this also increases the stun to 4 hits) (GOTNS is 32)
poison ammo now has lexorin and acts much faster (10 second to crit with 4 bullets)
poison and tranq ammo costs reduced by 1 each (4 and 3 tc)
estoc shoots in bursts of 3 again, shooting about 6 bullets per second in fast bursts

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
they are still ass and not used

## Technical details
<!-- Summary of code changes for easier review. -->
mnnnnn number

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
I have videos but github won't let me embed them (vagueposting king)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: .25 caseless poison ammo now uses lexorin and is faster acting.
- tweak: The estoc once again shoots in 3 round bursts, but still faster than before.
- tweak: Knuckledusters are now made of REAL plastitanium and deal 14 blunt per hit. Nanotrasen noggins can be rattled in 4 punches.

