### PR TITLE
Reduce Holoparasite Cost

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1293,9 +1293,9 @@
   productEntity: BoxHoloparasite
   discountCategory: usualDiscounts
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 4 #Delta-V was 8
   cost:
-    Telecrystal: 14
+    Telecrystal: 8 #Delta-V was 14
   categories:
   - UplinkAllies
   conditions:


### PR DESCRIPTION

## Why / Balance
wow i wish i could pay 14tc for gloves of the northstar in exchange for them not working half the time! I'm glad i bought an ally that will walk into shotguns and deal AP damage to me. 


**Changelog**
:cl:
- tweak: Reduced Holoparasite price to 8 (from 14), and 4 on discount (was 8)

