### PR TITLE
Small Midround Antag Balance Pass

### DIFF
--- a/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
+++ b/Content.Server/Revenant/EntitySystems/RevenantSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.StatusEffect;
 using Content.Shared.Store.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Tag;
+using Content.Shared.Weapons.Melee.Events; // DeltaV
 using Robust.Server.GameObjects;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Prototypes;
@@ -64,6 +65,7 @@ public sealed partial class RevenantSystem : EntitySystem
         SubscribeLocalEvent<RevenantComponent, StatusEffectAddedEvent>(OnStatusAdded);
         SubscribeLocalEvent<RevenantComponent, StatusEffectEndedEvent>(OnStatusEnded);
         SubscribeLocalEvent<RoundEndTextAppendEvent>(_ => MakeVisible(true));
+        SubscribeLocalEvent<RevenantComponent, MeleeAttackEvent>(OnMeleeAttack); // DeltaV
 
         SubscribeLocalEvent<RevenantComponent, GetVisMaskEvent>(OnRevenantGetVis);
 
@@ -129,6 +131,14 @@ public sealed partial class RevenantSystem : EntitySystem
 
         var essenceDamage = args.DamageDelta.GetTotal().Float() * component.DamageToEssenceCoefficient * -1;
         ChangeEssenceAmount(uid, essenceDamage, component);
+    }
+
+    /// <summary>
+    /// DeltaV - No more attack spam and remaining invisible
+    /// </summary>
+    private void OnMeleeAttack(Entity<RevenantComponent> ent, ref MeleeAttackEvent args)
+    {
+        _statusEffects.TryAddStatusEffect<CorporealComponent>(ent, "Corporeal", ent.Comp.MeleeRevealTime, false);
     }
 
     public bool ChangeEssenceAmount(EntityUid uid, FixedPoint2 amount, RevenantComponent? component = null, bool allowDeath = true, bool regenCap = false)

--- a/Content.Shared/Revenant/Components/RevenantComponent.cs
+++ b/Content.Shared/Revenant/Components/RevenantComponent.cs
@@ -300,4 +300,12 @@ public sealed partial class RevenantComponent : Component
     public string HarvestingState = "harvesting";
     #endregion
     [DataField] public EntityUid? HauntAction; // Imp
+
+    #region Melee
+    /// <summary>
+    /// DeltaV - The amount of time a rev is revealed after making a melee attack.
+    /// </summary>
+    [DataField]
+    public TimeSpan MeleeRevealTime = TimeSpan.FromSeconds(2);
+    #endregion
 }

--- a/Resources/Prototypes/Actions/ninja.yml
+++ b/Resources/Prototypes/Actions/ninja.yml
@@ -87,6 +87,7 @@
       params:
         volume: 5
     priority: -12
+    useDelay: 5 # DeltaV - small cooldown
   - type: TargetAction
     checkCanAccess: false
     range: 0

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -1086,12 +1086,6 @@
   - type: Item
     heldPrefix: green
   - type: AgentIDCard
-  - type: ActivatableUI # DeltaV - adds the agent ID ui
-    key: enum.AgentIDCardUiKey.Key
-  - type: UserInterface # DeltaV - adds the agent ID ui
-    interfaces:
-      enum.AgentIDCardUiKey.Key:
-        type: AgentIDCardBoundUserInterface
   - type: IdCard
     jobIcon: JobIconNinja
   - type: Access

--- a/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/identification_cards.yml
@@ -1086,6 +1086,12 @@
   - type: Item
     heldPrefix: green
   - type: AgentIDCard
+  - type: ActivatableUI # DeltaV - adds the agent ID ui
+    key: enum.AgentIDCardUiKey.Key
+  - type: UserInterface # DeltaV - adds the agent ID ui
+    interfaces:
+      enum.AgentIDCardUiKey.Key:
+        type: AgentIDCardBoundUserInterface
   - type: IdCard
     jobIcon: JobIconNinja
   - type: Access

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -163,7 +163,7 @@
   - type: LimitedCharges
     maxCharges: 3
   - type: AutoRecharge
-    rechargeDuration: 20
+    rechargeDuration: 30 # DeltaV - was 20
   - type: Clothing
     sprite: Objects/Weapons/Melee/energykatana.rsi
     slots:

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -84,20 +84,20 @@
     lightThreshold: 0.7
     darkDamage:
       types:
-        Blunt: -5
-        Piercing: -5
-        Slash: -5
-        Heat: -5
-        Poison: -5
-        Asphyxiation: -2.5
-        Bloodloss: -2.5
-        Cellular: -5
+        Blunt: -2
+        Piercing: -2
+        Slash: -2
+        Heat: -2
+        Poison: -2
+        Asphyxiation: -2
+        Bloodloss: -2
+        Cellular: -2
         Soul: -1
     lightDamage:
       types:
-        Blunt: 1.5
-        Piercing: 1.5
-        Slash: 1.5
+        Blunt: 3
+        Piercing: 3
+        Slash: 3
     healWhenDead: true
     darkMovementSpeedMultiplier: 1.25
     lightMovementSpeedMultiplier: 1.0

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -95,9 +95,9 @@
         Soul: -1
     lightDamage:
       types:
-        Blunt: 3
-        Piercing: 3
-        Slash: 3
+        Blunt: 2
+        Piercing: 2
+        Slash: 2
     healWhenDead: true
     darkMovementSpeedMultiplier: 1.25
     lightMovementSpeedMultiplier: 1.0


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
I'm going for small changes only to see how this feels. I would rather not change a lot all at once, so I'm just going to target one ability on each antag.

* Added a 5 second cooldown to ninja's teleport
* Increased the charge cooldown of ninja teleport from 20s to 30s
* Reduced Skia regeneration in the dark and increased damage in light a bit.
  * Skia dark regen nerfed from 5 healing per tick (all damage types) to 2 healing per tick (all damage types)
  * Skia light damage increased from 1.5 to 2
* Added 2 seconds of Corporeal when a revenant melee attacks something.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some midround antags are impossible or just very annoying to deal with due to lack of counterplay.

Ninja teleport cooldown changes require the ninja to plan their teleports better, and prevents multiple teleports in a row. If you are caught by security. I play a lot of ninja and I think this will allow security to trap the ninja in some situations because they cannot use their teleport as liberally in succession. Getting cornered as a ninja is how they die.

Skia are just oppressive as a midround antag. They are similar to ninja in a lot of regards but have innate healing and deal shadow damage, which is usually "true" damage and hard to heal a lot of the time (med runs out of salts quick). They have no footsteps so its hard to know if they are around if they haven't screamed. It takes 1 melee to break a light but much longer to replace said light. 

Skia healing makes them VERY strong because they can just walk away and heal up their damage at most 20 seconds. This gives security a bit more time to find the hurt skia and potentially deal with it, instead of it being back to full health and the cycle repeating.

Revenant melee attack is just annoying when all they do is break station lights and there's absolutely no way to deal with it. They can also just focus on one person and deal small amounts of damage (one being soul damage) and there is just no counterplay to that.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

https://github.com/user-attachments/assets/a6d3383a-8586-471c-ad1a-f98d91839bc0

<img width="1065" height="645" alt="image" src="https://github.com/user-attachments/assets/7afaedaa-a728-4c5d-9686-8896e5e7aa1f" />

https://github.com/user-attachments/assets/9418aa52-ff89-4faf-8073-4647cf00f6d6

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Ninja's katana dash now has a 5 second cooldown between uses.
- tweak: Ninja's katana dash now takes 30 seconds to recharge each use, up from 20 seconds.
- tweak: Reduced skia's healing in the dark from 5 of each damage type to 2 of each damage type.
- tweak: Increased skia's damage from light from 1.5 brute to 2 brute.
- tweak: Revenant's melee attack will now reveal them for 2 seconds. 