### PR TITLE
Fix: Correct Medicine Effect due to DamageGroupPrototype Being Obsolete From Upstream Merge

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -85,14 +85,19 @@
     darkDamage:
       types:
         Blunt: -5
+        Piercing: -5
+        Slash: -5
         Heat: -5
         Poison: -5
-        Asphyxiation: -5
+        Asphyxiation: -2.5
+        Bloodloss: -2.5
         Cellular: -5
         Soul: -1
     lightDamage:
       types:
-        Blunt: 5
+        Blunt: -1.5
+        Piercing: -1.5
+        Slash: -1.5
     healWhenDead: true
     darkMovementSpeedMultiplier: 1.25
     lightMovementSpeedMultiplier: 1.0

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -95,9 +95,9 @@
         Soul: -1
     lightDamage:
       types:
-        Blunt: -1.5
-        Piercing: -1.5
-        Slash: -1.5
+        Blunt: 1.5
+        Piercing: 1.5
+        Slash: 1.5
     healWhenDead: true
     darkMovementSpeedMultiplier: 1.25
     lightMovementSpeedMultiplier: 1.0

--- a/Resources/Prototypes/_Funkystation/Reagents/exotic.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/exotic.yml
@@ -29,10 +29,17 @@
           min: 11
         damage:
           types:
-            Asphyxiation: -6
-            Poison: -4
-            Blunt: -4.5
-            Heat: -6
+            Asphyxiation: -3
+            Bloodloss: -3
+            Poison: -2
+            Radiation: -2
+            Blunt: -1.5
+            Slash: -1.5
+            Piercing: -1.5
+            Heat: -1.5
+            Shock: -1.5
+            Cold: -1.5
+            Caustic: -1.5
       - !type:ModifyStatusEffect
         conditions:
         - !type:ReagentCondition
@@ -60,10 +67,17 @@
           min: 30
         damage:
           types:
-            Asphyxiation: -2
-            Blunt: -1.2
-            Heat: -1.6
-            Poison: -2
+            Asphyxiation: -1
+            Bloodloss: -1
+            Blunt: -0.4
+            Slash: -0.4
+            Piercing: -0.4
+            Heat: -0.4
+            Shock: -0.4
+            Cold: -0.4
+            Caustic: -0.4
+            Poison: -1
+            Radiation: -1
 
 - type: reagent
   id: StabilisedStimulants
@@ -115,9 +129,15 @@
           min: 90 # Heals a bit above crit # DeltaV - this brings people to a bit more stable condition
         damage:
           types: # 5 Damage every type except rad/pois
-            Asphyxiation: -10
-            Blunt: -15
-            Heat: -20
+            Asphyxiation: -5
+            Bloodloss: -5
+            Blunt: -5
+            Slash: -5
+            Piercing: -5
+            Heat: -5
+            Shock: -5
+            Cold: -5
+            Caustic: -5
 
 - type: reagent
   id: Corgium

--- a/Resources/Prototypes/_Funkystation/Reagents/medicine.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/medicine.yml
@@ -75,7 +75,9 @@
           min: 30
         damage:
           types:
-            Blunt: -2.4
+            Blunt: -0.8
+            Piercing: -0.8
+            Slash: -0.8
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
@@ -83,8 +85,13 @@
           min: 15.5
         damage: # ODing causes damage but heals brute
           types:
-            Caustic: 2 # will cause minor caustic damage
-            Blunt: -2.4
+            Heat: 0.5
+            Shock: 0.5
+            Cold: 0.5
+            Caustic: 0.5
+            Blunt: -0.8
+            Piercing: -0.8
+            Slash: -0.8
       - !type:Jitter
         conditions:
         - !type:ReagentCondition
@@ -105,27 +112,33 @@
       metabolismRate: 0.2
       effects:
       - !type:HealthChange
-#        conditions:
-#          - !type:TotalDamageCondition
-#            min: 30
+        conditions:
+        - !type:TotalDamageCondition
+          min: 30
         damage:
           types:
-            Asphyxiation: -6
+            Asphyxiation: -3
+            Bloodloss: -3
       - !type:HealthChange
         conditions:
-          - !type:TotalDamageCondition
-            max: 30
+        - !type:TotalDamageCondition
+          max: 30
         damage:
-           types:
-            Asphyxiation: -1
+          types:
+            Asphyxiation: -0.5
+            Bloodloss: -0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentCondition
           reagent: Salbutamol
           min: 15.5
         damage:
-          types: # DeltaV - genetic is too evil
-            Asphyxiation: -6
+          types: # ODing heals airloss but causes damage
+            Asphyxiation: -3
+            Bloodloss: -3
+            Heat: 0.2
+            Shock: 0.2
+            Cold: 0.2
             Caustic: 0.2
 
 - type: reagent
@@ -164,6 +177,8 @@
         damage:
           types:
             Blunt: -0.1
+            Slash: -0.1
+            Piercing: -0.1
             Heat: -0.1
             Shock: -0.1
             Cold: -0.1


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
`DamageGroupPrototype` is now obsolete which means you can't use damage groupings (brute, burn, toxin, airloss) to define change in damage. This cause Funkychems to get nerf due to the switch not being done properly. It done made salicylic acid a blunt medicine instead of a brute medicine. Crimes against chemists.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fix, refer to Commit `cc5300d` that made the changes.
## Technical details
<!-- Summary of code changes for easier review. -->
Yamslop
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- fix: FunkyChems now properly heal all brutes types if they should instead of just healing blunt damage.
- fix: FunkyChems now properly heal all air loss types if they should instead of just healing asphyxiation damage.
- fix: Skia now properly heals all brute types instead of only healing blunt damage while in the dark.