### PR TITLE
Add denim jacket to Cargo Technician outer clothing

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Cargo/cargo_technician.yml
@@ -37,6 +37,18 @@
   equipment:
     outerClothing: ClothingOuterWinterCargo
 
+# DeltaV
+- type: loadout
+  id: CargoTechnicianDenimJacket
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:RoleTimeRequirement
+      role: JobCargoTechnician
+      time: 144000 # 40hr
+  equipment:
+    outerClothing: ClothingOuterDenimJacket
+
 # Shoes
 - type: loadout
   id: CargoWinterBoots

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1007,6 +1007,7 @@
   minLimit: 0
   loadouts:
   - CargoTechnicianWintercoat
+  - CargoTechnicianDenimJacket
 
 - type: loadoutGroup
   id: CargoTechnicianShoes


### PR DESCRIPTION
Denim jacket is part of my Default Drip™ on cargo technician and this would save me from seconds to minutes every round start, depending on where I spawn.

<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I added the Denim Jacket to the Cargo Technician's outer clothing, subject to a 40hr time requirement so un-robust technicians don't steal my drip.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This will save me anywhere from a few seconds to a few minutes at the start of every round. There shouldn't be much effect on balance, This doesn't change the rest of the character silhouette much or make me look like a different department. 

## Technical details
<!-- Summary of code changes for easier review. -->
Inserted the following at line 40 in `Resources/Prototypes/Loadouts/Jobs/Cargo/cargo_technician.yml`:
```yaml
# DeltaV
- type: loadout
  id: CargoTechnicianDenimJacket
  effects:
  - !type:JobRequirementLoadoutEffect
    requirement:
      !type:RoleTimeRequirement
      role: JobCargoTechnician
      time: 144000 # 40hr
  equipment:
    outerClothing: ClothingOuterDenimJacket
```

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

~~This would just be a photo of Nahi in a denim jacket, which many of you have seen already.~~

<img width="256" height="256" alt="Screenshot_20260713_230857" src="https://github.com/user-attachments/assets/df957697-c431-4d67-a472-333a72e765b6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: After much pestering, NanoTrasen has begrudgingly added Denim Jackets as an outer clothing option for Cargo Technicians.