### PR TITLE
Add Vestine to the ChemVend

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -32,6 +32,7 @@
   emaggedInventory: # DeltaV
     ChemistryBottleLead: 2 # DeltaV - Added lead to standard chemvend
     BluespaceBeaker: 1 # Funkychem - let traitor chemists make nefarious batches
+    ChemistryBottleVestine: 2 # DeltaV
 
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -32,7 +32,7 @@
   emaggedInventory: # DeltaV
     ChemistryBottleLead: 2 # DeltaV - Added lead to standard chemvend
     BluespaceBeaker: 1 # Funkychem - let traitor chemists make nefarious batches
-    ChemistryBottleVestine: 2 # DeltaV
+    VestineChemistryVial: 2 # DeltaV
 
 - type: vendingMachineInventory
   id: ChemVendInventorySyndicate

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
@@ -28,18 +28,3 @@
           Quantity: 100
         - ReagentId: Saline
           Quantity: 100
-
-- type: entity
-  id: ChemistryBottleVestine
-  suffix: Vestine
-  parent: BaseChemistryBottleFilled
-  components:
-  - type: Label
-    currentLabel: reagent-name-vestine
-  - type: SolutionContainerManager
-    solutions:
-      drink:
-        maxVol: 30
-        reagents:
-        - ReagentId: Vestine
-          Quantity: 30

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Chemistry/chemical-containers.yml
@@ -28,3 +28,18 @@
           Quantity: 100
         - ReagentId: Saline
           Quantity: 100
+
+- type: entity
+  id: ChemistryBottleVestine
+  suffix: Vestine
+  parent: BaseChemistryBottleFilled
+  components:
+  - type: Label
+    currentLabel: reagent-name-vestine
+  - type: SolutionContainerManager
+    solutions:
+      drink:
+        maxVol: 30
+        reagents:
+        - ReagentId: Vestine
+          Quantity: 30


### PR DESCRIPTION
## About the PR
Adds 2 Vestine bottles to the chemvend for emagging

## Why / Balance
Syndicate Traitors can actually use chems now, other than just wasting TC on a chem kit, they can actually hack / emag the chemvend for a similar result

Makes more Vestine available in game, Promotes more chem - sided gameplay, and gives traitors another option that isnt MRDM'ing the station

## Technical details
2 bottles vestine, 30U each, thats 60U of vestine accessible 

## Media
no 

## Requirements

- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing

- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->


**Changelog**
:cl:
- add: Traitors can now access Vestine through the Chemvend by emagging it.
