### PR TITLE
Fix pills not having a taste (#5063)

### DIFF
--- a/Resources/Locale/en-US/nutrition/components/ingestion-system.ftl
+++ b/Resources/Locale/en-US/nutrition/components/ingestion-system.ftl
@@ -34,7 +34,8 @@ edible-nom = Nom. {$flavors}{ -edible-satiated(satiated: $satiated, verb: "eat")
 edible-nom-other = Nom.
 edible-slurp = Slurp. {$flavors}{ -edible-satiated(satiated: $satiated, verb: "drink") }
 edible-slurp-other = Slurp.
-edible-swallow = You swallow { THE($food) }.{ -edible-satiated(satiated: $satiated, verb: "swallow") }
+# DeltaV - Fix pills not having a taste (#5063)
+edible-swallow = You swallow { THE($food) }. {$flavors}{ -edible-satiated(satiated: $satiated, verb: "swallow") }
 edible-gulp = Gulp. {$flavors}
 edible-gulp-other = Gulp.
 


### PR DESCRIPTION
## About the PR
This makes pills have tastes again.

## Why / Balance
See #5063 
I also just wanted a simple good first task to orient myself to this codebase as I'm interested in contributing coming from ss13 :D

## Technical details
The edible-swallow locale message used by pills was missing the {$flavors} placeholder that edible-nom, edible-slurp and edible-gulp all have. IngestionSystem always passes the computed flavor text, so pills silently dropped it. Eating a pill now shows its taste again, e.g. "You swallow the pill. Tastes sweet."

## Media
<img width="513" height="254" alt="Animationgood" src="https://github.com/user-attachments/assets/ee68d261-ecd7-4d44-905d-ce31ec31a718" />

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Pills now have taste again! Sorry Lexorin-pilled people.
