### PR TITLE
IAA Subgamemode and objective changes 

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -37,6 +37,7 @@ public sealed partial class AdminVerbSystem
     private static readonly EntProtoId DefaultConspiratorRule = "Conspirators"; // Harmony
     private static readonly EntProtoId DefaultWizardRule = "Wizard";
     private static readonly EntProtoId DefaultHitmanRule = "HitmanRule";
+    private static readonly EntProtoId DefaultNtAgentRule = "NtAgentRule";
     private static readonly EntProtoId DefaultNinjaRule = "NinjaSpawn";
     private static readonly ProtoId<StartingGearPrototype> PirateGearId = "PirateGear";
 
@@ -248,18 +249,18 @@ public sealed partial class AdminVerbSystem
         };
         args.Verbs.Add(cosmiccult);
 
-        var ntAgent = Loc.GetString("admin-verb-make-NTAgent");
+        var ntAgentName = Loc.GetString("admin-verb-make-NTAgent");
         Verb agent = new()
         {
-            Text = ntAgent,
+            Text = ntAgentName,
             Category = VerbCategory.Antag,
             Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/Interface/Misc/job_icons.rsi"), "Nanotrasen"),
             Act = () =>
             {
-                _antag.ForceMakeAntag<NTAgentRuleComponent>(targetPlayer, "NTAgentRule");
+                _antag.ForceMakeAntag<NTAgentRuleComponent>(targetPlayer, DefaultNtAgentRule);
             },
             Impact = LogImpact.High,
-            Message = string.Join(": ", ntAgent, Loc.GetString("admin-verb-text-make-NTAgent")),
+            Message = string.Join(": ", ntAgentName, Loc.GetString("admin-verb-text-make-NTAgent")),
         };
         args.Verbs.Add(agent);
         // End DeltaV Additions

--- a/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Antags.cs
@@ -37,7 +37,7 @@ public sealed partial class AdminVerbSystem
     private static readonly EntProtoId DefaultConspiratorRule = "Conspirators"; // Harmony
     private static readonly EntProtoId DefaultWizardRule = "Wizard";
     private static readonly EntProtoId DefaultHitmanRule = "HitmanRule";
-    private static readonly EntProtoId DefaultNtAgentRule = "NtAgentRule";
+    private static readonly EntProtoId DefaultNTAgentRule = "NTAgentRule";
     private static readonly EntProtoId DefaultNinjaRule = "NinjaSpawn";
     private static readonly ProtoId<StartingGearPrototype> PirateGearId = "PirateGear";
 
@@ -257,7 +257,7 @@ public sealed partial class AdminVerbSystem
             Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/Interface/Misc/job_icons.rsi"), "Nanotrasen"),
             Act = () =>
             {
-                _antag.ForceMakeAntag<NTAgentRuleComponent>(targetPlayer, DefaultNtAgentRule);
+                _antag.ForceMakeAntag<NTAgentRuleComponent>(targetPlayer, DefaultNTAgentRule);
             },
             Impact = LogImpact.High,
             Message = string.Join(": ", ntAgentName, Loc.GetString("admin-verb-text-make-NTAgent")),

--- a/Resources/Locale/en-US/_DV/ntagent/preset-NTAgent.ftl
+++ b/Resources/Locale/en-US/_DV/ntagent/preset-NTAgent.ftl
@@ -16,5 +16,7 @@ NTAgent-round-end-name = Internal Affairs Agent
 objective-condition-frame-person-title = Frame {$targetName}, {CAPITALIZE($job)}.
 objective-condition-fired-person-title = Get {$targetName}, {CAPITALIZE($job)} fired.
 objective-condition-dossier-person-title = Make a Dossier on {$targetName}, {CAPITALIZE($job)}
+objective-condition-slander-person-title = Make {$targetName}, {CAPITALIZE($job)} Look Incompetent.
+
 
 roles-antag-NT-agent-objective = Do dirty work for NanoTrasen.

--- a/Resources/Locale/en-US/_DV/ntagent/preset-NTAgent.ftl
+++ b/Resources/Locale/en-US/_DV/ntagent/preset-NTAgent.ftl
@@ -15,5 +15,6 @@ NTAgent-round-end-name = Internal Affairs Agent
 
 objective-condition-frame-person-title = Frame {$targetName}, {CAPITALIZE($job)}.
 objective-condition-fired-person-title = Get {$targetName}, {CAPITALIZE($job)} fired.
+objective-condition-dossier-person-title = Make a Dossier on {$targetName}, {CAPITALIZE($job)}
 
 roles-antag-NT-agent-objective = Do dirty work for NanoTrasen.

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -34,6 +34,10 @@
     - id: Hitman
       prob: 0.2 #as requested
     # end deltaV additions - add hitman
+    #begin DeltaV additions - ntagent subgamemode
+    - id: NTAgent
+      prob: 0.25 #as requested
+    # end deltaV additions - ntagent subgamemode
 
 - type: entity
   parent: BaseGameRule
@@ -53,6 +57,10 @@
     - id: Hitman
       prob: 0.2 #as requested
     # end deltaV additions - add hitman
+    #begin DeltaV additions - ntagent subgamemode
+    - id: NTAgent
+      prob: 0.25 #as requested
+    # end deltaV additions - ntagent subgamemode
 
 - type: entity
   parent: BaseGameRule
@@ -67,7 +75,10 @@
     #begin DeltaV additions - add hitman
     - id: Hitman
       prob: 0.2 #as requested
-    # end deltaV additions - add hitman
+    # end deltaV additions - add hitman\#begin DeltaV additions - ntagent subgamemode
+    - id: NTAgent
+      prob: 0.25 #as requested
+    # end deltaV additions - ntagent subgamemode
 
 - type: entity
   parent: BaseGameRule
@@ -81,6 +92,10 @@
     - id: Hitman
       prob: 0.2 #as requested
     # end deltaV additions - add hitman
+    #begin DeltaV additions - ntagent subgamemode
+    - id: NTAgent
+      prob: 0.25 #as requested
+    # end deltaV additions - ntagent subgamemode
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -438,8 +438,10 @@
     occursDuringRoundEnd: false
   - type: AntagRandomObjectives
     sets:
-    - groups: NTAgentObjectiveGroup
-      maxPicks: 2
+    - groups: NTAgentBigObjectiveGroup
+      maxPicks: 1
+    - groups: NTAgentSmallObjectiveGroup
+      maxPicks: 1
     maxDifficulty: 100
   - type: AntagSelection
     agentName: NTAgent-round-end-name

--- a/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
@@ -64,4 +64,3 @@
         - NanolinkSubImplant
   - type: DynamicRuleCost
     cost: 50 # really arent that much more than thief
-

--- a/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
@@ -28,8 +28,15 @@
 
 - type: entity
   parent: [NTAgentRule]
-  id: NTAgentSubgameMode
+  id: NTAgent
   components:
+  - type: AntagRandomObjectives
+    sets:
+    - groups: NTAgentBigObjectiveGroup
+      maxPicks: 1
+    - groups: NTAgentSmallObjectiveGroup
+      maxPicks: 1
+    maxDifficulty: 100
   - type: AntagSelection
     agentName: NTAgent-round-end-name
     selectionTime: IntraPlayerSpawn

--- a/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
@@ -64,4 +64,4 @@
         - NanolinkSubImplant
   - type: DynamicRuleCost
     cost: 50 # really arent that much more than thief
-  
+

--- a/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/_DV/GameRules/subgamemodes.yml
@@ -25,3 +25,36 @@
         sound: "/Audio/_DV/Ambience/Antag/hitman_briefing_piano_between.ogg"
   - type: DynamicRuleCost
     cost: 100 # bit more than thief
+
+- type: entity
+  parent: [NTAgentRule]
+  id: NTAgentSubgameMode
+  components:
+  - type: AntagSelection
+    agentName: NTAgent-round-end-name
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ NTAgent ]
+      min: 1
+      max: 3
+      playerRatio: 20
+      lateJoinAdditional: true
+      allowNonHumans: true
+      multiAntagSetting: NotExclusive
+      blacklist:
+        components:
+        - AntagImmune
+      briefing:
+        text: NTAgent-role-greeting-human
+        color: lightblue
+        sound: /Audio/_DV/Ambience/Antag/centcomm_nt_agent.ogg
+      mindRoles:
+      - MindRoleNTAgent
+      components:
+      - type: AutoImplant
+        implants:
+        - RadioImplantCentcomm
+        - NanolinkSubImplant
+  - type: DynamicRuleCost
+    cost: 50 # really arent that much more than thief
+  

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -19,6 +19,15 @@
       sprite: Objects/Misc/bureaucracy.rsi
       state: paper_words
 
+- type: entity
+  parent: BaseNTAgentObjective
+  id: BaseNTAgentSlanderDepartment
+  components:
+  - type: Objective
+    icon:
+      sprite: Structures/Wallmounts/screen.rsi
+      state: screen
+
 # listen to CC
 - type: entity
   parent: BaseNTAgentObjective
@@ -54,6 +63,29 @@
         - KillPersonCondition
         - TargetObjectiveImmune # DeltaV
 
+# Dossier
+- type: entity
+  parent: BaseNTAgentObjective
+  id: DossierRandomPersonObjective
+  description: Nanotrasen wants to know more about this person. Figure out what you can and report to central.
+  components:
+  - type: Objective
+    icon:
+      sprite: Objects/Misc/bureaucracy.rsi
+      state: paper_words
+    difficulty: 1
+    unique: false
+  - type: TargetObjective
+    title: objective-condition-dossier-person-title
+  - type: PickRandomPerson
+    filters:
+    # Can't have multiple objectives to kill the same person.
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - KillPersonCondition
+        - TargetObjectiveImmune # DeltaV
+  
 # fire someone
 - type: entity
   parent: BaseNTAgentObjective
@@ -82,19 +114,75 @@
   parent: BaseNTAgentTestDepartment
   id: TestSecurityObjective
   name: Audit Security.
-  description: Test their response time, their knowledge of law or whatever else. Send the results to Central.
+  description: Test their response time, armory/perma secuirty, or whatever else. Send the results to Central.
 
 - type: entity
   parent: BaseNTAgentTestDepartment
   id: TestEngineeringObjective
   name: Audit Engineering.
-  description: Test their response time to sabotage, structural damage or whatever else. Send the results to Central.
+  description: Test their response time to sabotage, power output, or whatever else. Send the results to Central.
 
 - type: entity
   parent: BaseNTAgentTestDepartment
   id: TestMedicalObjective
   name: Audit Medical.
-  description: Test their response time, their medical knowledge or whatever else. Send the results to Central.
+  description: Test their response time, reactions to types of damage, emergencies or whatever else. Send the results to Central.
+
+- type: entity
+  parent: BaseNTAgentTestDepartment
+  id: TestEpistemicsObjective
+  name: Audit Epistemics.
+  description: Test their artifact secuirty, anomaly finding capabilities, glimmer control, or whatever else. Send the results to Central.
+
+- type: entity
+  parent: BaseNTAgentTestDepartment
+  id: TestServiceObjective
+  name: Audit service.
+  description: test the quality and quanity of their food and drink or whatever else. Send the results to Central.
+
+- type: entity
+  parent: BaseNTAgentTestDepartment
+  id: TestLogisticsObjective
+  name: Audit Logistics.
+  description: test the speed of delivery, material silo secuirty  or whatever else. Send the results to Central.
+
+#look bad 
+
+- type: entity
+  parent: BaseNTAgentSlanderDepartment
+  id: SlanderSecurityObjective
+  name: Make Secuirty Look Bad
+  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+
+- type: entity
+  parent: BaseNTAgentSlanderDepartment
+  id: SlanderEngineeringObjective
+  name: Make Engineering Look Bad
+  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+
+- type: entity
+  parent: BaseNTAgentSlanderDepartment
+  id: SlanderMedicalObjective
+  name: Make Medical Look Bad
+  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+
+- type: entity
+  parent: BaseNTAgentSlanderDepartment
+  id: SlanderEpistemicsObjective
+  name: Make Epistemics Look Bad
+  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+
+- type: entity
+  parent: BaseNTAgentSlanderDepartment
+  id: SlanderLogisticsObjective
+  name: Make Logistics Look Bad
+  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+
+- type: entity
+  parent: BaseNTAgentSlanderDepartment
+  id: SlanderCommandObjective
+  name: Make Command Look Bad
+  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
 
 # defunding
 - type: entity
@@ -107,3 +195,14 @@
     icon:
       sprite: _DV/Objects/Misc/first_bill.rsi
       state: icon
+
+- type: entity
+  parent: BaseNTAgentObjective
+  id: CutCostsObjective
+  name: Cut station costs.
+  description: Nanotrasen wants to cut costs. Remove uneeded machines or equipment.
+  components:
+  - type: Objective
+    icon:
+      sprite: _DV/Objects/Misc/first_bill.rsi
+      state: icon   

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -114,7 +114,7 @@
   parent: BaseNTAgentTestDepartment
   id: TestSecurityObjective
   name: Audit Security.
-  description: Test their response time, armory/perma secuirty, or whatever else. Send the results to Central.
+  description: Test their response time, armory/perma security, or whatever else. Send the results to Central.
 
 - type: entity
   parent: BaseNTAgentTestDepartment
@@ -132,7 +132,7 @@
   parent: BaseNTAgentTestDepartment
   id: TestEpistemicsObjective
   name: Audit Epistemics.
-  description: Test their artifact secuirty, anomaly finding capabilities, glimmer control, or whatever else. Send the results to Central.
+  description: Test their artifact security, anomaly finding capabilities, glimmer control, or whatever else. Send the results to Central.
 
 - type: entity
   parent: BaseNTAgentTestDepartment
@@ -144,7 +144,7 @@
   parent: BaseNTAgentTestDepartment
   id: TestLogisticsObjective
   name: Audit Logistics.
-  description: test the speed of delivery, material silo secuirty  or whatever else. Send the results to Central.
+  description: test the speed of delivery, material silo security  or whatever else. Send the results to Central.
 
 #look bad
 

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -137,7 +137,7 @@
 - type: entity
   parent: BaseNTAgentTestDepartment
   id: TestServiceObjective
-  name: Audit service.
+  name: Audit Service.
   description: Test the quality and quantity of their food and drink, hygiene standards, or whatever else. Send the results to Central.
 
 - type: entity

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -199,7 +199,7 @@
 - type: entity
   parent: BaseNTAgentObjective
   id: CutCostsObjective
-  name: Cut station costs.
+  name: Liquidate unneeded assets.
   description: Nanotrasen wants to cut costs. Remove uneeded machines or equipment.
   components:
   - type: Objective

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -132,7 +132,7 @@
   parent: BaseNTAgentTestDepartment
   id: TestEpistemicsObjective
   name: Audit Epistemics.
-  description: Test their artifact security, anomaly finding capabilities, glimmer control, or whatever else. Send the results to Central.
+  description: Evaluate their artifact safety standards, anomaly detection capabilities, glimmer control, or whatever else. Send the results to Central.
 
 - type: entity
   parent: BaseNTAgentTestDepartment
@@ -144,7 +144,7 @@
   parent: BaseNTAgentTestDepartment
   id: TestLogisticsObjective
   name: Audit Logistics.
-  description: test the speed of delivery, material silo security  or whatever else. Send the results to Central.
+  description: Test the speed of delivery, material silo security or whatever else. Send the results to Central.
 
 #look bad
 
@@ -152,37 +152,37 @@
   parent: BaseNTAgentSlanderDepartment
   id: SlanderSecurityObjective
   name: Make Security Look Bad
-  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+  description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderEngineeringObjective
   name: Make Engineering Look Bad
-  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+  description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderMedicalObjective
   name: Make Medical Look Bad
-  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+  description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderEpistemicsObjective
   name: Make Epistemics Look Bad
-  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+  description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderLogisticsObjective
   name: Make Logistics Look Bad
-  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+  description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderCommandObjective
   name: Make Command Look Bad
-  description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
+  description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 # defunding
 - type: entity

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -138,7 +138,7 @@
   parent: BaseNTAgentTestDepartment
   id: TestServiceObjective
   name: Audit service.
-  description: test the quality and quanity of their food and drink or whatever else. Send the results to Central.
+  description: Test the quality and quantity of their food and drink, hygiene standards, or whatever else. Send the results to Central.
 
 - type: entity
   parent: BaseNTAgentTestDepartment

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -200,7 +200,7 @@
   parent: BaseNTAgentObjective
   id: CutCostsObjective
   name: Liquidate unneeded assets.
-  description: Nanotrasen wants to cut costs. Remove uneeded machines or equipment.
+  description: Nanotrasen wants to cut costs. Remove unneeded machines or equipment.
   components:
   - type: Objective
     icon:

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -63,6 +63,29 @@
         - KillPersonCondition
         - TargetObjectiveImmune # DeltaV
 
+# slander someone
+- type: entity
+  parent: BaseNTAgentObjective
+  id: SlanderRandomPersonObjective
+  description: We want to fire this person. Make everyone think they're incompetent.
+  components:
+  - type: Objective
+    icon:
+      sprite: Structures/Wallmounts/screen.rsi
+      state: screen
+    difficulty: 1.75
+    unique: false
+  - type: TargetObjective
+    title: objective-condition-slander-person-title
+  - type: PickRandomPerson
+    filters:
+    # Can't have multiple objectives to kill the same person.
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - KillPersonCondition
+        - TargetObjectiveImmune # DeltaV
+
 # Dossier
 - type: entity
   parent: BaseNTAgentObjective
@@ -151,37 +174,37 @@
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderSecurityObjective
-  name: Make Security Look Bad
+  name: Make Security Look Incompetent
   description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderEngineeringObjective
-  name: Make Engineering Look Bad
+  name: Make Engineering Look Incompetent
   description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderMedicalObjective
-  name: Make Medical Look Bad
+  name: Make Medical Look Incompetent
   description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderEpistemicsObjective
-  name: Make Epistemics Look Bad
+  name: Make Epistemics Look Incompetent
   description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderLogisticsObjective
-  name: Make Logistics Look Bad
+  name: Make Logistics Look Incompetent
   description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderCommandObjective
-  name: Make Command Look Bad
+  name: Make Command Look Incompetent
   description: NanoTrasen wants a reason to fire people. Make them look incompetent to the public.
 
 # defunding

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -85,7 +85,7 @@
         components:
         - KillPersonCondition
         - TargetObjectiveImmune # DeltaV
-  
+
 # fire someone
 - type: entity
   parent: BaseNTAgentObjective
@@ -146,7 +146,7 @@
   name: Audit Logistics.
   description: test the speed of delivery, material silo secuirty  or whatever else. Send the results to Central.
 
-#look bad 
+#look bad
 
 - type: entity
   parent: BaseNTAgentSlanderDepartment
@@ -205,4 +205,4 @@
   - type: Objective
     icon:
       sprite: _DV/Objects/Misc/first_bill.rsi
-      state: icon   
+      state: icon

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -67,7 +67,7 @@
 - type: entity
   parent: BaseNTAgentObjective
   id: DossierRandomPersonObjective
-  description: Nanotrasen wants to know more about this person. Figure out what you can and report to central.
+  description: NanoTrasen wants to know more about this person. Figure out what you can and report to Central.
   components:
   - type: Objective
     icon:

--- a/Resources/Prototypes/_DV/Objectives/NTAgent.yml
+++ b/Resources/Prototypes/_DV/Objectives/NTAgent.yml
@@ -151,7 +151,7 @@
 - type: entity
   parent: BaseNTAgentSlanderDepartment
   id: SlanderSecurityObjective
-  name: Make Secuirty Look Bad
+  name: Make Security Look Bad
   description: Nanotrasen wants a reason to fire people. Make them look incompetent to the public.
 
 - type: entity

--- a/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
@@ -241,6 +241,7 @@
     FrameRandomPersonObjective: 1
     # FireRandomPersonObjective: 1
     DossierRandomPersonObjective: 1
+    SlanderRandomPersonObjective: 1
 
 - type: weightedRandom
   id: NTAgentObjectiveGroupAudit

--- a/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
@@ -265,5 +265,5 @@
 - type: weightedRandom
   id: NTAgentObjectiveGroupCutCosts
   weights:
-    DefundDepartmentObjective: 1
+    # DefundDepartmentObjective: 1
     CutCostsObjective: 1

--- a/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
@@ -223,16 +223,24 @@
 
 # NTAgent
 - type: weightedRandom
-  id: NTAgentObjectiveGroup
+  id: NTAgentBigObjectiveGroup
+  weights:
+    NTAgentObjectiveGroupAudit: 1
+    NTAgentObjectiveGroupCutCosts: 1
+    NTAgentObjectiveGroupSlander: 1
+    
+
+- type: weightedRandom
+  id: NTAgentSmallObjectiveGroup
   weights:
     NTAgentObjectiveGroupPerson: 1
-    NTAgentObjectiveGroupAudit: 1
 
 - type: weightedRandom
   id: NTAgentObjectiveGroupPerson
   weights:
     FrameRandomPersonObjective: 1
-    FireRandomPersonObjective: 1
+    # FireRandomPersonObjective: 1
+    DossierRandomPersonObjective: 1
 
 - type: weightedRandom
   id: NTAgentObjectiveGroupAudit
@@ -240,4 +248,22 @@
     TestSecurityObjective: 1
     TestEngineeringObjective: 1
     TestMedicalObjective: 1
+    TestEpistemicsObjective: 1
+    TestServiceObjective: 1
+    TestLogisticsObjective: 1
+
+- type: weightedRandom
+  id: NTAgentObjectiveGroupSlander
+  weights:
+    SlanderSecurityObjective: 1
+    SlanderEngineeringObjective: 1
+    SlanderMedicalObjective: 1
+    SlanderEpistemicsObjective: 1
+    SlanderLogisticsObjective: 1
+    SlanderCommandObjective: 0.5
+
+- type: weightedRandom
+  id: NTAgentObjectiveGroupCutCosts
+  weights:
     DefundDepartmentObjective: 1
+    CutCostsObjective: 1

--- a/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
@@ -228,7 +228,7 @@
     NTAgentObjectiveGroupAudit: 1
     NTAgentObjectiveGroupCutCosts: 1
     NTAgentObjectiveGroupSlander: 1
-    
+
 
 - type: weightedRandom
   id: NTAgentSmallObjectiveGroup

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -44,7 +44,7 @@
   <GuideEntityEmbed Entity="NanoRepStationReport" Caption="Station Report Paper"/>
 
   - You may want to join the persons deparment to get better access to them.
-  - Striking up a friendship with the person can make figuring out about them easier
+  - Striking up a friendship with the person can make it easier to learn more about them.
 
   ##Auditing a Department
   [italic]NanoTrasen needs you to check how their valued departments operate.[/italic]

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -63,7 +63,7 @@
   ##Making a Department Look bad
   [italic]Nanotrasen wants a reason to fire people. Make them look incompetent to the public.[/italic]
 
-  Like Auditing, this is a very open-ended objective. Do whatever you think will make the given department look bad, [bold] but remeber Central command doesnt want the station destoryed.[/bold]
+  Like Auditing, this is a very open-ended objective. Do whatever you think will make the given department look bad, [bold]but remember: Central Command doesn't want the station destroyed.[/bold]
 
   - The easiest method is to just make them mess up their job, but this is also the most illegal and desturctive method.
   - Pretending to be a member of the deparment and being a annoyance could do a lot towards making the deparment look bad.

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -42,7 +42,7 @@
 
   You should probably write your report on a [bolditalic]station report paper[/bolditalic], available through your NanoLink! [italic]Anything written on it will appear in the “Station Report” tab on the round-end screen.[/italic]
   <GuideEntityEmbed Entity="NanoRepStationReport" Caption="Station Report Paper"/>
-  
+
   - You may want to join the persons deparment to get better access to them.
   - Striking up a friendship with the person can make figuring out about them easier
 
@@ -65,7 +65,7 @@
 
   Like Auditing, this is a very open-ended objective. Do whatever you think will make the given department look bad, [bold] but remeber Central command doesnt want the station destoryed.[/bold]
 
-  - The easiest method is to just make them mess up their job, but this is also the most illegal and desturctive method. 
+  - The easiest method is to just make them mess up their job, but this is also the most illegal and desturctive method.
   - Pretending to be a member of the deparment and being a annoyance could do a lot towards making the deparment look bad.
 
   ##Defunding a Department

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -74,7 +74,9 @@
   Pretty simple, but do remember that it is going to be very noticeable when you deconstruct or move machines.
 
   - If someone left something on the ground, it is probably unneeded!
-  - material silos, vending machines, out of the way lights, several monitoring consoles,and generally any redundant machine are uneeded things.
+  - Material silos, vending machines, out of the way lights, several monitoring consoles and generally any redundant machine are unneeded things.
+  - Crew might wisen up to your antics! Make up excuses, disguise as someone else or relocate your efforts somewhere else if it gets too hot!
+  - Remember that departments have unnecessary things as well, not just public hallways. Don't forget to "relocate" those assets too.
 
   ##Getting Called by Your Handler
   From time to time, you might get a small request from [color=green]Central Command Officials[/color] to do some extra work. While it's [italic]not mandatory[/italic] to complete them, they might be willing to help you out later if you help them now.

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -26,13 +26,6 @@
 
   You can also contact your [bold]handler[/bold], [color=green]Central Command[/color]. They might give you a hand with some things, but don't rely on it.
 
-  ##Getting Someone Fired
-  [italic]A certain employee might've gotten too comfortable in their position, which could potentially spell bad news for NanoTrasen. Help them explore other job opportunities.[/italic]
-
-  Getting someone fired might be easy or difficult, depending on their job. If they're a janitor, it should be easy, but if they're a Command member, it might be harder (especially if it's the Captain).
-
-  However, making up a reason shouldn't be too hard. Writing a "credible" report about their breach of [textlink="The Company Policy" link="companyPolicies"] or their behavior might help if you spy on them. Otherwise, putting them in a bad spot that you've made up might do the trick too. Convincing them to wear Syndicate clothing would make their bosses [italic]very happy![/italic]
-
   ##Getting Someone Framed
   [italic]Someone has gotten on NanoTrasen's bad side. They need you to ensure that they end up in prison.[/italic]
 
@@ -41,6 +34,17 @@
   - [bold]Use the environment to your advantage.[/bold] Was there sabotage or an explosion going off? You'd better inform the Security Officer about a [italic]certain suspicious individual you saw.[/italic]
 
   Remember, security is usually dumber (or smarter) than they seem. They might be too busy with their jobs to remember your face, but they might remember your small clue. Hell, you could become the Detective's best informant. Just try not to overdo it. The station might wise up to your antics. [italic]You need to SELL your lie effectively![/italic]
+
+  ##Make a Dossier on someone.
+  [italic]Nanotrasen wants to know more about this person. Figure out what you can and report to central.[/italic]
+
+  All you need to do is investagate this person, at worst they'll get weirded out at your stalking.
+
+  You should probably write your report on a [bolditalic]station report paper[/bolditalic], available through your NanoLink! [italic]Anything written on it will appear in the “Station Report” tab on the round-end screen.[/italic]
+  <GuideEntityEmbed Entity="NanoRepStationReport" Caption="Station Report Paper"/>
+  
+  - You may want to join the persons deparment to get better access to them.
+  - Striking up a friendship with the person can make figuring out about them easier
 
   ##Auditing a Department
   [italic]NanoTrasen needs you to check how their valued departments operate.[/italic]
@@ -56,6 +60,14 @@
 
   You're the auditor! Figure out what's MOST important to audit.
 
+  ##Making a Department Look bad
+  [italic]Nanotrasen wants a reason to fire people. Make them look incompetent to the public.[/italic]
+
+  Like Auditing, this is a very open-ended objective. Do whatever you think will make the given department look bad, [bold] but remeber Central command doesnt want the station destoryed.[/bold]
+
+  - The easiest method is to just make them mess up their job, but this is also the most illegal and desturctive method. 
+  - Pretending to be a member of the deparment and being a annoyance could do a lot towards making the deparment look bad.
+
   ##Defunding a Department
   [italic]NanoTrasen needs a good reason why overfunding certain departments is a bad idea.[/italic]
 
@@ -67,6 +79,14 @@
   - People are going to notice if certain important objects go missing from their departments, which can attract unwanted attention. Start small and work from there. Use distractions to your advantage and try to keep things unnoticed.
 
   Remember, some departments might be easier to defund than others. While defunding the Justice department would be easy, it would be more impressive to defund Security.
+
+  ##Cut uneeded Costs
+  [italic]Nanotrasen wants to cut costs. Remove uneeded machines or equipment.[/italic]
+
+  Pretty simple, but do remember that it is going to be very noticeable when you deconstruct or move machines.
+
+  - if someone left something on the ground, it is probably uneeded!
+  - material silos, vending machines, out of the way lights, several monitoring consoles,and generally any redundant machine are uneeded things.
 
   ##Getting Called by Your Handler
   From time to time, you might get a small request from [color=green]Central Command Officials[/color] to do some extra work. While it's [italic]not mandatory[/italic] to complete them, they might be willing to help you out later if you help them now.

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -68,18 +68,6 @@
   - The easiest method is to just make them mess up their job, but this is also the most illegal and desturctive method.
   - Pretending to be a member of the deparment and being a annoyance could do a lot towards making the deparment look bad.
 
-  ##Defunding a Department
-  [italic]NanoTrasen needs a good reason why overfunding certain departments is a bad idea.[/italic]
-
-  Your job is to pick a department of your choosing and ensure that its department budget is nearly empty by the end of the shift.
-
-  You can either secretly pocket all of the money or waste their funds on entirely useless things. If they don't have the cash, you can also ensure that the department starts lacking certain things, like chairs or even consoles!
-
-  - Withdrawing cash from the ordering console usually leaves a big radio announcement saying who did it. Limit your withdrawals or use someone else's ID to take it.
-  - People are going to notice if certain important objects go missing from their departments, which can attract unwanted attention. Start small and work from there. Use distractions to your advantage and try to keep things unnoticed.
-
-  Remember, some departments might be easier to defund than others. While defunding the Justice department would be easy, it would be more impressive to defund Security.
-
   ##Cut uneeded Costs
   [italic]Nanotrasen wants to cut costs. Remove uneeded machines or equipment.[/italic]
 

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -69,7 +69,7 @@
   - Pretending to be a member of the deparment and being a annoyance could do a lot towards making the deparment look bad.
 
   ##Cut uneeded Costs
-  [italic]Nanotrasen wants to cut costs. Remove uneeded machines or equipment.[/italic]
+  [italic]NanoTrasen wants to cut costs. Remove unneeded machines or equipment.[/italic]
 
   Pretty simple, but do remember that it is going to be very noticeable when you deconstruct or move machines.
 

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -35,6 +35,14 @@
 
   Remember, security is usually dumber (or smarter) than they seem. They might be too busy with their jobs to remember your face, but they might remember your small clue. Hell, you could become the Detective's best informant. Just try not to overdo it. The station might wise up to your antics. [italic]You need to SELL your lie effectively![/italic]
 
+  ##Make a person look incompetent
+  [italic]We want to fire this person. Make everyone think they're incompetent.[/italic]
+
+  This is a pretty open objective, but remember your efforts will be for naught if they figure out what youre trying to do.
+
+  - Framing them for a very big incident, like a artifact explosion or medical malpractice, will likey stick.
+  - Sabotaging whatever job they happen to have is also likely to be effective.
+
   ##Make a Dossier on someone.
   [italic]NanoTrasen wants to know more about this person. Figure out what you can and report to Central.[/italic]
 
@@ -60,13 +68,13 @@
 
   You're the auditor! Figure out what's MOST important to audit.
 
-  ##Making a Department Look bad
+  ##Making a Department Look Incompetent
   [italic]NanoTrasen wants a reason to fire people. Make them look incompetent to the public.[/italic]
 
-  Like Auditing, this is a very open-ended objective. Do whatever you think will make the given department look bad, [bold]but remember: Central Command doesn't want the station destroyed.[/bold]
+  Like Auditing, this is a very open-ended objective. Do whatever you think will make the given department look incompetent at their job, [bold]but remember: Central Command doesn't want the station destroyed.[/bold]
 
-  - The easiest method is to just make them mess up their job, but this is also the most illegal and desturctive method.
-  - Pretending to be a member of the deparment and being a annoyance could do a lot towards making the deparment look bad.
+  - The easiest method is to just sabotage something and cause them to blow up or, but this is also the most illegal and desturctive method.
+  - Pretending to be a member of the deparment and failing could do a lot towards making the deparment look incompetent.
 
   ##Cut uneeded Costs
   [italic]NanoTrasen wants to cut costs. Remove unneeded machines or equipment.[/italic]

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -73,7 +73,7 @@
 
   Pretty simple, but do remember that it is going to be very noticeable when you deconstruct or move machines.
 
-  - if someone left something on the ground, it is probably uneeded!
+  - If someone left something on the ground, it is probably unneeded!
   - material silos, vending machines, out of the way lights, several monitoring consoles,and generally any redundant machine are uneeded things.
 
   ##Getting Called by Your Handler

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -61,7 +61,7 @@
   You're the auditor! Figure out what's MOST important to audit.
 
   ##Making a Department Look bad
-  [italic]Nanotrasen wants a reason to fire people. Make them look incompetent to the public.[/italic]
+  [italic]NanoTrasen wants a reason to fire people. Make them look incompetent to the public.[/italic]
 
   Like Auditing, this is a very open-ended objective. Do whatever you think will make the given department look bad, [bold]but remember: Central Command doesn't want the station destroyed.[/bold]
 

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -36,7 +36,7 @@
   Remember, security is usually dumber (or smarter) than they seem. They might be too busy with their jobs to remember your face, but they might remember your small clue. Hell, you could become the Detective's best informant. Just try not to overdo it. The station might wise up to your antics. [italic]You need to SELL your lie effectively![/italic]
 
   ##Make a Dossier on someone.
-  [italic]Nanotrasen wants to know more about this person. Figure out what you can and report to central.[/italic]
+  [italic]NanoTrasen wants to know more about this person. Figure out what you can and report to Central.[/italic]
 
   All you need to do is investagate this person, at worst they'll get weirded out at your stalking.
 

--- a/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
+++ b/Resources/ServerInfo/Guidebook/_DV/Antagonist/NTAgent.xml
@@ -38,7 +38,7 @@
   ##Make a Dossier on someone.
   [italic]NanoTrasen wants to know more about this person. Figure out what you can and report to Central.[/italic]
 
-  All you need to do is investagate this person, at worst they'll get weirded out at your stalking.
+  All you need to do is investigate this person. At worst, they'll be weirded out by your stalking.
 
   You should probably write your report on a [bolditalic]station report paper[/bolditalic], available through your NanoLink! [italic]Anything written on it will appear in the “Station Report” tab on the round-end screen.[/italic]
   <GuideEntityEmbed Entity="NanoRepStationReport" Caption="Station Report Paper"/>


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
+ IAA subgamemode
+ service, epi, logi aduit objectives
+ make [deparment] look bad objective
+ cut costs objective
+ make a dossier on [person] objective
+- altered how IAA rolls objectives so they roll 1 big objective(department effecting ones) and 1 small objective(dossier or frame)
+ modified wording on audit objective to encoruage more antagy stuff(spell check this!)
- removed get [person] fired objective

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I think Iaa works well enough as a subgamemode and ive seen several compliants about not having enough time.
as for the objectives, I wanted to make sure their impact and what you're expected to do was a bit more standardized.
I removed fire since basically everyone found it impossible and added make a deparment look bad in place of it.
cut costs was added becacuse i think itd make for some interesting behavouir.(ex: removing all the material silos or lights or something)
dossier was something i think would be fun and encourage rp and I was already adding other objectives so this one was added.
i think audit can work on every deparment except maybe command but thats just due to how many command members there are.


## Technical details
<!-- Summary of code changes for easier review. -->
- added subgamemode to dv subgamemodes
- modifed the event for the objective set up change.
- modified objective groups and ntagent objectives for that
- made the admin tool IAA actually follow the conventions of that area.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="342" height="425" alt="objective example" src="https://github.com/user-attachments/assets/b09c0613-3380-4eb3-8f76-6310f9d13472" />
<img width="357" height="399" alt="Iaa objective 1 but better" src="https://github.com/user-attachments/assets/ad98c776-1605-477f-85b9-82cab56ff625" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: IAA as a subgamemode
- add: cut costs, make [department] look bad, make a dossier on [person] have been added as objectives to IAA
- remove: Iaa fire [person] objective was removed
- tweak: IAA's will now always have 1 department-affecting objective and 1 single person objective. 
- tweak: IAA audit [department] objective now inculdes epi, service, and logi