### PR TITLE
Securityborg Health Improvement Tweak

### DIFF
--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -190,3 +190,12 @@
     Radiation: 0.5
     Caustic: 0.5
     Cold: 0.8 # DeltaV - Cold res
+
+- type: damageModifierSet
+  id: SecurityCyborg
+  coefficients:
+    Blunt: 0.7
+    Slash: 0.7
+    Piercing: 0.7
+    Heat: 0.8
+    Shock: 1.2

--- a/Resources/Prototypes/_DV/borg_types.yml
+++ b/Resources/Prototypes/_DV/borg_types.yml
@@ -40,6 +40,9 @@
     fiberColor: fibers-blue
   - type: AccessReader
     access: [["Command"], ["Robotics"], ["Security"]]
+  - type: Damageable
+    damageContainer: Silicon
+    damageModifierSet: SecurityCyborg
 
   radioChannels:
   - Science


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Security cyborgs now have the armor vest values but take 20% more shock damage.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Security cyborg is a very laughable joke if it ever has to confront someone who is not mildly armed like with a basic melee weapon. It can't fight carps, can't fight the rat king servants very well either, it has the feelings of a mall cop only ever being able to deal with minor crimes from non antagonists while folding against almost any antagonist other than thief. This is the first of the few tweaks I wish to add, this one introduces the value of the basic armor vest for the security cyborg, reducing their blunt, slash and piercing by 30% and heat by 20%. They also take 120% of shock damage (maybe one day it will be exist outside of very few niche objects) which is more of a lore/RP reason than any balancing.
The damage reduction will make it sustain a bit better than against small firearms and basic wildlife/mobs than it's other cyborg counterparts.


## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
(A cyborg can dream)
<img width="254" height="214" alt="Screenshot_101" src="https://github.com/user-attachments/assets/3dd085e4-6dd2-4b0d-83c9-1496e1048359" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: Security cyborgs now have physical and heat resistance of an armor vest!