### PR TITLE
I love submodules. Always use submodules.

### DIFF
--- a/.github/workflows/build-docfx.yml
+++ b/.github/workflows/build-docfx.yml
@@ -12,21 +12,12 @@ jobs:
     - name: Setup submodule
       run: |
         git submodule update --init --recursive
-        pushd RobustToolbox/Lidgren.Network/Lidgren.Network
-        git fetch
-        git checkout 726dd552a4b104fb2b701848705f1250a073f060
-        popd
     - name: Pull engine updates
       uses: space-wizards/submodule-dependency@v0.1.5
     - name: Update Engine Submodules
       run: |
         cd RobustToolbox/
         git submodule update --init --recursive
-        pushd Lidgren.Network/Lidgren.Network
-        git fetch
-        git checkout 726dd552a4b104fb2b701848705f1250a073f060
-        popd
-
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4.1.0
       with:

--- a/.github/workflows/build-map-renderer.yml
+++ b/.github/workflows/build-map-renderer.yml
@@ -24,11 +24,7 @@ jobs:
       - name: Setup Submodule
         run: |
           git submodule update --init --recursive
-          pushd RobustToolbox/Lidgren.Network/Lidgren.Network
-          git fetch
-          git checkout 726dd552a4b104fb2b701848705f1250a073f060
-          popd
-          
+
       - name: Pull engine updates
         uses: space-wizards/submodule-dependency@v0.1.5
 
@@ -36,10 +32,6 @@ jobs:
         run: |
           cd RobustToolbox/
           git submodule update --init --recursive
-          pushd Lidgren.Network/Lidgren.Network
-          git fetch
-          git checkout 726dd552a4b104fb2b701848705f1250a073f060
-          popd
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.1.0

--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -24,10 +24,6 @@ jobs:
     - name: Setup Submodule
       run: |
         git submodule update --init --recursive
-        pushd RobustToolbox/Lidgren.Network/Lidgren.Network
-        git fetch
-        git checkout 726dd552a4b104fb2b701848705f1250a073f060
-        popd
 
     - name: Pull engine updates
       uses: space-wizards/submodule-dependency@v0.1.5
@@ -36,10 +32,6 @@ jobs:
       run: |
         cd RobustToolbox/
         git submodule update --init --recursive
-        pushd Lidgren.Network/Lidgren.Network
-        git fetch
-        git checkout 726dd552a4b104fb2b701848705f1250a073f060
-        popd
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ jobs:
     - uses: actions/checkout@v4.2.2
       with:
         submodules: 'recursive'
-
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4.1.0
       with:
@@ -30,12 +29,6 @@ jobs:
       run: |
         cd RobustToolbox
         git fetch --depth=1
-
-    - name: Get Engine Tag
-      run: |
-        cd RobustToolbox/Lidgren.Network/Lidgren.Network
-        git fetch
-        git checkout 726dd552a4b104fb2b701848705f1250a073f060
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -39,10 +39,6 @@ jobs:
       - name: Setup Submodule
         run: |
           git submodule update --init --recursive
-          pushd RobustToolbox/Lidgren.Network/Lidgren.Network
-          git fetch
-          git checkout 726dd552a4b104fb2b701848705f1250a073f060
-          popd
 
       - name: Pull engine updates
         uses: space-wizards/submodule-dependency@v0.1.5
@@ -51,10 +47,6 @@ jobs:
         run: |
           cd RobustToolbox/
           git submodule update --init --recursive
-          pushd Lidgren.Network/Lidgren.Network
-          git fetch
-          git checkout 726dd552a4b104fb2b701848705f1250a073f060
-          popd
 
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.1.0

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -17,20 +17,12 @@ jobs:
       - name: Setup submodule
         run: |
           git submodule update --init --recursive
-          pushd RobustToolbox/Lidgren.Network/Lidgren.Network
-          git fetch
-          git checkout 726dd552a4b104fb2b701848705f1250a073f060
-          popd
       - name: Pull engine updates
         uses: space-wizards/submodule-dependency@v0.1.5
       - name: Update Engine Submodules
         run: |
           cd RobustToolbox/
           git submodule update --init --recursive
-          pushd Lidgren.Network/Lidgren.Network
-          git fetch
-          git checkout 726dd552a4b104fb2b701848705f1250a073f060
-          popd
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4.1.0
         with:


### PR DESCRIPTION
I don't know what came over me in #6117.

Always use submodules. Smile.

Pre-emptive fallback fix to appease CODEOWNERS before they eep. In case of issues, break glass and merge, but only if server is literally not useable.