### PR TITLE
Replace nachos recipes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -29,7 +29,7 @@
   parent: [ ClothingEyesBase, BaseToggleClothing ] # DeltaV - Added BaseToggleClothing
   id: ClothingEyesHudDiagnostic
   name: diagnostic hud
-  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium. Has a camera mod to work with Station AI. # DeltaV - Add last se[...]
+  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium. Has a camera mod to work with Station AI. # DeltaV - Add last sentence
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/diag.rsi
@@ -185,23 +185,6 @@
     sprite: Clothing/Eyes/Hud/medonionbeer.rsi
   - type: ShowHungerIcons
   - type: ShowThirstIcons
-
-- type: entity
-  parent: [ClothingEyesBase, ShowMedicalIcons]
-  id: ClothingEyesHudZookeeperAnimal
-  name: zookeeper animal hud
-  description: A specialized heads-up display designed for zookeepers to monitor the health, hunger, and thirst status of animals in their care. Shows vital signs specific to fauna.
-  components:
-  - type: Sprite
-    sprite: Clothing/Eyes/Hud/medonionbeer.rsi
-  - type: Clothing
-    sprite: Clothing/Eyes/Hud/medonionbeer.rsi
-  - type: ShowHungerIcons
-  - type: ShowThirstIcons
-  - type: Tag
-    tags:
-    - HudMedical
-    - PetWearable
 
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons, BaseSecurityCommandContraband]

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -29,7 +29,7 @@
   parent: [ ClothingEyesBase, BaseToggleClothing ] # DeltaV - Added BaseToggleClothing
   id: ClothingEyesHudDiagnostic
   name: diagnostic hud
-  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium. Has a camera mod to work with Station AI. # DeltaV - Add last sentence
+  description: A heads-up display capable of analyzing the integrity and status of robotics and exosuits. Made out of see-borg-ium. Has a camera mod to work with Station AI. # DeltaV - Add last se[...]
   components:
   - type: Sprite
     sprite: Clothing/Eyes/Hud/diag.rsi
@@ -185,6 +185,23 @@
     sprite: Clothing/Eyes/Hud/medonionbeer.rsi
   - type: ShowHungerIcons
   - type: ShowThirstIcons
+
+- type: entity
+  parent: [ClothingEyesBase, ShowMedicalIcons]
+  id: ClothingEyesHudZookeeperAnimal
+  name: zookeeper animal hud
+  description: A specialized heads-up display designed for zookeepers to monitor the health, hunger, and thirst status of animals in their care. Shows vital signs specific to fauna.
+  components:
+  - type: Sprite
+    sprite: Clothing/Eyes/Hud/medonionbeer.rsi
+  - type: Clothing
+    sprite: Clothing/Eyes/Hud/medonionbeer.rsi
+  - type: ShowHungerIcons
+  - type: ShowThirstIcons
+  - type: Tag
+    tags:
+    - HudMedical
+    - PetWearable
 
 - type: entity
   parent: [ClothingEyesBase, ShowSecurityIcons, ShowMedicalIcons, BaseSecurityCommandContraband]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/ingredients.yml
@@ -818,6 +818,7 @@
     entries:
       Taco: CheeseTaco
       Burger: CheeseBurger
+      Nachos: CheeseTaco # DeltaV
   - type: Item
     size: Tiny
     storedOffset: 0,-3

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -114,8 +114,20 @@
   - type: FlavorProfile
     flavors:
       - nachos
+  #- type: Sprite # DeltaV - replaced below to add foodSequenceLayers slot for sequence system
+  #  state: nachos
+  # Begin DeltaV additions - nachos can be topped with cheese or chili to metamorph into variants
   - type: Sprite
-    state: nachos
+    sprite: Objects/Consumable/Food/meals.rsi
+    layers:
+    - state: nachos
+    - map: ["foodSequenceLayers"]
+  - type: Appearance
+  - type: FoodSequenceStartPoint
+    key: Nachos
+  - type: FoodMetamorphableByAdding
+    onlyFinal: false
+  # End DeltaV additions
   - type: SolutionContainerManager
     solutions:
       food:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -1503,6 +1503,7 @@
       Taco: ChiliPepper
       Burger: ChiliPepper
       Skewer: ChiliPepperSkewer
+      Nachos: ChiliPepper # DeltaV
 
 - type: entity
   name: chilly pepper

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/taco.yml
@@ -34,6 +34,11 @@
     nameGeneration: food-sequence-taco-gen
     contentSeparator: ", "
   - type: Appearance
+  # Begin DeltaV additions - slicing a taco shell with a knife yields 2 nachos
+  - type: SliceableFood
+    count: 2
+    slice: FoodMealNachos
+  # End DeltaV additions
 
 # Old tacos
 

--- a/Resources/Prototypes/Recipes/Cooking/sequence_metamorph.yml
+++ b/Resources/Prototypes/Recipes/Cooking/sequence_metamorph.yml
@@ -123,3 +123,31 @@
   - !type:LastElementHasTags # last bun
     tags:
     - Bun
+
+# Begin DeltaV additions - nachos metamorph recipes
+- type: metamorphRecipe
+  id: NachosCheesy
+  key: Nachos
+  result: FoodMealNachosCheesy
+  rules:
+  - !type:SequenceLength
+    range:
+      min: 1
+      max: 1
+  - !type:LastElementHasTags
+    tags:
+    - Cheese
+
+- type: metamorphRecipe
+  id: NachosCuban
+  key: Nachos
+  result: FoodMealNachosCuban
+  rules:
+  - !type:SequenceLength
+    range:
+      min: 1
+      max: 1
+  - !type:LastElementHasTags
+    tags:
+    - Vegetable # Only vegetable tag for now since the only vegetable we allow on nachos is chili and they don't have another tag
+# End DeltaV additions

--- a/Resources/Prototypes/_DV/Recipes/Cooking/deep_fryer_recipes.yml
+++ b/Resources/Prototypes/_DV/Recipes/Cooking/deep_fryer_recipes.yml
@@ -47,55 +47,56 @@
   baseRecipe: RecipeCarrotFries
   burnTime: 10
 
-- type: microwaveMealRecipe
-  id: RecipeNachos # Renamed to tortilla chips (nachos have cheese)
-  name: nachos recipe
-  result: FoodMealNachos
-  secretRecipe: true
-  time: 10
-  group: DeepFried
-  deepFried: true
-  solids:
-    FoodDoughTortillaFlat: 1
-
-- type: deepFryerRecipe
-  id: DeepFryerRecipeTortillaChips
-  baseRecipe: RecipeNachos
-  burnTime: 15
-
-- type: microwaveMealRecipe
-  id: RecipeNachosCheesy
-  name: cheesy nachos recipe
-  result: FoodMealNachosCheesy
-  secretRecipe: true
-  time: 10
-  group: DeepFried
-  deepFried: true
-  solids:
-    FoodCheeseSlice: 1
-    FoodDoughTortillaFlat: 1
-
-- type: deepFryerRecipe
-  id: DeepFryerRecipeNachosCheesy
-  baseRecipe: RecipeNachosCheesy
-  burnTime: 15
-
-- type: microwaveMealRecipe
-  id: RecipeNachosCuban
-  name: cuban nachos recipe
-  result: FoodMealNachosCuban
-  secretRecipe: true
-  time: 10
-  group: DeepFried
-  deepFried: true
-  solids:
-    FoodChiliPepper: 1
-    FoodDoughTortillaFlat: 1
-
-- type: deepFryerRecipe
-  id: DeepFryerRecipeNachosCuban
-  baseRecipe: RecipeNachosCuban
-  burnTime: 15
+# DeltaV - nachos are now made by slicing a taco shell; cheesy/cuban variants come from the sequence metamorph system
+#- type: microwaveMealRecipe
+#  id: RecipeNachos
+#  name: nachos recipe
+#  result: FoodMealNachos
+#  secretRecipe: true
+#  time: 10
+#  group: DeepFried
+#  deepFried: true
+#  solids:
+#    FoodDoughTortillaFlat: 1
+#
+#- type: deepFryerRecipe
+#  id: DeepFryerRecipeTortillaChips
+#  baseRecipe: RecipeNachos
+#  burnTime: 15
+#
+#- type: microwaveMealRecipe
+#  id: RecipeNachosCheesy
+#  name: cheesy nachos recipe
+#  result: FoodMealNachosCheesy
+#  secretRecipe: true
+#  time: 10
+#  group: DeepFried
+#  deepFried: true
+#  solids:
+#    FoodCheeseSlice: 1
+#    FoodDoughTortillaFlat: 1
+#
+#- type: deepFryerRecipe
+#  id: DeepFryerRecipeNachosCheesy
+#  baseRecipe: RecipeNachosCheesy
+#  burnTime: 15
+#
+#- type: microwaveMealRecipe
+#  id: RecipeNachosCuban
+#  name: cuban nachos recipe
+#  result: FoodMealNachosCuban
+#  secretRecipe: true
+#  time: 10
+#  group: DeepFried
+#  deepFried: true
+#  solids:
+#    FoodChiliPepper: 1
+#    FoodDoughTortillaFlat: 1
+#
+#- type: deepFryerRecipe
+#  id: DeepFryerRecipeNachosCuban
+#  baseRecipe: RecipeNachosCuban
+#  burnTime: 15
 
 - type: microwaveMealRecipe
   id: RecipeFriedChicken

--- a/Resources/Prototypes/_DV/tags.yml
+++ b/Resources/Prototypes/_DV/tags.yml
@@ -133,6 +133,9 @@
   id: MothroachHide
 
 - type: Tag
+  id: Nachos # Food sequence key
+
+- type: Tag
   id: Natural
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Replace nachos recipe to prevent deep fryer conflicts. Added the stacking ability for cuban and cheesy nachos

## Why / Balance
https://github.com/DeltaV-Station/Delta-v/issues/6023
Conflicts in the deep fryer recipe resutled in regular nachos not being able to be made

## Technical details
Removed deepfryer nacho recipes
Made nachos sliceable from a taco shell (1 shell, 2 nachos)
Made cuban and cheesy nachos stackable starting from regular nachos with either cheese or chili pepper

## Media
TBD

## Requirements
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- tweak: Changed taco recipes, cut them from taco shells and add chili or cheese for variants.

