### PR TITLE
Hitman disguise kit is now a full chameleon backpack

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/hitman_case_catalog.yml
+++ b/Resources/Prototypes/_DV/Catalog/hitman_case_catalog.yml
@@ -73,10 +73,7 @@
     state: icon
   content:
   - AgentIDCard
-  - ClothingUniformJumpsuitChameleon
-  - ClothingOuterChameleon
-  - ClothingHandsChameleon
-  - ClothingShoesChameleon
+  - ClothingBackpackChameleonFill
   - BionicVoiceMaskImplanter
   - FakeMindShieldImplanter
 


### PR DESCRIPTION
## About the PR
Changed the disguise kit for hitman to include a full backpack of chameleon clothes instead of a few chameleon clothes

## Why / Balance
Changing this mostly for consistency, and so the kit includes things such as a chameleon bag, hat and PDA

## Technical details
Changed HitmanDisguiseKit to include ClothingBackpackChameleonFill instead of various chameleon clothing pieces

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- tweak: Hitman's disguise kit now includes a full chameleon bag
