### PR TITLE
tweak: better screenshake

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -464,18 +464,21 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             var effect = 5 * MathF.Pow(totalIntensity, 0.5f) * (1 - distance / range);
             if (effect > 0.01f)
             {
-                // Starlight START
+                // DeltaV - Distance falloff START
                 // _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
-                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.4f);
+                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.4f * Math.Max(1 - distance/range, 0.1f));
+                // DeltaV END
+
+                // Starlight START
                 var shakeParams = rangeList.Count < queued.Proto.SmallSoundIterationThreshold
                     ? new ESScreenshakeParameters() { Trauma = 0.4f, DecayRate = 0.2f, Frequency = 0.014f }
                     : new ESScreenshakeParameters() { Trauma = 0.6f, DecayRate = 0.05f, Frequency = 0.014f };
 
-                // DeltaV - Distance fall-of START
+                // DeltaV - Distance falloff START
                 shakeParams.DecayRate *= Math.Min(1 + distance / range, 1.75f);
                 shakeParams.Frequency *= Math.Max(1 - distance / range, 0.33f);
                 shakeParams.Trauma *= Math.Max(1 - distance / range, 0.33f);
-                // DeltaV - Distance fall-of END
+                // DeltaV END
 
                 Log.Debug($"Decay rate was {shakeParams.DecayRate}");
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -475,9 +475,9 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
                     : new ESScreenshakeParameters() { Trauma = 0.6f, DecayRate = 0.05f, Frequency = 0.014f };
 
                 // DeltaV - Distance falloff START
-                shakeParams.DecayRate *= Math.Min(1 + distance / range, 1.75f);
-                shakeParams.Frequency *= Math.Max(1 - distance / range, 0.33f);
-                shakeParams.Trauma *= Math.Max(1 - distance / range, 0.33f);
+                shakeParams.DecayRate *= MathF.Min(1 + distance / range, 1.75f);
+                shakeParams.Frequency *= MathF.Max(1 - distance / range, 0.33f);
+                shakeParams.Trauma *= MathF.Max(1 - distance / range, 0.33f);
                 // DeltaV END
 
                 _shake.Screenshake(players, shakeParams, null);

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -382,11 +382,6 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
 
         var visualEnt = CreateExplosionVisualEntity(pos, queued.Proto.ID, spaceMatrix, spaceData, gridData.Values, iterationIntensity);
 
-        // camera shake
-        // Starlight BEGIN - moved down
-        // CameraShake(iterationIntensity.Count * 4f, pos, queued.TotalIntensity);
-        // Starlight END
-
         //For whatever bloody reason, sound system requires ENTITY coordinates.
         var mapEntityCoords = _transformSystem.ToCoordinates(_map.GetMap(pos.MapId), pos);
 

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -466,7 +466,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             {
                 // DeltaV - Camera kick falloff START
                 // _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
-                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.1f * MathF.Exp(-5f * (distance / range)));
+                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.033f * MathF.Exp(-4f * (distance / range)));
                 // DeltaV END
 
                 // Starlight START

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -464,9 +464,9 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             var effect = 5 * MathF.Pow(totalIntensity, 0.5f) * (1 - distance / range);
             if (effect > 0.01f)
             {
-                // DeltaV - Distance falloff START
+                // DeltaV - Camera kick falloff START
                 // _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
-                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.4f * Math.Max(1 - distance/range, 0.1f));
+                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.1f * MathF.Exp(-5f * (distance / range)));
                 // DeltaV END
 
                 // Starlight START
@@ -474,7 +474,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
                     ? new ESScreenshakeParameters() { Trauma = 0.4f, DecayRate = 0.2f, Frequency = 0.014f }
                     : new ESScreenshakeParameters() { Trauma = 0.6f, DecayRate = 0.05f, Frequency = 0.014f };
 
-                // DeltaV - Distance falloff START
+                // DeltaV - Screenshake falloff START
                 shakeParams.DecayRate *= MathF.Min(1 + distance / range, 1.75f);
                 shakeParams.Frequency *= MathF.Max(1 - distance / range, 0.33f);
                 shakeParams.Trauma *= MathF.Max(1 - distance / range, 0.33f);

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -463,7 +463,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
                 // _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
 
                 // Exponential decay: N(t) = N₀ ⋅ e^(-λ ⋅ t)
-                // In this case, N = effect and we aren't decaying over time but with increasing distance,
+                // In this case, N = effect and we aren't decaying over time but with increasing distance from the epicenter,
                 // so t = distance / range.  Higher values of λ lead to faster decay, lower values to slower decay.
                 //
                 // severity is a fixed factor used to decrease the overall severity of the camera kick,
@@ -482,6 +482,8 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
                     : new ESScreenshakeParameters() { Trauma = 0.6f, DecayRate = 0.05f, Frequency = 0.014f };
 
                 // DeltaV - Screenshake falloff START
+                // Linear falloff with increasing distance from epicenter,
+                // capped at certain values to avoid diminishing the effect completely near range.
                 shakeParams.DecayRate *= MathF.Min(1 + distance / range, 1.75f);
                 shakeParams.Frequency *= MathF.Max(1 - distance / range, 0.33f);
                 shakeParams.Trauma *= MathF.Max(1 - distance / range, 0.33f);

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -480,8 +480,6 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
                 shakeParams.Trauma *= Math.Max(1 - distance / range, 0.33f);
                 // DeltaV END
 
-                Log.Debug($"Decay rate was {shakeParams.DecayRate}");
-
                 _shake.Screenshake(players, shakeParams, null);
                 // Starlight END
             }

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -466,7 +466,19 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             {
                 // DeltaV - Camera kick falloff START
                 // _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
-                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.033f * MathF.Exp(-4f * (distance / range)));
+
+                // Exponential decay: N(t) = N₀ ⋅ e^(-λ ⋅ t)
+                // In this case, N = effect and we aren't decaying over time but with increasing distance,
+                // so t = distance / range.  Higher values of λ lead to faster decay, lower values to slower decay.
+                //
+                // severity is a fixed factor used to decrease the overall severity of the camera kick,
+                // as the values were so high by default that decay was only becoming really noticeable near range.
+                //
+                // these changes are made here instead of directly assigning to the effect variable
+                // above to maintain the same overall effect range as before.
+                const float severity = 0.033f;
+                const float lambda = 4f;
+                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * severity * MathF.Exp(-lambda * (distance / range)));
                 // DeltaV END
 
                 // Starlight START

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -383,9 +383,9 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
         var visualEnt = CreateExplosionVisualEntity(pos, queued.Proto.ID, spaceMatrix, spaceData, gridData.Values, iterationIntensity);
 
         // camera shake
-        // ES START
+        // Starlight BEGIN - moved down
         // CameraShake(iterationIntensity.Count * 4f, pos, queued.TotalIntensity);
-        // ES END
+        // Starlight END
 
         //For whatever bloody reason, sound system requires ENTITY coordinates.
         var mapEntityCoords = _transformSystem.ToCoordinates(_map.GetMap(pos.MapId), pos);
@@ -416,12 +416,7 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             ? queued.Proto.SmallSoundFar
             : queued.Proto.SoundFar;
 
-        // ES START
-        var farTranslationShake = iterationIntensity.Count < queued.Proto.SmallSoundIterationThreshold
-            ? new ESScreenshakeParameters() { Trauma = 0.4f, DecayRate = 0.2f, Frequency = 0.014f }
-            : new ESScreenshakeParameters() { Trauma = 0.6f, DecayRate = 0.05f, Frequency = 0.014f };
-        _shake.Screenshake(filter, farTranslationShake, null);
-        // ES END
+        CameraShake(iterationIntensity, pos, queued); // Starlight
 
         _audio.PlayGlobal(farSound, farFilter, true, farSound.Params);
 
@@ -444,8 +439,13 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             _damageableSystem);
     }
 
-    private void CameraShake(float range, MapCoordinates epicenter, float totalIntensity)
+    private void CameraShake(List<float> rangeList, MapCoordinates epicenter, QueuedExplosion queued) // Starlight - replace range with rangeList, totalIntensity with queued
     {
+        // Starlight BEGIN
+        var range = rangeList.Count * 4f;
+        var totalIntensity = queued.TotalIntensity * 10f;
+        // Starlight END
+
         var players = Filter.Empty();
         players.AddInRange(epicenter, range, _playerManager, EntityManager);
 
@@ -463,7 +463,25 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             var distance = delta.Length();
             var effect = 5 * MathF.Pow(totalIntensity, 0.5f) * (1 - distance / range);
             if (effect > 0.01f)
-                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
+            {
+                // Starlight START
+                // _recoilSystem.KickCamera(uid, -delta.Normalized() * effect);
+                _recoilSystem.KickCamera(uid, -delta.Normalized() * effect * 0.4f);
+                var shakeParams = rangeList.Count < queued.Proto.SmallSoundIterationThreshold
+                    ? new ESScreenshakeParameters() { Trauma = 0.4f, DecayRate = 0.2f, Frequency = 0.014f }
+                    : new ESScreenshakeParameters() { Trauma = 0.6f, DecayRate = 0.05f, Frequency = 0.014f };
+
+                // DeltaV - Distance fall-of START
+                shakeParams.DecayRate *= Math.Min(1 + distance / range, 1.75f);
+                shakeParams.Frequency *= Math.Max(1 - distance / range, 0.33f);
+                shakeParams.Trauma *= Math.Max(1 - distance / range, 0.33f);
+                // DeltaV - Distance fall-of END
+
+                Log.Debug($"Decay rate was {shakeParams.DecayRate}");
+
+                _shake.Screenshake(players, shakeParams, null);
+                // Starlight END
+            }
         }
     }
 }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -31,6 +31,7 @@ using Content.Shared.Weapons.Melee.Events;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Weapons.Ranged.Systems;
+using Content.Shared.Wieldable.Components; // Starlight | ES Screenshake
 using Content.Shared.Zombies; // DeltaV - Buff Zombies
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
@@ -72,6 +73,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private readonly SharedESScreenshakeSystem _shake = default!;
     // ES END
 
+    private static readonly string BluntDamageName = "Blunt"; // Starlight | ES Screenshake
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
     /// <summary>
@@ -597,18 +599,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         if (damageResult.GetTotal() > FixedPoint2.Zero)
         {
             DoDamageEffect(targets, user, targetXform);
-
-            // ES START
-            // dog shit copy plaste but thats melee for you
-            var userShakeRotation = new ESScreenshakeParameters()
-                { Trauma = 0.08f, DecayRate = 1.0f, Frequency = 0.009f };
-            var otherShakeTranslation = new ESScreenshakeParameters() { Trauma = 0.45f, DecayRate = 1.1f, Frequency = 0.04f };
-            _shake.Screenshake(user, null, userShakeRotation);
-            foreach (var shakeTarget in targets)
-            {
-                _shake.Screenshake(shakeTarget, otherShakeTranslation, null);
-            }
-            // ES END
+            DoScreenshake(meleeUid, damageResult, user, targets); // Starlight | ES Screenshake
         }
     }
 
@@ -774,21 +765,10 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             _meleeSound.PlayHitSound(target, user, GetHighestDamageSound(appliedDamage, _protoManager), hitEvent.HitSoundOverride, component);
         }
 
-        // ES START
-        // dog shit copy plaste but thats melee for you
-        var userShakeRotation = new ESScreenshakeParameters()
-            { Trauma = 0.08f, DecayRate = 1.0f, Frequency = 0.009f };
-        var otherShakeTranslation = new ESScreenshakeParameters() { Trauma = 0.45f, DecayRate = 1.1f, Frequency = 0.04f };
-        _shake.Screenshake(user, null, userShakeRotation);
-        foreach (var shakeTarget in targets)
-        {
-            _shake.Screenshake(shakeTarget, otherShakeTranslation, null);
-        }
-        // ES END
-
         if (appliedDamage.GetTotal() > FixedPoint2.Zero)
         {
             DoDamageEffect(targets, user, Transform(targets[0]));
+            DoScreenshake(meleeUid, damage, user, targets); // Starlight | ES Screenshake
         }
 
         return true;
@@ -1104,4 +1084,35 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
             }
         }
     }
+
+    //Starlight begin | ES Screenshake
+    private void DoScreenshake(EntityUid weapon, DamageSpecifier damage, EntityUid attacker, List<EntityUid> targets)
+    {
+        if(damage.GetTotal()>8) // only show to others if it hurts real bad
+        {
+            var otherTranslation = new ESScreenshakeParameters
+            {
+                Trauma = 0.45f,
+                DecayRate = 1.1f,
+                Frequency = 0.04f,
+            };
+            foreach(var target in targets)
+                _shake.Screenshake(target, otherTranslation, null);
+        }
+
+        // only show to attacker if they put real oompf into it, or the weapon is just THAT strong
+        var bluntRequirement = damage.DamageDict.TryGetValue(BluntDamageName, out var blunt) && blunt >= 20;
+        var wieldRequirement = TryComp<WieldableComponent>(weapon, out var wieldable) && wieldable.Wielded;
+
+        if (!bluntRequirement && !wieldRequirement)
+            return;
+        var userRotation = new ESScreenshakeParameters
+        {
+            Trauma = 0.08f,
+            DecayRate = 1,
+            Frequency = 0.009f,
+        };
+        _shake.Screenshake(attacker, null, userRotation);
+    }
+    //Starlight end
 }

--- a/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
+++ b/Content.Shared/Weapons/Melee/SharedMeleeWeaponSystem.cs
@@ -73,7 +73,6 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     [Dependency] private readonly SharedESScreenshakeSystem _shake = default!;
     // ES END
 
-    private static readonly string BluntDamageName = "Blunt"; // Starlight | ES Screenshake
     private const int AttackMask = (int) (CollisionGroup.MobMask | CollisionGroup.Opaque);
 
     /// <summary>
@@ -1088,7 +1087,7 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
     //Starlight begin | ES Screenshake
     private void DoScreenshake(EntityUid weapon, DamageSpecifier damage, EntityUid attacker, List<EntityUid> targets)
     {
-        if(damage.GetTotal()>8) // only show to others if it hurts real bad
+        if(damage.GetTotal()>4) // only show to others if it hurts real bad // DeltaV - reduce from 8 to 4
         {
             var otherTranslation = new ESScreenshakeParameters
             {
@@ -1101,17 +1100,37 @@ public abstract class SharedMeleeWeaponSystem : EntitySystem
         }
 
         // only show to attacker if they put real oompf into it, or the weapon is just THAT strong
-        var bluntRequirement = damage.DamageDict.TryGetValue(BluntDamageName, out var blunt) && blunt >= 20;
-        var wieldRequirement = TryComp<WieldableComponent>(weapon, out var wieldable) && wieldable.Wielded;
+        // var bluntRequirement = damage.DamageDict.TryGetValue(BluntDamageName, out var blunt) && blunt >= 20; // DeltaV - unused
+        var isWielding = TryComp<WieldableComponent>(weapon, out var wieldable) && wieldable.Wielded;
 
-        if (!bluntRequirement && !wieldRequirement)
-            return;
-        var userRotation = new ESScreenshakeParameters
+        // DeltaV - unused
+        // if (!bluntRequirement && !wieldRequirement)
+        //    return;
+
+        // DeltaV - heavy/light screenshake variants START
+        ESScreenshakeParameters userRotation;
+        if (damage.GetTotal() >= 15 || isWielding)
         {
-            Trauma = 0.08f,
-            DecayRate = 1,
-            Frequency = 0.009f,
-        };
+            // heavy damage or two-handed
+            userRotation = new ESScreenshakeParameters
+            {
+                Trauma = 0.08f,
+                DecayRate = 1,
+                Frequency = 0.009f,
+            };
+        }
+        else
+        {
+            // light damage
+            userRotation = new ESScreenshakeParameters
+            {
+                Trauma = 0.06f,
+                DecayRate = 1,
+                Frequency = 0.0045f,
+            };
+        }
+        // DeltaV END
+
         _shake.Screenshake(attacker, null, userRotation);
     }
     //Starlight end


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
- Explosion screenshake now falls off with increasing distance and includes camera kick for directionality.
- Melee screenshake now depends on damage/wielding

## Why / Balance
Makes the explosion screenshake feel less random. Screenshake when attacking with knives and other small weapons was weird, now they have less heavy screenshake if damage < 15 and they're not wielded.

## Technical details
- Ported damage-dependent melee screenshake and camera kick from https://github.com/ss14Starlight/space-station-14/pull/3707
  - Threw a lot of it out in later commits
- Modified damage-based screenshake function to instead differentiate between light and heavy attacks by just comparing with totaldamage and wielding status
- Modified the screenshake and camera kick parameters for the explosion system to take distance into account

## Media
<details>
<summary>Initial PR/changes</summary>

[pr-screenshake-tweaks.webm](https://github.com/user-attachments/assets/7aeaf75a-2cf1-464d-b034-db3b2f68f49b)

[pr-screenshake-tweaks-melee.webm](https://github.com/user-attachments/assets/079cc82e-792b-45a2-8cab-61de69ec974f)

**First explosion kick adjustment**

[pr-screenshake-tweaks-explosion-kick-falloff-2.webm](https://github.com/user-attachments/assets/62c1f000-93c9-403d-97f2-05661f63dbe9)

</details>

<details open>
<summary>Current state</summary>

[pr-screenshake-tweaks-explosion-kick-falloff-3.webm](https://github.com/user-attachments/assets/e24f1b51-63fb-4305-97de-7db111f436fc)

[pr-screenshake-tweaks-melee-2.webm](https://github.com/user-attachments/assets/75f7b7b4-d27c-4e5b-a1c7-ada4df2b9b22)
</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: DisposableCrewmember42, neomoth
- tweak: Melee screenshake for the attacker now has a heavy and light damage variant. The heavy damage variant is also triggered by two-handed weapons being wielded.
- tweak: Melee screenshake only occurs for the target if total damage > 4
- tweak: Explosion screenshake now includes a directional camera kick that falls off with distance
- tweak: Explosion screenshake now falls off with distance
