### PR TITLE
Rodentia Ears + Whiskers

### DIFF
--- a/Resources/Prototypes/_DV/Body/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Body/Species/rodentia.yml
@@ -33,7 +33,7 @@
       required: true
       default: [ RodentiaHeadTopEarDefault ]
     enum.HumanoidVisualLayers.HeadSide:
-      limit: 1
+      limit: 2
       required: false
     enum.HumanoidVisualLayers.Chest:
       limit: 2

--- a/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/rodentia.yml
@@ -244,7 +244,7 @@
 
 - type: marking
   id: RodentiaCheeksWhiskers
-  bodyPart: HeadTop # for layering
+  bodyPart: HeadSide
   groupWhitelist: [Rodentia]
   sprites:
     - sprite: _DV/Mobs/Customization/Rodentia/cheek_markings.rsi


### PR DESCRIPTION
## About the PR
Rodentia whiskers were moved to being a cheek marking so that you can have mouse ears and mouse whiskers at the same time. Then HeadSide's marking limit was raised to 2, so you can have whiskers, ears, AND fluffy cheeks.

## Why / Balance
Something that was asked for in wyci. The whiskers are even listed among the HeadSide cheek markings in the yml, but is set as HeadTop with the comment "for layering". I'm uncertain of the meaning, and it seems to look fine.
HeadSide's limit is also raised to 2 so you can have whiskers and cheek fluff. Two different cheek fluff markings are possible, but admittedly difficult to make look good.

## Technical details
Markings\rodentia.yml - Whiskers changed from bodyPart HeadTop to HeadSide, comment removed.
Species\rodentia.yml - Limit on HeadSide layer increased from 1 to 2.

## Media
Pictured: Bald Ratto with Whiskers, Cheeks - Round, and Ears - Mouse (Large). Round snoot too.
<img width="120" height="253" alt="Screenshot 2026-07-08 210722" src="https://github.com/user-attachments/assets/1131b798-7de5-499d-903a-341e3d9f2482" /> <img width="135" height="255" alt="Screenshot 2026-07-08 210624" src="https://github.com/user-attachments/assets/ec42b2a6-7244-4ba5-aa0b-af0264e00ebe" />

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt)
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- tweak: Rodentia can now have whiskers and ears at the same time. Cheek fluff too.