### PR TITLE
grand sabo for borg murder isnt real

### DIFF
--- a/.wiki/_DV/Laws/StandardOperatingProcedure.txt
+++ b/.wiki/_DV/Laws/StandardOperatingProcedure.txt
@@ -31,7 +31,7 @@ Examples of Pets include, but are not limited to:
 :* hand-held "personal AI" devices
 
 == Synthetic ==
-Any Entity consisting primarily of non-organic matter, designed and/or constructed by NanoTrasen or its Employees for the purpose of performing tasks aboard a Space Station. Synthetics are bound by software limitations, typically referred to as Synthetic or Silicon Laws, and physically incorporated into their chassis. Any damage to a Synthetic- including un-authorized modification of their Laws- may leave the offender liable to charges of Sabotage. Irrevocable destruction of a Synthetic may leave the offender liable to the crime of Grand Sabotage.
+Any Entity consisting primarily of non-organic matter, designed and/or constructed by NanoTrasen or its Employees for the purpose of performing tasks aboard a Space Station. Synthetics are bound by software limitations, typically referred to as Synthetic or Silicon Laws, and physically incorporated into their chassis. Any damage to a Synthetic- including un-authorized modification of their Laws- may leave the offender liable to charges of Sabotage.
 Examples of Synthetics include, but are not limited to:
 :* Crew-constructed Cyborgs
 :* The Station AI


### PR DESCRIPTION

## About the PR
removed vestigial line in SoP about killing borgs being Grand Sabotage.

## Why / Balance
Never referenced anywhere else, does not fit the definition of Grand Sabo, as opposed to harming (and destroying) a borg being sabotage per its own definition
no updates to guidebook or crime app because, again, its vestigial and already the case. 

Grand Sabo is for irreversibly (longer than 10s to repair) destroying a part of the station, not for gibbing a borg, since the borg is not part of the station.

**Changelog**
:cl:
- tweak: Clarified that destroying a borg is sabotage and not grand sabotage.
