### PR TITLE
Surplus boots - cosmetic jackboots

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/clothesmate.yml
@@ -142,6 +142,7 @@
     ClothingUniformBrownSuitSkirt: 2
     ClothingShoesLeather: 2
     ClothingShoesBootsLaceup: 2
+    ClothingShoesBootsSurplus: 3
     # End DeltaV additions
   contrabandInventory:
     ClothingMaskNeckGaiter: 2

--- a/Resources/Prototypes/_DV/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Shoes/boots.yml
@@ -20,3 +20,14 @@
     sprite: _DV/Clothing/Shoes/Boots/fishing_boots.rsi
   - type: Clothing
     sprite: _DV/Clothing/Shoes/Boots/fishing_boots.rsi
+
+- type: entity
+  parent: [ClothingShoesBaseButcherable]
+  id: ClothingShoesBootsSurplus
+  name: surplus boots
+  description: An old pair of boots. Not so useful for combat, but still plenty stylish.
+  components:
+  - type: Sprite
+    sprite: Clothing/Shoes/Boots/jackboots.rsi
+  - type: Clothing
+    sprite: Clothing/Shoes/Boots/jackboots.rsi


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Added surplus boots: a strictly cosmetic variant of jackboots. They're made available in clothesmate vendors.

## Why / Balance
Mainly for better character customization. Might lessen people competing over maints combat boots and/or people trying to bum them off of security. There isn't really a lot of good options for boots as a civilian.

## Technical details
Amended the _DV subfolder's boots.yml to include surplus boots. They use the same sprite as jackboots, but are mechanically identical to regular shoes.

## Media
<img width="494" height="315" alt="surplus boots" src="https://github.com/user-attachments/assets/6b7b86f3-74ae-4547-ad41-75d814ddbbde" />


## Requirements
- [x] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an in-game showcase.
## Licensing
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->

**Changelog**
:cl:
- add: Added surplus boots, a strictly-cosmetic variant of jackboots. Available now at your local Clothesmate vendor.
