### PR TITLE
Asakim Tweaks

### DIFF
--- a/Resources/Locale/en-US/_DV/ghost/roles/asakim.ftl
+++ b/Resources/Locale/en-US/_DV/ghost/roles/asakim.ftl
@@ -1,9 +1,9 @@
 ghost-role-information-asakim-name = Asakim Warrior
 ghost-role-information-asakim-description = A genetically enhanced bioweapon, stranded in the sector after cryostasis failure.
 ghost-role-information-asakim-rules =
-    You are a [color=yellow][bold]Free-Agent[/bold][/color]. You may pursue your given objectives, or find your own way through life.
+    You are a [color=yellow][bold]Free-Agent[/bold][/color]. Your objectives will put you in varying levels of conflict with the station.
     You have [color=red]no knowledge[/color] (maybe basic at most) [color=red]of this sector of space, its inhabitants, its factions, or its culture[/color]. While you cannot speak their language, you can understand it.
-    You may kill your targets if you have any, and you may kill to defend yourself and your property. [color=green]Civilians and the innocent are not your enemy[/color], and may be useful to you (if you can get past the language barrier - try an AAC tablet!). Fight with honor.
+    You may kill your targets if you have any, and you may kill to defend yourself and your property. [color=yellow]You should be somewhat wary of crewmembers, especially Security[/color]- but they may be useful to you (if you can get past the language barrier - try an AAC tablet!). Fight with honor.
 asakim-role-briefing =
     You are an Asakim, a genetically-engineered weapon from a distant part of space.
     You've awoken from long-term cryosleep in an unfamiliar sector, and an unfamiliar time.

--- a/Resources/Prototypes/_DV/Body/Species/asakim.yml
+++ b/Resources/Prototypes/_DV/Body/Species/asakim.yml
@@ -216,11 +216,6 @@
     color: "#ae65bf"
     activateSound: null
     deactivateSound: null
-  - type: MobThresholds
-    thresholds:
-      0: Alive
-      120: Critical
-      240: Dead
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/_DV/Body/Species/asakim.yml
+++ b/Resources/Prototypes/_DV/Body/Species/asakim.yml
@@ -101,12 +101,14 @@
     baseWalkSpeed : 2.7
     baseSprintSpeed : 4.65
     weightlessAcceleration: 1.5 # Slightly more manueverable in space.
+  - type: ClothingSlowResistance
+    modifier: 1.0 # Completely unaffected by clothing slow
   - type: Fixtures
     fixtures: # TODO: This needs a second fixture just for mob collisions.
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.48
+          radius: 0.39
         density: 275 # Its an abandoned bioweapon species with 4 arms, of course it should be able to fight a Oni.
         restitution: 0.0
         mask:
@@ -214,6 +216,11 @@
     color: "#ae65bf"
     activateSound: null
     deactivateSound: null
+  - type: MobThresholds
+    thresholds: 
+      0: Alive
+      120: Critical
+      240: Dead
 
 - type: entity
   parent: OrganBase

--- a/Resources/Prototypes/_DV/Body/Species/asakim.yml
+++ b/Resources/Prototypes/_DV/Body/Species/asakim.yml
@@ -217,7 +217,7 @@
     activateSound: null
     deactivateSound: null
   - type: MobThresholds
-    thresholds: 
+    thresholds:
       0: Alive
       120: Critical
       240: Dead

--- a/Resources/Prototypes/_DV/Objectives/asakim.yml
+++ b/Resources/Prototypes/_DV/Objectives/asakim.yml
@@ -71,14 +71,6 @@
 
 - type: entity
   parent: [BaseAsakimObjective, BaseSurviveObjective]
-  id: AsakimUpgradeObjective
-  name: ">UPGRADE"
-  description: Preliminary sector scans detect possible high-value cybernetics. Upgrade your body.
-  components:
-  - type: Objective
-
-- type: entity
-  parent: [BaseAsakimObjective, BaseSurviveObjective]
   id: AsakimAllyObjective
   name: ">AFFILIATE"
   description: Prior records indicate possible persons-of-interest in this sector. Find or make allies in the local populace.

--- a/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/_DV/Objectives/objectiveGroups.yml
@@ -116,7 +116,6 @@
     AsakimObjectiveGroupTheft: 1
     AsakimObjectiveGroupInfiltrate: 1
     AsakimObjectiveGroupInterrogate: 1
-    AsakimObjectiveGroupUpgrade: 1
     AsakimObjectiveGroupAlly: 1
 
 - type: weightedRandom
@@ -138,11 +137,6 @@
   id: AsakimObjectiveGroupInterrogate
   weights:
     AsakimInterrogateObjective: 1
-
-- type: weightedRandom
-  id: AsakimObjectiveGroupUpgrade
-  weights:
-    AsakimUpgradeObjective: 1
 
 - type: weightedRandom
   id: AsakimObjectiveGroupAlly

--- a/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Clothing/OuterClothing/Hardsuits/asakim.yml
@@ -47,8 +47,8 @@
         Poison: 0.4
         Caustic: 0.4
   - type: ClothingSpeedModifier
-    walkModifier: 1
-    sprintModifier: 1
+    walkModifier: 0.2
+    sprintModifier: 0.2
   - type: HeldSpeedModifier
   - type: ToggleableClothing # Goobstation - Modsuits change - Mono - this is a solution for helmet attachment/cover to not fit on hardsuits
     requiredSlot: outerclothing

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/asakim.yml
@@ -43,15 +43,15 @@
     zeroVisible: false
   - type: BatteryAmmoProvider
     proto: HandheldAutopulserProjectile
-    fireCost: 33 # DeltaV - increased fire cost, was 25. 33 comes out to 30 shots.
+    fireCost: 50 # DeltaV - doubled fire cost, was 25
   - type: BatteryWeaponFireModes # DeltaV - selectable disabler mode
     fireModes:
     - proto: HandheldAutopulserProjectile
-      fireCost: 33 # DeltaV - increased fire cost, was 25
+      fireCost: 50 # DeltaV - doubled fire cost, was 25
     - proto: HandheldAutopulserDisablerProjectile
-      fireCost: 25
+      fireCost: 35 # DeltaV - less than doubled fire cost for disable mode, was 25
   - type: Appearance
   - type: StaticPrice
     price: 1750
   - type: BatterySelfRecharger
-    autoRechargeRate: 25 # DeltaV - double to compensate for increased cost, was 15
+    autoRechargeRate: 30 # DeltaV - double to compensate for increased cost, was 15

--- a/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/asakim.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Weapons/Guns/Battery/asakim.yml
@@ -43,15 +43,15 @@
     zeroVisible: false
   - type: BatteryAmmoProvider
     proto: HandheldAutopulserProjectile
-    fireCost: 50 # DeltaV - doubled fire cost, was 25
+    fireCost: 33 # DeltaV - increased fire cost, was 25. 33 comes out to 30 shots.
   - type: BatteryWeaponFireModes # DeltaV - selectable disabler mode
     fireModes:
     - proto: HandheldAutopulserProjectile
-      fireCost: 50 # DeltaV - doubled fire cost, was 25
+      fireCost: 33 # DeltaV - increased fire cost, was 25
     - proto: HandheldAutopulserDisablerProjectile
-      fireCost: 35 # DeltaV - less than doubled fire cost for disable mode, was 25
+      fireCost: 25
   - type: Appearance
   - type: StaticPrice
     price: 1750
   - type: BatterySelfRecharger
-    autoRechargeRate: 30 # DeltaV - double to compensate for increased cost, was 15
+    autoRechargeRate: 25 # DeltaV - double to compensate for increased cost, was 15


### PR DESCRIPTION
## About the PR
pr freeze over? splendid! 500 microbalance PRs

- Asakim armor is now practically unusable by other species, as it comes with a base 80% slowdown. Asakim now ignore all armor slowdown.
- ~~Asakim crit/death thresholds have been raised to 120/240, since Euphoria did that and nobody's complained yet. I think.~~
- ~~The Asakim autopulser can now fire 30 lethal or 40 disabler rounds at full charge, up from like 20 lethal and something like 30 disabler. Recharge rate has been adjusted to match, and should be a little bit faster.~~
- The `>UPGRADE` objective has been removed, as shitmed no longer exists. This will bias Asakim towards being hostile more often.
- Ghostrole rules have been reworded to be less friendly, but it's not like anybody reads those anyways
- Asakim fixture size has been lowered, as this allegedly caused a bug with fitting through doors. Haven't seen it myself, but it [was reported downstream](https://github.com/Floof-Station/Panta-Rhei/pull/713)

## Why / Balance
Judging by the overall sentiment I've seen on the Discord, Asakim have been generally underperforming in combat situations against crew. While this is largely due to the inherent aspect of a rare ghostrole getting taken by unrobust gamers, I do believe there are some changes that should probably be made to counteract this. A single hostile asakim *should* be a genuine threat to Security, and should probably require an armed response to take down.

Crewmembers really should not be wearing the literal springtrap suit that Asakim armor is. 80% slowdown should be a good enough deterrent, or at the very least, will be an entertaining punishment for those who wish to powergame. Fully ignoring equipment slowdown is something that would only end up being an issue in the most niche of niche circumstances, especially considering Asakim are already the rarest antag in the game. And in that case it would probably be really funny

I felt it would probably be overkill to straight up say "DO NOT VALIDHUNT" in the ghostrole rules, and a bit overly limiting at that. It's already way too long as-is.

## Technical details
mono namespaced changes are taken from https://github.com/Monolith-Station/Monolith/pull/2372, and are thus not commented

## Media
<img width="519" height="459" alt="image" src="https://github.com/user-attachments/assets/bd713a73-c561-4998-92eb-0b17279412a2" />

non-asakim armor slowdown

https://github.com/user-attachments/assets/0a3870d2-463d-4c02-80b7-196bd6e31c9a



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
<!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- remove: Removed a shitmed-remnant Asakim objective.
- tweak: Asakim ghostrole rules have been reworded to be a little less friendly.
- tweak: Asakim armor now slows any non-Asakim by 80%, to discourage crewmembers from intentionally springlocking themselves.
- fix: Asakim shouldn't get stuck in doors.
