### PR TITLE
Change block coefficient for shields from .5 to .35, causing shields …

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -14,6 +14,7 @@
       size: Ginormous
       #heldPrefix: riot #Harmony Change: Removed due to being redundant
     - type: Blocking
+      passiveBlockFraction: 0.35 # DeltaV - Reduce default block coefficient from .5 to .35
       passiveBlockModifier:
         coefficients:
           Blunt: 0.9


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->

Changed the amount of damage that shields split with the user from 50/50 to 35/75, meaning shields now take 35% of the damage taken from 50%.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

This actually doesn't change player crit breakpoints by that much at all, often not changing them at all. For example, a player in a security hardsuit will go down to a dragon in 8 swings either way. This is because formerly, the shield would block more damage, but then break on the 6th hit, leaving the player shieldless for the remaining two hits until they crit. Now, the shield does not break at all due to splitting less damage up front. But because it blocks less damage, you go down in 8 hits anyway. This is basically a change that's intended to disincentivize picking up a shield and receiving too large of an up front power boost

This change affects all shields since it's a change done on the parent shield entity, but if we want, say, nukie shields to remain strong, you could make the energy shield still split 50% of damage taken, while other shields sit at 35%, or some combination thereof.

## Technical details
<!-- Summary of code changes for easier review. -->

a single line of yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- tweak: Reduced the passive block of shields from 50% to 35%, changing them to block less damage up front while still retaining the same amount of overall damage blocked over the lifetime of a single shield.
