### PR TITLE
increase execution damage

### DIFF
--- a/Content.Server/_DV/Execution/ExecutionSystem.cs
+++ b/Content.Server/_DV/Execution/ExecutionSystem.cs
@@ -49,7 +49,7 @@ public sealed class ExecutionSystem : EntitySystem
     [Dependency] private readonly GunSystem _gunSystem = default!;
 
     private const float GunExecutionTime = 6.0f;
-    private const float DamageModifier = 9.0f;
+    private const float DamageModifier = 15.0f;
 
     /// <inheritdoc/>
     public override void Initialize()


### PR DESCRIPTION


## About the PR
increase execution damage modifier from 9 to 15

## Why / Balance
i cuffed a secoff and forgot to take their armor off so they survived me executing them with a combat knife, idk how to make executing AP so this is what we get instead

number is made up because i felt like it.

## Requirements

- [X] I have not  tested any added content or changes.
- [X] I have not added media to this PR even if it does require an in-game showcase.



**Changelog**

:cl:
- tweak: Executing now deals 15x damage (from 9x)


