### PR TITLE
Fix syndie meal test failure

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/box.yml
@@ -569,7 +569,7 @@
   components:
   - type: Storage
     grid:
-    - 0,0,5,2
+    - 0,0,6,2 # DeltaV - Slightly bigger so tests don't fail when Python
   - type: EntityTableContainerFill
     containers:
       storagebase: !type:AllSelector


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Made the syndie snack box slightly bigger so tests don't fail. It should not affect, if at all.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Test fails bad.

## Technical details
<!-- Summary of code changes for easier review. -->
Tests fail when the python is picked, due to it being the only 3 grid-sized item. 

```
  Failed NoMaterialArbitrage [5 s]
  Error Message:
   SERVER: 2.587s [ERRO] system.container_fill: Entity syndicate snack box (368416/n368416, HappyHonkNukieSnacks) with a EntityTableContainerFillComponent failed to insert an entity: valid salad (368436/n368436, FoodSaladValid).
Current contents:
	 - Python (368417/n368417, WeaponRevolverPythonAP)
	 - Space Cola can (368418/n368418, DrinkColaCan)
	 - Space Cola can (368421/n368421, DrinkColaCan)
	 - Space Cola can (368424/n368424, DrinkColaCan)
	 - Space Cola can (368427/n368427, DrinkColaCan)
	 - valid salad (368430/n368430, FoodSaladValid)
	 - valid salad (368432/n368432, FoodSaladValid)
	 - valid salad (368434/n368434, FoodSaladValid) Exception: 

```


## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no CL
