### PR TITLE
Glimmer alerts

### DIFF
--- a/Content.Client/_DV/Psionics/GlimmerAlertSystem.cs
+++ b/Content.Client/_DV/Psionics/GlimmerAlertSystem.cs
@@ -1,0 +1,40 @@
+using Content.Shared.Psionics.Glimmer;
+using Content.Shared._DV.Psionics.Components;
+using Content.Shared.Alert;
+using Robust.Client.Player;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._DV.Psionics;
+
+public sealed class GlimmerAlertSystem : EntitySystem
+{
+    [Dependency] private readonly AlertsSystem _alerts = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    private ProtoId<AlertPrototype> _highGlimmerAlert = "HighGlimmer";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<GlimmerChangedEvent>(OnGlimmerChanged);
+    }
+
+    private void OnGlimmerChanged(GlimmerChangedEvent eventArgs)
+    {
+        // Update alert on glimmer change
+        if (_player.LocalSession?.AttachedEntity is not { } ent)
+            return;
+
+        if (!TryComp<PotentialPsionicComponent>(ent, out var PotentialPsionic))
+            return;
+
+        var alertProto = _prototype.Index(_highGlimmerAlert);
+
+        if(eventArgs.Glimmer > 700)
+            _alerts.ShowAlert(ent, alertProto);
+        else
+            _alerts.ClearAlert(ent, alertProto);
+    }
+}

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -130,4 +130,7 @@ alerts-high-glimmer-name = High Glimmer
 alerts-high-glimmer-desc = Glimmer around you is [color=cyan]dangerously high[/color]! Psionically insulative clothing, such as a [color=green]tinfoil hat[/color] can protect you from psionic discharges.
 
 alerts-psionically-insulated-name = [color=green]Psionically Insulated[/color]
-alerts-psionically-insulated-desc = You're wearing psionically insulative clothing; you won't be affected by psionics, but won't be able to use your own!
+alerts-psionically-insulated-desc = You're wearing psionically insulative clothing; you won't be affected by psionics!
+
+alerts-psionically-insulated-name = [color=red]Psionically Supressed[/color]
+alerts-psionically-insulated-desc = You can't use psionic abilities!

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -125,3 +125,6 @@ alerts-stealthy-desc = Whether you are currently pickpocketing. Click to toggle.
 
 alerts-prying-name = Prying
 alerts-prying-desc = You can innately pry doors open using alternative interaction.
+
+alerts-high-glimmer-name = High Glimmer
+alerts-high-glimmer-desc = Glimmer around you is [color=cyan]dangerously high[/color]! Psionically insulative clothing, such as a [color=green]tinfoil hat[/color] can protect you from psionic discharges.

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -128,3 +128,6 @@ alerts-prying-desc = You can innately pry doors open using alternative interacti
 
 alerts-high-glimmer-name = High Glimmer
 alerts-high-glimmer-desc = Glimmer around you is [color=cyan]dangerously high[/color]! Psionically insulative clothing, such as a [color=green]tinfoil hat[/color] can protect you from psionic discharges.
+
+alerts-psionically-insulated-name = [color=green]Psionically Insulated[/color]
+alerts-psionically-insulated-desc = You're wearing psionically insulative clothing; you won't be affected by psionics, but won't be able to use your own!

--- a/Resources/Locale/en-US/alerts/alerts.ftl
+++ b/Resources/Locale/en-US/alerts/alerts.ftl
@@ -132,5 +132,5 @@ alerts-high-glimmer-desc = Glimmer around you is [color=cyan]dangerously high[/c
 alerts-psionically-insulated-name = [color=green]Psionically Insulated[/color]
 alerts-psionically-insulated-desc = You're wearing psionically insulative clothing; you won't be affected by psionics!
 
-alerts-psionically-insulated-name = [color=red]Psionically Supressed[/color]
-alerts-psionically-insulated-desc = You can't use psionic abilities!
+alerts-psionically-suppressed-name = [color=red]Psionically Suppressed[/color]
+alerts-psionically-suppressed-desc = You can't use psionic abilities!

--- a/Resources/Prototypes/Alerts/alerts.yml
+++ b/Resources/Prototypes/Alerts/alerts.yml
@@ -24,6 +24,7 @@
     - category: Temperature
     - category: Hunger
     - category: Thirst
+    - category: Glimmer
     - alertType: Magboots
     - alertType: Rooted
     - alertType: Pacified

--- a/Resources/Prototypes/Alerts/categories.yml
+++ b/Resources/Prototypes/Alerts/categories.yml
@@ -33,3 +33,6 @@
 
 - type: alertCategory
   id: Battery
+
+- type: alertCategory
+  id: Glimmer

--- a/Resources/Prototypes/Alerts/glimmer.yml
+++ b/Resources/Prototypes/Alerts/glimmer.yml
@@ -14,3 +14,12 @@
     - sprite: Nyanotrasen/Clothing/Head/Hats/tinfoil.rsi
   name: alerts-psionically-insulated-name
   description: alerts-psionically-insulated-desc
+
+- type: alert
+  id: PsionicallySupressed
+  category: Glimmer
+  icons:
+    - sprite: _DV/Interface/Actions/actions_psionics.rsi
+      state: dispel
+  name: alerts-psionically-supressed-name
+  description: alerts-psionically-supressed-desc

--- a/Resources/Prototypes/Alerts/glimmer.yml
+++ b/Resources/Prototypes/Alerts/glimmer.yml
@@ -1,0 +1,8 @@
+- type: alert
+  id: HighGlimmer
+  category: Glimmer
+  icons:
+    - sprite: _DV/Interface/Actions/actions_psionics.rsi
+      state: eruption
+  name: alerts-high-glimmer-name
+  description: alerts-high-glimmer-desc

--- a/Resources/Prototypes/Alerts/glimmer.yml
+++ b/Resources/Prototypes/Alerts/glimmer.yml
@@ -12,6 +12,7 @@
   category: Glimmer
   icons:
     - sprite: Nyanotrasen/Clothing/Head/Hats/tinfoil.rsi
+      state: icon
   name: alerts-psionically-insulated-name
   description: alerts-psionically-insulated-desc
 

--- a/Resources/Prototypes/Alerts/glimmer.yml
+++ b/Resources/Prototypes/Alerts/glimmer.yml
@@ -6,3 +6,11 @@
       state: eruption
   name: alerts-high-glimmer-name
   description: alerts-high-glimmer-desc
+
+- type: alert
+  id: PsionicallyInsulated
+  category: Glimmer
+  icons:
+    - sprite: Nyanotrasen/Clothing/Head/Hats/tinfoil.rsi
+  name: alerts-psionically-insulated-name
+  description: alerts-psionically-insulated-desc


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Added data to support an alert for high glimmer (>700, same as the high glimmer shader), as well as alerts to show when you're psionically insulated and when you're psionically suppressed by worn clothing!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Clarity. It can be hard to understand the glimmer system, and the high glimmer alert would help those who don't have the shader turned on, as well as alerting new players that glimmer is something to be scared of.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new alert category: Glimmer
Added three new alerts in the glimmer category: HighGlimmer, PsionicallyInsulated, PsionicallySuppressed

## To Do
- Create a component that runs a similar logic to the glimmer overlay component, checking when to show the alert upon glimmer changing
- Add the alert system dependency to the glimmer system, show the relevant alerts when insulated and suppressed by worn clothing.
- [Optional] Create custom sprites for the high glimmer alert and the psionically suppressed alert.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Added new alerts to show when you're psionically insulated, supressed, and when glimmer is too high
