### PR TITLE
Configure atmospherics to work more like LINDA

### DIFF
--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -60,3 +60,10 @@ storage_limit = 3
 [audio] # DeltaV
 attenuation = 4 # inversedistanceclamped 1 << 2, see audioparams.cs
 z_offset = -2
+
+# Begin DeltaV
+[atmos]
+monstermos_depressurization = false
+monstermos_equalization = false
+excited_groups = true
+# End DeltaV

--- a/Resources/ConfigPresets/DeltaV/deltav.toml
+++ b/Resources/ConfigPresets/DeltaV/deltav.toml
@@ -81,7 +81,9 @@ initiator_ghost_requirement = false
 voter_ghost_requirement = false
 
 [atmos]
-space_wind = true
+monstermos_depressurization = false
+monstermos_equalization = false
+excited_groups = true
 
 [shuttle]
 arrivals = true


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- atmos now uses LINDA rather than monstermos

## Why / Balance
- our maps are all designed with LINDA-style firelock setups (single-tile firelocks) rather than MMOS-style firelock setups (double thin firelocks) so spacing isn't contained when people need to do things like "get out of the spaced area"
- spacewind specifically in MMOS feels bad to play around, as it applies large impulses that because of how our how our physics control works, takes control away and grants it back to players at seemingly random times
- atmos situations should generally be reactable rather than "welp guess i'm spaced now" or "welp i'm plasmafired now"
- <img width="864" height="864" alt="Dahlia_Trit_Fire" src="https://github.com/user-attachments/assets/66aa85b7-6827-4bc5-8191-e6ff8c8c446b" />

## Technical details
cvars yay

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Atmospherics now uses LINDA instead of Monstermos for tile equalization. 
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
