### PR TITLE
Feat/Tweak: Enable Xenoborg as a Gamemode in Secret + Tweak Role Requirement

### DIFF
--- a/Resources/Prototypes/Roles/Antags/xenoborgs.yml
+++ b/Resources/Prototypes/Roles/Antags/xenoborgs.yml
@@ -7,7 +7,14 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 18000  # 5 hrs
+    time: 72000  # DeltaV - 20 hrs, was 18000 # 5 hrs
+# Begin DeltaV Additions
+  - !type:OverallPlaytimeRequirement
+    time: 48h
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 2h
+# End DeltaV Additions
   guides: [ Xenoborgs ]
 
 - type: antag
@@ -19,5 +26,12 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 18000  # 5 hrs
+    time: 36000  # DeltaV - 10 hrs, was 18000 # 5 hrs
+# Begin DeltaV Additions
+  - !type:OverallPlaytimeRequirement
+    time: 24h
+  - !type:DepartmentTimeRequirement
+    department: Engineering
+    time: 2h
+# End DeltaV Additions
   guides: [ Xenoborgs ]

--- a/Resources/Prototypes/Roles/Antags/xenoborgs.yml
+++ b/Resources/Prototypes/Roles/Antags/xenoborgs.yml
@@ -7,14 +7,17 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 72000  # DeltaV - 20 hrs, was 18000 # 5 hrs
-# Begin DeltaV Additions
+    time: 20h  # DeltaV - was 18000 # 5 hrs
+  # Begin DeltaV Additions
   - !type:OverallPlaytimeRequirement
     time: 48h
+  - !type:RoleTimeRequirement
+    role: JobRoboticist
+    time: 2h
   - !type:DepartmentTimeRequirement
     department: Engineering
     time: 2h
-# End DeltaV Additions
+  # End DeltaV Additions
   guides: [ Xenoborgs ]
 
 - type: antag
@@ -26,12 +29,12 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 36000  # DeltaV - 10 hrs, was 18000 # 5 hrs
-# Begin DeltaV Additions
+    time: 10h  # DeltaV - was 18000 # 5 hrs
+  # Begin DeltaV Additions
   - !type:OverallPlaytimeRequirement
     time: 24h
   - !type:DepartmentTimeRequirement
     department: Engineering
     time: 2h
-# End DeltaV Additions
+  # End DeltaV Additions
   guides: [ Xenoborgs ]

--- a/Resources/Prototypes/_DV/secret_weights.yml
+++ b/Resources/Prototypes/_DV/secret_weights.yml
@@ -1,9 +1,10 @@
 - type: weightedRandom
   id: SecretDeltaV
   weights:
-    Survival: 0.30
-    Nukeops: 0.15
-    Zombie: 0.10
-    Traitor: 0.35
-    CosmicCult: 0.10 # my cult so cosmic!
+    Survival: 0.28
+    Nukeops: 0.14
+    Zombie: 0.08
+    Traitor: 0.34
+    CosmicCult: 0.08 # my cult so cosmic!
+    Xenoborgs: 0.08
     #Pirates: 0.15 #ahoy me bucko

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -238,6 +238,7 @@
     - xenoborgs
   name: xenoborgs-title
   description: xenoborgs-description
+  cooldown: 2 # DeltaV
   showInVote: false
   rules:
   - Xenoborgs
@@ -247,6 +248,8 @@
   - MeteorSwarmScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
+  - RampingStationEventScheduler # DeltaV
+  - GlimmerEventScheduler # DeltaV
 
 - type: gamePreset
   id: Zombie

--- a/Resources/ServerInfo/Guidebook/_DV/Rules/GameRules/2_Metagaming.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Rules/GameRules/2_Metagaming.xml
@@ -89,6 +89,16 @@
   - being a Mystagogue
   - being a Cosmic Cultist
 
+  ## Xenoborgs
+
+  The goal of Xenoborgs which is to turn all carbon-base life into silicon.
+
+  The revealing condition for this shield is any of the following:
+  - being a Xenoborg
+  - being put into a Xenoborg chassis
+  - seeing someone get borg-ed or crushed
+  - finding the mothership and seeing a body crusher
+
   ## Explicitly Not Shielded
   The following is a list of things that are explicitly not shielded. If something is not on this list, it doesn't mean that it is shielded, but if something is on it then it definitely is not shielded.
   - The fact that the shift will end. For example, acting upon the knowledge that a crew transfer shuttle is typically sent around the two hour mark of a shift.

--- a/Resources/ServerInfo/Guidebook/_DV/Rules/GameRules/2_Metagaming.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Rules/GameRules/2_Metagaming.xml
@@ -89,16 +89,6 @@
   - being a Mystagogue
   - being a Cosmic Cultist
 
-  ## Xenoborgs
-
-  The goal of Xenoborgs which is to turn all carbon-base life into silicon.
-
-  The revealing condition for this shield is any of the following:
-  - being a Xenoborg
-  - being put into a Xenoborg chassis
-  - seeing someone get borg-ed or crushed
-  - finding the mothership and seeing a body crusher
-
   ## Explicitly Not Shielded
   The following is a list of things that are explicitly not shielded. If something is not on this list, it doesn't mean that it is shielded, but if something is on it then it definitely is not shielded.
   - The fact that the shift will end. For example, acting upon the knowledge that a crew transfer shuttle is typically sent around the two hour mark of a shift.


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Three PRs in one, if CR needs this split between three PRs, I can do that:

- Xenoborg is included in the secret game mode pool at 8%, with tweaks to all weights to accommodate it. It is the same weight as Coscult and Zombie.
- `RampingStationEventScheduler` and `GlimmerEventScheduler` was added to the list of rules that run with Xenoborgs.
- Xenoborgs have a game mode cooldown of 2.

**Mothership Core Requirement:**
-20 Hours Cyborgs (Up from 5)
-48 Hours Gameplay
-2 Hours Engineering
-2 Hours Roboticist
**Xenoborg Requirement:**
-10 Hours Cyborgs (Up from 5)
-24 Hours Gameplay
-2 Hours Engineering

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Apart of my [Xenoborg Design Document found on the Discord](https://discord.com/channels/968983104247185448/1511610202405863527).

## Technical details
<!-- Summary of code changes for easier review. -->
YML + XML

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- add: Xenoborgs game mode was added to the secret game mode pool.
- tweak: Mothership Core and Xenoborgs time requirement were increased.
