### PR TITLE
Make Security's radio red again

### DIFF
--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -46,7 +46,7 @@
   name: chat-radio-security
   keycode: 's'
   frequency: 1359
-  color: "#8c93f5" # DeltaV - Security is blue, was "#ff4242"
+  color: "#ff4242"
 
 - type: radioChannel
   id: Service


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I made security's radio red.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I really don't think that having a blue radio is worthwhile. Several blue radios have been tried, and they've all been fairly ambiguous. The current radio has a fair bit of overlap with dead chat, and frankly doesn't even _match_ the department's colors. There's already plenty of blue radios already in the game, and I'm not confident that there is _space_ to make a distinct blue radio that doesn't overlap with something else.  

There's already precedent established with radios mismatching departmental colors for the sake of clarity, with command being yellow despite the departmental colours being blue. I feel like it's more useful for security's radio to be clearly visible than having it match the departmental blue. Having a distinct color is very useful in a game where chat spam is common.

70% of the server (or at least 70% of those who pay attention to polls) voted to change the color back to red, which is not a small margin? The server isn't a democracy of course, but that's a significant margin for a fairly minor change. 

<sub> This is a lot of yap for a single line change ;-; </sub>

## Technical details
<!-- Summary of code changes for easier review. -->
one (1) (i)  line of yaml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="304" height="38" alt="Screenshot 2026-06-22 225932" src="https://github.com/user-attachments/assets/46dd0542-6e2c-4876-a984-7a70cf415fd7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Security's radio is now red (again)