### PR TITLE
Universal Bag-Hiding, Smaller Kitsune

### DIFF
--- a/Content.Shared/Nyanotrasen/Item/PseudoItem/PseudoItemComponent.cs
+++ b/Content.Shared/Nyanotrasen/Item/PseudoItem/PseudoItemComponent.cs
@@ -15,13 +15,32 @@ public sealed partial class PseudoItemComponent : Component
 
     /// <summary>
     /// An optional override for the shape of the item within the grid storage.
-    /// If null, a default shape will be used based on <see cref="Size"/>.
+    /// If null, a default shape will be used based on what felinids used to have.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public List<Box2i>? Shape;
+    public List<Box2i>? Shape = new()
+    {
+        new Box2i(0, 2, 5, 4), // body: 6 wide x 3 tall
+        new Box2i(0, 0, 1, 1), // top-left ear: 2x2 (low Y renders at the top)
+        new Box2i(4, 0, 5, 1), // top-right ear: 2x2
+    };
 
     [DataField, AutoNetworkedField]
     public Vector2i StoredOffset;
+
+    /// <summary>
+    /// A static, per-species multiplier applied on top of the character's visual scale
+    /// Used for smaller species that use full sprite-scale. (Allulalo)
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float SizeMultiplier = 1f;
+
+    /// <summary>
+    /// The effective scale at (or above) which the entity is too big to fit inside a duffel bag.
+    /// A default human's minimum height is 0.9, so at the default they are always slightly too large.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float MaxDuffelScale = 0.9f;
 
     public bool Active = false;
 

--- a/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.Checks.cs
+++ b/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.Checks.cs
@@ -20,15 +20,22 @@ public partial class SharedPseudoItemSystem
             return false;
 
         TryComp<ItemComponent>(itemEnt, out var item);
-        // If the entity doesn't have an item comp, create a fake one
-        // The fake component is never actually added to the entity
-        item ??= new ItemComponent
+        // If the entity doesn't have an item comp, create a fake one from the scaled footprint.
+        // The fake component is never actually added to the entity.
+        if (item == null)
         {
-            Owner = itemEnt,
-            Shape = itemEnt.Comp.Shape,
-            Size = itemEnt.Comp.Size,
-            StoredOffset = itemEnt.Comp.StoredOffset
-        };
+            // Too big to be stored at its current effective scale (e.g. above the duffel cutoff).
+            if (!TryGetScaledShape((itemEnt, itemEnt.Comp), out var shape))
+                return false;
+
+            item = new ItemComponent
+            {
+                Owner = itemEnt,
+                Shape = shape,
+                Size = itemEnt.Comp.Size,
+                StoredOffset = itemEnt.Comp.StoredOffset
+            };
+        }
 
         return _storage.CanInsert(storageEnt, itemEnt, out _, storageEnt.Comp, item, ignoreStacks: true);
     }

--- a/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
+++ b/Content.Shared/Nyanotrasen/Item/PseudoItem/SharedPseudoItemSystem.cs
@@ -7,11 +7,13 @@ using Content.Shared.Interaction.Events;
 using Content.Shared.Item;
 using Content.Shared.Item.PseudoItem;
 using Content.Shared.Popups;
+using Content.Shared.Sprite;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Nyanotrasen.Item.PseudoItem;
@@ -25,6 +27,7 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly SharedScaleVisualsSystem _scaleVisuals = default!;
 
     private readonly ProtoId<TagPrototype> PreventTag = "PreventLabel";
     private readonly EntProtoId SleepActionId = "ActionSleep"; // The action used for sleeping inside bags. Currently uses the default sleep action (same as beds)
@@ -80,8 +83,12 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
         if (!CheckItemFits((toInsert, component), (storageUid, storage)))
             return false;
 
+        // Compute the footprint from the entity's current scale. If it is too big, bail out.
+        if (!TryGetScaledShape((toInsert, component), out var shape))
+            return false;
+
         var itemComp = new ItemComponent
-            { Size = component.Size, Shape = component.Shape, StoredOffset = component.StoredOffset };
+            { Size = component.Size, Shape = shape, StoredOffset = component.StoredOffset };
         AddComp(toInsert, itemComp);
         _item.VisualsChanged(toInsert);
 
@@ -177,5 +184,83 @@ public abstract partial class SharedPseudoItemSystem : EntitySystem
     {
         if (component.Active)
             args.Cancel();
+    }
+
+    /// <summary>
+    /// The effective scale used to decide whether (and how) the entity fits in storage.
+    /// This combines the character's visual scale (species base scale + height slider) with the
+    /// per-species <see cref="PseudoItemComponent.SizeMultiplier"/>.
+    /// </summary>
+    public float GetEffectiveScale(Entity<PseudoItemComponent> ent)
+    {
+        var visual = _scaleVisuals.GetSpriteScale(ent);
+        var averaged = (visual.X + visual.Y) / 2f;
+        return averaged * ent.Comp.SizeMultiplier;
+    }
+
+    /// <summary>
+    /// Computes the stored grid footprint for the entity at its current effective scale.
+    /// Returns false when the entity is too big to be stored (effective scale >= MaxDuffelScale),
+    /// or when it has no base shape to scale.
+    /// </summary>
+    public bool TryGetScaledShape(Entity<PseudoItemComponent> ent, out List<Box2i> shape)
+    {
+        shape = new List<Box2i>();
+
+        if (ent.Comp.Shape is not { } baseShape)
+            return false;
+
+        if (GetEffectiveScale(ent) is var scale && scale >= ent.Comp.MaxDuffelScale)
+            return false;
+
+        shape = ScaleAndRasterize(baseShape, scale);
+        return true;
+    }
+
+    /// <summary>
+    /// Scales a base grid shape by a factor and re-rasterizes it onto whole grid cells using
+    /// nearest-neighbor sampling, returning one 1x1 box per occupied cell.
+    /// Looks good enough for most scales. Especially the mins and maxes.
+    /// </summary>
+    private static List<Box2i> ScaleAndRasterize(IReadOnlyList<Box2i> baseShape, float scale)
+    {
+        // Collect the filled cells of the base shape and its bounds.
+        var filled = new HashSet<Vector2i>();
+        int minX = int.MaxValue, minY = int.MaxValue, maxX = int.MinValue, maxY = int.MinValue;
+        foreach (var box in baseShape)
+        {
+            for (var x = box.Left; x <= box.Right; x++)
+            for (var y = box.Bottom; y <= box.Top; y++)
+            {
+                filled.Add(new Vector2i(x, y));
+                minX = Math.Min(minX, x);
+                minY = Math.Min(minY, y);
+                maxX = Math.Max(maxX, x);
+                maxY = Math.Max(maxY, y);
+            }
+        }
+
+        if (filled.Count == 0)
+            return new List<Box2i>();
+
+        var baseWidth = maxX - minX + 1;
+        var baseHeight = maxY - minY + 1;
+
+        // Target footprint size, rounded up so the largest baggable characters reach the full size.
+        var targetWidth = Math.Max(1, (int)MathF.Ceiling(baseWidth * scale));
+        var targetHeight = Math.Max(1, (int)MathF.Ceiling(baseHeight * scale));
+
+        var cells = new List<Box2i>();
+        for (var tx = 0; tx < targetWidth; tx++)
+        for (var ty = 0; ty < targetHeight; ty++)
+        {
+            // Sample the base cell under the centre of this target cell.
+            var sx = minX + Math.Min(baseWidth - 1, (int)((tx + 0.5f) / scale));
+            var sy = minY + Math.Min(baseHeight - 1, (int)((ty + 0.5f) / scale));
+            if (filled.Contains(new Vector2i(sx, sy)))
+                cells.Add(new Box2i(tx, ty, tx, ty));
+        }
+
+        return cells;
     }
 }

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -176,6 +176,7 @@
     - AnomalyHost
   - type: CosmicCenserTarget # DeltaV - Cosmic Cult
   - type: Carriable # DeltaV
+  - type: PseudoItem # DeltaV - Any humanoid can be stuffed into a bag, but only if small enough. Footprint based on a mix of species multiplier, and character height.
   - type: GrappleTarget # DeltaV - Allow targets to be grappled
   - type: RMCSetPose # DeltaV - RMC pose port
 

--- a/Resources/Prototypes/_DV/Body/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Body/Species/felinid.yml
@@ -108,12 +108,6 @@
     baseCritThreshold: 85
   - type: TypingIndicator
     proto: felinid
-  - type: PseudoItem
-    storedOffset: 0,17
-    shape:
-    - 0,0,1,4
-    - 0,2,3,4
-    - 4,0,5,4
   - type: Vocal
     wilhelm: "/Audio/Nyanotrasen/Voice/Felinid/cat_wilhelm.ogg"
     sounds:

--- a/Resources/Prototypes/_DV/Body/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Body/Species/kitsune.yml
@@ -128,12 +128,6 @@
         Heat: 5
   - type: LightweightDrunk
     boozeStrengthMultiplier: 3
-  - type: PseudoItem
-    storedOffset: "0,17"
-    shape:
-    - 0,0,1,4
-    - 0,2,3,4
-    - 4,0,5,4
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/_DV/Body/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Body/Species/rodentia.yml
@@ -124,11 +124,6 @@
       Unsexed: MaleRodentia
   - type: Rummager
   - type: AlwaysTriggerMousetrap
-  - type: PseudoItem
-    storedOffset: -10,0
-    shape:
-    - 0, 0, 3, 2
-    - 0, 2, 5, 4
   - type: MouthStorage
     mouthProto: CheekStorage
     openStorageAction: ActionOpenMouthStorage

--- a/Resources/Prototypes/_DV/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Species/kitsune.yml
@@ -6,5 +6,5 @@
   dollPrototype: AppearanceKitsune
   skinColoration: HumanToned
   baseScale: 1, 1
-  minHeight: .85
+  minHeight: .75
   maxHeight: 1.05

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/allulalo.yml
@@ -101,9 +101,7 @@
   - type: TypingIndicator
     proto: allulalo
   - type: PseudoItem # DeltaV - Allows Allulalo to fit inside bags
-    storedOffset: 0,17
-    shape:
-    - 0,0,3,3
+    sizeMultiplier: 0.5 # Allulalo are WAY smaller even at full sprite scale
   - type: Vocal
     sounds:
       Male: Allulalo


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
All characters of appropriate size can now fit in Duffel-Bags. Appropriate size is total scale <0.9.
Additionally, Kitsune have had their min-scale set to 0.75 to be more inline with Felinids and their initial design.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Makes the bag-hiding mechanic universal and not species specific, to avoid singling out any species.
This is in response to feedback from #6303

## Technical details
<!-- Summary of code changes for easier review. -->
Height is calculated as a mix of their sprite height (species base * character height), and a static scale (Used for Allulalo).
The default shape matches the current Felinid shape, (two 2x2 boxes stacked atop a 6x3 box). This is than scaled and re-rasterized depending on the target height.

Larger species, humans and up, cannot become small enough to fit.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="311" height="177" alt="image" src="https://github.com/user-attachments/assets/14e80cc9-44fb-4862-a11e-6a2bf55a8987" />
<img width="153" height="92" alt="image" src="https://github.com/user-attachments/assets/4cfd7e29-91af-4236-bb6e-51ca270ab5b7" />
<img width="215" height="146" alt="image" src="https://github.com/user-attachments/assets/a4144347-a23a-4c86-9cc2-78d5b89ad690" />
<img width="199" height="154" alt="image" src="https://github.com/user-attachments/assets/406bd942-e9b2-4ebe-923b-5f5eba51c8f4" />
<img width="183" height="147" alt="image" src="https://github.com/user-attachments/assets/27bd7e0d-cd67-4264-a7b2-2a9fc67aef63" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Lowered Kitsune Min-Height to be more in-line with their design.
- tweak: Everyone small enough can now fit in bags, no-longer should Felinids and Rodentia get all the fun!
