### PR TITLE
Fix and Tweak Random Shuttle Spawns

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -34,7 +34,6 @@
     - !type:NestedSelector # DeltaV
       tableId: BasicAntagEventsTableDeltaV
     - id: DragonSpawn
-    - id: ColossusSpawn # DeltaV
     #- id: ClosetSkeleton # DeltaV - replaced with MenaceSkeleton
     #- id: KingRatMigration # DeltaV - disabled
     - id: RevenantSpawn

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -623,7 +623,7 @@
     maximumSpanUntilFirstEvent: 900 # At longest takes an hour to show up.
     minMaxEventTiming:
       min: 1200 # 20 mins
-      max: 7200 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible.
+      max: 3600 # DeltaV - was 120 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible.
     scheduledGameRules: !type:NestedSelector
       prob: 0.05 # Only 1 in 20 rounds...
       tableId: SpaceTrafficControlTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -623,9 +623,9 @@
     maximumSpanUntilFirstEvent: 900 # At longest takes an hour to show up.
     minMaxEventTiming:
       min: 1200 # 20 mins
-      max: 3600 # DeltaV - was 120 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible.
+      max: 5400 # 120 mins # you probably arent getting a second visitor shuttle in one round, but it is possible. # DeltaV - was 7200, now 90min
     scheduledGameRules: !type:NestedSelector
-      prob: 0.05 # Only 1 in 20 rounds...
+      #prob: 0.05 # Only 1 in 20 rounds... # DeltaV - remove 1/20
       tableId: SpaceTrafficControlTable
 
 # variation passes

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -5,7 +5,7 @@
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - !type:NestedSelector # DeltaV
-      tableId: UnknownShuttlesFreelanceTableDeltaV
+      tableId: UnknownShuttlesTableDeltaV
     - id: LoneOpsSpawn
     - id: UnknownShuttleManOWar
     #- id: UnknownShuttleInstigator # DeltaV: remove random ops
@@ -50,7 +50,7 @@
   id: UnknownShuttleSyndieEvacPod
   components:
   - type: StationEvent
-    weight: 5 # lower because weird freelance roles
+    weight: 6
     maxOccurrences: 2
   - type: LoadMapRule
     gridPath: /Maps/_DV/Shuttles/Event/syndie_evacpod.yml # DeltaV - Switched to our version, was /Maps/Shuttles/ShuttleEvent/syndie_evacpod.yml

--- a/Resources/Prototypes/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/GameRules/unknown_shuttles.yml
@@ -4,7 +4,9 @@
   id: UnknownShuttlesHostileTable
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
-    #- id: LoneOpsSpawn # DeltaV: This is already in antag events table
+    - !type:NestedSelector # DeltaV
+      tableId: UnknownShuttlesFreelanceTableDeltaV
+    - id: LoneOpsSpawn
     - id: UnknownShuttleManOWar
     #- id: UnknownShuttleInstigator # DeltaV: remove random ops
 

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -239,7 +239,7 @@
   id: RoboNeuroticist
   components:
   - type: StationEvent
-    weight: 1
+    weight: 2
     minimumPlayers: 35 #big threat, but has to have ghosts to matter
     reoccurrenceDelay: 30
     duration: null # so it shows up in round end

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -18,6 +18,9 @@
     - id: SkiaSpawn
     - id: RatKingSpawn
     - id: NTAgentSleeper
+    - id: ColossusSpawn
+    - id: AsakimShuttle
+    - id: HitmanShuttle
 
 # Replaces upstream meteor events until they're good
 - type: entity
@@ -473,7 +476,7 @@
     startAnnouncement: station-event-pitbull-start-announcement
     startAudio:
       path: /Audio/_DV/Announcements/attention.ogg
-    earliestStart: 1
+    earliestStart: 30
     minimumPlayers: 10
     weight: 1
     duration: 15

--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -1,5 +1,5 @@
 - type: entityTable
-  id: UnknownShuttlesFreelanceTableDeltaV
+  id: UnknownShuttlesTableDeltaV
   table: !type:AllSelector # we need to pass a list of rules, since rules have further restrictions to consider via StationEventComp
     children:
     - id: SyndicateRecruiter
@@ -8,6 +8,7 @@
     - id: AsakimShuttle
     - id: HitmanShuttle
     - id: RoboNeuroticist
+    - id: UnknownShuttleSyndieEvacPod
 
 - type: entity
   parent: BaseUnknownShuttleRule

--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -7,13 +7,14 @@
     - id: SyndicateArmsdealer
     - id: AsakimShuttle
     - id: HitmanShuttle
+    - id: RoboNeuroticist
 
 - type: entity
   parent: BaseUnknownShuttleRule
   id: SyndicateRecruiter
   components:
   - type: StationEvent
-    weight: 4
+    weight: 6
     minimumPlayers: 20
     maxOccurrences: 1
     duration: null
@@ -58,7 +59,7 @@
   id: SynthesisSpecialist
   components:
   - type: StationEvent
-    weight: 4
+    weight: 6
     minimumPlayers: 20
     maxOccurrences: 1
     duration: null
@@ -102,7 +103,7 @@
   id: SyndicateArmsdealer
   components:
   - type: StationEvent
-    weight: 2
+    weight: 6
     minimumPlayers: 25
     maxOccurrences: 1
     duration: null
@@ -147,7 +148,7 @@
   id: HitmanShuttle
   components:
   - type: StationEvent
-    weight: 2
+    weight: 6
     minimumPlayers: 25
     maxOccurrences: 1
     duration: null

--- a/Resources/Prototypes/_Mono/GameRules/asakim.yml
+++ b/Resources/Prototypes/_Mono/GameRules/asakim.yml
@@ -17,7 +17,7 @@
     #startAnnouncement: station-event-asakim-shuttle-detected # DeltaV - no
     #  startAudio:
     #    path: /Audio/Misc/notice1.ogg
-    weight: 1.5 # DeltaV -  was 2, now less common then Arms Dealer. rare role
+    weight: 3
     minimumPlayers: 25 # DeltaV
     maxOccurrences: 1 # DeltaV - was 4
     duration: null # DeltaV


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Freelance visitor shuttles were removed and some of our antags were not spawning since it was tied to that table.

Also, re-added lone op to that table but made it more rare. The weights for the SpaceTrafficEventScheduler are now:
* DisasterVictims: 6
* SyndicateRecruiter: 6
* SynthesisSpecialist: 6
* SyndicateArmsdealer: 6
* HitmanShuttle: 6
* AsakimShuttle: 3
* LoneOp: 3
* RoboNeuroticist: 2

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The `SpaceTrafficControlEventScheduler` would fire events between 20 and 120 minutes in the round. You could have multiple shuttles per round, but most of the time, it would just be 1, possibly 2.

We have so many shuttle events that I decreased the max time from 20 to 90 minutes per shuttle event. That should give 2-3 a round. Re-added LoneOp as a rare shuttle spawn because ghosts love it. Added SRN to the table as a very rare spawn as well, because it is in in a shuttle. :)

Also, just generally fixed them not spawning.

## Technical details
<!-- Summary of code changes for easier review. -->
Also moved ColossusSpawn to the DV events table since that was outside of it for some reason.

Upstream also added a 1/20 chance of the shuttle events even happening, so I removed that.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="740" height="478" alt="image" src="https://github.com/user-attachments/assets/585a1671-64c7-4c3d-aba8-847ec292a936" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Fixed some visitor shuttles (e.g. Asakim, Interdyne Chemists, Syndie Recruiter, etc) not spawning.
- tweak: There should roughly be 1.5x as many random shuttle events per round.
- tweak: Slightly increased the chances of Asakim, LoneOp and SRN events to happen.
- tweak: Asakim and Hitman shuttles are now more likely to appear during survival rounds.