### PR TITLE
FIX: Emergency access doesn't change the BOLT/Emergency permissions on a door using remote control

### DIFF
--- a/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
+++ b/Content.Shared/Remotes/EntitySystems/SharedDoorRemoteSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Access.Components;
+using Content.Shared.Access.Systems; // DeltaV
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Doors.Components;
@@ -18,6 +19,7 @@ namespace Content.Shared.Remotes.EntitySystems;
 public abstract class SharedDoorRemoteSystem : EntitySystem
 {
     [Dependency] private readonly SharedAirlockSystem _airlock = default!;
+    [Dependency] private readonly AccessReaderSystem _accessReader = default!; // DeltaV
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedDoorSystem _doorSystem = default!;
     [Dependency] private readonly SharedElectrocutionSystem _electrify = default!;
@@ -86,6 +88,19 @@ public abstract class SharedDoorRemoteSystem : EntitySystem
             _popup.PopupClient(Loc.GetString("door-remote-denied"), args.User, args.User);
             return;
         }
+
+        // Begin DeltaV - Emergency access only bypasses open/close; bolting and toggling emergency access still require actual access.
+        if (entity.Comp.Mode != OperatingMode.OpenClose
+            && accessComponent != null
+            && !_accessReader.IsAllowed(accessTarget, args.Target.Value, accessComponent))
+        {
+            if (isAirlock)
+                _doorSystem.Deny(args.Target.Value, doorComp, user: args.User, predicted: true);
+
+            _popup.PopupClient(Loc.GetString("door-remote-denied"), args.User, args.User);
+            return;
+        }
+        // End DeltaV
 
         switch (entity.Comp.Mode)
         {


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Prevent remotes without sufficient access to BOLT/EMERGENCY doors that are currently set in EMERGERNCY mode.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Remotes should only be able to close/open doors that are in AA, if they do not have the required access they shouldn't be able to change the bolt status or the AA status

## Technical details
<!-- Summary of code changes for easier review. -->
Extra check when a remote operation isn't open/close, to see if they have sufficient access

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
Before: can change AA/Bolt using MED remote on SEC door if it's in AA mode
https://github.com/user-attachments/assets/d5e89a1b-2f36-42bd-937b-7d58b6be82d1
After: Fixed
https://github.com/user-attachments/assets/dffadcd8-3d2f-4379-b520-1ae8e19e83ea


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Emergency access no longer allows anyone with a remote to bolt the door and checks if the remote has access to bolt.