### PR TITLE
Pka upstream merge

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -55,7 +55,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      250: Dead
+      150: Dead
   - type: MeleeWeapon
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -386,7 +386,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      75: Dead
+      45: Dead
   - type: MeleeWeapon
     angle: 0
     animation: WeaponArcBite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -43,7 +43,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        50: Dead # DeltaV, was 40
+        40: Dead
     - type: MovementSpeedModifier
       baseWalkSpeed: 2.5
       baseSprintSpeed: 3.5

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -10,7 +10,6 @@
   - type: Item
     size: Small
   - type: GunUpgrade
-  - type: GunUpgradeCost # DeltaV
   - type: StaticPrice
     price: 750
   - type: Tag
@@ -32,13 +31,13 @@
     - state: overlay-3
       color: "#eb4c13"
   - type: GunUpgrade
-    #tags: [ GunUpgradeDamage ] # DeltaV - allow multiple
+    tags: [ GunUpgradeDamage ]
     examineText: gun-upgrade-examine-text-damage
   - type: GunUpgradeDamage
     damage:
       types:
-        Blunt: 5 # DeltaV - modkits can still exist but greatly lowering how much it does so we don't have 70 damage monster gun anymore
-        #Structural: 15 # DeltaV - SS13 parity, 10 blunt per shot only
+        Blunt: 10
+        Structural: 15
 
 - type: entity
   id: PKAUpgradeRange
@@ -55,12 +54,10 @@
     - state: overlay-3
       color: "#1373eb"
   - type: GunUpgrade
-    #tags: [ GunUpgradeRange ] # DeltaV - allow multiple
+    tags: [ GunUpgradeRange ]
     examineText: gun-upgrade-examine-text-range
-  - type: GunUpgradeRange # DeltaV - actually change range not speed
-    coefficient: 1.15 # DeltaV - lowered further to account for increased base range
-  - type: GunUpgradeCost # DeltaV
-    cost: 25
+  - type: GunUpgradeSpeed
+    coefficient: 1.5
 
 - type: entity
   id: PKAUpgradeFireRate
@@ -77,8 +74,7 @@
     - state: overlay-3
       color: "#9bf134"
   - type: GunUpgrade
-    #tags: [ GunUpgradeReloadSpeed ] # DeltaV - allow multiple
+    tags: [ GunUpgradeReloadSpeed ]
     examineText: gun-upgrade-examine-text-reload
   - type: GunUpgradeFireRate
-    coefficient: 1.25 # DeltaV - was 1.5, SS13 parity (maths used is different but same result: 0.64s recharge time with 3 upgrades)
-
+    coefficient: 1.5

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_pka.yml
@@ -15,7 +15,7 @@
     maxAngle: -43
   - type: Wieldable
   - type: Gun
-    fireRate: 1.5 # DeltaV - revert back to prebase feel
+    fireRate: 0.5
     selectedMode: SemiAuto
     angleDecay: 45
     minAngle: 44
@@ -35,7 +35,7 @@
           False: { visible: True }
         #todo: add other 'empty' animations
   - type: RechargeBasicEntityAmmo
-    rechargeCooldown: 0.5 # DeltaV
+    rechargeCooldown: 0.75
     rechargeSound:
       path: /Audio/Weapons/Guns/MagIn/kinetic_reload.ogg
   - type: BasicEntityAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -14,12 +14,9 @@
   # todo: add itemcomponent with inhandVisuals states using unused texture and animation assets in kinetic_accelerator.rsi
   # todo: add clothingcomponent with clothingVisuals states using unused texture and animations assets in kinetic_accelerator.rsi
   - type: UpgradeableGun
-    maxUpgradeCount: 10 # DeltaV - use cost for limiting modkits instead
     whitelist:
       tags:
       - PKAUpgrade
-  - type: UpgradeableGunCost # DeltaV
-    maxCost: 100
   - type: ContainerContainer
     containers:
       upgrades: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -573,11 +573,11 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 20 # DeltaV- Was 15
+        Blunt: 15
         Structural: 30
   # Short lifespan
   - type: TimedDespawn
-    lifetime: 0.4 # DeltaV - Revert to Prebase stats, was 0.22
+    lifetime: 0.22 # roughly 5.5 tiles
   - type: GatheringProjectile
 
 - type: entity
@@ -1467,4 +1467,4 @@
     transferAmount: 1.5
     solution: bolt
   - type: TimedDespawn # DeltaV - limit range to match taser
-    lifetime: 0.170 
+    lifetime: 0.170

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -27,6 +27,9 @@
   - MineralScannerEmpty
   - AdvancedMineralScannerEmpty
   - OreBagOfHolding
+  - PKAUpgradeDamage
+  - PKAUpgradeRange
+  - PKAUpgradeFireRate
   - ClothingShoesBootsJump # DV - Jump Boots since its mining research
 
 - type: latheRecipePack

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -202,6 +202,9 @@
     - MiningDrillDiamond
     - AdvancedMineralScannerEmpty
     - BorgModuleAdvancedMining
+    - PKAUpgradeDamage
+    - PKAUpgradeRange
+    - PKAUpgradeFireRate
 
 # Tier 3
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Changed the PKA to match the existing PKA in upstream. Reintroduced the PKA upgrade modkits as a researchable upgrade (Available in Mass Excavation, T2 industrial). Reduced the health of some salvage mobs to match their health values in upstream

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Our current PKA is a very strong weapon available roundstart, and the range trivializes many encounters. With this change, salvage still has a usable weapon but threats such as goliaths pose a challenge early into the round, and they're also able to upgrade their PKA after some research, similarly to upgrading your crusher to a glaive as a melee salvager.

## Technical details
<!-- Summary of code changes for easier review. -->
Reimplemented the PKA modkits from upstream, removing the upgrade cost system that had been leftover. Reduced the PKA's base firerate and projectile lifetime. Reduced damage until death for some salvage enemies to compensate.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="400" height="315" alt="Research" src="https://github.com/user-attachments/assets/bcdba0f5-9f8f-4c67-b466-3be57fb00d7d" />
<img width="629" height="527" alt="upgrades" src="https://github.com/user-attachments/assets/b11930a8-f7ec-4965-be19-9d323d096c88" />
<img width="772" height="527" alt="lathe" src="https://github.com/user-attachments/assets/4feb34cf-3d33-4912-aa50-f19f36ff8015" />
<img width="771" height="523" alt="lathe2" src="https://github.com/user-attachments/assets/f751df65-b271-4ad6-a2a3-1ca86cc6074a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: reintroduced researchable PKA modkits
- tweak: Changed the PKA to its current upstream state
- tweak: Reduced the health of some salvage mobs