### PR TITLE
Fix: Make Xeno Announcement the same as other vent-spawns

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -46,7 +46,7 @@
   - type: StationEvent
     startAnnouncement: station-event-xeno-vent-start-announcement
     startAudio:
-      path: /Audio/_DV/Announcements/aliens.ogg
+      path: /Audio/_DV/Announcements/attention.ogg
     earliestStart: 25
     minimumPlayers: 30
     weight: 2


### PR DESCRIPTION
## About the PR
Changes back the xeno ventspawn announcement from the "All knowing metaknowledge announce called Aliens.ogg" to the standard ventspawn announcement

## Why / Balance
the vent spawn announcement and otherwise is the same, the audio is being used to "meta" the game rule a bit since this one sounds louder etc etc, people can tell if xenos are coming, and regularly call it out prior

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.


## Licensing

- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->


**Changelog**
:cl:
- tweak: Xeno Announcements are now properly carried out, They no longer have their own announcement
