### PR TITLE
fix: don't show SSD examine on dead people/ghost role

### DIFF
--- a/Content.Client/Administration/AdminNameOverlay.cs
+++ b/Content.Client/Administration/AdminNameOverlay.cs
@@ -237,11 +237,12 @@ internal sealed class AdminNameOverlay : Overlay
             }
 
             // DeltaV - SSD Time START
-            if (_entityManager.TryGetComponent<SSDIndicatorComponent>(entity, out var ssdIndicator) && ssdIndicator.IsSSD)
+            if (_entityManager.TryGetComponent<SSDIndicatorComponent>(entity, out var ssdIndicator)
+                && ssdIndicator.SsdSince is {} ssdSince)
             {
                 color = Color.MediumPurple;
                 color.A = alpha;
-                var ssdText = Loc.GetString("admin-overlay-ssd-time", ("time", (_timing.CurTime - ssdIndicator.SsdSince).ToString("%hh':'mm':'ss")));
+                var ssdText = Loc.GetString("admin-overlay-ssd-time", ("time", (_timing.CurTime - ssdSince).ToString("%hh':'mm':'ss")));
                 args.ScreenHandle.DrawString(_font, screenCoordinates + currentOffset, ssdText, uiScale, color);
                 currentOffset += lineoffset;
             }

--- a/Content.Shared/Mind/MindExamineSystem.cs
+++ b/Content.Shared/Mind/MindExamineSystem.cs
@@ -122,6 +122,11 @@ public sealed class MindExamineSystem : EntitySystem
         else
             ent.Comp.State = MindState.None;
 
+        // DeltaV - SSD Recency START
+        var ev = new MindStateUpdatedEvent(ent.Comp.State);
+        RaiseLocalEvent(ent, ref ev);
+        // DeltaV END
+
         Dirty(ent);
     }
 }

--- a/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorComponent.cs
@@ -50,11 +50,12 @@ public sealed partial class SSDIndicatorComponent : Component
     // DeltaV - SSD Recency Additions START
 
     /// <summary>
-    /// The time at which the Entity became SSD.
+    /// The time at which the player became SSD.
+    /// This will remain unset on SSD entities that never had minds attached, such as newly spawn ghost roles.
     /// </summary>
     [AutoNetworkedField, AutoPausedField]
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
-    public TimeSpan SsdSince = TimeSpan.Zero;
+    public TimeSpan? SsdSince;
 
     /// <summary>
     /// The icon displayed next to the associated entity when it is recently SSD (stage 2).

--- a/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
+++ b/Content.Shared/SSDIndicator/SSDIndicatorSystem.cs
@@ -1,6 +1,9 @@
 using Content.Shared._DV.CCVars; // DeltaV - SSD Recency
+using Content.Shared._DV.Mind; // DeltaV - SSD Recency
 using Content.Shared.CCVar;
 using Content.Shared.Examine; // DeltaV - SSD Recency
+using Content.Shared.Mobs.Systems; // DeltaV - SSD Recency
+using Content.Shared.Mind.Components; // DeltaV - SSD Recency
 using Content.Shared.StatusEffectNew;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
@@ -19,18 +22,20 @@ public sealed class SSDIndicatorSystem : EntitySystem
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!; // DeltaV - SSD Recency
 
     private bool _icSsdSleep;
     private float _icSsdSleepTime;
 
-    private TimeSpan _cryoableSsdSeconds; // DeltaV
-    private TimeSpan _recentSsdSeconds; // DeltaV
+    private TimeSpan _cryoableSsdSeconds; // DeltaV - SSD Recency
+    private TimeSpan _recentSsdSeconds; // DeltaV - SSD Recency
 
     public override void Initialize()
     {
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerAttachedEvent>(OnPlayerAttached);
         SubscribeLocalEvent<SSDIndicatorComponent, PlayerDetachedEvent>(OnPlayerDetached);
         SubscribeLocalEvent<SSDIndicatorComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<SSDIndicatorComponent, MindStateUpdatedEvent>(OnMindStateUpdated); // DeltaV - SSD Recency
 
         _cfg.OnValueChanged(CCVars.ICSSDSleep, obj => _icSsdSleep = obj, true);
         _cfg.OnValueChanged(CCVars.ICSSDSleepTime, obj => _icSsdSleepTime = obj, true);
@@ -43,12 +48,15 @@ public sealed class SSDIndicatorSystem : EntitySystem
     // DeltaV - SSD Recency START
     private void OnExamine(Entity<SSDIndicatorComponent> ent, ref ExaminedEvent args)
     {
-        if (!ent.Comp.IsSSD)
+        if (ent.Comp.SsdSince is not { } ssdSince)
+            return;
+
+        if (_mobState.IsDead(ent))
             return;
 
         using (args.PushGroup(nameof(SSDIndicatorComponent)))
         {
-            var timestamp = (_timing.CurTime - ent.Comp.SsdSince).ToString("%hh':'mm':'ss");
+            var timestamp = (_timing.CurTime - ssdSince).ToString("%hh':'mm':'ss");
             args.PushMarkup(Loc.GetString("ssd-examine-duration", ("time", timestamp)));
             args.PushMarkup(Loc.GetString($"ssd-examine-{GetStage(ent).ToString().ToLower()}"));
         }
@@ -58,17 +66,28 @@ public sealed class SSDIndicatorSystem : EntitySystem
     {
         var curTime = _timing.CurTime;
 
-        if (ent.Comp.SsdSince + _cryoableSsdSeconds < curTime)
+        if (ent.Comp.SsdSince + _recentSsdSeconds >= curTime)
         {
-            return SsdStage.Cryoable;
+            return SsdStage.VeryRecent;
         }
 
-        if (ent.Comp.SsdSince + _recentSsdSeconds < curTime)
+        if (ent.Comp.SsdSince + _cryoableSsdSeconds >= curTime)
         {
             return SsdStage.Recent;
         }
 
-        return SsdStage.VeryRecent;
+        return SsdStage.Cryoable;
+    }
+
+    public void OnMindStateUpdated(Entity<SSDIndicatorComponent> ent, ref MindStateUpdatedEvent args)
+    {
+        if (args.State is MindState.SSD or MindState.DeadSSD) {
+            if (ent.Comp.SsdSince is null)
+                 ent.Comp.SsdSince = _timing.CurTime;
+        }
+        else
+            ent.Comp.SsdSince = null;
+        Dirty(ent, ent.Comp);
     }
     // DeltaV END
 
@@ -95,8 +114,6 @@ public sealed class SSDIndicatorSystem : EntitySystem
         {
             component.FallAsleepTime = _timing.CurTime + TimeSpan.FromSeconds(_icSsdSleepTime);
         }
-
-        component.SsdSince = _timing.CurTime; // DeltaV - SSD Recency
 
         Dirty(uid, component);
     }

--- a/Content.Shared/_DV/Mind/MindStateUpdatedEvent.cs
+++ b/Content.Shared/_DV/Mind/MindStateUpdatedEvent.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared._DV.Mind;
+
+using Content.Shared.Mind.Components;
+
+[ByRefEvent]
+public record struct MindStateUpdatedEvent(MindState State);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
1. SSD timers no longer show on untaken ghost roles
2. SSD timers no longer show on the dead
3. SSD timers correctly track when players connect/disconnect instead of tracking when the mind is in the body
4. Catatonics now automatically receive a green SSD symbol instead of red
5. SSD timers no longer show on the catatonic

## Why / Balance
Untaken ghost roles: Not useful information. There is no player attached and the catatonic info text already provides all of the needed information.
Dead: To avoid metagaming in cases where a player leaves directly after dying and to discourage treatment priority based on logout time.
Track connect/disconnect: A more accurate metric. Does not get confused by ghosts leaving their bodies.

## Technical details
Completely ceased usage of the `IsSSD` member variable for the SSD timers (indicators still use it). `SsdSince` is now nullable, only not null when player properly SSD (disconnected). `IsSSD` is true when the player is out of their body.
Created new event `MindStateUpdatedEvent`, raised by `MindExamineSystem`, which already accurately tracks player SSD status.
If `SSD` or `DeadSSD`, start keeping track of the time. If this changes to any other value, reset the time to 0.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Don't display SSD duration when examining dead players or untaken ghost roles
