### PR TITLE
Swap emergency shuttles to use NTNet

### DIFF
--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_academy.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_academy.yml
@@ -97,7 +97,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_basu.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_basu.yml
@@ -77,7 +77,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_bc20.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_bc20.yml
@@ -90,7 +90,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_box.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_box.yml
@@ -64,7 +64,7 @@ entities:
     - type: DeviceNetwork
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
       deviceNetId: Wireless
     - type: DecalGrid
       chunkCollection:

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_centipede.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_centipede.yml
@@ -88,7 +88,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_dart.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_dart.yml
@@ -76,7 +76,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: ImplicitRoof
     - type: GridPathfinding
     - type: Gravity

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_delta.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_delta.yml
@@ -71,7 +71,7 @@ entities:
     - type: DeviceNetwork
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
       deviceNetId: Wireless
     - type: DecalGrid
       chunkCollection:

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_fishbowl.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_fishbowl.yml
@@ -95,7 +95,7 @@ entities:
     - type: DeviceNetwork
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_kaeri.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_kaeri.yml
@@ -78,7 +78,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_lox.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_lox.yml
@@ -69,7 +69,7 @@ entities:
     - type: DeviceNetwork
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
       deviceNetId: Wireless
     - type: DecalGrid
       chunkCollection:

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_propeller.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_propeller.yml
@@ -109,7 +109,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_right.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_right.yml
@@ -97,7 +97,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_seal.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_seal.yml
@@ -85,7 +85,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_titan.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_titan.yml
@@ -75,7 +75,7 @@ entities:
     - type: DeviceNetwork
       configurators: [ ]
       deviceLists: [ ]
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
       deviceNetId: Wireless
     - type: GridPathfinding
     - type: DecalGrid

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_transport.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_transport.yml
@@ -126,7 +126,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: GridPathfinding
     - type: DecalGrid
       chunkCollection:

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_uclb.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_uclb.yml
@@ -94,7 +94,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_vertex.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_vertex.yml
@@ -75,7 +75,7 @@ entities:
     - type: DeviceNetwork
       configurators: [ ]
       deviceLists: [ ]
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
       deviceNetId: Wireless
     - type: GridPathfinding
     - type: DecalGrid

--- a/Resources/Maps/_DV/Shuttles/Evac/ntes_yggdrasil.yml
+++ b/Resources/Maps/_DV/Shuttles/Evac/ntes_yggdrasil.yml
@@ -81,7 +81,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: Gravity
       gravityShakeSound: !type:SoundPathSpecifier
         path: /Audio/Effects/alert.ogg

--- a/Resources/Maps/_DV/Shuttles/Misc/escape_pod_dv.yml
+++ b/Resources/Maps/_DV/Shuttles/Misc/escape_pod_dv.yml
@@ -73,7 +73,7 @@ entities:
       deviceNetId: Wireless
       configurators: []
       deviceLists: []
-      transmitFrequencyId: ShuttleTimer
+      transmitFrequencyId: NTNet
     - type: DecalGrid
       chunkCollection:
         version: 2


### PR DESCRIPTION
<!-- If you are new to the Delta-V repository, please read the [Contributing Guidelines](https://github.com/DeltaV-Station/Delta-v/blob/master/CONTRIBUTING.md) -->

## About the PR
Swapped all emergency shuttles to use `NTNet` instead of `ShuttleTimer`.

## Why / Balance
It's good if displays actually work when displaying ETA/ETD

## Technical details

#5954 Made it so the displays could be multifunctional, and swapped the receive frequency to `NTNet`, the shuttles weren't updated so they never had any listeners.

## Media

<img width="589" height="229" alt="image" src="https://github.com/user-attachments/assets/e0134114-9c95-4c93-a418-e029ad1f1444" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] AGPL (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to DeltaV -->
  - [X] MIT (https://github.com/DeltaV-Station/Delta-v/blob/master/LICENSE-MIT.txt) <!-- Optional - A lot of other SS14 forks use MIT -->
<!-- Feel free to add more licenses as you see fit -->

**Changelog**

:cl:
- fix: Fixed displays for ETA/ETD not displaying 

