### PR TITLE
kill cult metashield

### DIFF
--- a/Resources/ServerInfo/Guidebook/_DV/Rules/GameRules/2_Metagaming.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Rules/GameRules/2_Metagaming.xml
@@ -80,14 +80,6 @@
    - being a Command role
    - being a traitor
 
-  ## Cultists
-
-  The fact that Cultists want to bring about the end of the world.
-
-  The revealing condition for this shield is any of the following:
-  - being a Captain
-  - being a Mystagogue
-  - being a Cosmic Cultist
 
   ## Explicitly Not Shielded
   The following is a list of things that are explicitly not shielded. If something is not on this list, it doesn't mean that it is shielded, but if something is on it then it definitely is not shielded.
@@ -95,7 +87,7 @@
   - The fact that the nuke disk must be protected and could be used by a bad actor to try to destroy the station.
   - The fact that the Syndicate are enemies of Nanotrasen, and that they regularly attempt to send covert agents to spy on, sabotage, or attack Nanotrasen.
   - A character's typical appearance. Though you should keep in mind that multiple characters can share the same name.
-  - The fact that Cultists are hostile to NanoTrasen, exist in some capacity, and should be reported.
+  - The fact that that Cultists want to bring about the end of the world.
 
   ## Metafriending and Metagrudging
   This section provides additional information on a concept that is prohibited by multiple metashield items that are never revealed IC. Giving a person or character preferential treatment based on something that your character should not know is considered metafriending. Treating a person or character negatively based on something that your character should not know is considered metagrudging.


### PR DESCRIPTION

## Why / Balance
no other game mode relies on the metashield to this insane a degree. kill it and let cultists do what they usually do but now we dont have to have annoying arguments over what constitutes noöspheric tampering and what is just 'being a cultist and thus not illegal'.
technically every 'deconvert every cultist they are mindwashed code red cultists kos' is an illegal order that should get cap jailed. thats stupid.

## Requirements
- [X] I am cool and awesome
- [X] I believe my PRs are goated as am I.

**Changelog**
:cl:
- remove: "Cosmic Cultists want to end the world" is now common knowledge. Their metashield has been removed.

