### PR TITLE
Anti-tamper Rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -13,7 +13,7 @@
         - id: MagazinePistolSubMachineGunTopMounted
           amount: 4
   - type: AntiTamper # DeltaV - port impstation's anti-tamper
-  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
@@ -117,4 +117,4 @@
         - id: MagazineRifle
           amount: 4
   - type: AntiTamper # DeltaV - port impstation's anti-tamper
-  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -12,6 +12,8 @@
           amount: 2
         - id: MagazinePistolSubMachineGunTopMounted
           amount: 4
+  - type: AntiTamper # DeltaV - port impstation's anti-tamper
+  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
@@ -114,3 +116,5 @@
           amount: 2
         - id: MagazineRifle
           amount: 4
+  - type: AntiTamper # DeltaV - port impstation's anti-tamper
+  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -203,8 +203,8 @@
     sprite: _DV/Structures/Storage/Crates/sec_gear.rsi # DeltaV - resprite security crates
   - type: AccessReader
     access: [["Security"]]
-  - type: AntiTamper # DeltaV - port impstation's anti-tamper
-    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+#  - type: AntiTamper # DeltaV - port impstation's anti-tamper
+#    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: CrateBaseSecure
@@ -309,8 +309,8 @@
     sprite: Structures/Storage/Crates/weapon.rsi
   - type: AccessReader
     access: [["Armory"]]
-  - type: AntiTamper # DeltaV - port impstation's anti-tamper
-    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+ # - type: AntiTamper # DeltaV - port impstation's anti-tamper
+ #   containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: [ CrateBaseSecure, BaseSecurityContraband ]

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
@@ -10,7 +10,7 @@
           amount: 2
         - id: BoxSpeedLoaderLightRifle
   - type: AntiTamper # DeltaV - port impstation's anti-tamper
-  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: CrateWeaponSecure
@@ -91,7 +91,7 @@
       entity_storage: !type:NestedSelector
         tableId: NT3Table
   - type: AntiTamper # DeltaV - port impstation's anti-tamper
-  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
+    containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: CrateWeaponSecure

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
@@ -9,6 +9,8 @@
         - id: WeaponSniperGrand
           amount: 2
         - id: BoxSpeedLoaderLightRifle
+- type: AntiTamper # DeltaV - port impstation's anti-tamper
+  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: CrateWeaponSecure
@@ -88,6 +90,8 @@
     containers:
       entity_storage: !type:NestedSelector
         tableId: NT3Table
+  - type: AntiTamper # DeltaV - port impstation's anti-tamper
+  containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity
   parent: CrateWeaponSecure

--- a/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_DV/Catalog/Fills/Crates/armory.yml
@@ -9,7 +9,7 @@
         - id: WeaponSniperGrand
           amount: 2
         - id: BoxSpeedLoaderLightRifle
-- type: AntiTamper # DeltaV - port impstation's anti-tamper
+  - type: AntiTamper # DeltaV - port impstation's anti-tamper
   containers: [ entity_storage ] # DeltaV - port impstation's anti-tamper
 
 - type: entity


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Removed most Anti-tamper from Security/Armor crates allowing crew easier access to Shotguns, Revolvers, Pistols, Armor, Nonlethals, and Laser Rifles.

Kept Anti-tamper for the following Assault weapons: Lecter, Wt550 SMG, Mk.1 Rifle, and the NT-3 Heavy Machine Gun Crates.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With WarOps and Ramping gamemodes back on the menu I believe that crew should have more of a fighting chance versus Nukies or other Antags should Security or Command fail to hold the line. As of currently, if Nukies kill all SecOffs and Command it is basically gameover for crew as you need Security ID, Warden ID, or HoS ID to bypass Anti-tamper.

## Technical details
<!-- Summary of code changes for easier review. -->
Comments out Generalized Anti-Tamper for all Security/Armory crates, narrows Anti-Tamper down to specific crates.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
<!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed Anti-Tamper from most Security/Armory Crates.
- add: Added Anti-Tamper to the following Assault Weapons: Lecter, Wt550, Mk.1 Rifle, and the NT-3 Heavy Machine gun crates.
