### PR TITLE
Buckle Bugfix + Dynamic CPR Prio

### DIFF
--- a/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
+++ b/Content.Shared/Buckle/SharedBuckleSystem.Buckle.cs
@@ -392,7 +392,6 @@ public abstract partial class SharedBuckleSystem
         if (TryComp<PhysicsComponent>(buckle, out var physics))
             _physics.ResetDynamics(buckle, physics);
 
-        // TOOD: DV - This fails when you try to buckle the entity you're carrying to something. Figure out why later.
         DebugTools.AssertEqual(xform.ParentUid, strap.Owner);
     }
 

--- a/Content.Shared/_DV/Body/Systems/CPRSystem.cs
+++ b/Content.Shared/_DV/Body/Systems/CPRSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared._DV.Body.Components;
 using Content.Shared._DV.Body.Events;
+using Content.Shared.Buckle;
 using Content.Shared.DoAfter;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -13,6 +14,7 @@ public sealed class CPRSystem : EntitySystem
     [Dependency] private readonly MobStateSystem _mobStateSystem = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+    [Dependency] private readonly SharedBuckleSystem _buckle = default!;
 
     public override void Initialize()
     {
@@ -85,7 +87,7 @@ public sealed class CPRSystem : EntitySystem
         {
             Act = () => StartCPR(user, target, cprComp.TimeLength),
             Text = Loc.GetString("cpr-verb-start"),
-            Priority = 2,
+            Priority = _buckle.IsBuckled(target) ? 3 : 1, // Higher priority if they are buckled. Otherwise, this conflicts with trying to carry.
             Disabled = alreadyAffected,
             Message = alreadyAffected ? Loc.GetString("cpr-verb-disabled-description") : Loc.GetString("cpr-verb-description"),
         };

--- a/Content.Shared/_DV/Carrying/CarryingSystem.cs
+++ b/Content.Shared/_DV/Carrying/CarryingSystem.cs
@@ -228,7 +228,6 @@ public sealed class CarryingSystem : EntitySystem
         DropCarried(ent.Comp.Carrier, ent, attachToGrid: false);
     }
 
-
     private void OnRemoved(Entity<BeingCarriedComponent> ent, ref ComponentRemove args)
     {
         /*
@@ -357,7 +356,8 @@ public sealed class CarryingSystem : EntitySystem
         _actionBlocker.UpdateCanMove(carried);
 
         // Some systems will handle re-parenting and then throw an event, and this changes the parent when it should not
-        if (attachToGrid) _transform.AttachToGridOrMap(carried);
+        if (attachToGrid)
+            _transform.AttachToGridOrMap(carried);
         _standingState.Stand(carried);
     }
 

--- a/Content.Shared/_DV/Carrying/CarryingSystem.cs
+++ b/Content.Shared/_DV/Carrying/CarryingSystem.cs
@@ -30,6 +30,7 @@ using System.Numerics;
 using Content.Shared._DV.Polymorph;
 using Content.Shared._Floof.OfferItem;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Buckle;
 
 namespace Content.Shared._DV.Carrying;
 
@@ -70,7 +71,7 @@ public sealed class CarryingSystem : EntitySystem
         SubscribeLocalEvent<BeingCarriedComponent, GettingInteractedWithAttemptEvent>(OnInteractedWith);
         SubscribeLocalEvent<BeingCarriedComponent, PullAttemptEvent>(OnPullAttempt);
         SubscribeLocalEvent<BeingCarriedComponent, StartClimbEvent>(OnDrop);
-        SubscribeLocalEvent<BeingCarriedComponent, BuckledEvent>(OnDrop);
+        SubscribeLocalEvent<BeingCarriedComponent, BuckledEvent>(OnBuckle);
         SubscribeLocalEvent<BeingCarriedComponent, UnbuckledEvent>(OnDrop);
         SubscribeLocalEvent<BeingCarriedComponent, StrappedEvent>(OnDrop);
         SubscribeLocalEvent<BeingCarriedComponent, UnstrappedEvent>(OnDrop);
@@ -220,6 +221,14 @@ public sealed class CarryingSystem : EntitySystem
         DropCarried(ent.Comp.Carrier, ent);
     }
 
+    private void OnBuckle(Entity<BeingCarriedComponent> ent, ref BuckledEvent args)
+    {
+        // Buckling to a bed already handles the reparenting to the entity that the carried
+        // entity is buckled to, and then relays the BuckledEvent, so don't reparent to the grid.
+        DropCarried(ent.Comp.Carrier, ent, attachToGrid: false);
+    }
+
+
     private void OnRemoved(Entity<BeingCarriedComponent> ent, ref ComponentRemove args)
     {
         /*
@@ -327,9 +336,9 @@ public sealed class CarryingSystem : EntitySystem
         return true;
     }
 
-    public void DropCarried(EntityUid carrier, EntityUid carried)
+    public void DropCarried(EntityUid carrier, EntityUid carried, bool attachToGrid = true)
     {
-        Drop(carried);
+        Drop(carried, attachToGrid);
         CleanupCarrier(carrier, carried);
     }
 
@@ -341,12 +350,14 @@ public sealed class CarryingSystem : EntitySystem
         _movementSpeed.RefreshMovementSpeedModifiers(carrier);
     }
 
-    private void Drop(EntityUid carried)
+    private void Drop(EntityUid carried, bool attachToGrid = true)
     {
         RemComp<BeingCarriedComponent>(carried);
         RemComp<KnockedDownComponent>(carried); // TODO SHITMED: make sure this doesnt let you make someone with no legs walk
         _actionBlocker.UpdateCanMove(carried);
-        _transform.AttachToGridOrMap(carried);
+
+        // Some systems will handle re-parenting and then throw an event, and this changes the parent when it should not
+        if (attachToGrid) _transform.AttachToGridOrMap(carried);
         _standingState.Stand(carried);
     }
 


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
* Fixed a long-standing bug with buckling while carrying. It shouldn't attempt to re-parent (since buckling already did that).
* Changed CPR prio to be less priority while the entity is not buckled.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Carrying and CPR verbs had conflicting priorities. I just tweaked it so picking up someone who's crit takes prio UNLESS they are strapped to a bed or rollerbed.

Also bug fix good.

## Technical details
<!-- Summary of code changes for easier review. -->
It was just the CPR change, but then I got debug assertion issues when I was recording so I fixed that too.

The issue was that buckling happened, updated the parent of the entity being buckled and then the `BuckleEvent` was being relayed. The Carrying system would re-parent to the grid itself instead of the entity that the carried person was buckled to. So I just added an optional param to not re-parent in that case.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/3ffdbd23-0eae-4418-8abf-432dc16401d1


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Buckling someone while they are being carried should work as intended now.
- tweak: Picking someone up that is criticla will have priority over CPR unless they are buckled to something.
