### PR TITLE
MedHUDs no longer show your own health bar :)

### DIFF
--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -11,6 +11,7 @@ using Content.Shared.StatusIcon;
 using Content.Shared.StatusIcon.Components;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
+using Robust.Client.Player; // DeltaV
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using static Robust.Shared.Maths.Color;
@@ -22,6 +23,7 @@ namespace Content.Client.Overlays;
 /// </summary>
 public sealed class EntityHealthBarOverlay : Overlay
 {
+    [Dependency] private readonly IPlayerManager _player = default!; // DeltaV
     private readonly IEntityManager _entManager;
     private readonly IPrototypeManager _prototype;
 
@@ -40,6 +42,8 @@ public sealed class EntityHealthBarOverlay : Overlay
 
     public EntityHealthBarOverlay(IEntityManager entManager, IPrototypeManager prototype)
     {
+        IoCManager.InjectDependencies(this); // DeltaV
+
         _entManager = entManager;
         _prototype = prototype;
         _transform = _entManager.System<SharedTransformSystem>();
@@ -69,6 +73,11 @@ public sealed class EntityHealthBarOverlay : Overlay
             out var damageableComponent,
             out var spriteComponent))
         {
+            // BEGIN DeltaV - You can't see your own bar :godo:
+            if (_player.LocalEntity is { } player && player.Id == uid.Id)
+                continue;
+            // END DeltaV
+
             if (statusIcon != null && !_statusIconSystem.IsVisible((uid, _entManager.GetComponent<MetaDataComponent>(uid)), statusIcon))
                 continue;
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I removed seeing your *own* health bar from the medical hud (and other medhud like items). :godo:

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I expect this to be controversial lol, but here is my reasoning:


* Seeing *exactly* how healthy you are at any given time is *very* powerful, especially in combat. But that information is already available on the right side of your screen. This makes it less central but still available.
* As a medical person, people will have to tell you that you are hurt instead of you knowing the moment you are slightly poisoned/irradiated/etc.
  * You can still scan yourself with your PDA and keep that UI up if you want. But its not an always on thing.
* It does kind of make no sense that you can see your own health bar if you think about it from your character's first-person perspective. You're using your eye piece to scan others that you can see, but you can't look at yourself without a mirror, so how does that work? Magic I guess.
* Medical people with the numb trait cannot cheat anymore (that's my character!)
  * I want to fall over from being dumb and not realizing I'm about to die lol, instead of it being obvious.

Kind of an indirect cult and zombie buff? Nukie agent nerf I guess. Could be modified to be enabled for that medhud specifically if needed.

## Technical details
<!-- Summary of code changes for easier review. -->
Nothing crazy.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="977" height="673" alt="image" src="https://github.com/user-attachments/assets/1c8f11b7-250e-4f79-8137-e1e49b1b4381" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: You can no longer see your own health bar with the medical hud (or similar eyewear).
