### PR TITLE
Fix: Fixes to both Harpy and Moth

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -51,7 +51,7 @@
       Female: UnisexMoth
       Unsexed: UnisexMoth
   - type: MovementSpeedModifier
-    baseWeightlessAcceleration: 1.5 # Move around more easily in space.
+    baseWeightlessAcceleration: 2.5 # DeltaV - Move around more easily in space. Make on par with Harpy
     baseWeightlessFriction: 1
     baseWeightlessModifier: 1
   - type: Flammable

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -130,6 +130,8 @@
           False: {visible: false}
           True: {visible: true}
   - type: MovementSpeedModifier
+    baseWalkSpeed: 4.95
+    baseSprintSpeed: 4.95
     weightlessAcceleration: 2.5
   - type: Inventory
     speciesId: harpy


### PR DESCRIPTION
## About the PR
fixes a bug where harpy's no longer had 10% walk speed buff, although documentation is still in game about

Fixes Moth "Space/nogravity" movement speed to be on par with harpies.

## Why / Balance
Generalized bug fixes, Players are alr informed of the buffs involved with harpies, the buff just wasnt present in the code. 

Moths/harpies have no documentation of being "Worse" than another by flying in space, and I feel it should be on par with eachother



## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**

:cl:

- tweak: Harpy movement speed now has the 10% buff, as this was a bug and wasnt present. Moths and Harpies now have equal Low-Gravity speed.