### PR TITLE
Port WearerGetsExamineText refactor from impstation

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Interaction;
-using Content.Shared.Inventory; // Harmony - for lanyards
+using Content.Shared.Inventory; // Harmony - lanyards, imp - examinable pins
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using JetBrains.Annotations;
@@ -294,7 +294,7 @@ namespace Content.Shared.Examine
     ///     If you're pushing multiple messages that should be grouped together (or ordered in some way),
     ///     call <see cref="PushGroup"/> before pushing and <see cref="PopGroup"/> when finished.
     /// </summary>
-    public sealed class ExaminedEvent : EntityEventArgs, IInventoryRelayEvent //Harmony InventoryRelayEvent for Lanyards
+    public sealed class ExaminedEvent : EntityEventArgs, IInventoryRelayEvent //Harmony InventoryRelayEvent for Lanyards, IMP EDIT: Inventory relayed
     {
         /// <summary>
         ///     The message that will be displayed as the examine text.
@@ -530,7 +530,7 @@ namespace Content.Shared.Examine
         }
 
         private record ExamineMessagePart(FormattedMessage Message, int Priority, bool DoNewLine, string? Group);
-        public SlotFlags TargetSlots { get; } = SlotFlags.NECK; // Harmony - For targeting lanyards.
+        public SlotFlags TargetSlots { get; } = SlotFlags.NECK; // Harmony - For targeting lanyards, IMP EDIT: Inventory relayed
     }
 
 

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -34,8 +34,7 @@ using Content.Shared.VoiceMask;
 using Content.Shared.Weapons.Ranged.Events;
 using Content.Shared.Wieldable;
 using Content.Shared.Zombies;
-using Content.Shared.Examine; //Harmony
-
+using Content.Shared.Examine; // Harmony, imp
 
 namespace Content.Shared.Inventory;
 
@@ -67,7 +66,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, BeforeEmoteEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, StoodEvent>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, DownedEvent>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, ExaminedEvent>(RelayInventoryEvent); // Harmony - added for lanyards.
+        SubscribeLocalEvent<InventoryComponent, ExaminedEvent>(RelayInventoryEvent); // Harmony - added for lanyards, imp - examinable pins
 
         // by-ref events
         SubscribeLocalEvent<InventoryComponent, RefreshFrictionModifiersEvent>(RefRelayInventoryEvent);

--- a/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextComponent.cs
+++ b/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared._Impstation.Clothing;
 /// <summary>
 /// Adds examine text to the entity that wears item, for making things obvious.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent]
 [Access(typeof(WearerGetsExamineTextSystem))]
 public sealed partial class WearerGetsExamineTextComponent : Component
 {
@@ -37,24 +37,11 @@ public sealed partial class WearerGetsExamineTextComponent : Component
     public LocId ExamineOnWearer = "obvious-desc-default";
 
     /// <summary>
-    /// Reference to the entity wearing this clothing.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public EntityUid? Wearer;
-    /// <summary>
     /// The string that is attached to this item's ExamineOnWearer.
     /// Typically doesn't need to be redefined.
     /// </summary>
     [DataField]
     public LocId PrefixExamineOnWearer = "obvious-prefix-wearing";
-
-    /// <summary>
-    /// If true, an entity with this item in any slot (i.e. in pockets) will gain the examine text,
-    /// instead of when just equipped as clothing.
-    /// Should be used sparingly only when truly appropriate; this is effectively a half-measure for lack of a special pin slot.
-    /// </summary>
-    [DataField]
-    public bool PocketEvident;
 
     /// <summary>
     /// If true, the entity's description will inform examiners what others will see on the wearer (before they equip it).

--- a/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextSystem.cs
+++ b/Content.Shared/_Impstation/Clothing/WearerGetsExamineTextSystem.cs
@@ -1,9 +1,7 @@
-using Content.Shared.Clothing.Components;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
-using Content.Shared.Inventory.Events;
+using Content.Shared.Inventory;
 using Content.Shared.Contraband;
-using Content.Shared._Impstation.Examine;
 using System.Text;
 
 namespace Content.Shared._Impstation.Clothing;
@@ -17,35 +15,16 @@ public sealed class WearerGetsExamineTextSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<WearerGetsExamineTextComponent, GotEquippedEvent>(OnEquipped);
-        SubscribeLocalEvent<WearerGetsExamineTextComponent, GotUnequippedEvent>(OnUnequipped);
         SubscribeLocalEvent<WearerGetsExamineTextComponent, ExaminedEvent>(OnExamine);
-    }
-
-    private void OnEquipped(Entity<WearerGetsExamineTextComponent> entity, ref GotEquippedEvent args)
-    {
-        if (!TryComp(entity, out ClothingComponent? clothing))
-            return;
-        var isCorrectSlot = (clothing.Slots & args.SlotFlags) != Inventory.SlotFlags.NONE;
-        if (!entity.Comp.PocketEvident) //if it can't be evident in our pockets
-        {
-            // Make sure the clothing item was equipped to the right slot, and not just held in a hand.
-            if (!isCorrectSlot)
-                return;
-        }
-
-        entity.Comp.Wearer = args.Equipee;
-        Dirty(entity);
-
-        //GIVE THEM INSPECT TEXT
-        var obviousExamine = EnsureComp<ExtraExamineTextComponent>(args.Equipee);
-        obviousExamine.Lines.TryAdd(entity.Owner,  //using try so that we don't cause an error if we move something from slot to slot
-            ConstructExamineText(entity, !isCorrectSlot, args.Equipee));
+        SubscribeLocalEvent<WearerGetsExamineTextComponent, InventoryRelayedEvent<ExaminedEvent>>(OnExamineWorn);
     }
 
 
     private string ConstructExamineText(Entity<WearerGetsExamineTextComponent> entity, bool prefixFallback, EntityUid affecting)
     {
+        if (!Exists(affecting))
+            return "";
+
         //parameters (these are the same between both constructions)
         var user = Identity.Entity(affecting, EntityManager);
         var nomen = Identity.Name(affecting, EntityManager);
@@ -68,44 +47,32 @@ public sealed class WearerGetsExamineTextSystem : EntitySystem
         return prefix + " " + suffix;
     }
 
-    private void OnUnequipped(Entity<WearerGetsExamineTextComponent> entity, ref GotUnequippedEvent args)
-    {
-        if (entity.Comp.Wearer is not { } wearer)
-            return;
-
-        if (TryComp(wearer, out ExtraExamineTextComponent? obviousExamine))
-        {
-            obviousExamine.Lines.Remove(entity.Owner);
-        }
-
-        entity.Comp.Wearer = null;
-        Dirty(entity);
-    }
-
     private void OnExamine(Entity<WearerGetsExamineTextComponent> entity, ref ExaminedEvent args)
     {
-        var currentlyWorn = entity.Comp.Wearer != null;
-        var outString = new StringBuilder(Loc.GetString(currentlyWorn ? "obvious-on-item-currently" : "obvious-on-item",
-            ("used", Loc.GetString(entity.Comp.PocketEvident ? "obvious-reveal-pockets" : "obvious-reveal-default")),
+        var outString = new StringBuilder(Loc.GetString("obvious-on-item",
+            ("used", Loc.GetString("obvious-reveal-default")),
             ("thing", entity.Comp.Category),
             ("me", Identity.Entity(entity, EntityManager))));
 
         if (entity.Comp.WarnExamine)
         {
-            if (!currentlyWorn && TryComp(entity, out ContrabandComponent? contra)) // if the item's contra and we're not wearing it yet
+            if (TryComp<ContrabandComponent>(entity, out var contra)) // if the item's contra and we're not wearing it yet
             {
                 var contraLocId = "obvious-on-item-contra-" + contra.Severity; // apply additional text if the item is contraband to note that displaying it might be really bad
                 if (Loc.HasString(contraLocId)) // saves us the trouble of making a switch block for this
                     outString.Append(" " + Loc.GetString(contraLocId));
             }
-            var affecting = currentlyWorn ? entity.Comp.Wearer.GetValueOrDefault() : args.Examiner;
-            var testOut = ConstructExamineText(entity, false, affecting);
+            var testOut = ConstructExamineText(entity, false, args.Examiner);
 
             outString.Append("\n" + Loc.GetString("obvious-on-item-for-others",
-                ("will", currentlyWorn ? "can" : "will"), // i love hardcoding strings it's my favorite thing ever
                 ("output", testOut)));
         }
 
         args.PushMarkup(outString.ToString());
+    }
+
+    private void OnExamineWorn(Entity<WearerGetsExamineTextComponent> entity, ref InventoryRelayedEvent<ExaminedEvent> args)
+    {
+        args.Args.PushMarkup(ConstructExamineText(entity, false, args.Args.Examined));
     }
 }

--- a/Resources/Locale/en-US/_Impstation/obvious.ftl
+++ b/Resources/Locale/en-US/_Impstation/obvious.ftl
@@ -1,6 +1,6 @@
 obvious-on-item = When {$used}, { SUBJECT($me) } will be [color=white]obvious[/color] to casual examination.
 obvious-on-item-currently = { CAPITALIZE(SUBJECT($me)) } { CONJUGATE-BE($me) } [color=white]obvious[/color] to casual examination.
-obvious-on-item-for-others = [italic][color=#777777]Others {$will} see:[/color] "{$output}"[/italic]
+obvious-on-item-for-others = [italic][color=#777777]Others will see:[/color] "{$output}"[/italic]
 
 obvious-reveal-default = worn
 obvious-reveal-pockets = worn or pocketed

--- a/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
@@ -37,7 +37,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckBase
@@ -56,7 +55,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckBase
@@ -75,7 +73,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckBase
@@ -94,7 +91,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckBase
@@ -113,7 +109,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckBase
@@ -132,7 +127,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckBase
@@ -153,5 +147,4 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 

--- a/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/medals.yml
@@ -16,7 +16,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-medal
     examineText: obvious-x-medal-nothing
-    pocketEvident: true
 
 
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/pins.yml
@@ -14,7 +14,6 @@
   - type: WearerGetsExamineText # imp
     thing: obvious-thing-pin
     examineText: obvious-desc-default
-    pocketEvident: true
 
 - type: entity
   parent: ClothingNeckPinBase


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
<!-- What did you change? -->
Fixes the issue where spawning with a novice badge (e.g. as tech assistant) did not show correct character pronouns in examine description, defaulting to "it".

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #6415

## Technical details
<!-- Summary of code changes for easier review. -->
Port of https://github.com/impstation/imp-station-14/pull/3286.
ExaminedEvent in Inventory was already relayed due to Harmony lanyards.
Does unfortunately kill examining from pockets (PocketEvident)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="608" height="389" alt="image" src="https://github.com/user-attachments/assets/fb748ad5-4e23-4939-8eb0-12618c409fdf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [ ] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
<!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed incorrect pronouns displaying on novice pins when spawning with them
- remove: Pins no longer display from pockets (technical reasons)
<!--
- add: Added fun!
- tweak: Changed fun!
-->
