### PR TITLE
Ramping Scheduler adjustments and changes

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -607,12 +607,13 @@
     - 10, 2
     - 10, 4
     - 15, 6
-    - 10, 8
     - 10, 2
+    - 10, 5
+    - 10, 7
+    - 20, 10
     - 10, 6
-    - 15, 10
-    - 10, 6
-    - 10, 2
+    - 20, 4
+    - 20, 2
     - 70, 4
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -599,17 +599,20 @@
   - type: NextEvent # DeltaV: Queue Event for precognition
   - type: RampingStationEventScheduler
     timeKeyPoints: # DeltaV
-    - 10, 10
-    - 10, 8
+    - 10, 7
     - 10, 6
-    - 10, 2
-    - 15, 8
+    - 10, 5
+    - 5, 2
     - 15, 10
-    - 15, 2
-    - 15, 8
     - 10, 2
     - 10, 4
-    - 70, 6
+    - 15, 8
+    - 10, 10
+    - 10, 6
+    - 10, 2
+    - 10, 10
+    - 10, 5
+    - 70, 4
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -606,12 +606,13 @@
     - 15, 10
     - 10, 2
     - 10, 4
-    - 15, 8
-    - 10, 10
+    - 15, 6
+    - 10, 8
+    - 10, 2
+    - 10, 6
+    - 15, 10
     - 10, 6
     - 10, 2
-    - 10, 10
-    - 10, 5
     - 70, 4
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -604,7 +604,7 @@
     - 10, 5
     - 5, 2
     - 15, 10
-    - 10, 2
+    - 10, 2 # Heavy event density from minute 50 through 60
     - 10, 4
     - 15, 6
     - 10, 2

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -602,15 +602,17 @@
     - 10, 7
     - 10, 6
     - 10, 5
-    - 5, 2
+    - 5, 2 # Heavy event density from minute 35 through 40
     - 15, 10
     - 10, 2 # Heavy event density from minute 50 through 60
     - 10, 4
     - 15, 6
-    - 10, 2
+    - 10, 2 # Heavy density from minute 85 through 95
+    # Probable EOR, start winding down
     - 10, 5
     - 10, 7
     - 20, 10
+    # Crew decided to stay so wind back up
     - 10, 6
     - 20, 4
     - 20, 2

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -600,16 +600,16 @@
   - type: RampingStationEventScheduler
     timeKeyPoints: # DeltaV
     - 10, 10
+    - 10, 8
     - 10, 6
-    - 10, 1
-    - 10, 3
-    - 15, 5
-    - 15, 4
-    - 20, 2
-    - 10, 1
+    - 10, 2
+    - 15, 8
+    - 15, 10
+    - 15, 2
+    - 15, 8
+    - 10, 2
     - 10, 4
-    - 10, 3
-    - 70, 4
+    - 70, 6
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 


### PR DESCRIPTION
## About the PR
Increases the minimum time that it takes for the scheduler to "Ramp up". Events do not have a 1 every minute spawn, and the baseline has been increased to 2 minutes for the smallest time between events, and the largest time is still 10 minutes. 

I will walk you through the OLD scheduler first, then the NEW adjustments

**Old Scheduler**
for the first 10 minutes, time between events is 10 minutes
10 minutes of time between being 6 minutes 
10 minutes of time between being 1 minute (10 events for this)
**40ish minute mark into the round, or the scheduler being added**
10 minutes of time being 3 minutes
15 minutes of time being 5 minutes
15 mins of time being 4
20 mins of time being 2
10 mins of time being 1
***1 hour 50ish into round, or scheduler being added ***
10 mins of time being 4
10 mins of time being 3
70 minutes of time being 4

**New Scheduler adjustments**
for the first 10 minutes, time between events is 7 minutes
10 minutes of time between events being 6 minutes
10 minutes of time between being 5 minutes 
5 minutes of time between being 2 minutes (This means many events in small span)
**35ish minute mark into the round, or the scheduler being added**
15 minutes of time being 10 minutes
10 minutes of time being 2 minutes
10 mins of time being 4
10 mins of time being 6
10 mins of time being 2
***1 hour 25ish into round, or scheduler being added***
***Begins to wind down for evac shuttle / standard EOR***
10 mins of time being 5
10 mins of time being 7
20 mins of time being 10
**Standard EOR ends here, If you say you get the more "Stable" version***
10 mins of 6
20 mins of 4
20 mins of 2
**Round is now at 3h, will be consistent from here**
70 minutes of time being 4

## Why / Balance
Most rounds do not take as long to ramp up, and do not give the chance for major roleplay moments. Also, this does not change how many antags are present in a round, it only changes how **often** the scheduler will spawn an event (antag, gas leak, ion storm, lone op, etc). 

Currently at the end of each round, we have roughly 4-8 massive antagonists in the round causing havoc across the station, while we do want disasters, we do not want people checking out at the hour 10 or so mark due to how overwhelming the round becomes. 

We want the round to progress "naturally" while still giving pressure to players to respond to events. Hopefully with the raising of the baseline from 1 minute to 2 minutes, and the addition of a "cooloff period" at ~1:10 mark, this can relieve some of the issues caused. 

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.

## Licensing
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->


**Changelog**

:cl:
- tweak: Survival Scheduler has been slightly tamed, and will give moments of calm, while also applying pressure via spawns. Survival Scheduler refused to read you a bedtime story, sorry chat.
