### PR TITLE
Remove headset from pockets when player get zombified

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -246,17 +246,15 @@ public sealed partial class ZombieSystem
         //Should prevent instances of zombies using comms for information they shouldnt be able to have.
         _inventory.TryUnequip(target, "ears", true, true);
 
-        //DeltaV - remove radio form pockets of Laika and normal security dogs
-        var prototype = MetaData(target).EntityPrototype?.ID;
-        if (prototype is "MobSecDogLaika" or "MobSecDog")
+        // BEGIN DeltaV - Remove innate radio and radios from pockets
+        for (var i = 1; i <= 4; i++) // Arachnids have 4 pockets
         {
-            if (_inventory.TryGetSlotEntity(target, "pocket1", out var headset)
-                && HasComp<HeadsetComponent>(headset))
-            {
-                _inventory.TryUnequip(target, "pocket1", true, true);
-            }
+            if (_inventory.TryGetSlotEntity(target, $"pocket{i}", out var headset) && HasComp<HeadsetComponent>(headset))
+                _inventory.TryUnequip(target, $"pocket{i}", true, true);
         }
-        //End DeltaV
+
+        RemComp<ActiveRadioComponent>(target); // If the zombie has an innate radio, get rid of it.
+        // END DeltaV
 
         //popup
         _popup.PopupEntity(Loc.GetString("zombie-transform", ("target", target)), target, PopupType.LargeCaution);

--- a/Content.Server/Zombies/ZombieSystem.Transform.cs
+++ b/Content.Server/Zombies/ZombieSystem.Transform.cs
@@ -43,6 +43,7 @@ using Content.Shared.Tag;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Content.Shared.NPC.Prototypes;
+using Content.Shared.Radio.Components; // DeltaV
 using Content.Shared.Roles;
 using Content.Shared.Temperature.Components;
 
@@ -244,6 +245,18 @@ public sealed partial class ZombieSystem
         //_inventory.TryUnequip(target, "gloves", true, true); // DeltaV - Buff Zombies
         //Should prevent instances of zombies using comms for information they shouldnt be able to have.
         _inventory.TryUnequip(target, "ears", true, true);
+
+        //DeltaV - remove radio form pockets of Laika and normal security dogs
+        var prototype = MetaData(target).EntityPrototype?.ID;
+        if (prototype is "MobSecDogLaika" or "MobSecDog")
+        {
+            if (_inventory.TryGetSlotEntity(target, "pocket1", out var headset)
+                && HasComp<HeadsetComponent>(headset))
+            {
+                _inventory.TryUnequip(target, "pocket1", true, true);
+            }
+        }
+        //End DeltaV
 
         //popup
         _popup.PopupEntity(Loc.GetString("zombie-transform", ("target", target)), target, PopupType.LargeCaution);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Removes the headset from Laikas and the generic K9s pocket when they get zombified.
Fix for #5531 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Normal characters drop their headset when the get zombified, so they cant listen on comms/ metagame. The same should also apply to the Secdogs.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a check in `ZombieSystem.Transform` if the target is Laika or a K9. If a headset is in the pocket, drop it.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Zombified crew and other entities like Laika will drop headsets which are in their pockets. No more listening to survivor comms!