### PR TITLE
Shrink entropic blades

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Objects/cosmicweapons.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Objects/cosmicweapons.yml
@@ -65,6 +65,8 @@
   - type: DisarmMalus
   - type: Item
     size: Huge
+    shape:
+    - 0,0,1,3
     sprite: _DV/CosmicCult/Objects/cosmicsword-inhands.rsi
     inhandVisuals:
       left:


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Changed the cult's entropic blade to 2x4, down from 4x4.

## Why / Balance
To put it simply: cult rarely bothers to prepare for going loud. Everyone tries to rush all the rituals at once when T3 hits, which causes a mess both from the damage those deal AND the general clusterfuck of 10 people rushing in the place at once with half of them not having anything to convert in the first place.
Part of this, I think, is the fact that while you can start preparing weapons as early as T2, giving you both an out in case of emergencies AND saving time and health later, they are _**SO DAMN BIG**_ that nobody wants to sacrifice half of your entire bag space just for one.

So: I'm making them smaller. Still big, but a size that feels more reasonable to sneak around with.

## Technical details
2 lines of YAML to change their shape. Still Huge.

## Media
<img width="108" height="149" alt="sord" src="https://github.com/user-attachments/assets/9418b5ba-7143-4791-b044-b6f472914a24" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Cosmic Cult's Entropic Blades are now smaller (2x4 spaces)


