### PR TITLE
Sabotage borg nerf

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -1,4 +1,4 @@
-﻿# Be careful with these as they get removed on shutdown too!
+# Be careful with these as they get removed on shutdown too!
 - type: entity
   id: AiHeld
   save: false # DeltaV - AI PDAs
@@ -668,11 +668,11 @@
       borg_brain:
         - SyndicateNeuroling # DeltaV
       borg_module:
-        - BorgModuleAdvancedTool # Delta V - replaced tool module
+        - BorgModuleTool
         - BorgModuleCable # DeltaV
         - BorgModuleConstruction # DeltaV
         - BorgModuleOperative
-        - BorgModuleSyndicateWeapon
+        # - BorgModuleSyndicateWeapon # DeltaV - removed for balance
         - BorgModuleCloakDeviceSyndicate # DeltaV
       borg_id_chip: # DeltaV - borg id chips
       - IdChipSyndie

--- a/Resources/Prototypes/_DV/Catalog/Uplink/allies.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/allies.yml
@@ -50,6 +50,6 @@
   discountDownTo:
     Telecrystal: 7
   cost:
-    Telecrystal: 13
+    Telecrystal: 12
   categories:
   - UplinkAllies


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Remove advanced tools module (back to basic tools)
Remove weapons module

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
sabotage borg had:
advanced toolkit (over 8tc value alone)
invisibility (Hard to calculate)
emag and AAO (also 8tc)
recharging viper and epen (5tc+)
+/- being a ghost role so this thing can operate completely independently. Sometimes these are purchased and not really given orders so they default to fucking with everything they can touch including sabotaging the singulo (as if it had DAGD, free DAGD consequences with your 13tc purchase)

It can infinitely weld itself and hold cables. Sabotage targets engineering and is very hard for security to counter as it's basically one cut or unanchor pipe to set the station back 10 minutes. This combined with having a kit to defend itself, be invisible, and have practically AA (infinitely recharging emags are such a joke) that this guy is able to run laps around just about anyone. For 13tc any syndicate can basically end the round or severely set it back almost guarenteed. Basically all the problems with ninja minus instastun apply here. Also a concerning pattern of these being bought and the modules get looted by crew borgs.
The kit is just insanely pushed and these things make the round miserable by being massive trolls with high mobility and easy escape + weld and its like nothing happened. 

Also the advanced tool module minorly doesn't make sense why does the syndicate have NT JOL and research items. It also straight up doesn't need it. I'd like there to be some skill needed to really show the borg hacking everything instead of just prying open doors. Also the infinite welding fuel is an issue as stated above. Default tool module gets 250 fuel which is quite a bit of healing + a couple reinforced walls without needing to refuel.

I have wanted this nerfed for a while and thought to just increase the TC cost but halo asked that the kit be nerfed instead of cost increased so that it is not accessible for a regular syndicate / traitor.

## Technical details
<!-- Summary of code changes for easier review. -->
Change 2 modules

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5c3fa40f-9f52-4267-ae4b-0307d9d52c5f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: The syndicate saboteur cyborg no longer comes with weapons or an advanced tool module.  Cybersun stocks are down 13%. 

