### PR TITLE
Reimplement Mouse Walk

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -65,8 +65,8 @@ public enum CollisionGroup
     TabletopMachineLayer = Opaque | BulletImpassable,
 
     // Airlocks, windoors, firelocks
-    GlassAirlockLayer = HighImpassable | MidImpassable | LowImpassable | BulletImpassable | InteractImpassable, // DeltaV - we have ventcrawling
-    AirlockLayer = Opaque | LowImpassable | GlassAirlockLayer, // DeltaV - we have ventcrawling
+    GlassAirlockLayer = HighImpassable | MidImpassable | BulletImpassable | InteractImpassable,
+    AirlockLayer = Opaque | GlassAirlockLayer,
 
     // Airlock assembly
     HumanoidBlockLayer = HighImpassable | MidImpassable,


### PR DESCRIPTION
## About the PR
Reimplements Mouse Walking for Mice, RK, Skia, and others. NodeCrawling is not a solution to movement, especially for a game so heavily centered around movement, Nodecrawl implementation has effectively removed multiple roles from being viable. 

While NodeCrawl can be a feature, I am not here to argue the legitimacy, however, in its current state, this is not the case. Mapping standards currently do not require small rooms to have atmos, nor do they require maints to have atmos, making NodeCrawl useless. CableCrawling with also not fix this, as most rooms in maints / etc, are not required to have cabling. 

In other words, While It may seem like a decent idea on paper, I've spent the last day or so watching multiple roles including my beloved mouse role get turned from a fun role to play, into a "You might as well just close the game". A lot of thought was put into this by people who do not play these roles, and its showing.

And just to put this in perspective, theres a reason that this is like this upstream, and it isnt because they didnt have the capabilities to add nodecrawl.

## Why / Balance
Explained above

## Technical details
Removes the collission layer allowing mousewalk again


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Mousewalk returns

