### PR TITLE
Various Crew Monitor Fixes/Tweaks

### DIFF
--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
@@ -1,5 +1,6 @@
 using Content.Client.Pinpointer.UI;
 using Robust.Client.Graphics;
+using Robust.Client.Player; // DeltaV
 using Robust.Client.UserInterface.Controls;
 using Robust.Shared.Timing;
 
@@ -7,6 +8,9 @@ namespace Content.Client.Medical.CrewMonitoring;
 
 public sealed partial class CrewMonitoringNavMapControl : NavMapControl
 {
+    [Dependency] private IPlayerManager _playerManager = default!; // DeltaV
+    private readonly SharedTransformSystem _xform; // DeltaV
+
     public NetEntity? Focus;
     public Dictionary<NetEntity, string> LocalizedNames = new();
 
@@ -15,6 +19,9 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
 
     public CrewMonitoringNavMapControl() : base()
     {
+        IoCManager.InjectDependencies(this); // DeltaV - Gotta inject!
+        _xform = EntManager.System<SharedTransformSystem>(); // DeltaV - Gotta inject!
+
         WallColor = new Color(192, 122, 196);
         TileColor = new(71, 42, 72);
         BackgroundColor = Color.FromSrgb(TileColor.WithAlpha(BackgroundOpacity));
@@ -76,5 +83,27 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
 
         _trackedEntityLabel.Text = string.Empty;
         _trackedEntityPanel.Visible = false;
+    }
+
+    /// <summary>
+    /// DeltaV - Do some things before the base NavMap Draw and also force the redraw of the map
+    /// after if the MapUid was null when the CrewMonitor UI was opened.
+    /// </summary>
+    /// <param name="handle"></param>
+    protected override void Draw(DrawingHandleScreen handle)
+    {
+        var forceMapUpdate = false;
+        if (!MapUid.HasValue && _playerManager.LocalEntity is { } player)
+        {
+            MapUid = _xform.GetGrid(player);
+            forceMapUpdate = true;
+        }
+
+        base.Draw(handle);
+
+        // We need to call this after Draw() because UpdateNavMap has functions that uses variables
+        // set in Draw()
+        if (forceMapUpdate)
+            UpdateNavMap();
     }
 }

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringNavMapControl.cs
@@ -92,6 +92,7 @@ public sealed partial class CrewMonitoringNavMapControl : NavMapControl
     /// <param name="handle"></param>
     protected override void Draw(DrawingHandleScreen handle)
     {
+        // MapUid will not have a value if the crew monitor UI was activated off-grid.
         var forceMapUpdate = false;
         if (!MapUid.HasValue && _playerManager.LocalEntity is { } player)
         {

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -69,7 +69,16 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
         base.FrameUpdate(args);
 
         // Begin DeltaV - handle navmap visibility based on current position
-        if (_station.GetOwningStation(ShuttleMap.Owner) is not null)
+        var ent = ShuttleMap.Owner;
+
+        // If an entity is being tracked, use them as the focus, since they may be off-station
+        // and we want to use the nav map if they are.
+        if (_trackedEntity is { } trackedEntity)
+            ent = _entManager.GetEntity(trackedEntity);
+
+        // We need to make sure the entity is valid because for some reason, it *could* be an 
+        // invalid entity and GetOwningStation will throw an exception.
+        if (ent.HasValue && ent.Value.IsValid() && _station.GetOwningStation(ent) is not null)
         {
             NavMap.Visible = true;
             ShuttleMap.Visible = false;
@@ -343,6 +352,12 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
                     if (_trackedEntity == sensor.SuitSensorUid)
                     {
                         _trackedEntity = null;
+                        // BEGIN DeltaV - center on crew monitor user if deselecting
+                        if (ShuttleMap.Owner is { } handheld &&
+                            _transformSystem.TryGetMapOrGridCoordinates(handheld, out var userCoords) &&
+                            userCoords is { } coords)
+                            NavMap.CenterToCoordinates(coords);
+                        // END DeltaV
                     }
 
                     else

--- a/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
+++ b/Content.Client/Medical/CrewMonitoring/CrewMonitoringWindow.xaml.cs
@@ -353,6 +353,8 @@ public sealed partial class CrewMonitoringWindow : FancyWindow
                     {
                         _trackedEntity = null;
                         // BEGIN DeltaV - center on crew monitor user if deselecting
+                        // This fixes some weird bug where if you deselect a tracked entity, it will
+                        // just not draw the map at all in some cases.
                         if (ShuttleMap.Owner is { } handheld &&
                             _transformSystem.TryGetMapOrGridCoordinates(handheld, out var userCoords) &&
                             userCoords is { } coords)

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -114,7 +114,7 @@
     receiveFrequencyId: NTNet # DeltaV - NTNet
     transmitFrequencyId: ShuttleTimer
   - type: WirelessNetworkConnection
-    range: 500
+    range: 10000 # DeltaV
   #- type: StationLimitedNetwork # DeltaV - Off-station coordinates 
   - type: Thieving
     stripTimeReduction: 9999

--- a/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/admin_ghost.yml
@@ -115,7 +115,7 @@
     transmitFrequencyId: ShuttleTimer
   - type: WirelessNetworkConnection
     range: 500
-  - type: StationLimitedNetwork
+  #- type: StationLimitedNetwork # DeltaV - Off-station coordinates 
   - type: Thieving
     stripTimeReduction: 9999
     stealthy: true

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -25,5 +25,5 @@
     deviceNetId: Wireless
     receiveFrequencyId: NTNet # DeltaV - NTNet
   - type: WirelessNetworkConnection
-    range: 500
+    range: 3600
   - type: Appearance

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -26,5 +26,4 @@
     receiveFrequencyId: NTNet # DeltaV - NTNet
   - type: WirelessNetworkConnection
     range: 500
-  - type: StationLimitedNetwork
   - type: Appearance


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
A few fixes and UI/UX responsiveness updates after #6054.

* Fixes the admin and borg crew monitors
* When a player clicks on coordinates off-grid (but the player with the crew monitor is on the station), it will use use the new long-range sensors display.
  * The current behavior will just display the station instead of the new nav map.
* When a player is off-station, opens the crew monitor interface, and then boards the station, it will properly display the map of the station.
  * The current behavior doesn't draw any map when you switch parent grids AFTER floating/jetpacking in space.
* When deselecting a tracked player on the crew monitor, it will now re-center on the map on the player.
  * The current behavior doesn't draw any map when you deselect a tracked player.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I really love the changes in #6054, but there were a few bugs that popped up when changing grids and I wanted to make it feel snappier.

## Technical details
<!-- Summary of code changes for easier review. -->


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/74bb8c34-e5d3-4081-995a-ae0f01206bf2


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: The crew monitor's UI should properly draw the map when changing grids, deselecting tracked people, and switch the long-range view when tracking someone off station.
- fix: Fixed the admin and borg crew monitors.