### PR TITLE
Fugi paper fix

### DIFF
--- a/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
+++ b/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
@@ -109,7 +109,9 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         var report = new FormattedMessage();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-title"));
         report.PushNewline();
+        report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-first-line"));
+        report.PushNewline();
         report.PushNewline();
 
         if (!TryComp<HumanoidProfileComponent>(uid, out var humanoid))
@@ -121,8 +123,11 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         var species = PrototypeManager.Index(humanoid.Species);
 
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-morphotype", ("species", Loc.GetString(species.Name))));
+        report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-age", ("age", humanoid.Age)));
+        report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-sex", ("sex", humanoid.Sex)));
+        report.PushNewline();
 
         if (TryComp<PhysicsComponent>(uid, out var physics))
             report.AddMarkupOrThrow(Loc.GetString("fugitive-report-weight", ("weight", Math.Round(physics.FixturesMass))));
@@ -133,6 +138,7 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
             0 => Loc.GetString("fugitive-report-detail-dna", ("dna", GetDNA(uid))),
             _ => Loc.GetString("fugitive-report-detail-prints", ("prints", GetPrints(uid)))
         });
+        report.PushNewline();
 
         report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crimes-header"));
@@ -172,6 +178,7 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         {
             var count = RobustRandom.Next(rule.MinCounts, rule.MaxCounts + 1);
             report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crime", ("crime", Loc.GetString(crime)), ("count", count)));
+            report.PushNewline();
         }
     }
 }

--- a/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
+++ b/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
@@ -130,8 +130,10 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
         report.PushNewline();
 
         if (TryComp<PhysicsComponent>(uid, out var physics))
+        {
             report.AddMarkupOrThrow(Loc.GetString("fugitive-report-weight", ("weight", Math.Round(physics.FixturesMass))));
-
+            report.PushNewline();
+        }
         // add a random identifying quality that officers can use to track them down
         report.AddMarkupOrThrow(RobustRandom.Next(0, 2) switch
         {

--- a/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
+++ b/Content.Server/_DV/StationEvents/GameRules/FugitiveRule.cs
@@ -142,7 +142,7 @@ public sealed class FugitiveRule : StationEventSystem<FugitiveRuleComponent>
 
         report.PushNewline();
         report.AddMarkupOrThrow(Loc.GetString("fugitive-report-crimes-header"));
-
+        report.PushNewline();
         // generate some random crimes to avoid this situation
         // "officer what are my charges?"
         // "uh i dunno a piece of paper said to arrest you thats it"


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
+9 \n to fugitive paper

## Why / Balance
<img width="469" height="511" alt="image" src="https://github.com/user-attachments/assets/9d146810-1f48-4c92-a817-ffc2ffd2b1d9" />


## Technical details
C# 9 PushNewLine()

## Media
Back to this
<img width="503" height="713" alt="image" src="https://github.com/user-attachments/assets/639ef2fa-b8f1-48d7-880d-fc1d42f840fc" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Wanted Fugitive paper is no longer clustered.

