### PR TITLE
Commented out Surgeon Job Requirement for CMO

### DIFF
--- a/Resources/Prototypes/_DV/Roles/Jobs/requirement_overrides.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/requirement_overrides.yml
@@ -65,9 +65,9 @@
     - !type:RoleTimeRequirement
       role: JobChemist
       time: 6h
-    - !type:RoleTimeRequirement
-      role: JobSurgeon
-      time: 3h
+    #- !type:RoleTimeRequirement
+    #  role: JobSurgeon
+    #  time: 3h
     - !type:RoleTimeRequirement
       role: JobMedicalDoctor
       time: 12h


### PR DESCRIPTION
## About the PR
Commented out Surgeon Job requirement for CMO so new players and returning veterans can actually play CMO, as Surgeons are no longer a job for now.

## Why / Balance
We need more CMOs.

## Technical details
I want to be able to play CMO again some day.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl:
- remove: Removed the Surgeon time requirement for Chief Medical Officer, since surgery is once again a week away.