### PR TITLE
Allow Slime people to change hair and facial hair color

### DIFF
--- a/Resources/Prototypes/Body/Species/slime.yml
+++ b/Resources/Prototypes/Body/Species/slime.yml
@@ -41,10 +41,10 @@
   appearances:
     enum.HumanoidVisualLayers.Hair:
       layerAlpha: 0.72
-      matchSkin: true
+#      matchSkin: true                          #Delta V - Allow Slime people to change hair color
     enum.HumanoidVisualLayers.FacialHair:
       layerAlpha: 0.72
-      matchSkin: true
+#      matchSkin: true                          #Delta V - Allow Slime people to change facial hair color
 
 - type: entity
   parent: BaseSpeciesAppearance


### PR DESCRIPTION
## About the PR
Removed the forced skin matching on Slime people's hair and facial hair to allow color picking for them.

## Why / Balance
Currently, a big problem is just how different the hair color can appear compared to the skin color. There are many hues/shades/values that make the hair look completely strange or overly see-through. In many cases the hair will look very different compared to the skin color. Because the hairs are also all individually made, it's much easier to allow color-picking than to resprite all the hairs to work nicely with Slime's sprite opacity.

Also more creativity is always good. The hair still has the same opacity/jellylike qualities. This will simply make it so you can make more fun combinations and are not forced to pick certain skin colors to get certain hair looks.

## Technical details

-  Disabled "matchSkin: true" in slime.yml for enum.HumanoidVisualLayers.Hair and enum.HumanoidVisualLayers.FacialHair

## Media
Comparison:
<img width="916" height="847" alt="Screenshot 2026-07-13 100600" src="https://github.com/user-attachments/assets/d5e97579-4a64-43ee-a041-6112bec5f556" />

<img width="878" height="834" alt="Screenshot 2026-07-13 100637" src="https://github.com/user-attachments/assets/030b234d-e30c-4a4a-8940-c40f2e80a6e5" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) 
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) 

**Changelog**
:cl:
- tweak: Slime people can now change their hair color!

