### PR TITLE
PORT: Marking Shaders from Macrocosm

### DIFF
--- a/Content.Client/Body/VisualBodySystem.cs
+++ b/Content.Client/Body/VisualBodySystem.cs
@@ -199,6 +199,18 @@ public sealed class VisualBodySystem : SharedVisualBodySystem
                     _sprite.LayerSetColor(target, layerId, marking.MarkingColors[i]);
                 else
                     _sprite.LayerSetColor(target, layerId, Color.White);
+
+                if (displacement != null && proto.CanBeDisplaced)
+                    _displacement.TryAddDisplacement(displacement, (target, target.Comp), index + i + 1, layerId, out _);
+
+                // MACRO START - marking layer shaders
+                if (proto.Shaders is not null &&
+                    proto.Shaders.TryGetValue(rsi.RsiState, out var shader))
+                {
+                    EnsureComp<SpriteComponent>(target, out var spriteComp); // why is this method in the component?????
+                    spriteComp.LayerSetShader(index + i + 1, shader);
+                }
+                // MACRO END
             }
 
             applied.Add(marking);

--- a/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingPrototype.cs
@@ -36,6 +36,14 @@ namespace Content.Shared.Humanoid.Markings
         [DataField("sprites", required: true)]
         public List<SpriteSpecifier> Sprites { get; private set; } = default!;
 
+        // MACRO ADDITION
+        /// <summary>
+        ///     Optional dictionary allowing assignment of shaders to sprite layers in a marking.
+        ///     This implementation is very messy but unfortunately Robust doesn't like shaders in SpriteSpecifiers.
+        /// </summary>
+        [DataField]
+        public Dictionary<string, string>? Shaders { get; private set; }
+
         public Marking AsMarking()
         {
             return new Marking(ID, Sprites.Count);


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Title!
PR Ported: [[FEATURE] Marking Shaders #2](https://github.com/syndicate-ss14/macrocosm/pull/2)

This feature is likely coming in a future upstream merge anyways due to [Randomized Markings (take two) #38528](https://github.com/Space-Wizards-Federation/space-station-14/pull/87).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fun and whimsy? Let me glow. Needed in future marking PRs.
## Technical details
<!-- Summary of code changes for easier review. -->

> `MarkingPrototype` now has an additional 'shaders' datafield, which takes a dictionary of two strings: state, and shader name.
> If this field is undefined, markings will use the default shader.
> 
> Shaders are modified in `ApplyMarkings`. Unfortunately shader layer methods arent in the system, so we had to grab `SpriteComponent`. This isnt ideal but I'm not fucking with robust toolbox. In a beautiful world shaders would be attached to sprites directly anyway

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
Not player facing.