### PR TITLE
Make SuperSynths craftable + musician trinket item only

### DIFF
--- a/Resources/Locale/en-US/_DV/recipes/tags.ftl
+++ b/Resources/Locale/en-US/_DV/recipes/tags.ftl
@@ -50,3 +50,7 @@ construction-graph-tag-silversword = silver sword
 # Other
 construction-graph-tag-jug = jug
 construction-graph-tag-beaker = beaker
+construction-graph-tag-eletricguitar = Eletric Guitar
+construction-graph-tag-harmonica = Harmonica
+construction-graph-tag-daw = Digital Audio Workstation Machine board
+construction-graph-tag-Synthesizer = Synthesizer

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -833,6 +833,11 @@
           amount: 1
           defaultPrototype: SaxophoneInstrument
           examineName: construction-insert-info-examine-name-instrument-woodwind
+  # Begin DeltaV additions
+  - type: Tag
+    tags:
+    - DawInstrumentMachineCircuitboard
+  # End DeltaV additions
 
 - type: entity
   id: PortableGeneratorPacmanMachineCircuitboard

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instrument_keyed.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instrument_keyed.yml
@@ -22,6 +22,11 @@
     sprite: Objects/Fun/Instruments/h_synthesizer.rsi
   - type: StaticPrice
     price: 90
+  # Begin DeltaV additions
+  - type: Tag
+    tags:
+    - SynthesizerInstrument
+  # End DeltaV additions
 
 - type: entity
   parent: BaseKeyedInstrument
@@ -48,6 +53,9 @@
     heldPrefix: super
     size: Normal #DeltaV - Ensures that the sprite properly renders, had to add this because it wouldn't render properly on the ground and in UI/bag UI otherwise.
     sprite: Objects/Fun/Instruments/h_synthesizer.rsi
+  - type: Construction
+    graph: SuperSynthesizerGraph
+    node: supersynth
 
 - type: entity
   parent: SuperSynthesizerInstrument

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_string.yml
@@ -44,6 +44,9 @@
     damage:
       types:
         Blunt: 6
+  - type: Tag
+    tags:
+    - EletricGuitarInstrument
   # End DeltaV additions
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/Instruments/instruments_wind.yml
@@ -49,7 +49,12 @@
     slots:
     - neck
   - type: ActivatableUI
-    inHandsOnly: false  
+    inHandsOnly: false
+  # Begin DeltaV additions
+  - type: Tag
+    tags:
+    - HarmonicaInstrument
+  # End DeltaV additions
 
 - type: entity
   parent: BaseWoodwindInstrument

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -76,7 +76,6 @@
   - TapeRecorder
   - ClothingHeadHatUshanka
   - Eyepatch
-  - SuperSynthesizerInstrument #Delta-V - Ports Super Synth Trinket from Starlight
   - LighterFlippo
   - LighterDonkCo
   - LighterHonkCo
@@ -909,6 +908,7 @@
   - PanFlute
   - Ocarina
   - Bagpipe
+  - SuperSynthesizerInstrument # DeltaV - Make SuperSynths musician only
 
 - type: loadoutGroup
   id: MusicianJobTrinkets

--- a/Resources/Prototypes/_DV/Recipes/Crafting/Graphs/supersynth.yml
+++ b/Resources/Prototypes/_DV/Recipes/Crafting/Graphs/supersynth.yml
@@ -1,0 +1,33 @@
+- type: constructionGraph
+  id: SuperSynthesizerGraph
+  start: start
+  graph:
+    - node: start
+      edges:
+        - to: supersynth
+          steps:
+            - tag: EletricGuitarInstrument
+              name: construction-graph-tag-eletricguitar
+              icon:
+                sprite: Objects/Fun/Instruments/eguitar.rsi
+                state: icon
+            - tag: HarmonicaInstrument
+              name: construction-graph-tag-harmonica
+              icon:
+                sprite: Objects/Fun/Instruments/harmonica.rsi
+                state: icon
+            - tag: DawInstrumentMachineCircuitboard
+              name: construction-graph-tag-daw
+              icon:
+                sprite: Objects/Misc/module.rsi
+                state: service
+            - tag: SynthesizerInstrument
+              name: construction-graph-tag-Synthesizer
+              icon:
+                sprite: Objects/Fun/Instruments/h_synthesizer.rsi
+                state: icon
+            - material: Bluespace
+              amount: 2
+              doAfter: 5
+    - node: supersynth
+      entity: SuperSynthesizerInstrument

--- a/Resources/Prototypes/_DV/Recipes/Crafting/supersynth.yml
+++ b/Resources/Prototypes/_DV/Recipes/Crafting/supersynth.yml
@@ -1,0 +1,7 @@
+- type: construction
+  id: SuperSynthesizerInstrument
+  graph: SuperSynthesizerGraph
+  startNode: start
+  targetNode: supersynth
+  category:  construction-category-misc
+  objectType: Item

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -281,3 +281,15 @@
 
 - type: Tag
   id: PurifyingSalts
+
+- type: Tag
+  id: EletricGuitarInstrument # ConstructionGraph: SuperSynthesizerGraph
+
+- type: Tag
+  id: HarmonicaInstrument # ConstructionGraph: SuperSynthesizerGraph
+
+- type: Tag
+  id: DawInstrumentMachineCircuitboard # ConstructionGraph: SuperSynthesizerGraph
+
+- type: Tag
+  id: SynthesizerInstrument # ConstructionGraph: SuperSynthesizerGraph


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removes the Super Synth from trinkets. Makes it only musician trinket in loadouts after certain hours and also craftable. 
Crafting requirements are:
- Eletric guitar
- Harmonica
- Syntheziser
- DAW board
- 2 bluespace crystals

## Why / Balance
Mostly by request of the community feedback thing.

Personally, it detracts the experience for me. Why bother buying cool instruments and forming a band, when you can be a one man band by slinging this thing over your shoulder and playing wherever you go? So if you want the super synth, earn it. I don't play musician a lot, but it's "better" DAW, since you can easily carry it around wherever, than lugging some computer.

**Also, I kindly ask CM to think whenever this should remain as a musician trinket too. I left it there since it was a trinket originally. I personally believe that trinkets should generally not give you an advantage or be better than other options. They can either be joke/useless things or just some variantion.**

## Technical details
First time making crafting PR. I dunno how things go.

## Media
<img width="546" height="386" alt="image" src="https://github.com/user-attachments/assets/3db923c1-a880-42d8-b9e2-4599d5afc5de" />
<img width="582" height="559" alt="image" src="https://github.com/user-attachments/assets/4e0c026e-e4ab-4522-ad3b-38f807d15743" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- remove: Removed Super Synthesizers from loadout trinkets. It's now a musician only item, in instruments.
- add: Super Synthesizers are now craftable! Will require some makeshift instrument tinkering and bluespace magic.