### PR TITLE
Make HOP a second-in-command

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -132,11 +132,11 @@
       # Yes they do fuck you.
     - id: ClothingBackpackIan
       prob: 0.5
-    #- id: ClothingHeadsetCommand # DeltaV - HOP is head of service.
+    - id: ClothingHeadsetCommand
     - id: ClothingNeckGoldmedal
     - id: DoorRemoteService
     - id: HoPIDCard
-    #- id: WeaponDisabler # DeltaV - There is no reason for the service head to have a disabler.
+    - id: WeaponDisabler
     - id: ClothingEyesHudCommand
 
 - type: entity

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -36,34 +36,45 @@
   - Janitor
   - Theatre
   - Kitchen
-  #- Chapel # DeltaV - Chapel is in Epistemics
+  - Chapel
   - Hydroponics
   - External
   - Cryogenics
   # I mean they'll give themselves the rest of the access levels *anyways*.
   # As of 15/03/23 they can't do that so here's MOST of the rest of the access levels.
   # Head level access that isn't their own was deliberately left out, get AA from the captain instead.
-  # Begin DeltaV Removals - fuck all of this HoP is a service role
-  #- Chemistry
-  #- Engineering
-  #- Research
-  #- Detective
-  #- Salvage
-  #- Security # NoooOoOo!! My HoPcurity!1
-  #- Brig
-  #- Lawyer # Lawyer is now part of the justice dept
-  #- Cargo
-  #- Atmospherics
-  #- Medical
-  # End DeltaV Removals
-  # Begin DeltaV Additions - fine-grained service accesses
+  - Chemistry
+  - Engineering
+  - Research
+  - Detective
+  - Salvage
+  - Security
+  #- Brig # DeltaV - We don't use it.
+  - Lawyer
+  - Cargo
+  - Atmospherics
+  - Medical
+  - GenpopEnter
+  - GenpopLeave
+  # Begin DeltaV additions
   - Boxer
   - Clown
   - Mime
   - Musician
   - Reporter
   - Zookeeper
-  # End DeltaV Additions
+  - Mantis
+  - Corpsman
+  - Mail
+  - Prosecutor
+  - Robotics
+  - Surgery
+  - Psychologist
+  - Paramedic
+  - Clerk
+  - Justice
+  - Library
+  # End DeltaV additions
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -90,7 +90,7 @@
     #shoes: ClothingShoesLeather # DeltaV - Commented for Loadouts
     id: HoPPDA
     #gloves: ClothingHandsGlovesHop # DeltaV - Commented for Loadouts
-    ears: ClothingHeadsetHoP # DeltaV - HoP is now a service role, replaces ClothingHeadsetAltCommand headset.
+    ears: ClothingHeadsetAltCommand
     belt: BoxFolderClipboardThreePapers
     eyes: ClothingEyesHudCommand
   storage:

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -20,11 +20,12 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 2.5h
-  weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
+  weight: 20
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"
   requireAdminNotify: true # DeltaV
   joinNotifyCrew: true # DeltaV
+  whitelisted: true # DeltaV
   supervisors: job-supervisors-captain
   canBeAntag: false
   access:

--- a/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Lockers/heads.yml
@@ -26,7 +26,6 @@
   id: LockerFillHeadOfPersonnelDeltaV
   table: !type:AllSelector
     children:
-    - id: ClothingHeadsetAltService
     - id: ClothingOuterCoatHoPArmored
     - id: BookIanDossier # HoP steal objective, see Resources/Prototypes/_DV/Entities/Objects/Misc/ian_dossier.yml
     - id: PersonalAILearnerService # imp


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
This PR enables the HoP as it was before being just the Head of Service.
This PR intends to make the HoP:
- Make a second-in-command that isn't HoS as it usually ends up being unofficially.
- Give more content to HoP since they usually end up sitting in their office or walking around without anything to do.
- Fallback of basic access for Heads of Staff if they wish to hire someone.
- A better choice for ACO when a captain is no more instead of falling it, again, on the HoS which already have a lot going on the round at that point.
- Whitelist them so they are less of a possible nuisance to administration.

Changes done to facilitate this:
- Given the general access back, plus some that were missing.
- Restored their disabler to the locker.
- Restored the weight of the job since it might be more difficult to kill them.

I do fear that this might end up in HoPcurity like before or them giving accesses without consulting other heads of staff, maybe a change in SOP would fix this, but it is something I think might happen.

## Why / Balance
Mostly because of a [thread on discord](https://discord.com/channels/968983104247185448/1529150931432902746) and to make HoP have some responsibilities.

## Technical details
N/A

## Media
Access:
<img width="819" height="530" alt="image" src="https://github.com/user-attachments/assets/b0dce881-4882-4c19-a4b6-47f36cc8c9a3" />
Whitelist:
<img width="959" height="82" alt="image" src="https://github.com/user-attachments/assets/bf0b1f69-e5d4-4a09-ae47-604c0d44d636" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The HOP has most of the access on station back again in order to make them similar to upstream.