### PR TITLE
fix: Ion Laws will no longer command crew to eat assholes

### DIFF
--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -1009,7 +1009,7 @@
   - ANARCHISTS AND BANDITS
   - ANOMALIES
   - ARTIFICIAL PRESERVATIVES
-  - ASSHOLES
+  # ASSHOLES - DeltaV - Prevents the AI from ordering crew to eat assholes
   - BANDITS
   - BEARS
   - BEES
@@ -1034,6 +1034,7 @@
   - GRIFFONS
   - HORRORTERRORS
   - INSECTS
+  - JERKS
   - LIGHTS
   - MAINTS SLASHERS
   - MEGAFAUNA


### PR DESCRIPTION
So in this file there are a bunch of antagonist adjectives/nouns to be used as
the subject of a sentence. This results in the potential for something like:
<role> must eat <adjective> assholes. To most English speakers this combination
is lewd and alludes to analingus. We discovered this recently during a round
where salvagers were commanded to eat smooth assholes. My friend was made
uncomfortable and left early.

To fix this, I have removed ASSHOLES and replaced it with JERKS in the same
section. I made sure to keep the list in alphabetical order.

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I replaced `ASSHOLES` with `JERKS` in `ion_storm.yml`.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In English, "eating assholes" would typically be interpreted colloquially as analingus. In the round I was in recently we rolled "Salvagers must eat smooth assholes" as an ion storm law. This made my friend uncomfortable and they left.

## Technical details
<!-- Summary of code changes for easier review. -->
I kept `ASSHOLES` in the file but commented out with a note to match what I have seen before.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
<!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Ion Laws will no longer command crew to eat assholes
