### PR TITLE
Kill combat medkits free storage

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -190,12 +190,13 @@
     containers:
       storagebase: !type:AllSelector
         children:
+        - id: MedkitCombatFilled # DeltaV - Changed order from last to first
         - id: ChemistryBottleEpinephrine
           amount: 2
         - id: ChemistryBottleEphedrine
           amount: 2
         - id: ChemistryBottleOmnizine
-        - id: MedkitCombatFilled
+        #- id: MedkitCombatFilled # DeltaV - Moved a bit up
 
 - type: entity
   parent: ClothingBeltWand

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -190,13 +190,12 @@
     containers:
       storagebase: !type:AllSelector
         children:
-        - id: MedkitCombatFilled # DeltaV - Changed order from last to first
         - id: ChemistryBottleEpinephrine
           amount: 2
         - id: ChemistryBottleEphedrine
           amount: 2
         - id: ChemistryBottleOmnizine
-        #- id: MedkitCombatFilled # DeltaV - Moved a bit up
+        - id: MedkitCombatFilled
 
 - type: entity
   parent: ClothingBeltWand

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -114,6 +114,4 @@
     state: blackkit
   - type: Item
     heldPrefix: blackkit
-    #size: Normal # DeltaV - Same size as the rest of them.
-  - type: ExplosionResistance # DeltaV - Gave explosion resistance to differentiate.
-    damageCoefficient: 0.1
+    size: Normal

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -115,4 +115,5 @@
   - type: Item
     heldPrefix: blackkit
     #size: Normal # DeltaV - Same size as the rest of them.
-
+  - type: ExplosionResistance # DeltaV - Gave explosion resistance to differentiate.
+    damageCoefficient: 0.1

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -115,3 +115,5 @@
   - type: Item
     heldPrefix: blackkit
     size: Normal
+    shape: # DeltaV - Retain 2x2
+    - 0,0,1,1

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -112,5 +112,5 @@
     state: blackkit
   - type: Item
     heldPrefix: blackkit
-    size: Normal
+    #size: Normal # DeltaV - Same size as the rest of them.
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -26,7 +26,9 @@
     grid:
     - 0,0,3,1
   - type: Item
-    size: Large
+    #size: Large # DeltaV - Change size
+    shape: # DeltaV - Change size
+    - 0,0,2,1
     sprite: Objects/Specific/Medical/firstaidkits.rsi
     heldPrefix: firstaid
   - type: PhysicalComposition

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -83,7 +83,7 @@
   - MedkitBrute
   - MedkitAdvanced
   - MedkitRadiation
-  - MedkitCombat
+  #- MedkitCombat # DeltaV - No printable combat medkits
 
 - type: latheRecipePack
   id: MedicalBoardsStatic


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
I made medkits take up a 2x3 in storage, from 2x4. Also removes the combat medkit from the lathe.

## Why / Balance
Medkits made a bit smaller for ease of use while removing the combat medkit from the lathe to minimize the free storage it provides for paramedics and corpsmen.

## Technical details
N/A

## Media
<img width="317" height="187" alt="image" src="https://github.com/user-attachments/assets/b00ef9fa-33b1-4f47-9a4a-755ce8e85dc5" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Medkits now occupy a 2x3 in your bag, from 2x4.

