### PR TITLE
Add Meridian server config preset

### DIFF
--- a/Resources/ConfigPresets/DeltaV/meridian.toml
+++ b/Resources/ConfigPresets/DeltaV/meridian.toml
@@ -1,0 +1,9 @@
+[game]
+hostname         = "[EN][MRP] Delta-v (Ψ) | Meridian [EU West]"
+soft_max_players = 40
+
+[hub]
+tags = "lang:en-US,region:eu_w,rp:med,no_tag_infer"
+
+[debug]
+pow3r_disable_parallel = false


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added `meridian.yml` server config preset as preparation for the Meridian server.

## Why / Balance
Provides a reference config preset for Meridian, to be adjusted as needed throughout the testing period.

## Technical details
Copy and pasted from `apoapsis.yml`. Adjusted maximum player count to 40, adjusted tags to EU west, adjusted hostname. There is no tag for EU central, so EU west was chosen instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->
