### PR TITLE
Locking Probers @ 750 Glimmer + Bigger Prober Explosions over 900 Glimmer

### DIFF
--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -220,7 +220,7 @@ namespace Content.Server.Psionics.Glimmer
 
             var totalIntensity = (float)(_glimmerSystem.Glimmer * explosionMultiplier);
             var slope = (float)(11 - _glimmerSystem.Glimmer / 100);
-            var maxIntensity = 20;
+            var maxIntensity = 75; // Same as syndicate bomb
 
             var removed = (float) _glimmerSystem.Glimmer * _random.NextFloat(0.06f, 0.08f);
             _glimmerSystem.Glimmer -= (int)removed;

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -222,7 +222,7 @@ namespace Content.Server.Psionics.Glimmer
             var slope = (float)(11 - _glimmerSystem.Glimmer / 100);
             var maxIntensity = 75; // Same as syndicate bomb
 
-            var removed = (float) _glimmerSystem.Glimmer * _random.NextFloat(0.06f, 0.08f);
+            var removed = _glimmerSystem.Glimmer * _random.NextFloat(0.06f, 0.08f);
             _glimmerSystem.Glimmer -= (int)removed;
             BeamRandomNearProber(uid, _glimmerSystem.Glimmer / 350, _glimmerSystem.Glimmer / 50);
             _explosionSystem.QueueExplosion(uid, "Default", totalIntensity, slope, maxIntensity, addLog: true);
@@ -234,7 +234,7 @@ namespace Content.Server.Psionics.Glimmer
             if (component.Locked)
             {
                 _sharedAudioSystem.PlayPvs(component.ShockNoises, args.User);
-                _electrocutionSystem.TryDoElectrocution(args.User, null, _glimmerSystem.Glimmer / 200, TimeSpan.FromSeconds((float) _glimmerSystem.Glimmer / 100), false);
+                _electrocutionSystem.TryDoElectrocution(args.User, uid, _glimmerSystem.Glimmer / 200, TimeSpan.FromSeconds((float) _glimmerSystem.Glimmer / 100), false);
                 args.Cancel();
             }
         }

--- a/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
+++ b/Content.Server/Nyanotrasen/Psionics/Glimmer/GlimmerReactiveSystem.cs
@@ -209,20 +209,24 @@ namespace Content.Server.Psionics.Glimmer
 
         private void OnDestroyed(EntityUid uid, SharedGlimmerReactiveComponent component, DestructionEventArgs args)
         {
-            Spawn("MaterialBluespace1", Transform(uid).Coordinates);
-
+            var proberCoords = Transform(uid).Coordinates;
             var tier = _glimmerSystem.GetGlimmerTier();
             if (tier < GlimmerTier.High)
                 return;
 
-            var totalIntensity = (float) (_glimmerSystem.Glimmer * 2);
-            var slope = (float) (11 - _glimmerSystem.Glimmer / 100);
+            var explosionMultiplier = 2;
+            if (_glimmerSystem.GetGlimmerTier() == GlimmerTier.Critical) // YOU DONE FUCKED UP
+                explosionMultiplier = 3;
+
+            var totalIntensity = (float)(_glimmerSystem.Glimmer * explosionMultiplier);
+            var slope = (float)(11 - _glimmerSystem.Glimmer / 100);
             var maxIntensity = 20;
 
             var removed = (float) _glimmerSystem.Glimmer * _random.NextFloat(0.06f, 0.08f);
-            _glimmerSystem.Glimmer -= (int) removed;
+            _glimmerSystem.Glimmer -= (int)removed;
             BeamRandomNearProber(uid, _glimmerSystem.Glimmer / 350, _glimmerSystem.Glimmer / 50);
-            _explosionSystem.QueueExplosion(uid, "Default", totalIntensity, slope, maxIntensity);
+            _explosionSystem.QueueExplosion(uid, "Default", totalIntensity, slope, maxIntensity, addLog: true);
+            Spawn("MaterialBluespace1", proberCoords); // Congrats on your bluespace!
         }
 
         private void OnUnanchorAttempt(EntityUid uid, SharedGlimmerReactiveComponent component, UnanchorAttemptEvent args)

--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
@@ -184,7 +184,8 @@ public sealed class OracleSystem : EntitySystem
 
         while (i != 0)
         {
-            Spawn("MaterialBluespace1", Transform(user).Coordinates);
+            var entityToSpawn = _random.Next(0, 2) == 0 ? "MaterialBluespace1" : "CrystalNormality";
+            Spawn(entityToSpawn, Transform(user).Coordinates);
             i--;
         }
 

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -8,15 +8,15 @@
     - id: NoosphericSilence
     - id: MassMindSwap
     - id: GlimmerWispSpawn
-    - id: FreeProber
+    - id: GlimmerFreeProber
     - id: GlimmerRevenantSpawn
     - id: GlimmerMiteSpawn
     - id: GlimmerRandomSentience
     - id: GlimmerRandomAnimation
     - id: ThavenMoodUpset
-    #- id: LockProbers
+    - id: GlimmerLockProbers
     - id: PsionicNosebleedEvent
-    - id: MinorMassMindSwap # Delta V
+    - id: MinorMassMindSwap
     - id: GlimmerFoxfireSpawn
     - id: GlimmerRestyle
 
@@ -121,7 +121,7 @@
 
 - type: entity
   parent: BaseGlimmerSignaturesEvent
-  id: FreeProber
+  id: GlimmerFreeProber
   components:
   - type: FreeProberRule
 
@@ -184,13 +184,13 @@
     glimmerBurnUpper: 70
   - type: ThavenMoodUpsetRule
 
-#- type: entity
-#  parent: BaseGlimmerEvent
-#  id: LockProbers
-#  components:
-#  - type: GlimmerEvent
-#    minimumGlimmer: 500
-#  - type: LockProbersRule
+- type: entity
+  parent: BaseGlimmerEvent
+  id: GlimmerLockProbers
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 750
+  - type: LockProbersRule
 
 - type: entity
   parent: BaseGlimmerEvent

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -8,7 +8,7 @@
     - id: NoosphericSilence
     - id: MassMindSwap
     - id: GlimmerWispSpawn
-    - id: GlimmerFreeProber
+    - id: GlimmerSpawnProber
     - id: GlimmerRevenantSpawn
     - id: GlimmerMiteSpawn
     - id: GlimmerRandomSentience
@@ -121,7 +121,7 @@
 
 - type: entity
   parent: BaseGlimmerSignaturesEvent
-  id: GlimmerFreeProber
+  id: GlimmerSpawnProber
   components:
   - type: FreeProberRule
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
* Probers now have a chance to lock at 750+ glimmer.
* Prober explosions are 1.5x as big if glimmer is over 900.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm tired of seeing glimmer continuously over 800 every game and Epi not giving a shit. Their hubris should be punished.

This can be round-ending in a way, but that's fine. Epi needs to manage glimmer.

## Technical details
<!-- Summary of code changes for easier review. -->
Nothing crazy. These really need to be re-written at some point.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
(Will just post in the CR thread since they are bigger files)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Glimmer probers can once again turn on and lock into place when glimmer is over 750.
- tweak: Glimmer prober explosions are 1.5x bigger if glimmer is over 900. You better build drainers! :)
- tweak: The oracle can now give normality crystals when completing her requests.
